### PR TITLE
Make menus work using CSS without JavaScript.

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -8,6 +8,11 @@
   padding-right:5px;
 }
 
+/* make drop-down menus work without javascript */
+.dropdown-toggle:focus + .dropdown-menu,
+.dropdown:focus-within .dropdown-menu {
+    display: block;
+}
 
 /* Adapted from start-bootstrap freelancer*/
 #mainNav {


### PR DESCRIPTION
The first rule should work for mouse navigation with older browsers
that don't support :focus-within, but it will not work for keyboard
navigation.  The second rule should work for keyboard navigation with
current Firefox (60+), and possibly other browsers.

(In Firefox 52, :focus-within is supported but seems buggy in this
regard.)
