### PR TITLE
URL compatibility fixes

### DIFF
--- a/deploy/physionet_nginx.conf
+++ b/deploy/physionet_nginx.conf
@@ -26,6 +26,17 @@ server {
         alias /data/pn-static/published-projects;
     }
 
+    location /physiobank/database {
+        autoindex on;
+        alias /data/pn-static/physiobank/database;
+        location = /physiobank/database/ {
+            return 301 /data/;
+        }
+        location ~ /physiobank/database/([-\w]+)/$ {
+            return 301 /content/$1/;
+        }
+    }
+
     #### End of public data ####
 
     error_log /var/log/nginx/physionet_error.log warn;
@@ -78,6 +89,17 @@ server {
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
+    }
+
+    location /physiobank/database {
+        autoindex on;
+        alias /data/pn-static/physiobank/database;
+        location = /physiobank/database/ {
+            return 301 /data/;
+        }
+        location ~ /physiobank/database/([-\w]+)/$ {
+            return 301 /content/$1/;
+        }
     }
 
     #### End of public data ####

--- a/deploy/physionet_nginx.conf
+++ b/deploy/physionet_nginx.conf
@@ -13,6 +13,10 @@ server {
     # max upload size
     client_max_body_size 1G;
 
+    #### Public data ####
+
+    include /etc/nginx/custom-mime.types;
+
     location /static {
         alias /data/pn-static;
     }
@@ -21,6 +25,8 @@ server {
         autoindex on;
         alias /data/pn-static/published-projects;
     }
+
+    #### End of public data ####
 
     error_log /var/log/nginx/physionet_error.log warn;
     access_log /var/log/nginx/physionet_access.log;
@@ -47,8 +53,6 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
-    include /etc/nginx/custom-mime.types;
-
     # SSL stapling
     ssl_stapling on;
     ssl_stapling_verify on;
@@ -60,12 +64,28 @@ server {
 }
 
 server {
-    # Security headers
-    if ($host = alpha.physionet.org) {
-        return 301 https://$host$request_uri;
-    } # managed by Certbot
-
     listen      80;
     server_name alpha.physionet.org physionet-production.ecg.mit.edu;
-    return 404; # managed by Certbot
+
+    #### Public data ####
+
+    include /etc/nginx/custom-mime.types;
+
+    location /static {
+        alias /data/pn-static;
+    }
+
+    location /static/published-projects {
+        autoindex on;
+        alias /data/pn-static/published-projects;
+    }
+
+    #### End of public data ####
+
+    error_log /var/log/nginx/physionet_error.log warn;
+    access_log /var/log/nginx/physionet_access.log;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }

--- a/deploy/physionet_nginx.conf
+++ b/deploy/physionet_nginx.conf
@@ -37,6 +37,17 @@ server {
         }
     }
 
+    location /physiotools {
+        autoindex on;
+        alias /data/pn-static/physiotools
+        location = /physiotools/ {
+            return 301 /software/;
+        }
+        location ~ /physiotools/([-\w]+)/$ {
+            return 301 /content/$1/;
+        }
+    }
+
     #### End of public data ####
 
     error_log /var/log/nginx/physionet_error.log warn;
@@ -98,6 +109,17 @@ server {
             return 301 /data/;
         }
         location ~ /physiobank/database/([-\w]+)/$ {
+            return 301 /content/$1/;
+        }
+    }
+
+    location /physiotools {
+        autoindex on;
+        alias /data/pn-static/physiotools
+        location = /physiotools/ {
+            return 301 /software/;
+        }
+        location ~ /physiotools/([-\w]+)/$ {
             return 301 /content/$1/;
         }
     }


### PR DESCRIPTION
* HTTP access to public data (issue #230).

(It'd be better to move this configuration to a separate file
rather than duplicating it in both server blocks...)

* WFDB access (/physiobank/database/ alias) (issues #217, #242).

The /physiobank/database/ directory, and DBS file, should really
be managed by the project publication process, but in order to
quickly get things to a usable state, we can create the directory
by hand for now.

* /physiotools/ alias for existing PhysioTools files that need to
be kept where they are.
