### PR TITLE
Fixed the one time only password strength progress bar

### DIFF
--- a/physionet-django/static/zxcvbn/zxcvbn_ProgressBar_Register.js
+++ b/physionet-django/static/zxcvbn/zxcvbn_ProgressBar_Register.js
@@ -1,10 +1,8 @@
 $(document).ready(function()
 {
-	$('input[type=text]').change(function() {
-		$("#StrengthProgressBar").zxcvbnProgressBar({
-			passwordInput: "#id_password", 
-			userInputs: [$("#id_email").val(), $("#id_first_name").val(), 
-				$("#id_middle_names").val(), $("#id_last_name").val()]
-		});
+	$("#StrengthProgressBar").zxcvbnProgressBar({
+		passwordInput: "#id_password", 
+		userInputs: [$("#id_email").val(), $("#id_first_name").val(), 
+			$("#id_middle_names").val(), $("#id_last_name").val()]
 	});
 });


### PR DESCRIPTION
Removed on change input type text. The password progress bar wasn't working because it was tied to a input type text.