### PR TITLE
Sanitize path inputs for showing project folders

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -16,7 +16,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 
 from .utility import get_tree_size, get_file_info, get_directory_info, list_items, StorageInfo, get_tree_files, list_files
-from .validators import validate_doi
+from .validators import validate_doi, validate_subdir
 from user.validators import validate_alphaplus, validate_alphaplusplus
 
 
@@ -142,6 +142,7 @@ class PublishedAuthor(BaseAuthor):
 
     def initialed_name(self):
         return '{}, {}'.format(self.last_name, ' '.join('{}.'.format(i[0]) for i in self.first_names.split()))
+
 
 class Topic(models.Model):
     """
@@ -530,6 +531,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Return information for displaying file and directories
         """
+        # Sanitize input
+        validate_subdir(subdir)
+
         inspect_dir = os.path.join(self.file_root(), subdir)
         file_names , dir_names = list_items(inspect_dir)
         display_files, display_dirs = [], []
@@ -1017,6 +1021,9 @@ class PublishedProject(Metadata, SubmissionInfo):
         Return information for displaying files and directories from
         the main file root
         """
+        # Sanitize input
+        validate_subdir(subdir)
+
         inspect_dir = os.path.join(self.main_file_root(), subdir)
         file_names , dir_names = list_items(inspect_dir)
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -527,14 +527,25 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         "Storage allowed in bytes"
         return self.core_project.storage_allowance
 
+    def get_inspect_dir(subdir):
+        """
+        Return the folder to inspect if valid. subdir joined onto
+        the file root of this project.
+        """
+        # Sanitize subdir for illegal characters
+        validate_subdir(subdir)
+        # Folder must be a subfolder of the file root and exist
+        inspect_dir = os.path.join(self.file_root(), subdir)
+        if inspect_dir.startswith(self.file_root()) and os.path.isdir(inspect_dir):
+            return inspect_dir
+        else:
+            raise Exception('Invalid directory request')
+
     def get_directory_content(self, subdir=''):
         """
         Return information for displaying file and directories
         """
-        # Sanitize input
-        validate_subdir(subdir)
-
-        inspect_dir = os.path.join(self.file_root(), subdir)
+        inspect_dir = self.get_inspect_dir(subdir)
         file_names , dir_names = list_items(inspect_dir)
         display_files, display_dirs = [], []
 
@@ -544,7 +555,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             file_info.full_file_name = os.path.join(subdir, file)
             display_files.append(file_info)
 
-        # Directories require
+        # Directories require links
         for dir_name in dir_names:
             dir_info = get_directory_info(os.path.join(inspect_dir, dir_name))
             dir_info.full_subdir = os.path.join(subdir, dir_name)
@@ -1016,18 +1027,30 @@ class PublishedProject(Metadata, SubmissionInfo):
         if make_zip:
             self.make_zip()
 
+    def get_inspect_dir(subdir):
+        """
+        Return the folder to inspect if valid. subdir joined onto the
+        main file root of this project.
+        """
+        # Sanitize subdir for illegal characters
+        validate_subdir(subdir)
+        # Folder must be a subfolder of the file root and exist
+        inspect_dir = os.path.join(self.main_file_root(), subdir)
+        if inspect_dir.startswith(self.main_file_root()) and os.path.isdir(inspect_dir):
+            return inspect_dir
+        else:
+            raise Exception('Invalid directory request')
+
     def get_main_directory_content(self, subdir=''):
         """
         Return information for displaying files and directories from
         the main file root
         """
-        # Sanitize input
-        validate_subdir(subdir)
-
-        inspect_dir = os.path.join(self.main_file_root(), subdir)
+        # Get folder to inspect if valid
+        inspect_dir = self.get_inspect_dir(subdir)
         file_names , dir_names = list_items(inspect_dir)
-
         display_files, display_dirs = [], []
+
         # Files require desciptive info and download links
         for file in file_names:
             file_info = get_file_info(os.path.join(inspect_dir, file))
@@ -1036,7 +1059,7 @@ class PublishedProject(Metadata, SubmissionInfo):
             else:
                 file_info.static_url = os.path.join('published-projects', str(self.slug), 'files', subdir, file)
             display_files.append(file_info)
-        # Directories require
+        # Directories require links
         for dir_name in dir_names:
             dir_info = get_directory_info(os.path.join(inspect_dir, dir_name))
             dir_info.full_subdir = os.path.join(subdir, dir_name)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -527,7 +527,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         "Storage allowed in bytes"
         return self.core_project.storage_allowance
 
-    def get_inspect_dir(subdir):
+    def get_inspect_dir(self, subdir):
         """
         Return the folder to inspect if valid. subdir joined onto
         the file root of this project.
@@ -1027,7 +1027,7 @@ class PublishedProject(Metadata, SubmissionInfo):
         if make_zip:
             self.make_zip()
 
-    def get_inspect_dir(subdir):
+    def get_inspect_dir(self, subdir):
         """
         Return the folder to inspect if valid. subdir joined onto the
         main file root of this project.

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -28,7 +28,7 @@ def validate_doi(value):
             params={'doi':value})
 
 
-def validate_subdir(value):
+def validate_subdir(file_root, subdir):
     """
     Validate a subdirectory used to explore a project's files.
     Only letters, numbers, dashes, underscores, dots, and / allowed,

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -26,3 +26,13 @@ def validate_doi(value):
     if not re.fullmatch(r'10\.13026/[\w]{5,10}', value):
         raise ValidationError('Invalid DOI: %(doi)s',
             params={'doi':value})
+
+
+def validate_subdir(value):
+    """
+    Validate a subdirectory used to explore a project's files.
+    Only letters, numbers, dashes, underscores, dots, and / allowed,
+    or empty. No consecutive dots or fwd slashes.
+    """
+    if not re.fullmatch(r'[\w\-\./]*', value) or '..' in value or value.startswith('/') or '//' in value:
+        raise ValidationError('Invalid path')

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -28,7 +28,7 @@ def validate_doi(value):
             params={'doi':value})
 
 
-def validate_subdir(file_root, subdir):
+def validate_subdir(value):
     """
     Validate a subdirectory used to explore a project's files.
     Only letters, numbers, dashes, underscores, dots, and / allowed,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -647,7 +647,7 @@ def project_files_panel(request, project_slug, **kwargs):
     is_editor = request.user == project.editor
     subdir = request.GET['subdir']
 
-    if not request.is_ajax:
+    if not request.is_ajax():
         return redirect('project_files', project_slug=project_slug)
 
     display_files, display_dirs, dir_breadcrumbs, parent_dir = get_project_file_info(
@@ -788,7 +788,7 @@ def preview_files_panel(request, project_slug, **kwargs):
     project = kwargs['project']
     subdir = request.GET['subdir']
 
-    if not request.is_ajax:
+    if not request.is_ajax():
         return redirect('project_preview', project_slug=project_slug)
 
     display_files, display_dirs, dir_breadcrumbs, parent_dir = get_project_file_info(
@@ -982,7 +982,7 @@ def published_files_panel(request, published_project_slug):
     project = PublishedProject.objects.get(slug=published_project_slug)
     subdir = request.GET['subdir']
 
-    if not request.is_ajax:
+    if not request.is_ajax():
         return redirect('published_project',
             published_project_slug=published_project_slug)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -647,6 +647,9 @@ def project_files_panel(request, project_slug, **kwargs):
     is_editor = request.user == project.editor
     subdir = request.GET['subdir']
 
+    if not request.is_ajax:
+        return redirect('project_files', project_slug=project_slug)
+
     display_files, display_dirs, dir_breadcrumbs, parent_dir = get_project_file_info(
         project=project, subdir=subdir)
     (upload_files_form, create_folder_form, rename_item_form,
@@ -784,6 +787,9 @@ def preview_files_panel(request, project_slug, **kwargs):
     """
     project = kwargs['project']
     subdir = request.GET['subdir']
+
+    if not request.is_ajax:
+        return redirect('project_preview', project_slug=project_slug)
 
     display_files, display_dirs, dir_breadcrumbs, parent_dir = get_project_file_info(
         project=project,subdir=subdir)
@@ -971,10 +977,14 @@ def published_submission_history(request, project_slug):
 def published_files_panel(request, published_project_slug):
     """
     Return the main file panel for the published project, for all access
-    policies.
+    policies. Called via ajax.
     """
     project = PublishedProject.objects.get(slug=published_project_slug)
     subdir = request.GET['subdir']
+
+    if not request.is_ajax:
+        return redirect('published_project',
+            published_project_slug=published_project_slug)
 
     if project.has_access(request.user):
         display_files, display_dirs = project.get_main_directory_content(


### PR DESCRIPTION
Fixes #233 Thanks @bemoody for catching this.

I've sanitized user inputs for creating folders/files in `project/forms.py` but never sanitized the url directly.

There are two functions called by `Activeproject` and `PublishedProject` to get the directory content. I put a validator to validate the subdir input.