### PR TITLE
Add missing comma to author lists

### DIFF
--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -9,7 +9,7 @@
     {% if not published_project.is_legacy %}
       <p class="text-muted">
           {% for author in published_project.authors.all %}
-            {{ author.get_full_name }}
+          {{ author.get_full_name }}{% if not forloop.last %}, {% endif %}
           {% endfor %}
       </p>
     {% endif %}


### PR DESCRIPTION
Author lists are currently missing commas. e.g.:

![Screen Shot 2019-04-16 at 21 59 53](https://user-images.githubusercontent.com/822601/56255519-3bb9c480-6093-11e9-9b09-55113a22e897.png)

This change adds the commas. e.g.

![Screen Shot 2019-04-16 at 21 59 39](https://user-images.githubusercontent.com/822601/56255538-53914880-6093-11e9-9e26-42720bb84863.png)
