### PR TITLE
Password checking improvements

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -89,19 +89,6 @@ WSGI_APPLICATION = 'physionet.wsgi.application'
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-        'OPTIONS': { 'min_length': 8, }
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
-    {
         'NAME': 'user.validators.ComplexityValidator',
     },
 ]

--- a/physionet-django/static/zxcvbn/zxcvbn_ProgressBar_Change.js
+++ b/physionet-django/static/zxcvbn/zxcvbn_ProgressBar_Change.js
@@ -1,11 +1,18 @@
 $(document).ready(function()
 {
+	// NOTE: Keep list of forbidden words in sync with
+	// zxcvbn_ProgressBar_Register.js and ComplexityValidator in
+	// validators.py
+
 	var name = document.getElementById("helper").getAttribute("data-name");
 	var last = document.getElementById("helper").getAttribute("data-last");
-	var url = document.getElementById("helper").getAttribute("data-url");
 	var email = document.getElementById("helper").getAttribute("data-email");
+	var user = document.getElementById("helper").getAttribute("data-username");
+	var t = (email + ' ' + name + ' ' + last + ' ' + user +
+	         ' physio physionet');
+
 	$("#StrengthProgressBar").zxcvbnProgressBar({
 		passwordInput: "#id_new_password1",
-		userInputs: [name, last, url, email]
+		userInputs: t.match(/\d+|[^\W\d_]+/g)
 	});
 });

--- a/physionet-django/static/zxcvbn/zxcvbn_ProgressBar_Register.js
+++ b/physionet-django/static/zxcvbn/zxcvbn_ProgressBar_Register.js
@@ -1,8 +1,16 @@
 $("input").change(function()
 {
+	// NOTE: Keep list of forbidden words in sync with
+	// zxcvbn_ProgressBar_Change.js and ComplexityValidator in
+	// validators.py
+
+	var t = ($("#id_email").val() + ' ' +
+	         $("#id_first_names").val() + ' ' +
+	         $("#id_last_name").val() + ' ' +
+	         $("#id_username").val() + ' physio physionet');
+
 	$("#StrengthProgressBar").zxcvbnProgressBar({
 		passwordInput: "#id_password1",
-		userInputs: [$("#id_email").val(), $("#id_first_names").val(),
-			$("#id_last_name").val()]
+		userInputs: t.match(/\d+|[^\W\d_]+/g)
 	});
 });

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -208,7 +208,14 @@ class RegistrationForm(forms.ModelForm):
         password2 = self.cleaned_data.get('password2')
         if password1 and password2 and password1 != password2:
             raise forms.ValidationError("The passwords don't match")
-        self.instance.username = self.cleaned_data.get('username')
+
+        # Note: if any of the following fields are missing, the form
+        # should ultimately be rejected, but we want to go ahead and
+        # check the password anyway
+        self.instance.username = self.cleaned_data.get('username', '')
+        self.instance.first_names = self.cleaned_data.get('first_names', '')
+        self.instance.last_name = self.cleaned_data.get('last_name', '')
+        self.instance.email = self.cleaned_data.get('email', '')
         password_validation.validate_password(self.cleaned_data.get('password2'),
             self.instance)
         return password2

--- a/physionet-django/user/templates/user/settings.html
+++ b/physionet-django/user/templates/user/settings.html
@@ -39,5 +39,5 @@
 <script type="text/javascript" src="{% static 'bootstrap/js/offcanvas.js' %}"></script>
 <script type="text/javascript" src="{% static 'zxcvbn/zxcvbn.js' %}"></script>
 <script type="text/javascript" src="{% static 'zxcvbn/zxcvbn-bootstrap-strength-meter.js' %}"></script>
-<script type="text/javascript" id="helper" src="{% static 'zxcvbn/zxcvbn_ProgressBar_Change.js' %}" data-last='{{user.profile.last_name}}' data-name='{{user.profile.first_names}}' data-url='{{user.profile.url}}' data-email='{{user.email}}'></script>
+<script type="text/javascript" id="helper" src="{% static 'zxcvbn/zxcvbn_ProgressBar_Change.js' %}" data-last='{{user.profile.last_name}}' data-name='{{user.profile.first_names}}' data-username='{{user.username}}' data-email='{{user.email}}'></script>
 {% endblock %}

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -13,18 +13,12 @@ class ComplexityValidator():
     """
     def __init__(self):
         self.minimum_complexity = 2
-        self.maximum_complexity = 4
 
     def validate(self, password, user=None):
         if zxcvbn(password,[])['score'] < self.minimum_complexity:
             raise ValidationError(
                 _("This password is too weak."),
                 code='password_weak_password',
-            )
-        elif zxcvbn(password,[])['score'] > self.maximum_complexity:
-            raise ValidationError(
-                _("This password is incompatible."),
-                code='password_incompatible',
             )
 
     def get_help_text(self):


### PR DESCRIPTION
Here are a few related changes:

- Don't put silly limitations on passwords (e.g. not allowing
  passwords consisting of all digits.)

- Do put sensible limitations on passwords (e.g. treating the
  user's name, or the word "PhysioNet", as low entropy.)

- Try to ensure that the client-side restrictions match the
  server-side restrictions, because nobody wants to have to try
  to come up with a complex password, type it twice, THEN submit
  it and be told it isn't good enough.

Some aspects still need work:

- There doesn't seem to be any client side checking when changing
  password via a "reset" link.

- Password validation during initial registration needs to check
  the name and email address that were submitted in the form.
