### PR TITLE
Remove restriction on project types for users

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -312,8 +312,11 @@ class CreateProjectForm(forms.ModelForm):
     def __init__(self, user, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.user = user
+
+        # restrict projects type to admin
         if not user.is_admin:
-            self.fields['resource_type'].choices = self.fields['resource_type'].choices[:-1]
+            # no restrictions
+            pass
 
     class Meta:
         model = ActiveProject


### PR DESCRIPTION
Minor change to remove the restriction on project types for users. At the moment this only applies to challenges, which I'd like to open up. We may want to implement a restriction on types in future, so I've left the `if not user.is_admin:` in place.