### PR TITLE
In development server, permit any HTTP Host.

### DIFF
--- a/physionet-django/physionet/settings/development.py
+++ b/physionet-django/physionet/settings/development.py
@@ -4,7 +4,7 @@ from .base import *
 
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS += [
     'debug_toolbar',


### PR DESCRIPTION
ALLOWED_HOSTS indicates whether Django will accept requests with a given HTTP 'Host' header.  Setting this to '*' means requests will be accepted regardless of the Host.  Note that manage.py still only *listens* for connections from the local machine by default; you need to tell it (e.g. using './manage.py runserver 0.0.0.0:8000') if you want it to listen to other hosts.

This change simply makes it a little easier to test the development server with different browsers in different virtual machines.
