### PR TITLE
Reorganizing Share and About pages

### DIFF
--- a/physionet-django/templates/about/about.html
+++ b/physionet-django/templates/about/about.html
@@ -23,30 +23,19 @@ About
         <div class="card-body">
           <ul>
             <li><a href="#physionet">What is PhysioNet</a></li>
-            <li><a href="#sharing">Reasons to share</a></li>
             <li><a href="#databases">Database highlights</a></li>
             <li><a href="#funding">Funding</a></li>
-          </ul>
-        </div>
-      </div>
-
-       <div class="card my-4">
-        <h2 class="card-header">Contact</h2>
-        <div class="card-body">
-          <ul>
-            <li><a href="#form">Submit your message</a></li>
+            <li><a href="#contact">Get in touch</a></li>
           </ul>
         </div>
       </div>
     </div><div class="main-content">
-      <h1>About</h1>
-      <br>
       <div>{% include "about/about_physionet.html" %}</div>
       <br>
       <hr>
       <br>
       {% include "message_snippet.html" %}
-      <h1 id="contact">Contact</h1>
+      <h1 id="contact">Get in touch</h1>
       <br>
       <div>{% include "about/contact.html" %}</div>
       <br>

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -1,29 +1,16 @@
 <section id="physionet">
-  <h2>What is PhysioNet</h2>
+  <h1>What is PhysioNet</h1>
+  <br>
   <p>PhysioNet is a unique resource for research and education, offering free access to large collections of physiological data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/" target="_blank">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. PhysioNet is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. For a brief history, see our <a href="{% url 'timeline' %}">timeline</a>. </p>
 </section>
 
-<section id="sharing">
-  <h2>Reasons to share</h2>
-  <p>We invite you to <a href="{% url 'about_publish' %}#create">contribute</a> your data and software. Sharing on PhysioNet helps you to receive credit for your efforts through scholarly data citations. We understand the challenges of sharing in the health sciences and we are committed to helping to overcome them. </p>
-
-  <p>We work with you to help ensure that important data and software are properly archived, cleanly described, and easy to reuse. There are many advantages to sharing code and data, both for you and the public.</p>
-  <h5>Individual Incentives</h5>
-  <ul>
-    <li>Enabling reproducibility of your study, helping to establish credibility.</li>
-    <li>Improving the dicoverability of your work, through increased citations.</li>
-    <li>Increased opportunities for collaboration.</li>
-  </ul>
-  <h5>Public Incentives</h5>
-  <ul>
-    <li>Allow the scientific community to reuse your resource and maximize its impact.</li>
-    <li>Encourage better quality, more transparent research.</li>
-  </ul>
-  <p>Before submitting your work, please review our <a href="{% url 'about_publish' %}#guidelines">author guidelines</a>.</p>
-</section>
+<br>
+<hr>
+<br>
 
 <section id="databases">
-  <h2>Database highlights</h2>
+  <h1>Database highlights</h1>
+  <br>
   <p>PhysioBank is a large and growing archive of physiological data and software. To view a list of all data and software on PhysioNet, visit our <a href="{% url 'content_index' %}">content index</a>. Some brief highlights of this content follows below:</p>
   <h5>Electronic Health Record Databases</h5>
   <ul>
@@ -90,8 +77,13 @@
   </div>
 </section> -->
 
+<br>
+<hr>
+<br>
+
 <section id="funding">
-  <h2>Funding</h2>
+  <h1>Funding</h1>
+  <br>
   <p>PhysioNet was originally established under the auspices of the NIH's National Center for Research Resources in 1999. We gratefully acknowledge support from the following organizations:</p>
   <ul>
     <li>NIH National Institute of Biomedical Imaging and Bioengineering and the National Institute of General Medical Sciences, under grant <em>2R01GM104987-09</em>.</li>

--- a/physionet-django/templates/about/contact.html
+++ b/physionet-django/templates/about/contact.html
@@ -1,6 +1,4 @@
 <section id="form">
-  <h2>Submit your message</h2>
-  <br>
   <div>
     <form method="post" action="#contact">
       {% csrf_token %}

--- a/physionet-django/templates/about/publish.html
+++ b/physionet-django/templates/about/publish.html
@@ -19,51 +19,44 @@ Publish
     <div class="main-side">
 
       <div class="card">
-        <h2 class="card-header">Author Guidelines</h2>
+        <h2 class="card-header">Share</h2>
         <div class="card-body">
           <ul>
-            <li><a href="#submission">Submission process</a></li>
-            <li><a href="#preparing">Preparing for submission</a></li>
-            <li><a href="#criteria">Criteria for publication</a></li>
-            <li><a href="#editorial">Editorial process</a></li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="card my-4">
-        <h2 class="card-header">Licenses</h2>
-        <div class="card-body">
-          <ul>
-            <li><a href="#database">Database</a></li>
-            <li><a href="#software">Software</a></li>
-            <li><a href="#challenge">Challenge</a></li>
-          </ul>
-        </div>
-      </div>
-      
-      <div class="card my-4">
-        <h2 class="card-header">Submit</h2>
-        <div class="card-body">
-          <ul>
-            <li><a href="#create">Create your project</a></li>
+            <li><a href="#sharing">Sharing on Physionet</a></li>
+            <li><a href="#guidelines">Author Guidelines</a></li>
+            <!-- <li><a href="#guidelines">Protecting Privacy</a></li> -->
+            <li><a href="#licenses">Licenses</a></li>
+            <li><a href="#submit">Submit your Project</a></li>
           </ul>
         </div>
       </div>
     </div><div class="main-content">
+      <h1 id="sharing">Sharing on PhysioNet</h1>
+      <br>
+      <div>{% include "about/share.html" %}</div>
+      <br>
+      <hr>
+      <br>
       <h1 id="guidelines">Author Guidelines</h1>
       <br>
       <div>{% include "about/author_guidelines.html" %}</div>
       <br>
       <hr>
       <br>
+      <!-- <h1 id="guidelines">HIPAA Compliance</h1>
+      <br>
+      <div>{% include "about/author_guidelines.html" %}</div>
+      <br>
+      <hr>
+      <br> -->
       <h1 id="licenses">Licenses</h1>
       <br>
       <div>{% include "about/licenses.html" %}</div>
       <hr>
       <br>
-      <h1>Submit</h1>
+      <h1 id="submit">Submit your Project</h1>
       <br>
-      <div id="create">
+      <div>
           <p><a href="{% url 'create_project' %}">Click here</a> to create your project.</p>
       </div>
     </div>

--- a/physionet-django/templates/about/share.html
+++ b/physionet-django/templates/about/share.html
@@ -1,0 +1,21 @@
+<section id="pshare">
+  <p>We invite you to contribute your data and software. Sharing on PhysioNet helps you to receive credit for your efforts through scholarly data citations. We understand the challenges of sharing in the health sciences and we are committed to helping to overcome them. </p>
+
+  <p>We work with you to help ensure that important data and software are properly archived, cleanly described, and easy to reuse.</p>
+</section>
+
+<section id="reasons">
+  <p>There are many advantages to sharing code and data, both for you and the public.</p>
+  <h5>Individual Incentives</h5>
+  <ul>
+    <li>Enabling reproducibility of your study, helping to establish credibility.</li>
+    <li>Improving the dicoverability of your work, through increased citations.</li>
+    <li>Increased opportunities for collaboration.</li>
+  </ul>
+  <h5>Public Incentives</h5>
+  <ul>
+    <li>Allow the scientific community to reuse your resource and maximize its impact.</li>
+    <li>Encourage better quality, more transparent research.</li>
+  </ul>
+  <p>Before <a href="#submit">submitting</a> your work, please review our <a href="#guidelines">author guidelines</a>.</p>
+</section>


### PR DESCRIPTION
Multiple menus were a bit confusing in both pages, so this reorganizes it.

- `About` page now has only the About menu with the subitems:
  - `What is PhysioNet`
  - `Database highlights`
  - `Funding`
  - `Get in touch`
- `Share` page now has only the About menu with the subitems:
  - `Sharing on Physionet`
  - `Author Guidelines`
  - `Licenses`
  - `Submit your Project`