### PR TITLE
Make header consistent

### DIFF
--- a/physionet-django/notification/templates/notification/news.html
+++ b/physionet-django/notification/templates/notification/news.html
@@ -35,7 +35,7 @@ PhysioNet News - {{ year }}
         </div>
 
     </div>{# Left column #}<div class="main-content">
-      <h1>{{ year }} PhysioNet News</h1>
+      <h1>{{ year }} News</h1>
       <br>
       {% for news in news_pieces %}
         <p>

--- a/physionet-django/notification/views.py
+++ b/physionet-django/notification/views.py
@@ -15,7 +15,7 @@ def news(request):
     minmax = News.objects.all().aggregate(min=Min('publish_datetime'), max=Max('publish_datetime'))
     news_years = list(range(minmax['min'].year, minmax['max'].year+1))
     return render(request, 'notification/news.html',
-        {'year':'Latest ', 'news_pieces':news_pieces, 'news_years':news_years})
+        {'year':'Latest', 'news_pieces':news_pieces, 'news_years':news_years})
 
 def news_year(request, year):
     news_pieces = News.objects.filter(publish_datetime__year=int(year)).order_by('-publish_datetime')

--- a/physionet-django/notification/views.py
+++ b/physionet-django/notification/views.py
@@ -15,7 +15,7 @@ def news(request):
     minmax = News.objects.all().aggregate(min=Min('publish_datetime'), max=Max('publish_datetime'))
     news_years = list(range(minmax['min'].year, minmax['max'].year+1))
     return render(request, 'notification/news.html',
-        {'year':'All', 'news_pieces':news_pieces, 'news_years':news_years})
+        {'year':'Latest ', 'news_pieces':news_pieces, 'news_years':news_years})
 
 def news_year(request, year):
     news_pieces = News.objects.filter(publish_datetime__year=int(year)).order_by('-publish_datetime')

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -46,7 +46,7 @@ PhysioNet
           </div>
         </div>
       </div> <!--Right Column --><div class="main-content">
-        <h1>Latest resources</h1><br>
+        <h1>Latest Resources</h1><br>
         {% include "search/content_list.html" %}
         <div class="more"><a class="btn btn-outline-dark" href="{% url 'content_index' %}">More content</a></div>
         <br><br>


### PR DESCRIPTION
Minor change to the header text for news, to make it consistent with the front page (following up on #339).
- Front page used sentence case (Latest resources) but the news had title case (Latest News), so I've updated the front page for consistency. 
- Removed "PhysioNet" from the news header, because it seems redundant.