### PR TITLE
Tidier project layout

### DIFF
--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -72,15 +72,23 @@
   </p>
   <hr>
 
-  <strong>Please also include the standard citation for PhysioNet:</strong>
-    <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, 
-    Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and 
-    PhysioNet: Components of a New Research Resource for Complex Physiologic 
-    Signals (2003). Circulation. 101(23):e215-e220.</p>
-  <hr>
   <div class="row">
     <!-- Main column -->
-    <div class="col-md-8">
+    <div class="col-md-8" style="padding-left: 0;">
+
+    <div class="alert alert-secondary">
+    {% if not project.is_legacy %}
+    <strong>When using this resource, please cite:</strong>
+      <p>[Your citation will appear here]</p>
+    {% endif %}
+
+    <strong>Please also include the standard citation for PhysioNet:</strong>
+      <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, 
+      Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and 
+      PhysioNet: Components of a New Research Resource for Complex Physiologic 
+      Signals (2003). Circulation. 101(23):e215-e220.</p>
+    </div>
+
       {# 0: Database #}
       {% if project.resource_type == 0 %}
         {% include "project/database_metadata_preview.html" %}
@@ -98,9 +106,9 @@
     <!-- /.main column -->
 
     <!-- Sidebar Column -->
-    <div class="col-md-4">
+    <div class="col-md-4" style="padding-right: 0;">
 
-      <div class="card my-4">
+      <div class="card">
         <h5 class="card-header">Access</h5>
         <div class="card-body">
           <p>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -33,7 +33,48 @@
 
   <p>Published: {{ project.publish_datetime|date }}. Version: {{ project.version }}{% if not project.is_latest_version %} <a href="{% url 'published_project_latest' project.slug %}">&lt;View latest version&gt;</a>{% endif %}</p>
 
+  <hr>
+
+  <div class="row">
+    <!-- Main column -->
+    <div class="col-md-8" style="padding-left: 0;">
+
+  <div class="alert alert-secondary">
   {% if not project.is_legacy %}
+  <strong>When using this resource, please cite:</strong>
+    <p>{{ project.citation_text }}</p>
+  {% endif %}
+
+  <strong>Please also include the standard citation for PhysioNet:</strong>
+    <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, 
+    Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and 
+    PhysioNet: Components of a New Research Resource for Complex Physiologic 
+    Signals (2003). Circulation. 101(23):e215-e220.</p>
+  </div>
+
+      {% if project.is_legacy %}
+        {{ project.full_description|safe }}
+        <hr>
+      {% else %}
+        {# 0: Database #}
+        {% if project.resource_type == 0 %}
+          {% include "project/database_metadata.html" %}
+        {# 1: Software #}
+        {% elif project.resource_type == 1 %}
+          {% include "project/software_metadata.html" %}
+        {# 2: Challenge #}
+        {% elif project.resource_type == 2 %}
+          {% include "project/challenge_metadata.html" %}
+        {% endif %}
+      {% endif %}
+    </div>
+    <!-- /.main column -->
+
+    <!-- Sidebar Column -->
+    <div class="col-md-4" style="padding-right: 0;">
+
+  {% if not project.is_legacy %}
+  <div class="card" style="border: 0">
   <button class="btn btn-secondary dropdown-toggle btn-rsp btn-right" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Contents
   </button>
@@ -82,43 +123,9 @@
         <a class="dropdown-item" href="#files">Files</a>
     {% endif %}
     </div>
-    {% endif %}
-  <hr>
-
-  {% if not project.is_legacy %}
-  <strong>When using this resource, please cite:</strong>
-    <p>{{ project.citation_text }}</p>
-  {% endif %}
-
-  <strong>Please also include the standard citation for PhysioNet:</strong>
-    <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, 
-    Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and 
-    PhysioNet: Components of a New Research Resource for Complex Physiologic 
-    Signals (2003). Circulation. 101(23):e215-e220.</p>
-  <hr>
-  <div class="row">
-    <!-- Main column -->
-    <div class="col-md-8" style="padding-left: 0;">
-      {% if project.is_legacy %}
-        {{ project.full_description|safe }}
-        <hr>
-      {% else %}
-        {# 0: Database #}
-        {% if project.resource_type == 0 %}
-          {% include "project/database_metadata.html" %}
-        {# 1: Software #}
-        {% elif project.resource_type == 1 %}
-          {% include "project/software_metadata.html" %}
-        {# 2: Challenge #}
-        {% elif project.resource_type == 2 %}
-          {% include "project/challenge_metadata.html" %}
-        {% endif %}
-      {% endif %}
     </div>
-    <!-- /.main column -->
+    {% endif %}
 
-    <!-- Sidebar Column -->
-    <div class="col-md-4" style="padding-right: 0;">
       <div class="card my-4">
         <h5 class="card-header">Share</h5>
         <div class="card-body">
@@ -226,7 +233,7 @@
         {% include "project/files_panel.html" %}
       </div>
     {% else %}
-    <div class="alert alert-danger" role="alert">
+    <div class="alert alert-danger col-md-8" role="alert">
       This is a restricted-access resource. To access the files, you must {% if project.access_policy == 2 and not user.is_credentialed %}be a <a href="{% url 'edit_credentialing' %}">credentialed user</a> and {% endif %}<a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project.
     </div>
     {% endif %}


### PR DESCRIPTION
This pull request makes some minor improvements to the header section of published projects (and previews).

Current layout:

![Screen Shot 2019-04-16 at 23 21 03](https://user-images.githubusercontent.com/822601/56258719-88ef6380-609e-11e9-9fa6-8357fc71aba3.png)

Updated layout of published project:

![Screen Shot 2019-04-16 at 23 20 43](https://user-images.githubusercontent.com/822601/56258726-94428f00-609e-11e9-978b-49aba6d05fef.png)

Updated layout of a project preview:

![Screen Shot 2019-04-16 at 23 20 10](https://user-images.githubusercontent.com/822601/56258736-9b699d00-609e-11e9-90cd-a2d8afd31c97.png)
