### PR TITLE
Mark links in public profiles as rel=nofollow

### DIFF
--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -77,7 +77,7 @@ Profile for {{ public_user.username }}
             Website:
           </div>
           <div class="col-md-10">
-            <a href="{{ profile.website }}" target="_blank">{{ profile.website }}</a>
+            <a href="{{ profile.website }}" target="_blank" rel="nofollow">{{ profile.website }}</a>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
URLs provided by users in their public profiles are not vetted by
the editors.  Thus, mark them nofollow to forestall abuse.
