### PR TITLE
Add some extra hints to the editor's checklist

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -90,8 +90,11 @@ class EditSubmissionForm(forms.ModelForm):
         for f in rm_fields:
             del(self.fields[f])
 
-        for l in EditLog.LABELS[resource_type]:
-            self.fields[l].label = EditLog.LABELS[resource_type][l]
+        for (f, lbl) in EditLog.LABELS[resource_type].items():
+            hints = EditLog.HINTS.get(f)
+            if hints:
+                lbl += '<ul><li>' + '</li><li>'.join(hints) + '</li></ul>'
+            self.fields[f].label = lbl
 
         # Enforce the requirement of quality assurance fields
         for f in self.quality_assurance_fields:

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1393,6 +1393,21 @@ class EditLog(models.Model):
          'no_phi':'Is the content free of protected health information?'},
     )
 
+    HINTS = {
+        'no_phi': [
+            'No dates in WFDB header files (or anonymized dates only)?',
+            'No identifying information of any individual'
+            ' (caregivers as well as patients)?',
+            'No ages of individuals 90 years or older?',
+            'No hidden metadata (e.g. EDF headers)?',
+            'No internal timestamps, date-based UUIDs or other identifiers?',
+        ],
+        'open_format': [
+            'No compiled binaries or bytecode?',
+            'No minified or obfuscated source code?',
+        ],
+    }
+
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     project = GenericForeignKey('content_type', 'object_id')

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1398,7 +1398,7 @@ class EditLog(models.Model):
             'No dates in WFDB header files (or anonymized dates only)?',
             'No identifying information of any individual'
             ' (caregivers as well as patients)?',
-            'No ages of individuals 90 years or older?',
+            'No ages of individuals above 89 years?',
             'No hidden metadata (e.g. EDF headers)?',
             'No internal timestamps, date-based UUIDs or other identifiers?',
         ],

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -790,7 +790,7 @@ def project_files(request, project_slug, **kwargs):
                 is_active=True)
             if storage_request:
                 storage_request.get().delete()
-                messages.success(request, 'Your storage request has ben cancelled.')
+                messages.success(request, 'Your storage request has been cancelled.')
         else:
             # process the file manipulation post
             subdir = process_files_post(request, project)

--- a/physionet-django/static/custom/css/form-control-input.css
+++ b/physionet-django/static/custom/css/form-control-input.css
@@ -16,12 +16,6 @@ input, select, django-ckeditor-widget, textarea {
   outline: none;
 }
 
-form ul{
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
 form li label input{
   display: inline-block;
   width: unset;

--- a/physionet-django/templates/form_snippet.html
+++ b/physionet-django/templates/form_snippet.html
@@ -1,6 +1,6 @@
 {% for field in form.visible_fields %}
   <div class="form-group">
-    <label for="{{ field.name }}" title="{{ field.help_text }}">{{ field.label }}
+    <label for="{{ field.name }}" title="{{ field.help_text }}">{{ field.label|safe }}
     </label> {{ field }}
     {% for error in field.errors %}
       <div class="alert alert-danger">


### PR DESCRIPTION
These changes add some extra explanatory text to the checklist
that an editor sees when reviewing a project.

Under "Is the [data/software] provided in an open format?", we add:

* No compiled binaries or bytecode?
* No minified or obfuscated source code?

Under "Is the data free of protected health information?", we add:

* No dates in WFDB header files (or anonymized dates only)?
* No identifying information of any individual (caregivers as well as patients)?
* No ages of individuals 90 years or older?
* No hidden metadata (e.g. EDF headers)?
* No internal timestamps, date-based UUIDs or other identifiers?

I hope that these don't seem like too much extra text to add, but
I suspect it'd be easy to fall into a trap of saying "yes, yes,
yes" without thinking too much about each question.  These are
issues that are easy to overlook if you're not careful.

Feel free to nitpick the wording or add/remove items from the
list.
