### PR TITLE
Allow news items to be linked to published projects. Ref #368

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -281,4 +281,4 @@ class NewsForm(forms.ModelForm):
     """
     class Meta:
         model = News
-        fields = ('title', 'content', 'url')
+        fields = ('title', 'content', 'url', 'project')

--- a/physionet-django/notification/models.py
+++ b/physionet-django/notification/models.py
@@ -10,6 +10,8 @@ class News(models.Model):
     content = SafeHTMLField()
     publish_datetime = models.DateTimeField(auto_now_add=True)
     url = models.URLField(default='', blank=True)
+    project = models.ForeignKey('project.PublishedProject', null=True, blank=True,
+        on_delete=models.SET_NULL, related_name='news')
 
     def __str__(self):
         return '{} - {}'.format(self.title, self.publish_datetime.date())

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -35,11 +35,26 @@
 
   <hr>
 
+  <!-- Latest news and announcements -->
+  {% if news %}
+  
+    {% for new in news %}
+    <div class="alert alert-primary" role="alert">
+      <strong>{{ new.title|safe }}</strong>
+      <em>({{ new.publish_datetime }})</em>
+      <p>{{ new.content|safe }}</p>
+      </div>
+    {% endfor %}
+  
+  {% endif %}
+
   <div class="row">
     <!-- Main column -->
     <div class="col-md-8" style="padding-left: 0;">
 
   <div class="alert alert-secondary">
+
+
   {% if not project.is_legacy %}
   <strong>When using this resource, please cite:</strong>
     <p>{{ project.citation_text }}</p>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -37,35 +37,31 @@
 
   <!-- Latest news and announcements -->
   {% if news %}
-  
+  <div class="alert alert-primary" role="alert">
     {% for new in news %}
-    <div class="alert alert-primary" role="alert">
       <strong>{{ new.title|safe }}</strong>
       <em>({{ new.publish_datetime }})</em>
-      <p>{{ new.content|safe }}</p>
-      </div>
+      {{ new.content|safe }}
     {% endfor %}
-  
+  </div>
   {% endif %}
 
   <div class="row">
     <!-- Main column -->
     <div class="col-md-8" style="padding-left: 0;">
 
-  <div class="alert alert-secondary">
+    <div class="alert alert-secondary">
+      {% if not project.is_legacy %}
+        <strong>When using this resource, please cite:</strong>
+        <p>{{ project.citation_text }}</p>
+      {% endif %}
 
-
-  {% if not project.is_legacy %}
-  <strong>When using this resource, please cite:</strong>
-    <p>{{ project.citation_text }}</p>
-  {% endif %}
-
-  <strong>Please also include the standard citation for PhysioNet:</strong>
-    <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, 
-    Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and 
-    PhysioNet: Components of a New Research Resource for Complex Physiologic 
-    Signals (2003). Circulation. 101(23):e215-e220.</p>
-  </div>
+      <strong>Please also include the standard citation for PhysioNet:</strong>
+      <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG,
+      Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and
+      PhysioNet: Components of a New Research Resource for Complex Physiologic
+      Signals (2003). Circulation. 101(23):e215-e220.</p>
+    </div>
 
       {% if project.is_legacy %}
         {{ project.full_description|safe }}
@@ -87,59 +83,59 @@
 
     <!-- Sidebar Column -->
     <div class="col-md-4" style="padding-right: 0;">
-
-  {% if not project.is_legacy %}
-  <div class="card" style="border: 0">
-  <button class="btn btn-secondary dropdown-toggle btn-rsp btn-right" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    Contents
-  </button>
-  <div class="dropdown-menu">
-    {% if project.resource_type == 0 %}
-        <a class="dropdown-item" href="#abstract">Abstract</a>
-        <a class="dropdown-item" href="#background">Background</a>
-        <a class="dropdown-item" href="#methods">Methods</a>
-        <a class="dropdown-item" href="#description">Data Description</a>
-        <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
-        <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
-        <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-        <a class="dropdown-item" href="#references">References</a>
-        <a class="dropdown-item" href="#files">Files</a>
-    {% elif project.resource_type == 1 %}
-        <a class="dropdown-item" href="#abstract">Abstract</a>
-        <a class="dropdown-item" href="#background">Background</a>
-        <a class="dropdown-item" href="#description">Software Description</a>
-        {% if project.methods %}
-          <a class="dropdown-item" href="#implementation">Technical Implementation</a>
-        {% endif %}
-        {% if project.installation %}
-          <a class="dropdown-item" href="#installation">Installation and Requirements</a>
-        {% endif %}
-        <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
-        {% if project.release_notes %}
-          <a class="dropdown-item" href="#release-notes">Release Notes</a>
-        {% endif %}
-        {% if project.acknowledgements %}
-          <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
-        {% endif %}
-        <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-        <a class="dropdown-item" href="#references">References</a>
-        <a class="dropdown-item" href="#files">Files</a>
-    {% elif project.resource_type == 2 %}
-        <a class="dropdown-item" href="#abstract">Abstract</a>
-        <a class="dropdown-item" href="#background">Objective</a>
-        <a class="dropdown-item" href="#methods">Participation</a>
-        <a class="dropdown-item" href="#description">Data Description</a>
-        <a class="dropdown-item" href="#usage-notes">Evaluation</a>
-        <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
-        <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-        <a class="dropdown-item" href="#references">References</a>
-        <a class="dropdown-item" href="#files">Files</a>
-    {% else %}
-        <a class="dropdown-item" href="#files">Files</a>
-    {% endif %}
-    </div>
-    </div>
-    {% endif %}
+      {# Contents Button #}
+      {% if not project.is_legacy %}
+      <div class="card" style="border: 0">
+        <button class="btn btn-secondary dropdown-toggle btn-rsp btn-right" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Contents
+        </button>
+        <div class="dropdown-menu">
+          {% if project.resource_type == 0 %}
+            <a class="dropdown-item" href="#abstract">Abstract</a>
+            <a class="dropdown-item" href="#background">Background</a>
+            <a class="dropdown-item" href="#methods">Methods</a>
+            <a class="dropdown-item" href="#description">Data Description</a>
+            <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
+            <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+            <a class="dropdown-item" href="#references">References</a>
+            <a class="dropdown-item" href="#files">Files</a>
+          {% elif project.resource_type == 1 %}
+            <a class="dropdown-item" href="#abstract">Abstract</a>
+            <a class="dropdown-item" href="#background">Background</a>
+            <a class="dropdown-item" href="#description">Software Description</a>
+            {% if project.methods %}
+              <a class="dropdown-item" href="#implementation">Technical Implementation</a>
+            {% endif %}
+            {% if project.installation %}
+              <a class="dropdown-item" href="#installation">Installation and Requirements</a>
+            {% endif %}
+            <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
+            {% if project.release_notes %}
+              <a class="dropdown-item" href="#release-notes">Release Notes</a>
+            {% endif %}
+            {% if project.acknowledgements %}
+              <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            {% endif %}
+            <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+            <a class="dropdown-item" href="#references">References</a>
+            <a class="dropdown-item" href="#files">Files</a>
+          {% elif project.resource_type == 2 %}
+            <a class="dropdown-item" href="#abstract">Abstract</a>
+            <a class="dropdown-item" href="#background">Objective</a>
+            <a class="dropdown-item" href="#methods">Participation</a>
+            <a class="dropdown-item" href="#description">Data Description</a>
+            <a class="dropdown-item" href="#usage-notes">Evaluation</a>
+            <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+            <a class="dropdown-item" href="#references">References</a>
+            <a class="dropdown-item" href="#files">Files</a>
+          {% else %}
+            <a class="dropdown-item" href="#files">Files</a>
+          {% endif %}
+        </div>
+      </div>
+      {% endif %}
 
       <div class="card my-4">
         <h5 class="card-header">Share</h5>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1151,15 +1151,18 @@ def published_project(request, project_slug, version, subdir=''):
     topics = project.topics.all()
     languages = project.programming_languages.all()
     contact = Contact.objects.get(project=project)
+    news = project.news.all().order_by('-publish_datetime')
+
 
     has_access = project.has_access(request.user)
     current_site = get_current_site(request)
     all_project_versions = PublishedProject.objects.filter(
         slug=project_slug).order_by('version_order')
-    context = {'project':project, 'authors':authors,
-        'references':references, 'publication':publication, 'topics':topics,
-        'languages':languages, 'contact':contact, 'has_access':has_access,
-        'current_site':current_site, 'all_project_versions':all_project_versions}
+    context = {'project': project, 'authors': authors,
+               'references': references, 'publication': publication,
+               'topics': topics, 'languages': languages, 'contact': contact,
+               'has_access': has_access, 'current_site': current_site,
+               'news': news, 'all_project_versions': all_project_versions}
 
     # The file and directory contents
     if has_access:

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -1,7 +1,7 @@
 <section id="physionet">
   <h1>PhysioNet</h1>
   <br>
-  <p>PhysioNet is a unique resource for research and education, offering free access to large collections of physiological data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/" target="_blank">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. PhysioNet is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. For an overview of PhysioNet resources, see our <a href="{% url 'timeline' %}">content overview</a> or search our content.</p>
+  <p>PhysioNet is a unique resource for research and education, offering free access to large collections of physiological data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/" target="_blank">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. PhysioNet is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. For an overview of PhysioNet resources, see our <a href="{% url 'content_overview' %}">content overview</a> or search our content.</p>
 </section>
 
 <br>


### PR DESCRIPTION
Allow news items to be linked to a published project: 

- the news item is linked to a project using a new "project" field in the console
- news items are displayed in chronological order at the top of published projects
- one expected use for this functionality is to allow updates on challenges

Example of a project with two news items:

<img width="1007" alt="Screen Shot 2019-04-17 at 02 08 55" src="https://user-images.githubusercontent.com/822601/56265292-28b8eb80-60b7-11e9-968a-f6cef513eff5.png">

This display is similar to the current approach used on PhysioNet (e.g., see: https://physionet.org/challenge/2000/).

In the future, we may want to limit the number of items displayed at the top of projects, and move additional items to the side menu.