### PR TITLE
Fix content overview dropdown

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -38,36 +38,51 @@
     Contents
   </button>
   <div class="dropdown-menu">
-    <a class="dropdown-item" href="#abstract">Abstract</a>
-    <a class="dropdown-item" href="#background">Background</a>
     {% if project.resource_type == 0 %}
-      <a class="dropdown-item" href="#methods">Methods</a>
-      <a class="dropdown-item" href="#description">Data Description</a>
+        <a class="dropdown-item" href="#abstract">Abstract</a>
+        <a class="dropdown-item" href="#background">Background</a>
+        <a class="dropdown-item" href="#methods">Methods</a>
+        <a class="dropdown-item" href="#description">Data Description</a>
+        <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
+        <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+        <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+        <a class="dropdown-item" href="#references">References</a>
+        <a class="dropdown-item" href="#files">Files</a>
+    {% elif project.resource_type == 1 %}
+        <a class="dropdown-item" href="#abstract">Abstract</a>
+        <a class="dropdown-item" href="#background">Background</a>
+        <a class="dropdown-item" href="#description">Software Description</a>
+        {% if project.methods %}
+          <a class="dropdown-item" href="#implementation">Technical Implementation</a>
+        {% endif %}
+        {% if project.installation %}
+          <a class="dropdown-item" href="#installation">Installation and Requirements</a>
+        {% endif %}
+        <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
+        {% if project.release_notes %}
+          <a class="dropdown-item" href="#release-notes">Release Notes</a>
+        {% endif %}
+        {% if project.acknowledgements %}
+          <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+        {% endif %}
+        <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+        <a class="dropdown-item" href="#references">References</a>
+        <a class="dropdown-item" href="#files">Files</a>
+    {% elif project.resource_type == 2 %}
+        <a class="dropdown-item" href="#abstract">Abstract</a>
+        <a class="dropdown-item" href="#background">Objective</a>
+        <a class="dropdown-item" href="#methods">Participation</a>
+        <a class="dropdown-item" href="#description">Data Description</a>
+        <a class="dropdown-item" href="#usage-notes">Evaluation</a>
+        <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+        <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+        <a class="dropdown-item" href="#references">References</a>
+        <a class="dropdown-item" href="#files">Files</a>
     {% else %}
-      <a class="dropdown-item" href="#description">Software Description</a>
-      {% if project.methods %}
-        <a class="dropdown-item" href="#implementation">Technical Implementation</a>
-      {% endif %}
-      {% if project.installation %}
-        <a class="dropdown-item" href="#installation">Installation and Requirements</a>
-      {% endif %}
+        <a class="dropdown-item" href="#files">Files</a>
     {% endif %}
-    <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
-    {% if project.release_notes %}
-      <a class="dropdown-item" href="#release-notes">Release Notes</a>
+    </div>
     {% endif %}
-    {% if project.acknowledgements %}
-      <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
-    {% endif %}
-    <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-    {% if references %}
-      <a class="dropdown-item" href="#references">References</a>
-    {% endif %}
-    <div class="dropdown-divider"></div>
-    <a class="dropdown-item" href="#files">Files</a>
-  </div>
-  {% endif %}
-
   <hr>
   <strong>When using this content, please cite:</strong>
   {% if project.is_legacy %}


### PR DESCRIPTION
The content overview dropdown is hardcoded for each project type (as shown below), which makes it easy for sections to get mislabelled or missed. This pull request removes the button for now. We can add an improved approach later...

```html
  {% if not project.is_legacy %}
  <button class="btn btn-secondary dropdown-toggle" style="float:right" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
    Contents
  </button>
  <div class="dropdown-menu">
    <a class="dropdown-item" href="#abstract">Abstract</a>
    <a class="dropdown-item" href="#background">Background</a>
    {% if project.resource_type == 0 %}
      <a class="dropdown-item" href="#methods">Methods</a>
      <a class="dropdown-item" href="#description">Data Description</a>
    {% else %}
      <a class="dropdown-item" href="#description">Software Description</a>
      {% if project.methods %}
        <a class="dropdown-item" href="#implementation">Technical Implementation</a>
      {% endif %}
      {% if project.installation %}
        <a class="dropdown-item" href="#installation">Installation and Requirements</a>
      {% endif %}
    {% endif %}
    <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
    {% if project.release_notes %}
      <a class="dropdown-item" href="#release-notes">Release Notes</a>
    {% endif %}
    {% if project.acknowledgements %}
      <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
    {% endif %}
    <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
    {% if references %}
      <a class="dropdown-item" href="#references">References</a>
    {% endif %}
    <div class="dropdown-divider"></div>
    <a class="dropdown-item" href="#files">Files</a>
  </div>
  {% endif %}
```