### PR TITLE
Search

### DIFF
--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -15,7 +15,7 @@ def resource_badge(resource_type):
 
 @register.filter(name='topic_badge')
 def topic_badge(topic, show_count=False):
-    url = '{}?topic={}'.format(reverse('topic_search'), topic.description)
+    url = '{}?topic={}'.format(reverse('content_index'), topic.description)
     if show_count:
         badge = '<a href="{}"><span class="badge badge-pn">{} ({})</span></a>'.format(
             url, topic.description, topic.project_count)

--- a/physionet-django/search/forms.py
+++ b/physionet-django/search/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from user.validators import validate_alphaplus
 
 class TopicSearchForm(forms.Form):
-    topic = forms.CharField(max_length=50, required=False)
+    topic = forms.CharField(max_length=50, required=False, label='')
 
 
 class ProjectOrderForm(forms.Form):

--- a/physionet-django/search/forms.py
+++ b/physionet-django/search/forms.py
@@ -8,6 +8,7 @@ class TopicSearchForm(forms.Form):
 
 class ProjectOrderForm(forms.Form):
     ORDER_CHOICES = (
+        ('relevance', 'Relevance'),
         ('publish_datetime', 'Publish Date'),
         ('title', 'Title'),
         ('main_storage_size', 'Size'),

--- a/physionet-django/search/forms.py
+++ b/physionet-django/search/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from user.validators import validate_alphaplus
 
 class TopicSearchForm(forms.Form):
-    topic = forms.CharField(max_length=50, validators=[validate_alphaplus])
+    topic = forms.CharField(max_length=50, validators=[validate_alphaplus], required=False)
 
 
 class ProjectOrderForm(forms.Form):

--- a/physionet-django/search/forms.py
+++ b/physionet-django/search/forms.py
@@ -2,7 +2,6 @@ from django import forms
 
 from user.validators import validate_alphaplus
 
-
 class TopicSearchForm(forms.Form):
     topic = forms.CharField(max_length=50, validators=[validate_alphaplus])
 
@@ -19,9 +18,18 @@ class ProjectOrderForm(forms.Form):
         ('asc', 'Ascending'),
     )
 
-    orderby = forms.ChoiceField(choices=ORDER_CHOICES, label='Order By')
-    direction = forms.ChoiceField(choices=DIRECTION_CHOICES, label='Direction')
+    orderby = forms.ChoiceField(choices=ORDER_CHOICES, label='By')
+    direction = forms.ChoiceField(choices=DIRECTION_CHOICES, label='Order')
 
 
     def clean_order_by(self):
         pass
+
+class ProjectTypeForm(forms.Form):
+    PROJECT_TYPES = (
+        (0, 'Data'),
+        (1, 'Software'),
+        (2, 'Challenge'),
+    )
+
+    types = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, choices=PROJECT_TYPES, label='')

--- a/physionet-django/search/forms.py
+++ b/physionet-django/search/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from user.validators import validate_alphaplus
 
 class TopicSearchForm(forms.Form):
-    topic = forms.CharField(max_length=50, validators=[validate_alphaplus], required=False)
+    topic = forms.CharField(max_length=50, required=False)
 
 
 class ProjectOrderForm(forms.Form):

--- a/physionet-django/search/static/search/css/content-index.css
+++ b/physionet-django/search/static/search/css/content-index.css
@@ -1,8 +1,9 @@
-.jumbotron {
-  text-align: center;
-  background-color: transparent;
-  padding: 5px 0;
+.main-side label{
+	max-width: unset;
+	flex: unset;
 }
-.jumbotron .btn {
-  padding: 10px 20px;
+
+.main-side .col-md-10{
+	max-width: unset;
+	flex: unset;
 }

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -19,32 +19,29 @@ PhysioNet {{ main_label }} Index
         <p class="card-text mt-1">This page contains all of the {{ plural_label }} published on PhysioNet.</p>
       </div>
     </div>
-    <div class="card my-4">
-      <h2 class="card-header">Resource type</h2>
-      <div class="card-body">
-        <form method="GET" action="" class="no-pd">
-          {% include "inline_form_snippet.html" with form=form_type %}
-          <div style="display: none;">
-            {% include "inline_form_snippet.html" with form=form_order %}
-          </div>
-          <hr>
-          <button class="btn btn-primary btn-rsp" type="submit">Apply</button>
-        </form>
-      </div>
-    </div>
-    <div class="card my-4">
-      <h2 class="card-header">Sort</h2>
-      <div class="card-body">
-        <form method="GET" action="" class="no-pd">
-          {% include "inline_form_snippet.html" with form=form_order %}
-          <div style="display: none;">
+    <form method="GET" action="" class="no-pd">
+      <div class="card my-4">
+        <h2 class="card-header">Resource type</h2>
+        <div class="card-body">
+          
             {% include "inline_form_snippet.html" with form=form_type %}
-          </div>
-          <hr>
-          <button class="btn btn-primary btn-rsp" type="submit">Apply</button>
-        </form>
+            <div style="display: none;">
+              {% include "inline_form_snippet.html" with form=form_order %}
+            </div>
+        </div>
       </div>
-    </div>
+      <div class="card my-4">
+        <h2 class="card-header">Sort</h2>
+        <div class="card-body">
+            {% include "inline_form_snippet.html" with form=form_order %}
+            <div style="display: none;">
+              {% include "inline_form_snippet.html" with form=form_type %}
+            </div>
+        </div>
+      </div>
+      <hr>
+      <button class="btn btn-primary btn-rsp" type="submit">Apply</button>
+    </form>
     </div><div class="main-content">
       <h1>Resources</h1>
       <br>

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -16,7 +16,7 @@ PhysioNet {{ main_label }} Index
     <div class="card">
       <h2 class="card-header">PhysioNet Index</h2>
       <div class="card-body">
-        <p class="card-text mt-1">This page contains all of the {{ plural_label }} published on PhysioNet.</p>
+        <p class="card-text mt-1">This page contains all of the databases, softwares and challenges published on PhysioNet.</p>
       </div>
     </div>
     <form method="GET" action="" class="">
@@ -28,8 +28,9 @@ PhysioNet {{ main_label }} Index
       </div>
       <div class="card my-4">
         <h2 class="card-header">Resource type</h2>
-        <div class="card-body no-pd">
+        <div class="card-body no-pd" id="type-check">
             {% include "inline_form_snippet.html" with form=form_type %}
+            <a href="javascript:$('#type-check').find('input').prop('checked', true);">Select all</a>
         </div>
       </div>
       <div class="card my-4">

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -16,7 +16,7 @@ PhysioNet Index
     <div class="card">
       <h2 class="card-header">PhysioNet Index</h2>
       <div class="card-body">
-        <p class="card-text mt-1">This page contains all of the databases, softwares and challenges published on PhysioNet.</p>
+        <p class="card-text mt-1">This page contains all of the databases, software and challenges published on PhysioNet.</p>
       </div>
     </div>
     <form method="GET" action="" class="">

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-PhysioNet {{ main_label }} Index
+PhysioNet Index
 {% endblock %}
 
 {% block local_css %}

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -11,17 +11,44 @@ PhysioNet {{ main_label }} Index
 {% endblock %}
 
 {% block content %}
-<div class="container">
-  <div class="jumbotron">
-    <h1 class="display-4">PhysioNet {{ main_label }} Index</h1>
-    <p class="lead my-3">This page contains all of the {{ plural_label }} published on PhysioNet.</p>
-  </div>
-  <hr>
-  <form method="GET" action="" class="no-pd">
-    {% include "inline_form_snippet.html" %}
-    <button class="btn btn-primary btn-lg" type="submit">Order Results</button>
-  </form>
-  <hr>
-  {% include "search/content_list.html" %}
+<div class="main">
+  <div class="main-side">
+    <div class="card">
+      <h2 class="card-header">PhysioNet Index</h2>
+      <div class="card-body">
+        <p class="card-text mt-1">This page contains all of the {{ plural_label }} published on PhysioNet.</p>
+      </div>
+    </div>
+    <div class="card my-4">
+      <h2 class="card-header">Resource type</h2>
+      <div class="card-body">
+        <form method="GET" action="" class="no-pd">
+          {% include "inline_form_snippet.html" with form=form_type %}
+          <div style="display: none;">
+            {% include "inline_form_snippet.html" with form=form_order %}
+          </div>
+          <hr>
+          <button class="btn btn-primary btn-rsp" type="submit">Apply</button>
+        </form>
+      </div>
+    </div>
+    <div class="card my-4">
+      <h2 class="card-header">Sort</h2>
+      <div class="card-body">
+        <form method="GET" action="" class="no-pd">
+          {% include "inline_form_snippet.html" with form=form_order %}
+          <div style="display: none;">
+            {% include "inline_form_snippet.html" with form=form_type %}
+          </div>
+          <hr>
+          <button class="btn btn-primary btn-rsp" type="submit">Apply</button>
+        </form>
+      </div>
+    </div>
+    </div><div class="main-content">
+      <h1>Resources</h1>
+      <br>
+      {% include "search/content_list.html" %}
+    </div>
 </div>
 {% endblock %}

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -21,6 +21,12 @@ PhysioNet {{ main_label }} Index
     </div>
     <form method="GET" action="" class="">
       <div class="card my-4">
+        <h2 class="card-header">Search</h2>
+        <div class="card-body no-pd">
+            {% include "inline_form_snippet.html" with form=form_topic %}
+        </div>
+      </div>
+      <div class="card my-4">
         <h2 class="card-header">Resource type</h2>
         <div class="card-body no-pd">
             {% include "inline_form_snippet.html" with form=form_type %}

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -19,24 +19,17 @@ PhysioNet {{ main_label }} Index
         <p class="card-text mt-1">This page contains all of the {{ plural_label }} published on PhysioNet.</p>
       </div>
     </div>
-    <form method="GET" action="" class="no-pd">
+    <form method="GET" action="" class="">
       <div class="card my-4">
         <h2 class="card-header">Resource type</h2>
-        <div class="card-body">
-          
+        <div class="card-body no-pd">
             {% include "inline_form_snippet.html" with form=form_type %}
-            <div style="display: none;">
-              {% include "inline_form_snippet.html" with form=form_order %}
-            </div>
         </div>
       </div>
       <div class="card my-4">
         <h2 class="card-header">Sort</h2>
-        <div class="card-body">
+        <div class="card-body no-pd">
             {% include "inline_form_snippet.html" with form=form_order %}
-            <div style="display: none;">
-              {% include "inline_form_snippet.html" with form=form_type %}
-            </div>
         </div>
       </div>
       <hr>

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -45,6 +45,7 @@ PhysioNet Index
     </div><div class="main-content">
       <h1>Resources</h1>
       <br>
+      {% if nprojects < 1 %} No results {% endif %}
       {% include "search/content_list.html" %}
     </div>
 </div>

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -84,7 +84,7 @@ def content_index(request, resource_type=None):
     List of all published resources
     """
     LABELS = {0:['Database', 'databases'],
-        1:['Software', 'software'], 2:['Challenge', 'challenge']}
+        1:['Software', 'softwares'], 2:['Challenge', 'challenges']}
 
     form_type = forms.ProjectTypeForm()
     if 'types' in request.GET:
@@ -98,9 +98,9 @@ def content_index(request, resource_type=None):
         resource_type = [resource_type]
         form_type = forms.ProjectTypeForm({'types':resource_type})
 
-    for r in resource_type:
-        main_label = LABELS[r][0].join(',')
-        plural_label = LABELS[r][1].join(',')
+
+    main_label = ', '.join([LABELS[r][0] for r in resource_type])
+    plural_label = ', '.join([LABELS[r][1] for r in resource_type])
 
     orderby, direction = 'publish_datetime', 'desc'
     form_order = forms.ProjectOrderForm()

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -73,9 +73,9 @@ def get_content(resource_type, orderby, direction, topic):
     else:
         import re
         topic = re.split(r"\W",topic);
-        query = reduce(operator.or_, (Q(topics__description__contains = item) for item in topic))
-        query = query | reduce(operator.or_, (Q(abstract__contains = item) for item in topic))
-        query = query | reduce(operator.or_, (Q(title__contains = item) for item in topic))
+        query = reduce(operator.and_, (Q(topics__description__contains = item) for item in topic))
+        query = query | reduce(operator.and_, (Q(abstract__contains = item) for item in topic))
+        query = query | reduce(operator.and_, (Q(title__contains = item) for item in topic))
         query = query & Q(resource_type__in=resource_type)
         published_projects = PublishedProject.objects.filter(query).distinct()
 

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -73,9 +73,9 @@ def get_content(resource_type, orderby, direction, topic):
     else:
         import re
         topic = re.split(r"\W",topic);
-        query = reduce(operator.and_, (Q(topics__description__contains = item) for item in topic))
-        query = query | reduce(operator.and_, (Q(abstract__contains = item) for item in topic))
-        query = query | reduce(operator.and_, (Q(title__contains = item) for item in topic))
+        query = reduce(operator.or_, (Q(topics__description__contains = item) for item in topic))
+        query = query | reduce(operator.or_, (Q(abstract__contains = item) for item in topic))
+        query = query | reduce(operator.or_, (Q(title__contains = item) for item in topic))
         query = query & Q(resource_type__in=resource_type)
         published_projects = PublishedProject.objects.filter(query).distinct()
 

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -1,4 +1,5 @@
 import pdb
+import re
 
 from django.shortcuts import render, redirect, reverse
 
@@ -71,7 +72,6 @@ def get_content(resource_type, orderby, direction, topic):
         published_projects = PublishedProject.objects.filter(
             resource_type__in=resource_type).annotate(relevance=Count('core_project_id'))
     else:
-        import re
         topic = re.split(r"\W",topic);
         query = reduce(operator.or_, (Q(topics__description__contains = item) for item in topic))
         query = query | reduce(operator.or_, (Q(abstract__contains = item) for item in topic))

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -87,8 +87,9 @@ def get_content(resource_type, orderby, direction, topic):
     authors = [p.authors.all() for p in published_projects]
     topics = [p.topics.all() for p in published_projects]
     projects_authors_topics = zip(published_projects, authors, topics)
+    nprojects = len(published_projects)
 
-    return projects_authors_topics
+    return projects_authors_topics, nprojects
 
 
 def content_index(request, resource_type=None):
@@ -132,14 +133,14 @@ def content_index(request, resource_type=None):
         form_topic = forms.TopicSearchForm()
 
     # BUILD
-    projects_authors_topics = get_content(resource_type=resource_type,
+    projects_authors_topics, nprojects = get_content(resource_type=resource_type,
             orderby=orderby, direction=direction, topic=topic)
     
 
     return render(request, 'search/content_index.html', {'form_order':form_order,
         'projects_authors_topics':projects_authors_topics,
         'main_label':main_label, 'plural_label':plural_label,
-        'form_type':form_type, 'form_topic':form_topic})
+        'form_type':form_type, 'form_topic':form_topic,'nprojects':nprojects})
 
 
 def database_index(request):

--- a/physionet-django/static/custom/css/form-control-input.css
+++ b/physionet-django/static/custom/css/form-control-input.css
@@ -13,6 +13,33 @@ input, select, django-ckeditor-widget, textarea {
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 0.25rem;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+  outline: none;
+}
+
+form ul{
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+form li label input{
+  display: inline-block;
+  width: unset;
+}
+
+form select{
+  -webkit-appearance: none;
+  background-color: white;
+  background-image: 
+    linear-gradient(45deg, transparent 50%, black 50%),
+    linear-gradient(135deg, black 50%, transparent 50%);
+  background-position:
+    calc(100% - 20px) calc(1em + 2px),
+    calc(100% - 15px) calc(1em + 2px);
+  background-size:
+    5px 5px,
+    5px 5px;
+  background-repeat: no-repeat;
 }
 
 input::-ms-expand {

--- a/physionet-django/static/custom/css/home.css
+++ b/physionet-django/static/custom/css/home.css
@@ -4,23 +4,6 @@
   box-sizing: border-box;
 }
 
-.card{
-    border: unset;
-}
-
-.main-content{
-  padding: 40px 50px;
-  max-width: 75%;
-}
-
-.main-news{
-  padding: 30px;
-  min-width: 250px;
-  max-width: 25%;
-  background: rgba(0,0,0,0.03);
-  border-right: 0.05rem #e5e5e5 solid;
-}
-
 .btn-pn {
 /*  color: white;
   background-color: #694;*/
@@ -30,15 +13,4 @@
 
 .intro-badge {
   font-weight: 700;
-}
-
-@media screen and (max-width: 1000px) {
-  .main-news{
-    min-width: unset;
-    max-width: unset;
-  }
-
-  .main-content{
-    max-width: unset;
-  }
 }

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -210,6 +210,44 @@ a{
   text-align: right;
 }
 
+.main{
+  min-height: calc(100% - 56px - 10.5rem);
+  display: flex;
+}
+
+.main-content{
+  padding: 40px 50px;
+  max-width: 75%;
+  vertical-align: top;
+}
+
+.main-side{
+  padding: 30px;
+  min-width: 250px;
+  max-width: 25%;
+  background: rgba(0,0,0,0.03);
+  border-right: 0.05rem #e5e5e5 solid;
+}
+
+@media screen and (max-width: 1000px) {
+  .main{
+    display: block;
+  }
+  
+  .main-side{
+    min-width: unset;
+    max-width: unset;
+  }
+
+  .main-content{
+    max-width: unset;
+  }
+}
+
+.main-side .card{
+    border: unset;
+}
+
 .container{
   padding: 40px 30px;
 }
@@ -271,6 +309,7 @@ body > .container{
 
   .btn-rsp{
     width: 200px;
+    max-width: 100%;
     justify-content: center;
   }
 

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -18,7 +18,7 @@ PhysioNet
 
     <div class="row">
       {# Left column #}
-      <div class="main-news">
+      <div class="main-side">
 
         <div class="card">
           <h2 class="card-header">Welcome</h2>

--- a/physionet-django/templates/navbar.html
+++ b/physionet-django/templates/navbar.html
@@ -12,8 +12,8 @@
 	</div>
 
 	<div class="navbar-search">
-		<form class="form-inline" action="{% url 'redirect_google_custom_search' %}">
-	    	<input name="query" class="search-input" type="text" placeholder="Search">
+		<form class="form-inline" action="{% url 'content_index' %}">
+	    	<input name="topic" class="search-input" type="text" placeholder="Search">
 		    <span class="input-group-btn">
 		      <button id="search-button" type="submit" class="btn btn-search my-2 my-sm-0" type="button"><i class="fa fa-search"></i></button>
 		    </span>

--- a/physionet-django/templates/navbar_content.html
+++ b/physionet-django/templates/navbar_content.html
@@ -1,28 +1,10 @@
 {% load static %}
 <ul class="navbar-nav mr-auto">
 
-  <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" id="nav_resource_dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Find
+  <li class="nav-item">
+    <a id="nav_find" class="nav-link" href="{% url 'content_index' %}">
+        Find
     </a>
-    <div class="dropdown-menu" aria-labelledby="resource_dropdown">
-      <a id="nav_data" class="dropdown-item" href="{% url 'database_index' %}">
-        Data
-      </a>
-      <a id="nav_software" class="dropdown-item" href="{% url 'software_index' %}">
-        Software
-      </a>
-      <a id="nav_challenge" class="dropdown-item" href="{% url 'challenge_index' %}">
-        Challenges
-      </a>
-      <a id="nav_all_content" class="dropdown-item" href="{% url 'content_index' %}">
-        All content
-      </a>
-      <div class="dropdown-divider"></div>
-      <a id="nav_topic_search" class="dropdown-item" href="{% url 'topic_search' %}">
-        Topic Search
-      </a>
-    </div>
   </li>
 
   <li class="nav-item dropdown">


### PR DESCRIPTION
I've combined the topic search and content type pages in one.

Now in the find page the user can:

- See all content (default)
- Filter by content type (database, challenge, software)
- Search title, abstract and tags
- Sort results 
- It is now possible to use all filters together