### PR TITLE
Use default MIME types for known file types

### DIFF
--- a/deploy/custom-mime.types
+++ b/deploy/custom-mime.types
@@ -1,3 +1,4 @@
+include mime.types;
 types {
     application/octet-stream 16a;
     application/octet-stream abp;


### PR DESCRIPTION
For SVG files in particular, the MIME type must be set correctly in order for the file to be displayed as an image.
