### PR TITLE
Add "short_description" field for projects in the discovery information. Fixes #214

### DIFF
--- a/physionet-django/console/templates/console/copyedit_submission.html
+++ b/physionet-django/console/templates/console/copyedit_submission.html
@@ -53,12 +53,14 @@
       </div>
       <div class="tab-pane fade" id="metadata" role="tabpanel" aria-labelledby="metadata-tab">
         <form action="" method="post">
+          <h3>Description</h3>
           {{ description_form.media }}
           {% include "project/metadata_inline_form_snippet.html" with form=description_form %}
           {% include 'project/item_list.html' with item="reference" item_label=reference_formset.item_label formset=reference_formset form_name=reference_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
-          <br><br>
+          <h3>Access</h3>
           {% include "project/metadata_inline_form_snippet.html" with form=access_form %}
-          <br><br>
+          <h3>Discovery</h3>
+          {% include "project/metadata_inline_form_snippet.html" with form=discovery_form %}
           {% include 'project/item_list.html' with item="publication" item_label=publication_formset.item_label formset=publication_formset form_name=publication_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
           {% include 'project/item_list.html' with item="topic" item_label=topic_formset.item_label formset=topic_formset form_name=topic_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
           <button class="btn btn-lg btn-primary" type="submit" name="edit_metadata">Save Metadata</button>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -223,6 +223,9 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         resource_type=project.resource_type, instance=project)
     access_form = project_forms.AccessMetadataForm(include_credentialed=True,
         instance=project)
+    discovery_form = project_forms.DiscoveryForm(resource_type=project.resource_type,
+        instance=project)
+
     access_form.set_license_queryset(access_policy=project.access_policy)
     reference_formset = ReferenceFormSet(instance=project)
     publication_formset = PublicationFormSet(instance=project)
@@ -237,6 +240,8 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
                 instance=project)
             access_form = project_forms.AccessMetadataForm(
                 include_credentialed=True, data=request.POST, instance=project)
+            discovery_form = project_forms.DiscoveryForm(resource_type=project.resource_type,
+                data=request.POST, instance=project)
             reference_formset = ReferenceFormSet(data=request.POST,
                 instance=project)
             publication_formset = PublicationFormSet(request.POST,
@@ -245,9 +250,11 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
             if (description_form.is_valid() and access_form.is_valid()
                                             and reference_formset.is_valid()
                                             and publication_formset.is_valid()
-                                            and topic_formset.is_valid()):
+                                            and topic_formset.is_valid()
+                                            and discovery_form.is_valid()):
                 description_form.save()
                 access_form.save()
+                discovery_form.save()
                 reference_formset.save()
                 publication_formset.save()
                 topic_formset.save()
@@ -306,7 +313,8 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         'is_editor':True, 'copyedit_form':copyedit_form,
         'authors':authors, 'author_emails':author_emails,
         'storage_info':storage_info, 'edit_logs':edit_logs, 'copyedit_logs':copyedit_logs,
-        'add_item_url':edit_url, 'remove_item_url':edit_url})
+        'add_item_url':edit_url, 'remove_item_url':edit_url,
+        'discovery_form':discovery_form})
 
 
 @handling_editor

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -410,7 +410,6 @@ class MetadataForm(forms.ModelForm):
             self.fields[h].help_text = self.__class__.HELP_TEXTS[resource_type][h]
 
 
-
 class DiscoveryForm(forms.ModelForm):
     """
     Add discovery information to the project
@@ -422,15 +421,17 @@ class DiscoveryForm(forms.ModelForm):
 
     class Meta:
         model = ActiveProject
-        fields = ('project_home_page', 'programming_languages')
+        fields = ('short_description', 'project_home_page', 'programming_languages')
         help_texts = {
-            'project_home_page': 'External home page for the project.'
+            'project_home_page': 'External home page for the project.',
+            'short_description': 'Short (maximum 250 character) description of the project.'
         }
 
     def __init__(self, resource_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if resource_type != 1:
             del(self.fields['programming_languages'])
+
 
 class AffiliationFormSet(forms.BaseInlineFormSet):
     """
@@ -466,6 +467,7 @@ class AffiliationFormSet(forms.BaseInlineFormSet):
                 if name in names:
                     raise forms.ValidationError('Affiliation names must be unique.')
                 names.append(name)
+
 
 class ReferenceFormSet(BaseGenericInlineFormSet):
     """
@@ -515,7 +517,11 @@ class PublicationFormSet(BaseGenericInlineFormSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.max_forms = PublicationFormSet.max_forms
-        self.help_text = 'The article publication to be cited, alongside this resource, in <a href=http://www.bibme.org/citation-guide/apa/ target=_blank>APA</a> format. If the article is in press, leave the URL blank and contact us to update it once it is available. Maximum of {}.'.format(self.max_forms)
+        self.help_text = ('The article publication to be cited, alongside this '
+                          'resource, in <a href=http://www.bibme.org/citation-guide/apa/ '
+                          'target=_blank>APA</a> format. If the article is in '
+                          'press, leave the URL blank and contact us to update '
+                          'it once it is available. Maximum of {}.').format(self.max_forms)
 
     def clean(self):
         """
@@ -722,7 +728,7 @@ class InvitationResponseForm(forms.ModelForm):
     class Meta:
         model = AuthorInvitation
         fields = ('response',)
-        widgets= {'response':forms.Select(choices=RESPONSE_CHOICES)}
+        widgets = {'response':forms.Select(choices=RESPONSE_CHOICES)}
 
     def clean(self):
         """

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -280,6 +280,7 @@ class Metadata(models.Model):
     )
 
     resource_type = models.PositiveSmallIntegerField(choices=RESOURCE_TYPES)
+
     # Main body descriptive metadata
     title = models.CharField(max_length=200, validators=[validate_alphaplus])
     abstract = RichTextField(max_length=10000, blank=True)
@@ -292,6 +293,11 @@ class Metadata(models.Model):
     conflicts_of_interest = RichTextField(blank=True)
     version = models.CharField(max_length=15, default='', blank=True)
     release_notes = RichTextField(blank=True)
+
+    # Short description used for search results, social media, etc
+    short_description = models.CharField(max_length=250, blank=True, 
+        validators=[validate_alphaplusplus])
+
     # Access information
     access_policy = models.SmallIntegerField(choices=ACCESS_POLICIES,
                                              default=0)
@@ -300,16 +306,19 @@ class Metadata(models.Model):
     project_home_page = models.URLField(default='', blank=True)
     programming_languages = models.ManyToManyField(
         'project.ProgrammingLanguage', related_name='%(class)ss')
+
     # Public url slug, also used as a submitting project id.
     slug = models.SlugField(max_length=20, unique=True, db_index=True)
     core_project = models.ForeignKey('project.CoreProject',
                                      related_name='%(class)ss',
                                      on_delete=models.CASCADE)
+
     # When the submitting project was created
     creation_datetime = models.DateTimeField(auto_now_add=True)
 
     edit_logs = GenericRelation('project.EditLog')
     copyedit_logs = GenericRelation('project.CopyeditLog')
+
     # For ordering projects with multiple versions
     version_order = models.PositiveSmallIntegerField(default=0)
 

--- a/physionet-django/project/templates/project/project_discovery.html
+++ b/physionet-django/project/templates/project/project_discovery.html
@@ -19,10 +19,10 @@
   </div>
 {% elif not is_submitting %}
   <div class="alert alert-form alert-warning alert-dismissible">
-    <strong>Only the submitting author may edit the identifiers.</strong>
+    <strong>Only the submitting author may edit these details.</strong>
   </div>
 {% endif %}
-<form action="{% url 'project_discovery' project.slug %}" method="post" onsubmit="return validateItems('topic-list', 'description', 'Topics')">
+<form action="{% url 'project_discovery' project.slug %}" method="post" onsubmit="return validateItems('topic-list', 'description', 'Topics', 'short_description')">
   {% include "project/metadata_inline_form_snippet.html" with form=discovery_form %}
   {% include 'project/item_list.html' with item="publication" item_label=publication_formset.item_label formset=publication_formset form_name=publication_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
   {% include 'project/item_list.html' with item="topic" item_label=topic_formset.item_label formset=topic_formset form_name=topic_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -14,7 +14,11 @@
       </strong>
     </p>
   {% endif %}
-  {{ published_project.abstract|safe }}
+  {% if not published_project.short_description %}
+    {{ published_project.abstract|safe|truncatechars:250 }}
+  {% else %}
+    {{ published_project.short_description|safe }}
+  {% endif %}
   <p class="text-muted">
     Published: {{ published_project.publish_datetime|date }}.
     Version: {{ published_project.version }}


### PR DESCRIPTION
The short_description is a <250 character description of a project that can be used for things like:

- highlighting the project on social media 
- returning summary information in search results. 

If a short description is present for a project, it will be displayed on the front page instead of the abstract. If a short description is not present, a truncated 250 char version of the abstract is now displayed. 

This change also adds discovery information to the project copyedit page (it was missing before).
