### PR TITLE
Clean user-submitted HTML

### DIFF
--- a/physionet-django/notification/models.py
+++ b/physionet-django/notification/models.py
@@ -1,12 +1,13 @@
-from ckeditor.fields import RichTextField
 from django.db import models
+
+from project.models import SafeHTMLField
 
 
 class News(models.Model):
     """
     """
     title = models.CharField(max_length=40)
-    content = RichTextField()
+    content = SafeHTMLField()
     publish_datetime = models.DateTimeField(auto_now_add=True)
     url = models.URLField(default='', blank=True)
 

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -122,6 +122,71 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR,'static')]
 
+# List of permitted HTML tags and attributes for rich text fields.
+# The 'default' configuration permits all of the tags below.  Other
+# configurations may be added that permit different sets of tags.
+
+# Attributes that can be added to any HTML tag
+_generic_attributes = ['lang', 'title']
+
+# Inline/phrasing content
+_inline_tags = {
+    'a':      {'attributes': ['href']},
+    'abbr':   True,
+    'b':      True,
+    'bdi':    True,
+    'cite':   True,
+    'code':   True,
+    'dfn':    True,
+    'em':     True,
+    'i':      True,
+    'kbd':    True,
+    'q':      True,
+    'rb':     True,
+    'rp':     True,
+    'rt':     True,
+    'rtc':    True,
+    'ruby':   True,
+    's':      True,
+    'samp':   True,
+    'span':   True,
+    'strong': True,
+    'sub':    True,
+    'sup':    True,
+    'time':   True,
+    'var':    True,
+    'wbr':    True,
+}
+# Block/flow content
+_block_tags = {
+    # Paragraphs, lists, quotes, line breaks
+    'blockquote': True,
+    'br':         True,
+    'dd':         True,
+    'div':        True,
+    'dl':         True,
+    'dt':         True,
+    'li':         {'attributes': ['value']},
+    'ol':         {'attributes': ['start', 'type']},
+    'p':          True,
+    'pre':        True,
+    'ul':         True,
+
+    # Tables
+    'caption':    True,
+    'col':        {'attributes': ['span']},
+    'colgroup':   {'attributes': ['span']},
+    'table':      {'attributes': ['width']},
+    'tbody':      True,
+    'td':         {'attributes': ['colspan', 'headers', 'rowspan', 'style'],
+                   'styles': ['text-align']},
+    'tfoot':      True,
+    'th':         {'attributes': ['abbr', 'colspan', 'headers', 'rowspan',
+                                  'scope', 'sorted', 'style'],
+                   'styles': ['text-align']},
+    'thead':      True,
+    'tr':         True,
+}
 
 CKEDITOR_CONFIGS = {
     'default': {
@@ -137,6 +202,15 @@ CKEDITOR_CONFIGS = {
         'width': '100%',
         'format_tags': 'p;h3',
         'extraPlugins': 'codesnippet',
+        'allowedContent': {
+            **_inline_tags,
+            **_block_tags,
+            'h3': True,
+            'h4': True,
+            'h5': True,
+            'h6': True,
+            '*': {'attributes': _generic_attributes},
+        },
     }
 
 }

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -6,6 +6,7 @@ import uuid
 import pdb
 import pytz
 
+import bleach
 from ckeditor.fields import RichTextField
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
@@ -22,6 +23,81 @@ from .utility import (get_tree_size, get_file_info, get_directory_info,
 from .validators import validate_doi, validate_subdir, validate_version
 from user.validators import validate_alphaplus, validate_alphaplusplus
 from physionet.utility import zip_dir
+
+
+class SafeHTMLField(RichTextField):
+    """
+    An HTML text field that permits only "safe" content.
+
+    On the client side, this field is displayed as an interactive
+    WYSIWYG editor (see ckeditor.fields.RichTextField.)
+
+    On the server side, the HTML text is "cleaned" using the bleach
+    library to ensure that all tags are properly closed, entities are
+    well-formed, etc., and to remove or escape any unsafe tags or
+    attributes.
+
+    The permitted set of tags and attributes is generated from the
+    corresponding 'allowedContent' rules in settings.CKEDITOR_CONFIGS
+    (which also defines the client-side whitelisting rules and the set
+    of options that are visible to the user.)  For example:
+
+        'allowedContent': {
+            'a': {'attributes': ['href']},
+            'em': True,
+            '*': {'attributes': ['title']},
+        }
+
+    This would permit the use of 'a' and 'em' tags (all other tags are
+    forbidden.)  'a' tags are permitted to have an 'href' attribute,
+    and any tag is permitted to have a 'title' attribute.
+
+    NOTE: This class does not use ckeditor's 'disallowedContent'
+    rules.  Those rules can be used to perform tag/attribute
+    blacklisting on the client side, but will not be enforced on the
+    server side.
+    """
+
+    # The following protocols may be used in 'href', 'src', and
+    # similar attributes.
+    _protocols = ['http', 'https', 'ftp', 'mailto']
+
+    # The following attributes are forbidden on the server side even
+    # if permitted on client side.  (This is a kludge; permitting
+    # 'width' to be set on the client side makes editing tables
+    # easier.)
+    _attribute_blacklist = {('table', 'width')}
+
+    # The following CSS properties may be set via inline styles (but
+    # only on elements for which the 'style' attribute itself is
+    # permitted.)
+    _styles = ['text-align']
+
+    def __init__(self, config_name='default', strip=False,
+                 strip_comments=True, **kwargs):
+        super().__init__(config_name=config_name, **kwargs)
+
+        conf = settings.CKEDITOR_CONFIGS[config_name]
+        tags = []
+        attrs = {}
+        for (tag, props) in conf['allowedContent'].items():
+            if tag != '*':
+                tags.append(tag)
+            if isinstance(props, dict) and 'attributes' in props:
+                attrs[tag] = []
+                for attr in props['attributes']:
+                    if (tag, attr) not in self._attribute_blacklist:
+                        attrs[tag].append(attr)
+
+        self._cleaner = bleach.Cleaner(tags=tags, attributes=attrs,
+                                       styles=self._styles,
+                                       protocols=self._protocols,
+                                       strip=strip,
+                                       strip_comments=strip_comments)
+
+    def clean(self, value, model_instance):
+        value = self._cleaner.clean(value)
+        return super().clean(value, model_instance)
 
 
 class Affiliation(models.Model):

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -369,17 +369,17 @@ class Metadata(models.Model):
 
     # Main body descriptive metadata
     title = models.CharField(max_length=200, validators=[validate_alphaplus])
-    abstract = RichTextField(max_length=10000, blank=True)
-    background = RichTextField(blank=True)
-    methods = RichTextField(blank=True)
-    content_description = RichTextField(blank=True)
-    usage_notes = RichTextField(blank=True)
-    installation = RichTextField(blank=True)
-    acknowledgements = RichTextField(blank=True)
-    conflicts_of_interest = RichTextField(blank=True)
+    abstract = SafeHTMLField(max_length=10000, blank=True)
+    background = SafeHTMLField(blank=True)
+    methods = SafeHTMLField(blank=True)
+    content_description = SafeHTMLField(blank=True)
+    usage_notes = SafeHTMLField(blank=True)
+    installation = SafeHTMLField(blank=True)
+    acknowledgements = SafeHTMLField(blank=True)
+    conflicts_of_interest = SafeHTMLField(blank=True)
     version = models.CharField(max_length=15, default='', blank=True,
         validators=[validate_version])
-    release_notes = RichTextField(blank=True)
+    release_notes = SafeHTMLField(blank=True)
 
     # Short description used for search results, social media, etc
     short_description = models.CharField(max_length=250, blank=True,
@@ -1076,7 +1076,7 @@ class PublishedProject(Metadata, SubmissionInfo):
     approved_users = models.ManyToManyField('user.User', db_index=True)
     # Fields for legacy pb databases
     is_legacy = models.BooleanField(default=False)
-    full_description = RichTextField(default='')
+    full_description = SafeHTMLField(default='')
     is_latest_version = models.BooleanField(default=True)
 
     # Where all the published project files are kept, depending on access.
@@ -1330,7 +1330,7 @@ class License(models.Model):
     name = models.CharField(max_length=100)
     slug = models.SlugField(max_length=120)
     text_content = models.TextField(default='')
-    html_content = RichTextField(default='')
+    html_content = SafeHTMLField(default='')
     home_page = models.URLField()
     # A project must choose a license with a matching access policy and
     # resource type
@@ -1339,7 +1339,7 @@ class License(models.Model):
     resource_type = models.PositiveSmallIntegerField(choices=Metadata.RESOURCE_TYPES)
     # A protected license has associated DUA content
     dua_name = models.CharField(max_length=100, blank=True, default='')
-    dua_html_content = RichTextField(blank=True, default='')
+    dua_html_content = SafeHTMLField(blank=True, default='')
 
     def __str__(self):
         return self.name
@@ -1551,8 +1551,8 @@ class LegacyProject(models.Model):
     """
     title = models.CharField(max_length=255)
     slug = models.CharField(max_length=100)
-    abstract = RichTextField(blank=True, default='')
-    full_description = RichTextField()
+    abstract = SafeHTMLField(blank=True, default='')
+    full_description = SafeHTMLField()
     doi = models.CharField(max_length=100, blank=True, default='')
     version = models.CharField(max_length=20, default='1.0.0')
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -7,7 +7,7 @@ import pdb
 import pytz
 
 import bleach
-from ckeditor.fields import RichTextField
+import ckeditor.fields
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -25,7 +25,7 @@ from user.validators import validate_alphaplus, validate_alphaplusplus
 from physionet.utility import zip_dir
 
 
-class SafeHTMLField(RichTextField):
+class SafeHTMLField(ckeditor.fields.RichTextField):
     """
     An HTML text field that permits only "safe" content.
 

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -320,12 +320,14 @@ class TestState(TestMixin, TestCase):
         """
         self.client.login(username='rgmark@mit.edu', password='Tester11!')
         response = self.client.post(reverse('create_project'),
-            data={'title':'Database 1', 'resource_type':0, 'abstract':'abstract'})
+            data={'title': 'Database 1', 'resource_type': 0,
+                  'abstract': '<p class=xyz lang=en>x & y'})
 
         project = ActiveProject.objects.get(title='Database 1')
         self.assertRedirects(response, reverse('project_overview',
             args=(project.slug,)))
         self.assertEqual(project.authors.all().get().user.email, 'rgmark@mit.edu')
+        self.assertEqual(project.abstract, '<p lang="en">x &amp; y</p>')
 
     def test_archive(self):
         """

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -6,6 +6,22 @@ a[target='_blank']::after {
   padding: 0em 0.15em;
 }
 
+/* Main content: code examples */
+pre {
+  background-color: #f7f7f7;
+  border: 1px solid #dfdfdf;
+  padding: 0.25em;
+  margin: 0.75em;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+@media print {
+  pre {
+    background-color: transparent;
+    border: 0.25pt dotted black;
+  }
+}
+
 .navbar{
   display: block;
   height: 55px;

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -22,6 +22,30 @@ pre {
   }
 }
 
+/* Main content: tables */
+table {
+  border-collapse: collapse;
+  border-top: 1px solid #dfdfdf;
+  border-bottom: 1px solid #dfdfdf;
+  margin: 1em auto;
+}
+thead, tbody, tfoot {
+  border-top: 1px solid #dfdfdf;
+}
+th, td {
+  padding: 0.25em 0.5em;
+  text-align: left;
+}
+@media print {
+  table {
+    border-top: 0.25pt solid black;
+    border-bottom: 0.25pt solid black;
+  }
+  thead, tbody, tfoot {
+    border-top: 0.25pt solid black;
+  }
+}
+
 .navbar{
   display: block;
   height: 55px;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bleach==3.1.0
 coverage==4.4.2
 Django==2.1.7
 django-ckeditor==5.6.1


### PR DESCRIPTION
We need to ensure that HTML form fields are sanitized against a
whitelist, to ensure that the result is syntactically valid HTML,
won't break the page display (now or in the future), and to prevent
malicious inline scripts and such.

These changes implement server-side HTML whitelisting using the Bleach
library, and also *client*-side whitelisting using CKEditor's
allowedContent feature.

I previously sent around an an earlier version of these changes, which
Felipe was kind enough to review.  The major change in this version is
the addition of client-side whitelisting, which has two advantages:

- Controls for forbidden attributes are automatically hidden from the
  client side GUI.

- Manual editing of the source will also be automatically filtered, so
  that what the user sees in the WYSIWYG view should (approximately)
  match the server-side sanitization.

The same whitelist is used both on the client side (via ckeditor) and
the server side (via bleach); this makes the implementation slightly
more complicated, but I think it's worthwhile to avoid duplication.

Finally, to make up for the lack of custom table styling, I've added
some new CSS rules to produce (IMHO) pretty-looking tables as well as
code boxes.
