### PR TITLE
Server config fixes

### DIFF
--- a/deploy/physionet_nginx.conf
+++ b/deploy/physionet_nginx.conf
@@ -13,11 +13,6 @@ server {
     # max upload size
     client_max_body_size 1G;
 
-    # Django media
-    location /media  {
-        alias /data/pn-media;
-    }
-
     location /static {
         alias /data/pn-static;
     }

--- a/deploy/physionet_nginx.conf
+++ b/deploy/physionet_nginx.conf
@@ -23,10 +23,9 @@ server {
     }
 
     location /static/published-projects {
-            autoindex on;
+        autoindex on;
         alias /data/pn-static/published-projects;
-
-    }   
+    }
 
     error_log /var/log/nginx/physionet_error.log warn;
     access_log /var/log/nginx/physionet_access.log;


### PR DESCRIPTION
Felipe already fixed this issue on the live server but it was a serious one: /media was an alias that allowed unrestricted access to all supposedly-protected files.
