### PR TITLE
Browse subdirectories from project pages

### DIFF
--- a/physionet-django/project/templates/project/open_files_panel.html
+++ b/physionet-django/project/templates/project/open_files_panel.html
@@ -7,7 +7,7 @@
       {% if forloop.counter == dir_breadcrumbs|length %}
         {{ breadcrumb.name }}
       {% else %}
-        <a href="" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
+        <a href="?subdir={{ breadcrumb.full_subdir }}#files-panel" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
       {% endif %}
     {% endfor %}
     </div>
@@ -24,7 +24,7 @@
   {% if subdir %}
     <li class="list-group-item">
       <div class="row">
-        <div class="col-md-8">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
+        <div class="col-md-8">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="?subdir={{ parent_dir }}#files-panel" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
         <div class="col-md-2"></div>
         <div class="col-md-2"></div>
       </div>
@@ -33,7 +33,7 @@
   {% for dir in display_dirs %}
     <li class="list-group-item">
       <div class="row">
-        <div class="col-md-8"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
+        <div class="col-md-8"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="?subdir={{ dir.full_subdir }}#files-panel" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
         <div class="col-md-2"></div>
         <div class="col-md-2"></div>
       </div>

--- a/physionet-django/project/templates/project/preview_files_panel.html
+++ b/physionet-django/project/templates/project/preview_files_panel.html
@@ -7,7 +7,7 @@
       {% if forloop.counter == dir_breadcrumbs|length %}
         {{ breadcrumb.name }}
       {% else %}
-        <a href="" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
+        <a href="?subdir={{ breadcrumb.full_subdir }}#files-panel" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
       {% endif %}
     {% endfor %}
     </div>
@@ -24,7 +24,7 @@
   {% if subdir %}
     <li class="list-group-item">
       <div class="row">
-        <div class="col-md-8">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
+        <div class="col-md-8">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="?subdir={{ parent_dir }}#files-panel" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
         <div class="col-md-2"></div>
         <div class="col-md-2"></div>
       </div>
@@ -33,7 +33,7 @@
   {% for dir in display_dirs %}
     <li class="list-group-item">
       <div class="row">
-        <div class="col-md-8"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
+        <div class="col-md-8"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="?subdir={{ dir.full_subdir }}#files-panel" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
         <div class="col-md-2"></div>
         <div class="col-md-2"></div>
       </div>

--- a/physionet-django/project/templates/project/project_files_panel.html
+++ b/physionet-django/project/templates/project/project_files_panel.html
@@ -14,7 +14,7 @@
             {% if forloop.counter == dir_breadcrumbs|length %}
               {{ breadcrumb.name }}
             {% else %}
-              <a href="" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
+              <a href="?subdir={{ breadcrumb.full_subdir }}#files-panel" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
             {% endif %}
           {% endfor %}
           </div>
@@ -32,7 +32,7 @@
         {% if subdir %}
           <li class="list-group-item">
             <div class="row">
-              <div class="col-md-7">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
+              <div class="col-md-7">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="?subdir={{ parent_dir }}#files-panel" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
               <div class="col-md-2"></div>
               <div class="col-md-2"></div>
               <div class="col-md-1"></div>
@@ -42,7 +42,7 @@
         {% for dir in display_dirs %}
           <li class="list-group-item">
             <div class="row">
-              <div class="col-md-7"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
+              <div class="col-md-7"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="?subdir={{ dir.full_subdir }}#files-panel" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
               <div class="col-md-2"></div>
               <div class="col-md-2"></div>
               <div class="col-md-1"><input type="checkbox" name="items" value="{{ dir.name }}" onchange="countSelected(this)"></div>

--- a/physionet-django/project/templates/project/protected_files_panel.html
+++ b/physionet-django/project/templates/project/protected_files_panel.html
@@ -6,7 +6,7 @@
         {% if forloop.counter == dir_breadcrumbs|length %}
           {{ breadcrumb.name }}
         {% else %}
-          <a href="" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
+          <a href="?subdir={{ breadcrumb.full_subdir }}#files-panel" onclick="return navigateDir('{{ breadcrumb.full_subdir }}')">{{ breadcrumb.name }}</a>&nbsp;/&nbsp;
         {% endif %}
       {% endfor %}
       </div>
@@ -23,7 +23,7 @@
     {% if subdir %}
       <li class="list-group-item">
         <div class="row">
-          <div class="col-md-8">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
+          <div class="col-md-8">&nbsp;<i class="fas fa-angle-up"></i>&nbsp;&nbsp;<a href="?subdir={{ parent_dir }}#files-panel" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></div>
           <div class="col-md-2"></div>
           <div class="col-md-2"></div>
         </div>
@@ -32,7 +32,7 @@
     {% for dir in display_dirs %}
       <li class="list-group-item">
         <div class="row">
-          <div class="col-md-8"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
+          <div class="col-md-8"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;<a href="?subdir={{ dir.full_subdir }}#files-panel" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></div>
           <div class="col-md-2"></div>
           <div class="col-md-2"></div>
         </div>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1035,6 +1035,7 @@ def published_project(request, published_project_slug):
     Displays a published project
     """
     project = PublishedProject.objects.get(slug=published_project_slug)
+    subdir = request.GET.get('subdir', '')
 
     authors = project.authors.all().order_by('display_order')
     for a in authors:
@@ -1054,7 +1055,8 @@ def published_project(request, published_project_slug):
 
     # The file and directory contents
     if has_access:
-        display_files, display_dirs = project.get_main_directory_content()
+        display_files, display_dirs = project.get_main_directory_content(
+            subdir=subdir)
         dir_breadcrumbs = utility.get_dir_breadcrumbs('')
         main_size, compressed_size = [utility.readable_size(s) for s in
             (project.main_storage_size, project.compressed_storage_size)]

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -829,7 +829,7 @@ def project_preview(request, project_slug, **kwargs):
 
     subdir = request.GET.get('subdir', '')
     display_files, display_dirs = project.get_directory_content(subdir=subdir)
-    dir_breadcrumbs = utility.get_dir_breadcrumbs('')
+    dir_breadcrumbs = utility.get_dir_breadcrumbs(subdir)
 
     return render(request, 'project/project_preview.html', {
         'project':project, 'display_files':display_files, 'display_dirs':display_dirs,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -740,8 +740,7 @@ def project_files(request, project_slug, **kwargs):
             # process the file manipulation post
             subdir = process_files_post(request, project)
             project.modified_datetime = timezone.now()
-    if 'subdir' not in vars():
-        subdir = ''
+    subdir = request.GET.get('subdir', '')
 
     storage_info = project.get_storage_info()
     storage_request = StorageRequest.objects.filter(project=project,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1058,7 +1058,7 @@ def published_project(request, published_project_slug):
     if has_access:
         display_files, display_dirs = project.get_main_directory_content(
             subdir=subdir)
-        dir_breadcrumbs = utility.get_dir_breadcrumbs('')
+        dir_breadcrumbs = utility.get_dir_breadcrumbs(subdir)
         main_size, compressed_size = [utility.readable_size(s) for s in
             (project.main_storage_size, project.compressed_storage_size)]
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -827,7 +827,8 @@ def project_preview(request, project_slug, **kwargs):
         for e in project.integrity_errors:
             messages.error(request, e)
 
-    display_files, display_dirs = project.get_directory_content()
+    subdir = request.GET.get('subdir', '')
+    display_files, display_dirs = project.get_directory_content(subdir=subdir)
     dir_breadcrumbs = utility.get_dir_breadcrumbs('')
 
     return render(request, 'project/project_preview.html', {


### PR DESCRIPTION
Fix for issue #232:

The handlers for:
 - /projects/*/files/ (file management form)
 - /projects/*/preview/ (file display for an unpublished project)
 - /content/*/ (file display for a published project)
will each accept a 'subdir' query parameter, to display the
contents of a subdirectory within a project.

The corresponding HTML template files are updated to generate
these links appropriately.
