### PR TITLE
Added email for editors

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -16,7 +16,7 @@
       <li class="nav-item {% ifequal request.path editor_home %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
         <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
           <i class="fa fa-fw fa-book-open"></i>
-          <span class="nav-link-text">Editor's Home</span>
+          <span class="nav-link-text">Editor Home</span>
         </a>
       </li>
 

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -16,7 +16,7 @@
       <li class="nav-item {% ifequal request.path editor_home %}active{% endifequal %}" data-toggle="tooltip" data-placement="right">
         <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
           <i class="fa fa-fw fa-book-open"></i>
-          <span class="nav-link-text">Home</span>
+          <span class="nav-link-text">Editor's Home</span>
         </a>
       </li>
 

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -122,7 +122,7 @@
                   {% if project.editor == user %}
                     <td><a class="btn btn-primary btn-sm" href="{% url 'edit_submission' project.slug %}" role="button">Edit Project</a></td>
                   {% else %}
-                    <td><p>Ongoing</p></td>
+                    <td><p>Assigned</p></td>
                   {% endif %}
                   </td>
                 </tr>
@@ -191,7 +191,7 @@
                   {% if project.editor == user %}
                     <td><a class="btn btn-primary btn-sm" href="{% url 'copyedit_submission' project.slug %}" role="button">Copyedit Project</a></td>
                   {% else %}
-                    <td><p>Ongoing</p></td>
+                    <td><p>Assigned</p></td>
                   {% endif %}
                 </tr>
               {% endfor %}
@@ -265,7 +265,7 @@
                   {% if project.editor == user %}
                     <td><a class="btn btn-primary btn-sm" href="{% url 'publish_submission' project.slug %}" role="button">Publish Project</a></td>
                   {% else %}
-                    <td><p>Ongoing</p></td>
+                    <td><p>Assigned</p></td>
                   {% endif %}
                 </tr>
               {% endfor %}

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -102,6 +102,7 @@
                   <th>Editor</th>
                   <th>Submitted</th>
                   <th>Resubmitted</th>
+                  <th>Manage</th>
                 </tr>
               </thead>
               <tbody>
@@ -117,6 +118,12 @@
                     {% else %}
                       Not a resubmission
                     {% endif %}
+                  </td>
+                  {% if project.editor == user %}
+                    <td><a class="btn btn-primary btn-sm" href="{% url 'edit_submission' project.slug %}" role="button">Edit Project</a></td>
+                  {% else %}
+                    <td><p>Ongoing</p></td>
+                  {% endif %}
                   </td>
                 </tr>
               {% endfor %}
@@ -170,6 +177,7 @@
                   <th>Submitted</th>
                   <th>Editor Accepted</th>
                   <th>Editor</th>
+                  <th>Manage</th>
                 </tr>
               </thead>
               <tbody>
@@ -180,6 +188,11 @@
                   <td>{{ project.submission_datetime|date }}</td>
                   <td>{{ project.editor_accept_datetime|date }}</td>
                   <td>{{ project.editor }}</td>
+                  {% if project.editor == user %}
+                    <td><a class="btn btn-primary btn-sm" href="{% url 'copyedit_submission' project.slug %}" role="button">Copyedit Project</a></td>
+                  {% else %}
+                    <td><p>Ongoing</p></td>
+                  {% endif %}
                 </tr>
               {% endfor %}
               </tbody>
@@ -236,6 +249,7 @@
                   <th>Copyedit Completed</th>
                   <th>Author Approved</th>
                   <th>Editor</th>
+                  <th>Manage</th>
                 </tr>
               </thead>
               <tbody>
@@ -248,6 +262,11 @@
                   <td>{{ project.copyedit_completion_datetime|date }}</td>
                   <td>{{ project.author_approval_datetime|date }}</td>
                   <td>{{ project.editor }}</td>
+                  {% if project.editor == user %}
+                    <td><a class="btn btn-primary btn-sm" href="{% url 'publish_submission' project.slug %}" role="button">Publish Project</a></td>
+                  {% else %}
+                    <td><p>Ongoing</p></td>
+                  {% endif %}
                 </tr>
               {% endfor %}
               </tbody>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -61,6 +61,7 @@ def submitted_projects(request):
     """
     List of active submissions. Editors are assigned here.
     """
+    user = request.user
     if request.method == 'POST':
         assign_editor_form = forms.AssignEditorForm(request.POST)
         if assign_editor_form.is_valid():
@@ -68,6 +69,7 @@ def submitted_projects(request):
             project = ActiveProject.objects.get(id=assign_editor_form.cleaned_data['project'])
             project.assign_editor(assign_editor_form.cleaned_data['editor'])
             notification.assign_editor_notify(project)
+            notification.editor_notify_new_project(project, user)
             messages.success(request, 'The editor has been assigned')
 
     # Submitted projects

--- a/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
+++ b/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
@@ -3,8 +3,7 @@
 
 Dear {{ editor }},
 
-You have been asked to review a project entitled "{{ project.title }}" by "{{ user }}". 
-
+"{{ user }}" has assigned you the role of handling editor for a project entitled "{{ project.title }}".
 {{ signature }}
 
 {{ footer }}

--- a/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
+++ b/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
@@ -1,0 +1,11 @@
+{% load i18n %}{% autoescape off %}
+{{ project_info }}
+
+Dear {{ editor }},
+
+You have been asked to review a project entitled "{{ project.title }}" by "{{ user }}". 
+
+{{ signature }}
+
+{{ footer }}
+{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -172,17 +172,16 @@ def editor_notify_new_project(project, assignee):
     subject = 'Assigned new project to review as editor ({0})'.format(
         project.title)
 
-    for email, name in project.author_contact_info():
-        body = loader.render_to_string(
-            'notification/email/assign_editor_notify.html',
-            {'project':project, 'editor':project.editor,
-             'signature':email_signature(), 
-             'user':assignee.get_full_name(),
-             'project_info':email_project_info(project),
-             'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/editor_notify_new_project.html',
+        {'project':project, 'editor':project.editor,
+         'signature':email_signature(), 
+         'user':assignee.get_full_name(),
+         'project_info':email_project_info(project),
+         'footer':email_footer()})
 
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-                  [email], fail_silently=False)
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+              [project.editor.email], fail_silently=False)
 
 def edit_decision_notify(request, project, edit_log):
     """

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -165,6 +165,25 @@ def assign_editor_notify(project):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
+def editor_notify_new_project(project, assignee):
+    """
+    Notify authors when an editor is assigned
+    """
+    subject = 'Assigned new project to review as editor ({0})'.format(
+        project.title)
+
+    for email, name in project.author_contact_info():
+        body = loader.render_to_string(
+            'notification/email/assign_editor_notify.html',
+            {'project':project, 'editor':project.editor,
+             'signature':email_signature(), 
+             'user':assignee.get_full_name(),
+             'project_info':email_project_info(project),
+             'footer':email_footer()})
+
+        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+                  [email], fail_silently=False)
+
 def edit_decision_notify(request, project, edit_log):
     """
     Notify authors when an editor makes a decision

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1342,7 +1342,7 @@ class StorageRequest(BaseInvitation):
         validators=[MaxValueValidator(10240), MinValueValidator(1)])
     responder = models.ForeignKey('user.User', null=True,
         on_delete=models.SET_NULL)
-    response_message = models.CharField(max_length=300, default='', blank=True)
+    response_message = models.CharField(max_length=500, default='', blank=True)
 
     def __str__(self):
         return '{0}GB for project: {1}'.format(self.request_allowance,

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -107,6 +107,8 @@ class Author(BaseAuthor):
         if profile.affiliation:
             Affiliation.objects.create(name=profile.affiliation,
                 author=self)
+            return True
+        return False
 
     def set_display_info(self, set_affiliations=True):
         """
@@ -1340,7 +1342,7 @@ class StorageRequest(BaseInvitation):
         validators=[MaxValueValidator(10240), MinValueValidator(1)])
     responder = models.ForeignKey('user.User', null=True,
         on_delete=models.SET_NULL)
-    response_message = models.CharField(max_length=50, default='', blank=True)
+    response_message = models.CharField(max_length=300, default='', blank=True)
 
     def __str__(self):
         return '{0}GB for project: {1}'.format(self.request_allowance,

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -72,7 +72,7 @@
                   <p>Your current affiliation is "{{user.profile.affiliation}}", this affiliation will be added to this project automaticly.</p>
                   <p>You can add other affiliations or change it in the author's page of this project.</p>
                 {% else %}
-                  <p><font color='red'>After accepting, please add your personal institutional affiliation(s) that are relevant to this publication.</font></p>
+                  <p><font color='red'>After accepting, please add your affiliation to the project author page.</font></p>
                 {% endif %}
               </div>
 

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -69,8 +69,7 @@
                 <p>You have been invited to co-author {{ invitation_response_form.instance.project  }}.</p>
                 {{ invitation_response_form }}<br>
                 {% if user.profile.affiliation %}
-                  <p>Your current affiliation is "{{user.profile.affiliation}}", this affiliation will be added to this project automaticly.</p>
-                  <p>You can add other affiliations or change it in the author's page of this project.</p>
+                  <p>Your current affiliation "{{user.profile.affiliation}}" will be added to the project. To edit your affiliation, or to add an additional affiliation, please visit the project author page.</p>
                 {% else %}
                   <p><font color='red'>After accepting, please add your affiliation to the project author page.</font></p>
                 {% endif %}

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -68,7 +68,12 @@
               <div class="modal-body">
                 <p>You have been invited to co-author {{ invitation_response_form.instance.project  }}.</p>
                 {{ invitation_response_form }}<br>
-                <p><font color='red'>After accepting, please add your personal institutional affiliation(s) that are relevant to this publication.</font></p>
+                {% if user.profile.affiliation %}
+                  <p>Your current affiliation is "{{user.profile.affiliation}}", this affiliation will be added to this project automaticly.</p>
+                  <p>You can add other affiliations or change it in the author's page of this project.</p>
+                {% else %}
+                  <p><font color='red'>After accepting, please add your personal institutional affiliation(s) that are relevant to this publication.</font></p>
+                {% endif %}
               </div>
 
               <div class="modal-footer">

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -9,7 +9,6 @@ from project.models import (ArchivedProject, ActiveProject, PublishedProject,
     Author, AuthorInvitation, License, StorageRequest)
 from user.test_views import prevent_request_warnings, TestMixin
 
-
 PROJECT_VIEWS = [
     'project_overview', 'project_authors', 'project_metadata',
     'project_access', 'project_discovery', 'project_files',
@@ -456,6 +455,7 @@ class TestInteraction(TestMixin, TestCase):
             response = self.client.post(reverse('project_home'), data=data)
             self.assertEqual(AuthorInvitation.objects.get(id=iid).response,
                 bool(inv_response))
+
         # Test successful new author
         self.assertTrue(project.authors.filter(user__username='aewj'))
         # Fails if user is already an author


### PR DESCRIPTION
Fixes here #324, #323, #322 and #258
- Made it clear where is the "Editor's Home"
- Added a email notification to the editor once he is assigned a project. 
- Redirect the invited author to the project author's page to set the affiliation