### PR TITLE
Unlink files when uploading

### DIFF
--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -181,7 +181,11 @@ def write_uploaded_file(file, write_file_path):
     file: request.FILE
     write_file_path: full file path to be written
     """
-    with open(write_file_path, 'wb+') as destination:
+    try:
+        os.unlink(write_file_path)
+    except FileNotFoundError:
+        pass
+    with open(write_file_path, 'xb') as destination:
         for chunk in file.chunks():
             destination.write(chunk)
 

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -176,15 +176,16 @@ def readable_size(num, suffix='B'):
     return '{:.1f}{:s}{:s}'.format(num, 'Y', suffix)
 
 
-def write_uploaded_file(file, write_file_path):
+def write_uploaded_file(file, write_file_path, overwrite=True):
     """
     file: request.FILE
     write_file_path: full file path to be written
     """
-    try:
-        os.unlink(write_file_path)
-    except FileNotFoundError:
-        pass
+    if overwrite:
+        try:
+            os.unlink(write_file_path)
+        except FileNotFoundError:
+            pass
     with open(write_file_path, 'xb') as destination:
         for chunk in file.chunks():
             destination.write(chunk)


### PR DESCRIPTION
We were discussing the possibility of having multiple versions of
a project with files linked in multiple places, rather than
making a copy of every file.  In that case, it would be important
that an uploaded file is always written as a new file, not by
modifying an existing file.

Regardless of whether we end up doing that or not (and regardless
of whether we were to use symlinks, hard links, or reflinks),
this change should make things more robust.

(An issue that is not addressed here is the fact that the file
upload form tries to verify in advance whether the uploaded files
will conflict, rather than checking for exceptions at the time of
writing.  This is a problem for a number of reasons, but I am
leaving the behavior as-is for now.)

One user-visible consequence is that that if you try to upload
two files with the same name at once, it will now throw an ugly
error, whereas previously it would silently discard one of
them.  (I don't know off the top of my head of any browsers that
*allow* you to upload two files with the same name at once, but I
certainly wouldn't rule it out.)
