### PR TITLE
Fix "add news" and start guidelines section in console

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -10,6 +10,7 @@
   <!-- start of menu items -->
   <div class="collapse navbar-collapse" id="navbarResponsive">
     <ul class="navbar-nav navbar-sidenav" id="sideAccordion">
+
       <!-- editor home -->
       {% url 'editor_home' as editor_home %}
       <li class="nav-item {% ifequal request.path editor_home %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
@@ -18,6 +19,7 @@
           <span class="nav-link-text">Home</span>
         </a>
       </li>
+
       <!-- projects -->
       {% url 'unsubmitted_projects' as unsubmitted_projects %}
       {% url 'submitted_projects' as submitted_projects %}
@@ -122,6 +124,7 @@
           </li>
         </ul>
       </li>
+
       <!-- news -->
       {% url 'console_news' as console_news %}
       <li class="nav-item {% ifequal request.path console_news %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
@@ -130,6 +133,30 @@
           <span class="nav-link-text">News</span>
         </a>
       </li>
+
+      <!-- guidelines and documentation -->
+      {% url 'guidelines_review' as guidelines_review %}
+      <li class="nav-item" data-toggle="tooltip" data-placement="right">
+      {% if request.path == guidelines_review %}
+        <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#guidelinesComponents" data-parent="#sideAccordion" aria-expanded="true">
+      {% else %}
+        <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#guidelinesComponents" data-parent="#sideAccordion" aria-expanded="false">
+      {% endif %}
+          <i class="fa fa-fw fa-book"></i>
+          <span class="nav-link-text">Guidelines</span>
+        </a>
+        <!-- submenu -->
+      {% if request.path == guidelines_review %}
+        <ul class="sidenav-second-level collapse show" id="guidelinesComponents">
+      {% else  %}
+        <ul class="sidenav-second-level collapse" id="guidelinesComponents">
+      {% endif %}
+          <li class="nav-item {% ifequal request.path guidelines_review %}active{% endifequal %}">
+            <a href="{% url 'guidelines_review' %}">Project review</a>
+          </li>
+        </ul>
+      </li>
+
       <!-- usage stats -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion">
@@ -146,8 +173,9 @@
           </li>
         </ul>
       </li>
-    </ul>
+
     <!-- end of menu items -->
+    </ul>
 
     <ul class="navbar-nav sidenav-toggler">
       <li class="nav-item">

--- a/physionet-django/console/templates/console/guidelines_review.html
+++ b/physionet-django/console/templates/console/guidelines_review.html
@@ -1,0 +1,52 @@
+{% extends "console/base_console.html" %}
+
+{% block title %}Guidelines for reviewers{% endblock %}
+
+{% block content %}
+<div class="card mb-3">
+  <div class="card-header">
+      Guidelines for reviewers
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+    <p>When reviewing content, check that the requirements below are met. If not, you can copy the relevant points below into your message to the authors, preceded by "Please ensure that:".</p>
+
+    <h4>All projects</h4>
+    <ul>
+        <li>A README file is included alongside the files. At minimum, this file should include a title and a brief description of the package content.</li>
+        <li>Sensitive data and protected health information have been removed.</li>
+        <li>Filenames are clear and do not include spaces or special characters (e.g. "/","\,".").</li>
+    </ul>
+
+    <h4>Data (general)</h4>
+    <ul>
+        <li>All files are in non-proprietary formats (for example, CSV).</li>
+        <li>Tabulated data is arranged such that each variable is a column and each observation (or case) is a row ("tidy data").</li>
+    </ul>
+
+    <h4>Data (waveforms)</h4>
+    <ul>
+        <li>The shape of waveforms is as expected when plotted as a timeseries.</li>
+    </ul>
+
+    <h4>Software</h4>
+    <ul>
+        <li>Instructions for installation and usage are clearly documented.</li>
+        <li>Dependencies are clearly indicated, preferably in a requirements file.</li>
+        <li>The software is provided in a non-proprietary language, except where there is a clear reason not to do so (for example, when sharing a Matlab package). </li>
+        <li>Tests are provided to demonstrate correct functioning of major features of the software.</li>
+        <li>The software follows standard style guidelines (for example, PEP8 for Python).</li>
+        <li>The software is logically structured and packaged according to standard practice.</li> 
+    </ul>
+
+    <h4>Challenges</h4>
+    <ul>
+        <li>The objective of the Challenge is clearly stated.</li> 
+        <li>A timeline is provided, including a start date, final submission date, and scoring data.</li> 
+        <li>The criteria for assessment are clear and unambiguous.</li> 
+    </ul>
+
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -5,8 +5,6 @@
 {% load console_templatetags %}
 
 {% block content %}
-<h1>Submitted Projects</h1>
-<hr>
 <div class="card">
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -64,4 +64,8 @@ urlpatterns = [
     path('news/', views.console_news, name='console_news'),
     path('news/edit/<news_id>/', views.edit_news, name='edit_news'),
     path('news/add/', views.add_news, name='add_news'),
+
+    # guidelines
+    path('guidelines/review/', views.guidelines_review, name='guidelines_review'),
+
 ]

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -712,3 +712,11 @@ def add_news(request):
 
     return render(request, 'console/add_news.html', {'form':form})
 
+
+@login_required
+@user_passes_test(is_admin)
+def guidelines_review(request):
+    """
+    Guidelines for reviewers.
+    """
+    return render(request, 'console/guidelines_review.html')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -516,8 +516,6 @@ def rejected_submissions(request):
         {'projects':projects})
 
 
-
-
 @login_required
 @user_passes_test(is_admin)
 def users(request):
@@ -548,7 +546,8 @@ def admin_users(request):
     admin_users = User.objects.filter(is_admin=True)
     users = User.objects.all()
 
-    return render(request, 'console/admin_users.html', {'admin_users':admin_users, 'users':users})
+    return render(request, 'console/admin_users.html', 
+        {'admin_users':admin_users, 'users':users})
 
 @login_required
 @user_passes_test(is_admin)
@@ -700,6 +699,8 @@ def edit_news(request, news_id):
         'form':form})
 
 
+@login_required
+@user_passes_test(is_admin)
 def add_news(request):
     if request.method == 'POST':
         form = forms.NewsForm(data=request.POST)
@@ -710,3 +711,4 @@ def add_news(request):
         form = forms.NewsForm()
 
     return render(request, 'console/add_news.html', {'form':form})
+


### PR DESCRIPTION
Minor changes to:

- fix an issue with the "add news" tool
- add a guidelines section to the console 

This makes a start on https://github.com/MIT-LCP/physionet-build/issues/261. The idea is that the reviewer can work through the points, copying them directly to an email to authors where necessary.