### PR TITLE
Update notification emails

### DIFF
--- a/physionet-django/notification/models.py
+++ b/physionet-django/notification/models.py
@@ -3,6 +3,8 @@ from django.db import models
 
 
 class News(models.Model):
+    """
+    """
     title = models.CharField(max_length=40)
     content = RichTextField()
     publish_datetime = models.DateTimeField(auto_now_add=True)

--- a/physionet-django/notification/templates/notification/email/accept_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/accept_submission_notify.html
@@ -3,15 +3,13 @@
 
 Dear {{ name }},
 
-Based on the recommendations of our editors, we are delighted to accept your project entitled {{ project.title }} for publication on PhysioNet. 
+Based on the recommendations of our editors, we are delighted to accept your project entitled "{{ project.title }}" for publication on PhysioNet. 
 
 A summary of our standard set of editorial checks is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
 {% endfor %}
 Additional comments from the editorial team are listed below:
-"""
 {{ edit_log.editor_comments }}
-"""
 
 After copyediting of the project and files is complete, we will be in touch again. Then, once all authors approve of the copyedited version at: http://{{ domain }}{% url 'project_submission' project.slug %}, the project will be ready for publication. 
 

--- a/physionet-django/notification/templates/notification/email/accept_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/accept_submission_notify.html
@@ -1,18 +1,21 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-The editor has accepted the submission of your project: {{ project.title }}.
+Dear {{ name }},
 
-The standard quality assurance results are as follows:
+Based on the recommendations of our editors, we are delighted to accept your project entitled {{ project.title }} for publication on PhysioNet. 
+
+A summary of our standard set of editorial checks is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
 {% endfor %}
-The following comments were made:
+Additional comments from the editorial team are listed below:
 """
 {{ edit_log.editor_comments }}
 """
 
-The editor will now copyedit the project's metadata and files for any final changes. They will email you when they have finished making changes, to ask for your approval. When all of the project's authors approve of the copyedits at: http://{{ domain }}{% url 'project_submission' project.slug %}, the editor will be able to complete this step and publish the project.
+After copyediting of the project and files is complete, we will be in touch again. Then, once all authors approve of the copyedited version at: http://{{ domain }}{% url 'project_submission' project.slug %}, the project will be ready for publication. 
 
-Regards
-The PhysioNet Team
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/assign_editor_notify.html
+++ b/physionet-django/notification/templates/notification/email/assign_editor_notify.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-An editor has been assigned to your project: {{ project.title }}. Your editor is: {{ editor.get_full_name }}, and can be contacted at: {{ editor.email }}. You will be notified when they make a decision.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+We are pleased to say that your project entitled "{{ project.title }}" is now under review by the editorial team. We will be in touch again after our initial review is complete.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/author_response.html
+++ b/physionet-django/notification/templates/notification/email/author_response.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-Your invitation to {{ author_email }} to co-author your project: {{ project.title }}, has been {{ response }}.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+Your invitation to {{ author_email }} to co-author your project entitled "{{ project.title }}", has been {{ response }}.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/authors_approved_notify.html
+++ b/physionet-django/notification/templates/notification/email/authors_approved_notify.html
@@ -1,8 +1,13 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-All authors have approved the publication of your project: {{ project.title }}. The editor will publish your project shortly.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+We are pleased to say that all authors have approved the publication of your project entitled "{{ project.title }}". 
+
+Thanks for submitting your work to PhysioNet. The editors will publish your project shortly.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/cancel_submit_notify.html
+++ b/physionet-django/notification/templates/notification/email/cancel_submit_notify.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-The submission of your project: {{ project.title }} has cancelled by the submitting author.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+This is an update on the status of your project entitled "{{ project.title }}". The submitting author has withdrawn the submission from PhysioNet.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -1,12 +1,9 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ application.reference_name }}
+Dear {{ application.reference_name }},
 
-{{ applicant_name }} has listed you as their reference for their PhysioNet credentialing application.
+Your colleague {{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. Your name is listed as their reference for the application.
 
-If you recognize them, please verify their application before it expires by using the form at: http://{{ domain }}{% url 'credential_reference' application.slug %}
+If you support their application for credentialed access, please indicate your approval using the form at: http://{{ domain }}{% url 'credential_reference' application.slug %}. If you do not support their application, please ignore this email or update us directly via the link.
 
-If you do not want to verify them, you can ignore this email, or reject them from the same link.
-
-Regards
-The PhysioNet team
+{{ signature }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
+++ b/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
@@ -1,17 +1,18 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-The editor has finished copyediting your project: {{ project.title }}.
-{% if copyedit_log.made_changes %}
-The changes made are summarized as follows:
+Dear {{ name }},
+
+We are pleased to say that copyediting of your project entitled {{ project.title }}" is now complete. {% if copyedit_log.made_changes %}
+
+The changes made during this process are summarized below:
 """
 {{ copyedit_log.changelog_summary }}
-"""
-{% else %}
-They were satisfied with the state of your project and no changes were made.
-{% endif %}
-When all authors approve of the changes, the editor will publish your project.
+"""{% else %}We were satisfied with the state of your project and no changes were made.{% endif %}
 
-Regards
-The PhysioNet Team
+When all authors have approved this version of the project using the online system, it will be ready for publication on PhysioNet.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
+++ b/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
@@ -6,9 +6,8 @@ Dear {{ name }},
 We are pleased to say that copyediting of your project entitled {{ project.title }}" is now complete. {% if copyedit_log.made_changes %}
 
 The changes made during this process are summarized below:
-"""
 {{ copyedit_log.changelog_summary }}
-"""{% else %}We were satisfied with the state of your project and no changes were made.{% endif %}
+{% else %}We were satisfied with the state of your project and no changes were made.{% endif %}
 
 When all authors have approved this version of the project using the online system, it will be ready for publication on PhysioNet.
 

--- a/physionet-django/notification/templates/notification/email/invite_author.html
+++ b/physionet-django/notification/templates/notification/email/invite_author.html
@@ -1,12 +1,15 @@
 {% load i18n %}{% autoescape off %}
-Dear Sir or Madam
+{{ project_info }}
 
-You have been invited by {{ inviter_name }} ({{ inviter_email }}) to co-author the project: {{ project.title }}, on {{ domain }}.
+Dear Colleague,
 
-If you already have a {{ domain }} account, you may respond from your project home page: http://{{ domain }}{% url "project_home" %}. If this email is not associated with your account, you may add it from your email settings page, or ask your inviter to send the invitation to your account email.
+You have been invited by {{ inviter_name }} ({{ inviter_email }}) to co-author a project entitled "{{ project.title }}" on {{ domain }}. Please accept or decline this request as appropriate.
 
-If you do not have an account, you may register for one here: http://{{ domain }}{% url "register" %}, and find this invitation on your project home page.
+If you already have a {{ domain }} account, you may respond from your project home page: http://{{ domain }}{% url "project_home" %}. If this email address is not associated with your account, you may add it from your email settings page or ask your co-author to resend their invitation to an alternative address.
 
-Regards
-The PhysioNet Team
+If you do not have an account, please register here: http://{{ domain }}{% url "register" %}. Once you have registered, you will find the pending invitation on your project home page.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/outstanding_invitation_removal.html
+++ b/physionet-django/notification/templates/notification/email/outstanding_invitation_removal.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-Your invitation to: {{ email }} to co-author your project: {{ title }}, has not been accepted for 15 days and thus removed.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+Your invitation to {{ email }} to co-author your project entitled "{{ title }}" has not been accepted for two weeks. The invitation has therefore been closed. Please check your co-author's contact details and resend the invitation if appropriate.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -1,17 +1,20 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ applicant_name }}
+{{ project_info }}
+
+Dear {{ applicant_name }},
 {% if application.status == 2 %}
-Your PhysioNet credentialing application has been accepted. You are now a credentialed PhysioNet user and can access restricted-access PhysioNet databases if you agree to their terms of usage.
+We are pleased to say that your application for credentialed access to PhysioNet has been accepted. You are now a credentialed user with the ability to access restricted-access PhysioNet databases upon agreeing to the terms of usage.
 {% else %}
-Your PhysioNet credentialing application has been rejected. The following comments were made:
+Thank you for applying for credentialed access to PhysioNet. Your application has not been approved for the reason outlined below:
 
 """
 {{ application.responder_comments }}
 """
 
-You may address the issues and open a new credentialing application at: http://{{ domain }}{% url 'credential_application' %}
+If you are able to address these issues, please open a new credentialing application at: http://{{ domain }}{% url 'credential_application' %}
 {% endif %}
 
-Regards
-The PhysioNet team
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -6,10 +6,7 @@ Dear {{ applicant_name }},
 We are pleased to say that your application for credentialed access to PhysioNet has been accepted. You are now a credentialed user with the ability to access restricted-access PhysioNet databases upon agreeing to the terms of usage.
 {% else %}
 Thank you for applying for credentialed access to PhysioNet. Your application has not been approved for the reason outlined below:
-
-"""
 {{ application.responder_comments }}
-"""
 
 If you are able to address these issues, please open a new credentialing application at: http://{{ domain }}{% url 'credential_application' %}
 {% endif %}

--- a/physionet-django/notification/templates/notification/email/publish_notify.html
+++ b/physionet-django/notification/templates/notification/email/publish_notify.html
@@ -1,10 +1,13 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-Your project: {{ published_project.title }} version {{ published_project.version }}, is now published on PhysioNet at: http://{{ domain }}{% url 'published_project' published_project.slug %}.
+Dear {{ name }},
 
-Thank you for sharing your resources on PhysioNet.
+We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at: http://{{ domain }}{% url 'published_project' published_project.slug %}
 
-Regards
-The PhysioNet Team
+We encourage you to share this link on social media to increase your work's visibility within the research community. Thanks again for choosing to publish with PhysioNet, and we look forward to working with you again in the future.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/reject_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/reject_submission_notify.html
@@ -10,9 +10,7 @@ A summary of the review is listed below:
 {% endfor %}
 
 Additional comments by the editorial team follow below:
-"""
 {{ edit_log.editor_comments }}
-"""
 
 Your project has been closed, but we would welcome a new submission if you are able to address these issues. Thanks for submitting your work to PhysioNet and we are sorry not to be able to publish it on this occasion. 
 

--- a/physionet-django/notification/templates/notification/email/reject_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/reject_submission_notify.html
@@ -1,18 +1,22 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-The editor has rejected the submission of your project: {{ project.title }}.
+Dear {{ name }},
 
-The standard quality assurance results are as follows:
+We are writing to inform you that the review process for your project entitled "{{ project.title }}" is complete. Based on the review, our decision is that the project is not suitable for publication in its current form. 
+
+A summary of the review is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
 {% endfor %}
-The following comments were made:
+
+Additional comments by the editorial team follow below:
 """
 {{ edit_log.editor_comments }}
 """
 
-Your project has been closed.
+Your project has been closed, but we would welcome a new submission if you are able to address these issues. Thanks for submitting your work to PhysioNet and we are sorry not to be able to publish it on this occasion. 
 
-Regards
-The PhysioNet Team
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/reopen_copyedit_notify.html
+++ b/physionet-django/notification/templates/notification/email/reopen_copyedit_notify.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-The editor of your project: {{ project.title }}, has reopened it for copyediting. You will be notified when they have finished making changes.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+The editor of your project entitled "{{ project.title }}" is copyediting the project content. You will be notified when the editor has finished making changes.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/resubmit_notify.html
+++ b/physionet-django/notification/templates/notification/email/resubmit_notify.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-Your project: {{ project.title }}, has been resubmitted for review. You will be notified when the editor makes their decision.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+Your project entitled "{{ project.title }}" has been resubmitted to PhysioNet for review. You will be notified when the submission has been reviewed.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
+++ b/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
@@ -1,8 +1,13 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-The project you have requested revisions for: {{ project.title }} has been resubmitted for review. Please edit the project when you can.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+The project you have requested revisions for: {{ project.title }} has been resubmitted for review. 
+
+We would be grateful if you could review the revised submission within 7 days.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/revise_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/revise_submission_notify.html
@@ -1,18 +1,21 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name}}
+{{ project_info }}
 
-The editor has requested revisions for your project: {{ project.title }}.
+Dear {{ name }},
 
-The standard quality assurance results are as follows:
+Thank you for submitting your project entitled "{{ project.title }}" to PhysioNet. 
+
+A summary of our standard set of editorial checks is listed below: 
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
 {% endfor %}
-The following comments were made:
+We ask that you address the following comments before we proceed:
 """
 {{ edit_log.editor_comments }}
 """
 
-The submitting author must address the issues and resubmit the project when ready.
+Once these comments have been addressed, please resubmit your project.
 
-Regards
-The PhysioNet Team
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/revise_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/revise_submission_notify.html
@@ -9,9 +9,7 @@ A summary of our standard set of editorial checks is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
 {% endfor %}
 We ask that you address the following comments before we proceed:
-"""
 {{ edit_log.editor_comments }}
-"""
 
 Once these comments have been addressed, please resubmit your project.
 

--- a/physionet-django/notification/templates/notification/email/storage_response_notify.html
+++ b/physionet-django/notification/templates/notification/email/storage_response_notify.html
@@ -1,11 +1,15 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-Your {{ allowance}}GB storage request for project: {{ project.title }}, has been {{ response }}.
+Dear {{ name }},
+
+Your {{ allowance }}GB storage request for the project entitled "{{ project.title }}" has been {{ response }}.
 {% if response_message %}
 The following message was included:
 "{{ response_message }}"
 {% endif %}
-Regards
-The PhysioNet Team
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/submit_notify.html
+++ b/physionet-django/notification/templates/notification/email/submit_notify.html
@@ -1,8 +1,11 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+{{ project_info }}
 
-Your project: {{ project.title }}, has been submitted for review. You will be notified when an editor is assigned to your project.
+Dear {{ name }},
 
-Regards
-The PhysioNet Team
+Thank you for submitting your project entitled "{{ project.title }}" to PhysioNet. You will be notified when an editor is assigned to your project.
+
+{{ signature }}
+
+{{ footer }}
 {% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -87,8 +87,8 @@ def invitation_response_notify(invitation, affected_emails):
 
     subject = 'Authorship invitation {} for project: {}'.format(response,
                                                                 project.title)
-    email, firstname, fullname = project.author_contact_info(only_submitting=True)
-    email_context = {'name':firstname, 'project':project,
+    email, name = project.author_contact_info(only_submitting=True)
+    email_context = {'name':name, 'project':project,
         'response':response, 'signature':email_signature(),
         'project_info':email_project_info(project),'footer':email_footer()}
 
@@ -109,8 +109,8 @@ def submit_notify(project):
     email_context = {'project':project, 'signature':email_signature(),
         'project_info':email_project_info(project),'footer':email_footer()}
 
-    for email, firstname, fullname in project.author_contact_info():
-        email_context['name'] = firstname
+    for email, name in project.author_contact_info():
+        email_context['name'] = name
         body = loader.render_to_string(
             'notification/email/submit_notify.html', email_context)
 
@@ -126,8 +126,8 @@ def resubmit_notify(project):
     email_context = {'project':project, 'signature':email_signature(),
         'project_info':email_project_info(project),'footer':email_footer()}
 
-    for email, firstname, fullname in project.author_contact_info():
-        email_context['name'] = firstname
+    for email, name in project.author_contact_info():
+        email_context['name'] = name
         body = loader.render_to_string(
             'notification/email/resubmit_notify.html', email_context)
 
@@ -150,10 +150,10 @@ def assign_editor_notify(project):
     subject = 'Editor assigned to submission of project: {0}'.format(
         project.title)
 
-    for email, firstname, fullname in project.author_contact_info():
+    for email, name in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/assign_editor_notify.html',
-            {'name':firstname, 'project':project,
+            {'name':name, 'project':project,
              'editor':project.editor, 
              'signature':email_signature(),
              'project_info':email_project_info(project),
@@ -179,9 +179,9 @@ def edit_decision_notify(request, project, edit_log):
         subject = 'Submission accepted for project: {}'.format(project.title)
         template = 'notification/email/accept_submission_notify.html'
 
-    for email, firstname, fullname in project.author_contact_info():
+    for email, name in project.author_contact_info():
         body = loader.render_to_string(template,
-            {'name':firstname, 'project':project, 'edit_log':edit_log,
+            {'name':name, 'project':project, 'edit_log':edit_log,
              'domain':get_current_site(request),
              'signature':email_signature(),
              'project_info':email_project_info(project),
@@ -197,10 +197,10 @@ def copyedit_complete_notify(request, project, copyedit_log):
     """
     subject = 'Copyedit complete for project: {0}'.format(project.title)
 
-    for email, firstname, fullname in project.author_contact_info():
+    for email, name in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/copyedit_complete_notify.html',
-            {'name':firstname, 'project':project, 'copyedit_log':copyedit_log,
+            {'name':name, 'project':project, 'copyedit_log':copyedit_log,
              'domain':get_current_site(request),
              'signature':email_signature(),
              'project_info':email_project_info(project),
@@ -216,10 +216,10 @@ def reopen_copyedit_notify(request, project):
     """
     subject = 'Project reopened for copyediting: {0}'.format(project.title)
 
-    for email, firstname, fullname in project.author_contact_info():
+    for email, name in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/reopen_copyedit_notify.html',
-            {'name':firstname, 'project':project,
+            {'name':name, 'project':project,
              'domain':get_current_site(request),
              'signature':email_signature(),
              'project_info':email_project_info(project),
@@ -235,10 +235,10 @@ def authors_approved_notify(request, project):
     subject = 'All authors approved publication of project: {0}'.format(
         project.title)
 
-    for email, firstname, fullname in project.author_contact_info():
+    for email, name in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/authors_approved_notify.html',
-            {'name':firstname, 'project':project,
+            {'name':name, 'project':project,
              'domain':get_current_site(request),
              'signature':email_signature(),
              'project_info':email_project_info(project),
@@ -254,10 +254,10 @@ def publish_notify(request, published_project):
     subject = 'Your project has been published: {0}'.format(
         published_project.title)
 
-    for email, firstname, fullname in published_project.author_contact_info():
+    for email, name in published_project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/publish_notify.html',
-            {'name':firstname, 'published_project':published_project,
+            {'name':name, 'published_project':published_project,
              'domain':get_current_site(request),
              'signature':email_signature(),
              'project_info':email_project_info(published_project),
@@ -274,9 +274,9 @@ def storage_response_notify(storage_request):
     response = RESPONSE_ACTIONS[storage_request.response]
     subject = 'Storage request {0} for project: {1}'.format(response,
         project.title)
-    email, firstname, fullname = project.author_contact_info(only_submitting=True)
+    email, name = project.author_contact_info(only_submitting=True)
     body = loader.render_to_string('notification/email/storage_response_notify.html',
-        {'name':firstname, 'project':project, 'response':response,
+        {'name':name, 'project':project, 'response':response,
          'allowance':storage_request.request_allowance,
          'response_message':storage_request.response_message,
          'signature':email_signature(),

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -24,6 +24,38 @@ def send_contact_message(contact_form):
 
 # ---------- Project App ---------- #
 
+def email_signature():
+    """
+    Gets the signature for the emails
+    """
+    signature = ("Regards,\n\n"
+        "The PhysioNet Team,\n"
+        "MIT Laboratory for Computational Physiology,\n"
+        "Institute for Medical Engineering and Science,\n"
+        "45 Carleton St, Cambridge, MA 02142"
+        )
+
+    return signature
+
+def email_project_info(project):
+    """
+    Header for the email. e.g. Project ID, Project title, Submitting Author.
+    """
+    header = ("Project title: {}\n"
+        "Submission ID: {}\n"
+        "Submitting author: {}"
+        ).format(project.title, project.slug, project.submitting_author())
+
+    return header
+
+def email_footer():
+    """
+    Footer for the email. e.g. for privacy policy, link to update profile, etc.
+    """
+    footer = ""
+
+    return footer
+
 def invitation_notify(request, invite_author_form, target_email):
     """
     Notify someone when they are invited to author a project
@@ -34,12 +66,16 @@ def invitation_notify(request, invite_author_form, target_email):
     email_context = {'inviter_name':inviter.get_full_name(),
                      'inviter_email':inviter.email,
                      'project':project,
-                     'domain':get_current_site(request)}
+                     'domain':get_current_site(request),
+                     'signature':email_signature(),
+                     'project_info':email_project_info(project),
+                     'footer':email_footer()}
+
     body = loader.render_to_string('notification/email/invite_author.html',
                                     email_context)
+
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [target_email], fail_silently=False)
-
 
 def invitation_response_notify(invitation, affected_emails):
     """
@@ -51,28 +87,33 @@ def invitation_response_notify(invitation, affected_emails):
 
     subject = 'Authorship invitation {} for project: {}'.format(response,
                                                                 project.title)
-    email, name = project.author_contact_info(only_submitting=True)
-    email_context = {'name':name, 'project':project,
-        'response':response}
+    email, firstname, fullname = project.author_contact_info(only_submitting=True)
+    email_context = {'name':firstname, 'project':project,
+        'response':response, 'signature':email_signature(),
+        'project_info':email_project_info(project),'footer':email_footer()}
+
     # Send an email for each email belonging to the accepting user
     for author_email in affected_emails:
         email_context['author_email'] = author_email
         body = loader.render_to_string(
             'notification/email/author_response.html', email_context)
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
-
 
 def submit_notify(project):
     """
     Notify authors when a project is submitted
     """
     subject = 'Submission of project: {}'.format(project.title)
-    email_context = {'project':project}
-    for email, name in project.author_contact_info():
-        email_context['name'] = name
+    email_context = {'project':project, 'signature':email_signature(),
+        'project_info':email_project_info(project),'footer':email_footer()}
+
+    for email, firstname, fullname in project.author_contact_info():
+        email_context['name'] = firstname
         body = loader.render_to_string(
             'notification/email/submit_notify.html', email_context)
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
@@ -82,17 +123,21 @@ def resubmit_notify(project):
     Notify authors and the editor when a project is resubmitted
     """
     subject = 'Resubmission of project: {}'.format(project.title)
-    email_context = {'project':project}
-    for email, name in project.author_contact_info():
-        email_context['name'] = name
+    email_context = {'project':project, 'signature':email_signature(),
+        'project_info':email_project_info(project),'footer':email_footer()}
+
+    for email, firstname, fullname in project.author_contact_info():
+        email_context['name'] = firstname
         body = loader.render_to_string(
             'notification/email/resubmit_notify.html', email_context)
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                           [email], fail_silently=False)
 
     email_context['name'] = project.editor.get_full_name()
     body = loader.render_to_string(
         'notification/email/resubmit_notify_editor.html', email_context)
+
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [project.editor.email], fail_silently=False)
 
@@ -104,11 +149,16 @@ def assign_editor_notify(project):
     """
     subject = 'Editor assigned to submission of project: {0}'.format(
         project.title)
-    for email, name in project.author_contact_info():
+
+    for email, firstname, fullname in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/assign_editor_notify.html',
-            {'name':name, 'project':project,
-             'editor':project.editor})
+            {'name':firstname, 'project':project,
+             'editor':project.editor, 
+             'signature':email_signature(),
+             'project_info':email_project_info(project),
+             'footer':email_footer()})
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
@@ -129,10 +179,14 @@ def edit_decision_notify(request, project, edit_log):
         subject = 'Submission accepted for project: {}'.format(project.title)
         template = 'notification/email/accept_submission_notify.html'
 
-    for email, name in project.author_contact_info():
+    for email, firstname, fullname in project.author_contact_info():
         body = loader.render_to_string(template,
-            {'name':name, 'project':project, 'edit_log':edit_log,
-             'domain':get_current_site(request)})
+            {'name':firstname, 'project':project, 'edit_log':edit_log,
+             'domain':get_current_site(request),
+             'signature':email_signature(),
+             'project_info':email_project_info(project),
+             'footer':email_footer()})
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
@@ -142,11 +196,16 @@ def copyedit_complete_notify(request, project, copyedit_log):
     Notify authors when the editor has finished copyediting
     """
     subject = 'Copyedit complete for project: {0}'.format(project.title)
-    for email, name in project.author_contact_info():
+
+    for email, firstname, fullname in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/copyedit_complete_notify.html',
-            {'name':name, 'project':project, 'copyedit_log':copyedit_log,
-             'domain':get_current_site(request)})
+            {'name':firstname, 'project':project, 'copyedit_log':copyedit_log,
+             'domain':get_current_site(request),
+             'signature':email_signature(),
+             'project_info':email_project_info(project),
+             'footer':email_footer()})
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
@@ -156,25 +215,37 @@ def reopen_copyedit_notify(request, project):
     Notify authors when an editor reopens a project for copyediting
     """
     subject = 'Project reopened for copyediting: {0}'.format(project.title)
-    for email, name in project.author_contact_info():
+
+    for email, firstname, fullname in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/reopen_copyedit_notify.html',
-            {'name':name, 'project':project,
-             'domain':get_current_site(request)})
+            {'name':firstname, 'project':project,
+             'domain':get_current_site(request),
+             'signature':email_signature(),
+             'project_info':email_project_info(project),
+             'footer':email_footer()})
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
 def authors_approved_notify(request, project):
+    """
+    Notify ...
+    """
     subject = 'All authors approved publication of project: {0}'.format(
         project.title)
-    for email, name in project.author_contact_info():
+
+    for email, firstname, fullname in project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/authors_approved_notify.html',
-            {'name':name, 'project':project,
-             'domain':get_current_site(request)})
+            {'name':firstname, 'project':project,
+             'domain':get_current_site(request),
+             'signature':email_signature(),
+             'project_info':email_project_info(project),
+             'footer':email_footer()})
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
-
 
 def publish_notify(request, published_project):
     """
@@ -182,14 +253,18 @@ def publish_notify(request, published_project):
     """
     subject = 'Your project has been published: {0}'.format(
         published_project.title)
-    for email, name in published_project.author_contact_info():
+
+    for email, firstname, fullname in published_project.author_contact_info():
         body = loader.render_to_string(
             'notification/email/publish_notify.html',
-            {'name':name, 'published_project':published_project,
-             'domain':get_current_site(request)})
+            {'name':firstname, 'published_project':published_project,
+             'domain':get_current_site(request),
+             'signature':email_signature(),
+             'project_info':email_project_info(published_project),
+             'footer':email_footer()})
+
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
-
 
 def storage_response_notify(storage_request):
     """
@@ -199,14 +274,17 @@ def storage_response_notify(storage_request):
     response = RESPONSE_ACTIONS[storage_request.response]
     subject = 'Storage request {0} for project: {1}'.format(response,
         project.title)
-    email, name = project.author_contact_info(only_submitting=True)
+    email, firstname, fullname = project.author_contact_info(only_submitting=True)
     body = loader.render_to_string('notification/email/storage_response_notify.html',
-        {'name':name, 'project':project, 'response':response,
+        {'name':firstname, 'project':project, 'response':response,
          'allowance':storage_request.request_allowance,
-         'response_message':storage_request.response_message})
+         'response_message':storage_request.response_message,
+         'signature':email_signature(),
+         'project_info':email_project_info(project),
+         'footer':email_footer()})
+
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [email], fail_silently=False)
-
 
 def contact_reference(request, application):
     """
@@ -217,17 +295,25 @@ def contact_reference(request, application):
         applicant_name)
     body = loader.render_to_string('notification/email/contact_reference.html',
         {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request)})
+         'domain':get_current_site(request),
+         'signature':email_signature(),
+         'footer':email_footer()})
+
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [application.reference_email], fail_silently=False)
 
-
 def process_credential_complete(request, application):
+    """
+    Notify user of credentialing decision
+    """
     applicant_name = ' '.join([application.first_names, application.last_name])
     response = 'rejected' if application.status == 1 else 'accepted'
     subject = 'PhysioNet credentialling {}'.format(response)
     body = loader.render_to_string('notification/email/process_credential_complete.html',
         {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request)})
+         'domain':get_current_site(request),
+         'signature':email_signature(),
+         'footer':email_footer()})
+
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [application.user.email], fail_silently=False)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -322,10 +322,10 @@ class Metadata(models.Model):
         """
         if only_submitting:
             user = self.authors.get(is_submitting=True).user
-            return user.email, user.get_first_name, user.get_full_name
+            return user.email, user.get_full_name
         else:
             users = [a.user for a in self.authors.all()]
-            return ((u.email, u.get_first_name(), u.get_full_name()) for u in users)
+            return ((u.email, u.get_full_name()) for u in users)
 
     def corresponding_author(self):
         return self.authors.get(is_corresponding=True)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -23,7 +23,6 @@ from user.validators import validate_alphaplus, validate_alphaplusplus
 class Affiliation(models.Model):
     """
     Affiliations belonging to an author
-
     """
     name = models.CharField(max_length=202, validators=[validate_alphaplusplus])
     author = models.ForeignKey('project.Author', related_name='affiliations',
@@ -89,13 +88,14 @@ class Author(BaseAuthor):
         return self.user.profile.get_full_name()
 
     def disp_name_email(self):
+        """
+        """
         return '{} ({})'.format(self.get_full_name(), self.user.email)
 
     def import_profile_info(self):
         """
         Import profile information (names) into the Author object.
         Also create affiliation object if present in profile.
-
         """
         profile = self.user.profile
         if profile.affiliation:
@@ -192,6 +192,8 @@ class Reference(models.Model):
 
 
 class PublishedReference(models.Model):
+    """
+    """
     description = models.CharField(max_length=1000)
     project = models.ForeignKey('project.PublishedProject',
         related_name='references', on_delete=models.CASCADE)
@@ -262,7 +264,6 @@ class Metadata(models.Model):
     https://schema.datacite.org/
     https://schema.datacite.org/meta/kernel-4.0/doc/DataCite-MetadataKernel_v4.1.pdf
     https://www.nature.com/sdata/publish/for-authors#format
-
     """
     RESOURCE_TYPES = (
         (0, 'Database'),
@@ -319,10 +320,10 @@ class Metadata(models.Model):
         """
         if only_submitting:
             user = self.authors.get(is_submitting=True).user
-            return user.email, user.get_first_name
+            return user.email, user.get_first_name, user.get_full_name
         else:
             users = [a.user for a in self.authors.all()]
-            return ((u.email, u.get_first_name()) for u in users)
+            return ((u.email, u.get_first_name(), u.get_full_name()) for u in users)
 
     def corresponding_author(self):
         return self.authors.get(is_corresponding=True)
@@ -732,6 +733,8 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         return (self.submission_status == 30 and self.check_integrity())
 
     def resubmit(self, author_comments):
+        """
+        """
         if not self.is_resubmittable():
             raise Exception('ActiveProject is not resubmittable')
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -33,7 +33,9 @@ class Affiliation(models.Model):
 
 
 class PublishedAffiliation(models.Model):
-    "Affiliations belonging to a published author"
+    """
+    Affiliations belonging to a published author
+    """
     name = models.CharField(max_length=202, validators=[validate_alphaplus])
     author = models.ForeignKey('project.PublishedAuthor',
         related_name='affiliations', on_delete=models.CASCADE)
@@ -434,7 +436,9 @@ class UnpublishedProject(models.Model):
         return self.title
 
     def file_root(self):
-        "Root directory containing the project's files"
+        """
+        Root directory containing the project's files
+        """
         return os.path.join(self.__class__.FILE_ROOT, self.slug)
 
     def get_storage_info(self):
@@ -521,11 +525,15 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
     }
 
     def storage_used(self):
-        "Total storage used in bytes"
+        """
+        Total storage used in bytes
+        """
         return get_tree_size(self.file_root())
 
     def storage_allowance(self):
-        "Storage allowed in bytes"
+        """
+        Storage allowed in bytes
+        """
         return self.core_project.storage_allowance
 
     def get_inspect_dir(self, subdir):
@@ -690,7 +698,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             return True
 
     def is_submittable(self):
-        "Whether the project can be submitted"
+        """
+        Whether the project can be submitted
+        """
         return (not self.under_submission() and self.check_integrity())
 
     def submit(self, author_comments):
@@ -723,7 +733,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         self.save()
 
     def reject(self):
-        "Reject a project under submission"
+        """
+        Reject a project under submission
+        """
         self.archive(archive_reason=3)
 
     def is_resubmittable(self):
@@ -773,7 +785,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             return True
 
     def all_authors_approved(self):
-        "Whether all authors have approved the publication"
+        """
+        Whether all authors have approved the publication
+        """
         authors = self.authors.all()
         return len(authors) == len(authors.filter(
             approval_datetime__isnull=False))
@@ -937,11 +951,15 @@ class PublishedProject(Metadata, SubmissionInfo):
             return os.path.join(PublishedProject.PUBLIC_FILE_ROOT, self.slug)
 
     def main_file_root(self):
-        "Root directory where the main user uploaded files are located"
+        """
+        Root directory where the main user uploaded files are located
+        """
         return os.path.join(self.file_root(), 'files')
 
     def storage_used(self):
-        "Bytes of storage used by main files and compressed file if any"
+        """
+        Bytes of storage used by main files and compressed file if any
+        """
         main = get_tree_size(self.main_file_root())
         compressed = os.path.getsize(self.zip_name(full=True)) if os.path.isfile(self.zip_name(full=True)) else 0
         return main, compressed
@@ -999,7 +1017,9 @@ class PublishedProject(Metadata, SubmissionInfo):
             return os.path.join('published-projects', self.slug, self.zip_name())
 
     def make_checksum_file(self):
-        "Make the checksums file for the main files"
+        """
+        Make the checksums file for the main files
+        """
         fname = os.path.join(self.main_file_root(), 'SHA256SUMS.txt')
         if os.path.isfile(fname):
             os.remove(fname)
@@ -1013,7 +1033,9 @@ class PublishedProject(Metadata, SubmissionInfo):
         self.set_storage_info()
 
     def make_license_file(self):
-        "Make the license text file"
+        """
+        Make the license text file
+        """
         with open(os.path.join(self.main_file_root(), 'LICENSE.txt'), 'w') as outfile:
             outfile.write(self.license_content(fmt='text'))
 
@@ -1178,7 +1200,6 @@ class BaseInvitation(models.Model):
 class AuthorInvitation(BaseInvitation):
     """
     Invitation to join a project as an author
-
     """
     # The target email
     email = models.EmailField(max_length=255)
@@ -1192,7 +1213,6 @@ class AuthorInvitation(BaseInvitation):
     def get_user_invitations(user, exclude_duplicates=True):
         """
         Get all active author invitations to a user
-
         """
         emails = user.get_emails()
         invitations = AuthorInvitation.objects.filter(email__in=emails,
@@ -1237,7 +1257,6 @@ class StorageRequest(BaseInvitation):
 class EditLog(models.Model):
     """
     Log for an editor decision. Also saves submission info.
-
     """
     # Quality assurance fields for data and software
     QUALITY_ASSURANCE_FIELDS = (
@@ -1310,7 +1329,6 @@ class EditLog(models.Model):
 class CopyeditLog(models.Model):
     """
     Log for an editor copyedit
-
     """
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
@@ -1329,7 +1347,6 @@ class CopyeditLog(models.Model):
 class LegacyProject(models.Model):
     """
     Temporary model for migrating legacy databases
-
     """
     title = models.CharField(max_length=255)
     slug = models.CharField(max_length=100)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -319,10 +319,10 @@ class Metadata(models.Model):
         """
         if only_submitting:
             user = self.authors.get(is_submitting=True).user
-            return user.email, user.get_full_name
+            return user.email, user.get_first_name
         else:
             users = [a.user for a in self.authors.all()]
-            return ((u.email, u.get_full_name()) for u in users)
+            return ((u.email, u.get_first_name()) for u in users)
 
     def corresponding_author(self):
         return self.authors.get(is_corresponding=True)

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -351,11 +351,6 @@ class User(AbstractBaseUser):
     def get_short_name(self):
         return self.profile.first_names
 
-    def get_first_name(self):
-        names = self.profile.first_names.split(" ", 1)
-        first = names[0] if len(names[0]) > 1 else self.profile.first_names
-        return first
-
     def __str__(self):
         return self.username
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -351,6 +351,11 @@ class User(AbstractBaseUser):
     def get_short_name(self):
         return self.profile.first_names
 
+    def get_first_name(self):
+        names = self.profile.first_names.split(" ", 1)
+        first = names[0] if len(names[0]) > 1 else self.profile.first_names
+        return first
+
     def __str__(self):
         return self.username
 

--- a/physionet-django/user/templates/user/email/register_email.html
+++ b/physionet-django/user/templates/user/email/register_email.html
@@ -1,9 +1,7 @@
 {% load i18n %}{% autoescape off %}
-Dear {{ name }}
+Dear {{ name }},
 
-An account has been created for you on {{ domain }}. Please activate your account by clicking the following activation link, or copying and pasting the link into your web browser:
-
-http://{{ domain }}{% url 'activate_user' uidb64=uidb64 token=token %}
+Thanks for registering for an account on {{ domain }}. Please activate your account by clicking the following activation link or by copying and pasting the link into your web browser: http://{{ domain }}{% url 'activate_user' uidb64=uidb64 token=token %}
 
 Regards
 The PhysioNet Team


### PR DESCRIPTION
Summary of changes below:

- General tidying of the text.
- Got rid of those single quoted docstrings in project models.
- Add `get_first_name` method to the user class. Attempts to get first name from the first_names field. We could update this in future to avoid addressing emails to "Dear Dr" etc where someone has included the prefix in the name field when registering.
- Add header information to emails, called in `email_project_info` function
- Add `email_footer` function for getting information for the email footer. For now this is empty, but in future we can add privacy policy etc if needed.
- Move signature of emails to a `email_signature()` function