### PR TITLE
Minor changes to the console and admin pages

### DIFF
--- a/physionet-django/console/static/console/css/console.css
+++ b/physionet-django/console/static/console/css/console.css
@@ -501,3 +501,8 @@ footer.sticky-footer {
     width: calc(100% - 55px);
   }
 }
+.fa-fw {
+    text-align: center;
+    width: 1.25em;
+    margin-right: .25rem;
+}

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -13,94 +13,121 @@
   <div class="collapse navbar-collapse" id="navbarResponsive">
     <ul class="navbar-nav navbar-sidenav" id="sideAccordion">
       <!-- editor home -->
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
+      {% url 'editor_home' as editor_home %}
+      <li class="nav-item {% ifequal request.path editor_home %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
         <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
+          <i class="fa fa-fw fa-book-open"></i>
           <span class="nav-link-text">Home</span>
-          <i class="fas fa-book-open"></i>
         </a>
       </li>
       <!-- projects -->
+      {% url 'unsubmitted_projects' as unsubmitted_projects %}
+      {% url 'submitted_projects' as submitted_projects %}
+      {% url 'published_projects' as published_projects %}
+      {% url 'rejected_submissions' as rejected_submissions %}
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_projects_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#projectComponents" data-parent="#sideAccordion">
+      {% if request.path == unsubmitted_projects or request.path == submitted_projects or request.path == published_projects or request.path == rejected_submissions %}
+        <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#projectComponents" data-parent="#sideAccordion" aria-expanded="true">
+      {% else %}
+        <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#projectComponents" data-parent="#sideAccordion" aria-expanded="false">
+      {% endif %}
+          <i class="fa fa-fw fa-clipboard-list"></i>
           <span class="nav-link-text">Projects</span>
-          <i class="fas fa-clipboard-list"></i>
         </a>
         <!-- submenu -->
+      {% if request.path == unsubmitted_projects or request.path == submitted_projects or request.path == published_projects or request.path == rejected_submissions %}
+        <ul class="sidenav-second-level collapse show" id="projectComponents" style="">
+      {% else %}
         <ul class="sidenav-second-level collapse" id="projectComponents">
-          <li>
+      {% endif %}
+          <li class="nav-item {% ifequal request.path unsubmitted_projects %}active{% endifequal %}">
             <a id="nav_unsubmitted_projects" class="nav-link" href="{% url 'unsubmitted_projects' %}">Unsubmitted</a>
           </li>
-          <li>
+          <li class="nav-item {% ifequal request.path submitted_projects %}active{% endifequal %}">
             <a id="nav_submitted_projects" class="nav-link" href="{% url 'submitted_projects' %}">Submitted</a>
           </li>
-          <li>
+          <li class="nav-item {% ifequal request.path published_projects %}active{% endifequal %}">
             <a id="nav_published_projects" class="nav-link" href="{% url 'published_projects' %}">Published</a>
           </li>
-          <li>
+          <li class="nav-item {% ifequal request.path rejected_submissions %}active{% endifequal %}">
             <a id="nav_rejected_submissions" class="nav-link" href="{% url 'rejected_submissions' %}">Rejected</a>
           </li>          
         </ul>
       </li>
       <!-- storage requests -->
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
+      {% url 'storage_requests' as storage_requests %}
+      <li class="nav-item {% ifequal request.path storage_requests %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
         <a id="nav_storage_requests" class="nav-link" href="{% url 'storage_requests' %}">
+          <i class="fa fa-fw fa-cube"></i>
           <span class="nav-link-text">Storage</span>
-          <i class="fa fa-cube"></i>
         </a>
       </li>
       <!-- credentialing -->
+      {% url 'credential_applications' as credential_applications %}
+      {% url 'past_credential_applications' as past_credential_applications %}
+      {% url 'credentialed_users' as credentialed_users %}
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion">
+      {% if request.path == credential_applications or request.path == past_credential_applications or request.path == credentialed_users  %}
+        <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion" aria-expanded="true">
+      {% else %}
+        <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion" aria-expanded="false">
+      {% endif %}
+          <i class="fa fa-fw fa-hand-paper"></i>
           <span class="nav-link-text">Credentialing</span>
-          <i class="far fa-hand-paper"></i>
         </a>
         <!-- submenu -->
+      {% if request.path == credential_applications or request.path == past_credential_applications or request.path == credentialed_users  %}
+        <ul class="sidenav-second-level collapse show" id="credentialComponents">
+      {% else %}
         <ul class="sidenav-second-level collapse" id="credentialComponents">
-          <li>
+      {% endif %}
+          <li class="nav-item {% ifequal request.path credential_applications %}active{% endifequal %}">
             <a id="nav_credential_applications" href="{% url 'credential_applications' %}">Ongoing Applications</a>
           </li>
-          <li>
+          <li class="nav-item {% ifequal request.path past_credential_applications %}active{% endifequal %}">
             <a id="nav_past_credential_applications" href="{% url 'past_credential_applications' %}">Past Applications</a>
           </li>
-          <li>
+          <li class="nav-item {% ifequal request.path credentialed_users %}active{% endifequal %}">
             <a id="nav_credentialed_users" href="{% url 'credentialed_users' %}">Credentialed Users</a>
           </li>
         </ul>
       </li>
+
       <!-- users -->
+      {% url 'user_list' as user_list %}
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_users_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#userComponents" data-parent="#sideAccordion">
+      {% if request.path == user_list  %}
+        <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#userComponents" data-parent="#sideAccordion" aria-expanded="true">
+      {% else %}
+        <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#userComponents" data-parent="#sideAccordion" aria-expanded="false">
+      {% endif %}
+          <i class="fa fa-fw fa-user-check"></i>
           <span class="nav-link-text">Users</span>
-          <i class="fas fa-user-check"></i>
         </a>
         <!-- submenu -->
+      {% if request.path == user_list  %}
+        <ul class="sidenav-second-level collapse show" id="userComponents">
+      {% else  %}
         <ul class="sidenav-second-level collapse" id="userComponents">
-          <li>
+      {% endif %}
+          <li class="nav-item {% ifequal request.path user_list %}active{% endifequal %}">
             <a id="nav_all_users" class="nav-link" href="{% url 'user_list' %}">All Users</a>
           </li>
         </ul>
       </li>
       <!-- news -->
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_news_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#newsComponents" data-parent="#sideAccordion">
+      {% url 'console_news' as console_news %}
+      <li class="nav-item {% ifequal request.path console_news %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
+        <a id="nav_console_news" class="nav-link" href="{% url 'console_news' %}">
+          <i class="fa fa-fw fa-newspaper"></i>
           <span class="nav-link-text">News</span>
-          <i class="far fa-newspaper"></i>
         </a>
-        <!-- submenu -->
-        <ul class="sidenav-second-level collapse" id="newsComponents">
-          <li>
-            <a id="nav_add_news" class="nav-link" href="{% url 'add_news' %}">Add News</a>
-          </li>
-          <li>
-            <a id="nav_console_news" class="nav-link" href="{% url 'console_news' %}">News Items</a>
-          </li>
-        </ul>
       </li>
       <!-- usage stats -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion">
+          <i class="fa fa-fw fa-chart-area"></i>
           <span class="nav-link-text">Usage Stats</span>
-          <i class="fas fa-chart-area"></i>
         </a>
         <!-- submenu -->
         <ul class="sidenav-second-level collapse" id="statsComponents">
@@ -118,11 +145,12 @@
     <ul class="navbar-nav sidenav-toggler">
       <li class="nav-item">
         <a class="nav-link text-center" id="sidenavToggler">
-          <i class="fa fa-fw fa-angle-left"></i>
+          <i class="fa fa-fw fa-fw fa-angle-left"></i>
         </a>
       </li>
     </ul>
-
+<!--         <script>$("#nav_credentialing_dropdown").trigger('click');</script>
+ --> 
     {# The top navbar content #}
     {% include "navbar_content.html" %}
   </div>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -9,49 +9,52 @@
     <span class="navbar-toggler-icon"></span>
   </button>
 
+  <!-- start of menu items -->
   <div class="collapse navbar-collapse" id="navbarResponsive">
     <ul class="navbar-nav navbar-sidenav" id="sideAccordion">
+      <!-- editor home -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
-          <i class="fas fa-glasses"></i>
-          <span class="nav-link-text">Editor Home</span>
-        </a>
-      </li>
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_unsubmitted_projects" class="nav-link" href="{% url 'unsubmitted_projects' %}">
-          <i class="fas fa-gavel"></i>
-          <span class="nav-link-text">Unsubmitted Projects</span>
-        </a>
-      </li>
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_submitted_projects" class="nav-link" href="{% url 'submitted_projects' %}">
-          <i class="fas fa-clipboard-list"></i>
-          <span class="nav-link-text">Submitted Projects</span>
-        </a>
-      </li>
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_published_projects" class="nav-link" href="{% url 'published_projects' %}">
+          <span class="nav-link-text">Home</span>
           <i class="fas fa-book-open"></i>
-          <span class="nav-link-text">Published Projects</span>
         </a>
       </li>
+      <!-- projects -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_rejected_submissions" class="nav-link" href="{% url 'rejected_submissions' %}">
-          <i class="far fa-hand-paper"></i>
-          <span class="nav-link-text">Rejected Submissions</span>
+        <a id="nav_projects_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#projectComponents" data-parent="#sideAccordion">
+          <span class="nav-link-text">Projects</span>
+          <i class="fas fa-clipboard-list"></i>
         </a>
+        <!-- submenu -->
+        <ul class="sidenav-second-level collapse" id="projectComponents">
+          <li>
+            <a id="nav_unsubmitted_projects" class="nav-link" href="{% url 'unsubmitted_projects' %}">Unsubmitted</a>
+          </li>
+          <li>
+            <a id="nav_submitted_projects" class="nav-link" href="{% url 'submitted_projects' %}">Submitted</a>
+          </li>
+          <li>
+            <a id="nav_published_projects" class="nav-link" href="{% url 'published_projects' %}">Published</a>
+          </li>
+          <li>
+            <a id="nav_rejected_submissions" class="nav-link" href="{% url 'rejected_submissions' %}">Rejected</a>
+          </li>          
+        </ul>
       </li>
+      <!-- storage requests -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_storage_requests" class="nav-link" href="{% url 'storage_requests' %}">
+          <span class="nav-link-text">Storage</span>
           <i class="fa fa-cube"></i>
-          <span class="nav-link-text">Storage Requests</span>
         </a>
       </li>
+      <!-- credentialing -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion">
-          <i class="fab fa-wpforms"></i>
           <span class="nav-link-text">Credentialing</span>
+          <i class="far fa-hand-paper"></i>
         </a>
+        <!-- submenu -->
         <ul class="sidenav-second-level collapse" id="credentialComponents">
           <li>
             <a id="nav_credential_applications" href="{% url 'credential_applications' %}">Ongoing Applications</a>
@@ -64,22 +67,26 @@
           </li>
         </ul>
       </li>
+      <!-- users -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_users_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#userComponents" data-parent="#sideAccordion">
-          <i class="fas fa-user-check"></i>
           <span class="nav-link-text">Users</span>
+          <i class="fas fa-user-check"></i>
         </a>
+        <!-- submenu -->
         <ul class="sidenav-second-level collapse" id="userComponents">
           <li>
             <a id="nav_all_users" class="nav-link" href="{% url 'user_list' %}">All Users</a>
           </li>
         </ul>
       </li>
+      <!-- news -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_news_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#newsComponents" data-parent="#sideAccordion">
-          <i class="far fa-newspaper"></i>
           <span class="nav-link-text">News</span>
+          <i class="far fa-newspaper"></i>
         </a>
+        <!-- submenu -->
         <ul class="sidenav-second-level collapse" id="newsComponents">
           <li>
             <a id="nav_add_news" class="nav-link" href="{% url 'add_news' %}">Add News</a>
@@ -89,11 +96,13 @@
           </li>
         </ul>
       </li>
+      <!-- usage stats -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion">
-          <i class="fas fa-chart-area"></i>
           <span class="nav-link-text">Usage Stats</span>
+          <i class="fas fa-chart-area"></i>
         </a>
+        <!-- submenu -->
         <ul class="sidenav-second-level collapse" id="statsComponents">
           <li>
             <a href="#">Not Implemented</a>
@@ -104,6 +113,7 @@
         </ul>
       </li>
     </ul>
+    <!-- end of menu items -->
 
     <ul class="navbar-nav sidenav-toggler">
       <li class="nav-item">

--- a/physionet-django/console/templates/console/console_news.html
+++ b/physionet-django/console/templates/console/console_news.html
@@ -5,7 +5,7 @@
 {% block content %}
  <div class="card mb-3">
   <div class="card-header">
-    <i class="far fa-newspaper"></i> News Items <span class="badge badge-pill badge-info">{{ news_items|length }}</span>
+    News Items <span class="badge badge-pill badge-info">{{ news_items|length }}</span>
   </div>
   <div class="card-body">
     <p><a href="{% url 'add_news' %}" class="btn btn-lg btn-success">Add News Item</a></p>

--- a/physionet-django/console/templates/console/credentialed_users.html
+++ b/physionet-django/console/templates/console/credentialed_users.html
@@ -5,7 +5,7 @@
 {% block content %}
  <div class="card mb-3">
     <div class="card-header">
-      <i class="fa fa-user-check"></i> PhysioNet Credentialed Users <span class="badge badge-pill badge-info">{{ users|length }}</span>
+      PhysioNet Credentialed Users <span class="badge badge-pill badge-info">{{ users|length }}</span>
     </div>
     <div class="card-body">
       <div class="table-responsive">

--- a/physionet-django/console/templates/console/edit_submission.html
+++ b/physionet-django/console/templates/console/edit_submission.html
@@ -18,7 +18,7 @@
 {% include "console/submission_info_card.html" %}
 <div class="card mb-3">
   <div class="card-header">
-    Your Editor Response
+    Editor Response
   </div>
   <div class="card-body">
     <form action="" method="post" class="form-signin">

--- a/physionet-django/console/templates/console/editor_home.html
+++ b/physionet-django/console/templates/console/editor_home.html
@@ -14,10 +14,9 @@
 {# Awaiting editor decision #}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-glasses"></i> Awaiting Your Decision {{ decision_projects|task_count_badge|safe }}
+    Awaiting Editor Decision {{ decision_projects|task_count_badge|safe }}
   </div>
   <div class="card-body">
-    <p>You are assigned to edit the following projects.</p>
     {% if decision_projects %}
       <div class="table-responsive">
         <table class="table table-bordered">
@@ -58,10 +57,9 @@
 {# Awaiting revisions #}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-clock"></i> Awaiting Author Revisions {{ revision_projects|task_count_badge|safe }}
+    Awaiting Author Revisions {{ revision_projects|task_count_badge|safe }}
   </div>
   <div class="card-body">
-    <p>You have instructed the following projects to be revised by their authors.</p>
     {% if revision_projects %}
       <div class="table-responsive">
         <table class="table table-bordered">
@@ -94,10 +92,9 @@
 {# Awaiting editor copyedit #}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-glasses"></i> Awaiting Your Copyedits {{ copyedit_projects|task_count_badge|safe }}
+    Awaiting Editor Copyedits {{ copyedit_projects|task_count_badge|safe }}
   </div>
   <div class="card-body">
-    <p>You have accepted these projects for publication. Make any copyedits necessary to ensure their quality.</p>
     {% if copyedit_projects %}
       <div class="table-responsive">
         <table class="table table-bordered">
@@ -132,10 +129,9 @@
 {# Awaiting author approval #}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-clock"></i> Awaiting Author Approval {{ approval_projects|task_count_badge|safe }}
+    Awaiting Author Approval {{ approval_projects|task_count_badge|safe }}
   </div>
   <div class="card-body">
-    <p>You have copyedited these projects. Awaiting all authors to approve the final project. If the authors have requested additional changes, you may reopen the project for copyediting.</p>
     {% if approval_projects %}
       <div class="table-responsive">
         <table class="table table-bordered">
@@ -172,10 +168,9 @@
 {# Awaiting editor publish #}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-glasses"></i> Awaiting Your Publishing {{ publish_projects|task_count_badge|safe }}
+    Awaiting Publication {{ publish_projects|task_count_badge|safe }}
   </div>
   <div class="card-body">
-    <p>All authors have accepted these projects for publication. You may publish them.</p>
     {% if publish_projects %}
       <div class="table-responsive">
         <table class="table table-bordered">

--- a/physionet-django/console/templates/console/published_projects.html
+++ b/physionet-django/console/templates/console/published_projects.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fas fa-book-open"></i> Published Projects <span class="badge badge-pill badge-info">{{ projects|length}}</span>
+    Published Projects <span class="badge badge-pill badge-info">{{ projects|length}}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">
@@ -13,12 +13,12 @@
         <thead>
           <tr>
             <th>Project</th>
-            <th>Submission History</th>
+            <th>History</th>
             <th>Version</th>
-            <th>Submitting Author</th>
+            <th>Submitted By</th>
             <th>Editor</th>
-            <th>Creation Date</th>
-            <th>Publish Date</th>
+            <th>Created</th>
+            <th>Published</th>
             <th>Manage</th>
           </tr>
         </thead>

--- a/physionet-django/console/templates/console/rejected_submissions.html
+++ b/physionet-django/console/templates/console/rejected_submissions.html
@@ -1,11 +1,11 @@
 {% extends "console/base_console.html" %}
 
-{% block title %}Rejected Submissions{% endblock %}
+{% block title %}Rejected Projects{% endblock %}
 
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="far fa-hand-paper"></i> Rejected Submissions <span class="badge badge-pill badge-info">{{ projects|length}}</span>
+    Rejected Projects <span class="badge badge-pill badge-info">{{ projects|length}}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/console/templates/console/storage_requests.html
+++ b/physionet-django/console/templates/console/storage_requests.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-cube"></i> Storage Requests <span class="badge badge-pill badge-info">{{ storage_response_formset|length }}</span>
+    Storage Requests <span class="badge badge-pill badge-info">{{ storage_response_formset|length }}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -42,8 +42,8 @@
               <thead>
                 <tr>
                   <th>Project</th>
-                  <th>Submitting Author</th>
-                  <th>Submission Date</th>
+                  <th>Submitted By</th>
+                  <th>Submitted</th>
                 </tr>
               </thead>
               <tbody>
@@ -92,10 +92,10 @@
               <thead>
                 <tr>
                   <th>Project</th>
-                  <th>Submitting Author</th>
+                  <th>Submitted By</th>
                   <th>Editor</th>
-                  <th>Submission Date</th>
-                  <th>Resubmission Date</th>
+                  <th>Submitted</th>
+                  <th>Resubmitted</th>
                 </tr>
               </thead>
               <tbody>
@@ -129,9 +129,9 @@
               <thead>
                 <tr>
                   <th>Project</th>
-                  <th>Submitting Author</th>
-                  <th>Submission Date</th>
-                  <th>Revision Request Date</th>
+                  <th>Submitted By</th>
+                  <th>Submitted</th>
+                  <th>Revision Requested</th>
                   <th>Editor</th>
                 </tr>
               </thead>
@@ -160,9 +160,9 @@
               <thead>
                 <tr>
                   <th>Project</th>
-                  <th>Submitting Author</th>
-                  <th>Submission Date</th>
-                  <th>Editor Accept Date</th>
+                  <th>Submitted By</th>
+                  <th>Submitted</th>
+                  <th>Editor Accepted</th>
                   <th>Editor</th>
                 </tr>
               </thead>
@@ -191,10 +191,10 @@
               <thead>
                 <tr>
                   <th>Project</th>
-                  <th>Submitting Author</th>
-                  <th>Submission Date</th>
-                  <th>Editor Accept Date</th>
-                  <th>Copyedit Completion Date</th>
+                  <th>Submitted By</th>
+                  <th>Submitted</th>
+                  <th>Editor Accepted</th>
+                  <th>Copyedit Completed</th>
                   <th>Editor</th>
                 </tr>
               </thead>
@@ -224,11 +224,11 @@
               <thead>
                 <tr>
                   <th>Project</th>
-                  <th>Submitting Author</th>
-                  <th>Submission Date</th>
-                  <th>Editor Accept Date</th>
-                  <th>Copyedit Completion Date</th>
-                  <th>Author Approval Date</th>
+                  <th>Submitted By</th>
+                  <th>Submitted</th>
+                  <th>Editor Accepted</th>
+                  <th>Copyedit Completed</th>
+                  <th>Author Approved</th>
                   <th>Editor</th>
                 </tr>
               </thead>

--- a/physionet-django/console/templates/console/unsubmitted_projects.html
+++ b/physionet-django/console/templates/console/unsubmitted_projects.html
@@ -5,7 +5,7 @@
 {% block content %}
  <div class="card mb-3">
   <div class="card-header">
-    <i class="fas fa-gavel"></i> Unsubmitted Projects <span class="badge badge-pill badge-info">{{ projects|length}}</span>
+    Unsubmitted Projects <span class="badge badge-pill badge-info">{{ projects|length}}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">
@@ -13,8 +13,8 @@
         <thead>
           <tr>
             <th>Project</th>
-            <th>Submitting Author</th>
-            <th>Creation Date</th>
+            <th>Submitted By</th>
+            <th>Created</th>
           </tr>
         </thead>
         <tbody>

--- a/physionet-django/console/templates/console/users.html
+++ b/physionet-django/console/templates/console/users.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">
-    <i class="fa fa-user-check"></i> PhysioNet Users <span class="badge badge-pill badge-info">{{ users|length }}</span>
+    PhysioNet Users <span class="badge badge-pill badge-info">{{ users|length }}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1246,19 +1246,19 @@ class EditLog(models.Model):
     EDITOR_FIELDS = ('editor_comments', 'decision')
 
     COMMON_LABELS = {
-        'reusable':'All the information needed for reuse is present',
-        'pn_suitable':'The content is suitable for PhysioNet',
+        'reusable':'Does the project include everything needed for reuse by the community?',
+        'pn_suitable':'Is the content suitable for PhysioNet?',
         'editor_comments':'Comments to authors',
     }
 
     LABELS = (
-        {'soundly_produced':'The data is produced in a sound manner',
-         'well_described':'The data is adequately described',
-         'open_format':'The data files are provided in an open format',
-         'data_machine_readable':'The data files are machine readable',
-         'no_phi':'No protected health information is contained'},
-        {'well_described':'The software is adequately described',
-         'open_format':'The software is provided in open source format'}
+        {'soundly_produced':'Has the data been produced in a sound manner?',
+         'well_described':'Is the data adequately described?',
+         'open_format':'Is the data provided in an open format?',
+         'data_machine_readable':'Are the data files machine-readable?',
+         'no_phi':'Is the data free of protected health information?'},
+        {'well_described':'Is the software adequately described?',
+         'open_format':'Is the software provided in an open format?'}
     )
 
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)


### PR DESCRIPTION
This pull request introduces some minor changes to the console and admin pages. The main ones are:

- Remove icons from the headers of admin pages because they interfere with readability.
- Move projects to a submenu for consistency with the other menu items.
- Removes explanatory text from the sections in /console/editor-home/ based on feedback by Felipe. The headers are clear and we can add explanatory text later if requested.