### PR TITLE
changed from disable to readonly

### DIFF
--- a/physionet-django/static/custom/js/disable-title.js
+++ b/physionet-django/static/custom/js/disable-title.js
@@ -1,2 +1,2 @@
 // Disable all inputs and buttons on the page
-$('#id_title').attr('disabled', true);
+$('#id_title').attr('readonly', true);


### PR DESCRIPTION
Found error when the title is disabled. 
- Browsers wont submit the value of a "disabled" input, so it has to be changed to readonly