### PR TITLE
Restore serve_file functionality in development server

### DIFF
--- a/physionet-django/physionet/settings/development.py
+++ b/physionet-django/physionet/settings/development.py
@@ -35,6 +35,12 @@ DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir))
 
 MEDIA_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'media')
 
+# If defined, MEDIA_X_ACCEL_ALIAS is the virtual URL path
+# corresponding to MEDIA_ROOT.  If possible, when serving a file
+# located in MEDIA_ROOT, the response will use an X-Accel-Redirect
+# header so that nginx can serve the file directly.
+MEDIA_X_ACCEL_ALIAS = None
+
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
     MEDIA_ROOT = os.path.join(MEDIA_ROOT, 'test')
     STATICFILES_DIRS[0] = os.path.join(STATICFILES_DIRS[0], 'test')

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -35,6 +35,12 @@ DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir))
 
 MEDIA_ROOT = '/data/pn-media'
 
+# If defined, MEDIA_X_ACCEL_ALIAS is the virtual URL path
+# corresponding to MEDIA_ROOT.  If possible, when serving a file
+# located in MEDIA_ROOT, the response will use an X-Accel-Redirect
+# header so that nginx can serve the file directly.
+MEDIA_X_ACCEL_ALIAS = '/protected'
+
 STATIC_ROOT = '/data/pn-static'
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -35,6 +35,12 @@ DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir))
 
 MEDIA_ROOT = '/data/pn-media'
 
+# If defined, MEDIA_X_ACCEL_ALIAS is the virtual URL path
+# corresponding to MEDIA_ROOT.  If possible, when serving a file
+# located in MEDIA_ROOT, the response will use an X-Accel-Redirect
+# header so that nginx can serve the file directly.
+MEDIA_X_ACCEL_ALIAS = '/protected'
+
 STATIC_ROOT = '/data/pn-static'
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -9,16 +9,3 @@ def get_project_apps():
     Return a string list of all the apps in this django project
     """
     return [app for app in settings.INSTALLED_APPS if not app.startswith('django') and not app.startswith('ck') and not app.startswith('debug')]
-
-def serve_file(request, file_path):
-    """
-    Serve a file to download. file_path is the full file path of the
-    file on the server
-    """
-    if os.path.exists(file_path):
-        with open(file_path, 'rb') as f:
-            response = HttpResponse(f.read())
-            response['Content-Disposition'] = 'attachment; filename=' + os.path.basename(file_path)
-            return response
-    else:
-        return Http404()

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -213,3 +213,20 @@ def serve_file(file_name, file_path):
     return response
 
 
+def serve_abs_file(path):
+    """
+    Serve a file to download.  path is the real path of the file on
+    the server.
+    """
+    root = settings.MEDIA_ROOT
+    alias = settings.MEDIA_X_ACCEL_ALIAS
+    if alias and path.startswith(root + '/'):
+        response = HttpResponse()
+        response['X-Accel-Redirect'] = alias + path[len(root):]
+    else:
+        with open(path, 'rb') as f:
+            response = HttpResponse(f.read())
+    base = os.path.basename(path)
+    response['Content-Type'] = ''
+    response['Content-Disposition'] = 'attachment; filename=' + base
+    return response

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -201,18 +201,6 @@ def get_form_errors(form):
     return all_errors
 
 
-def serve_file(file_name, file_path):
-    """
-    Serve a file to download. file_path is the full file path of the
-    file on the server
-    """
-    response = HttpResponse()
-    response['Content-Type'] = ''
-    response['Content-Disposition'] = 'attachment; filename=' + os.path.basename(file_name)
-    response['X-Accel-Redirect'] = '/protected/' + file_path
-    return response
-
-
 def serve_abs_file(path):
     """
     Serve a file to download.  path is the real path of the file on

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -777,8 +777,8 @@ def serve_project_file(request, project_slug, file_name, **kwargs):
     Serve a file in a project. file_name is file path relative to
     project file root.
     """
-    file_path = os.path.join('active-projects',kwargs['project'].slug, file_name)
-    return utility.serve_file(file_name, file_path)
+    path = os.path.join(kwargs['project'].file_root(), file_name)
+    return utility.serve_abs_file(path)
 
 @project_auth(auth_mode=2)
 def preview_files_panel(request, project_slug, **kwargs):
@@ -1014,8 +1014,8 @@ def serve_published_project_file(request, published_project_slug, full_file_name
     """
     project = PublishedProject.objects.get(slug=published_project_slug)
     if project.has_access(request.user):
-        file_path = os.path.join('published-projects', published_project_slug, full_file_name)
-        return utility.serve_file(full_file_name, file_path)
+        path = os.path.join(project.file_root(), full_file_name)
+        return utility.serve_abs_file(path)
     raise Http404()
 
 def published_project_license(request, published_project_slug):

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -22,7 +22,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from .forms import AddEmailForm, AssociatedEmailChoiceForm, ProfileForm, RegistrationForm, UsernameChangeForm, CredentialApplicationForm, CredentialReferenceForm
 from . import forms
 from .models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential
-from physionet import utility
+from project import utility
 from project.models import Author, License
 from notification.utility import reference_deny_credential, credential_application_request
 
@@ -242,7 +242,7 @@ def profile_photo(request, username):
     Serve a user's profile photo
     """
     user = User.objects.get(username=username)
-    return utility.serve_file(request, user.profile.photo.path)
+    return utility.serve_abs_file(user.profile.photo.path)
 
 def register(request):
     """
@@ -412,7 +412,8 @@ def training_report(request, application_slug):
     """
     application = CredentialApplication.objects.get(slug=application_slug)
     if request.user == application.user or request.user.is_admin:
-        return utility.serve_file(request, application.training_completion_report.path)
+        path = application.training_completion_report.path
+        return utility.serve_abs_file(path)
 
 
 # @login_required


### PR DESCRIPTION
Recently Felipe added the ability for protected files to be served
directly by nginx (rather than reading the file into python and
returning it) which is important for performance and simplicity (let
the web server do what web servers are good at.)

Unfortunately this change also made it difficult to test the server
with 'manage.py runserver', because of course the built-in web server
doesn't understand X-Accel-Redirect.

These patches add a variable (MEDIA_X_ACCEL_ALIAS) which is set in the
'staging' and 'production' configurations, but not in the
'development' configuration.  Internally, files are still referred to
by their actual paths in the local filesystem, but when it is time to
serve the file to the user, we check whether it is located in
MEDIA_ROOT and issue an X-Accel-Redirect if so.  If files are stored
in locations other than MEDIA_ROOT, this may need further enhancement.

In addition to serve_project_file and serve_published_project_file
(which previously used project.utility.serve_file), there are also two
functions profile_photo and training_report which previously used
physionet.utility.serve_file.  (Those two functions were originally
duplicates, but their APIs had then diverged.)

All four functions now use the new function
project.utility.serve_abs_file, and both serve_file functions are
removed.

Please verify this doesn't conflict with Chen's pending changes to
project directory structure before merging.
