### PR TITLE
Fixes

### DIFF
--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -13,7 +13,7 @@
     </p>
   {% endif %}
   {% if not published_project.short_description %}
-    {{ published_project.abstract|safe|truncatechars:250 }}
+    {{ published_project.abstract|safe|truncatechars_html:250 }}
   {% else %}
     {{ published_project.short_description|safe }}
   {% endif %}

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -73,9 +73,9 @@ def get_content(resource_type, orderby, direction, topic):
             resource_type__in=resource_type).annotate(relevance=Count('core_project_id'))
     else:
         topic = re.split(r"\W",topic);
-        query = reduce(operator.or_, (Q(topics__description__contains = item) for item in topic))
-        query = query | reduce(operator.or_, (Q(abstract__contains = item) for item in topic))
-        query = query | reduce(operator.or_, (Q(title__contains = item) for item in topic))
+        query = reduce(operator.or_, (Q(topics__description__icontains = item) for item in topic))
+        query = query | reduce(operator.or_, (Q(abstract__icontains = item) for item in topic))
+        query = query | reduce(operator.or_, (Q(title__icontains = item) for item in topic))
         query = query & Q(resource_type__in=resource_type)
         published_projects = PublishedProject.objects.filter(query).annotate(relevance=Count('core_project_id'))
 

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -82,7 +82,7 @@ def get_content(resource_type, orderby, direction, topic):
     direction = '-' if direction == 'desc' else ''
 
     order_string = '{}{}'.format(direction, orderby)
-    published_projects = published_projects.order_by(orderby)
+    published_projects = published_projects.order_by(order_string)
 
     authors = [p.authors.all() for p in published_projects]
     topics = [p.topics.all() for p in published_projects]

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -73,9 +73,9 @@ def get_content(resource_type, orderby, direction, topic):
             resource_type__in=resource_type).annotate(relevance=Count('core_project_id'))
     else:
         topic = re.split(r"\W",topic);
-        query = reduce(operator.or_, (Q(topics__description__icontains = item) for item in topic))
-        query = query | reduce(operator.or_, (Q(abstract__icontains = item) for item in topic))
-        query = query | reduce(operator.or_, (Q(title__icontains = item) for item in topic))
+        query = reduce(operator.or_, (Q(topics__description__iregex = r'{0}'.format(item)) for item in topic))
+        query = query | reduce(operator.or_, (Q(abstract__iregex = r'\b{0}\b'.format(item)) for item in topic))
+        query = query | reduce(operator.or_, (Q(title__iregex = r'\b{0}\b'.format(item)) for item in topic))
         query = query & Q(resource_type__in=resource_type)
         published_projects = PublishedProject.objects.filter(query).annotate(relevance=Count('core_project_id'))
 

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -1,6 +1,4 @@
 html,body{height:100%; width: 100%;}
-html{overflow: hidden;}
-body{overflow: scroll;}
 
 /* Open in new window icon */
 a[target='_blank']::after {

--- a/physionet-django/static/custom/css/settings.css
+++ b/physionet-django/static/custom/css/settings.css
@@ -2,11 +2,6 @@
  * Style tweaks
  * --------------------------------------------------
  */
-html,
-body {
-  overflow-x: hidden; /* Prevent scroll on narrow devices */
-}
-
 .btn-custom {
   margin-top: 10px;
 }

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -23,7 +23,7 @@ PhysioNet
         <div class="card">
           <h2 class="card-header">Welcome</h2>
           <div class="card-body">
-            <p class="card-text mt-1">PhysioNet offers <strong>free</strong> web access to large collections of recorded physiologic <a href="{% url 'database_index' %}">data</a> and related open-source <a href="{% url 'software_index' %}">software</a>. For more information, see our <a href="{% url 'about_physionet' %}">about page</a>.</p>
+            <p class="card-text mt-1">PhysioNet offers free web access to large collections of recorded physiologic <a href="{% url 'database_index' %}">data</a> and related open-source <a href="{% url 'software_index' %}">software</a>. For more information, see our <a href="{% url 'about_physionet' %}">about page</a>.</p>
           </div>
         </div>
 


### PR DESCRIPTION
The following fixes for physionet:

- Order of sorting was not working
- Page scrolling on mobile devices
- Truncating abstracts was not html safe (some bulleted lists were messing up the page)
- Case insensitive and tokenized search