### PR TITLE
Improve handling of missing projects, missing/unreadable files

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -315,6 +315,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         'delete_items_form':delete_items_form,
         'subdir':subdir, 'display_files':display_files,
         'display_dirs':display_dirs, 'dir_breadcrumbs':dir_breadcrumbs,
+        'file_error':file_error,
         'is_editor':True, 'copyedit_form':copyedit_form,
         'authors':authors, 'author_emails':author_emails,
         'storage_info':storage_info, 'edit_logs':edit_logs,

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -297,8 +297,8 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         move_items_form, delete_items_form) = get_file_forms(project=project,
         subdir=subdir)
 
-    display_files, display_dirs, dir_breadcrumbs, _ = get_project_file_info(
-        project=project, subdir=subdir)
+    (display_files, display_dirs, dir_breadcrumbs, _,
+     file_error) = get_project_file_info(project=project, subdir=subdir)
 
     edit_url = reverse('edit_metadata_item', args=[project.slug])
 

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -8,6 +8,7 @@ from . import views
 import project.views as project_views
 
 
+handler403 = 'physionet.views.error_403'
 handler404 = 'physionet.views.error_404'
 handler500 = 'physionet.views.error_500'
 
@@ -42,6 +43,7 @@ urlpatterns = [
     path('about/citi-course/', views.citi_course, name='citi_course'),
 
     # # Custom error pages for testing
+    # path('403.html', views.error_403, name='error_403'),
     # path('404.html', views.error_404, name='error_404'),
     # path('500.html', views.error_500, name='error_500'),
 

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -100,6 +100,14 @@ def error_404(request, exception=None):
     return render(request,'404.html', status=404)
 
 
+def error_403(request, exception=None):
+    """
+    View for testing the 404 page. To test, uncomment the URL pattern
+        in urls.py.
+    """
+    return render(request,'403.html', status=403)
+
+
 def error_500(request, exception=None):
     """
     View for testing the 404 page. To test, uncomment the URL pattern

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -692,9 +692,10 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         # Sanitize subdir for illegal characters
         validate_subdir(subdir)
-        # Folder must be a subfolder of the file root and exist
+        # Folder must be a subfolder of the file root
+        # (but not necessarily exist or be a directory)
         inspect_dir = os.path.join(self.file_root(), subdir)
-        if inspect_dir.startswith(self.file_root()) and os.path.isdir(inspect_dir):
+        if inspect_dir.startswith(self.file_root()):
             return inspect_dir
         else:
             raise Exception('Invalid directory request')
@@ -1229,9 +1230,10 @@ class PublishedProject(Metadata, SubmissionInfo):
         """
         # Sanitize subdir for illegal characters
         validate_subdir(subdir)
-        # Folder must be a subfolder of the file root and exist
+        # Folder must be a subfolder of the file root
+        # (but not necessarily exist or be a directory)
         inspect_dir = os.path.join(self.file_root(), subdir)
-        if inspect_dir.startswith(self.file_root()) and os.path.isdir(inspect_dir):
+        if inspect_dir.startswith(self.file_root()):
             return inspect_dir
         else:
             raise Exception('Invalid directory request')

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -20,6 +20,11 @@
           </div>
         </div>
       </div>
+      {% if file_error %}
+      <div class="alert alert-danger col-md-8" role="alert">
+        {{ file_error|safe }}
+      </div>
+      {% else %}
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
           <div class="row">
@@ -60,6 +65,7 @@
           </li>
         {% endfor %}
       </ul>
+      {% endif %}
     </div>
   </form>
 

--- a/physionet-django/project/templates/project/files_panel.html
+++ b/physionet-django/project/templates/project/files_panel.html
@@ -11,6 +11,11 @@
     </div>
   </div>
 </div>
+{% if file_error %}
+  <div class="alert alert-danger col-md-8" role="alert">
+    {{ file_error|safe }}
+  </div>
+{% else %}
 <ul class="list-group list-group-flush">
   <li class="list-group-item">
     <div class="row">
@@ -47,7 +52,7 @@
     </li>
   {% endfor %}
 </ul>
-
+{% endif %}
 
 <script>
   // Navigate to another file directory and reload the file panel

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -251,11 +251,7 @@
   {% endif %}
 
   <h2 id="files">Files</h2>
-  {% if file_error %}
-  <div class="alert alert-danger col-md-8" role="alert">
-    {{ file_error|safe }}
-  </div>
-  {% elif project.access_policy %}
+  {% if project.access_policy %}
     {% if has_access %}
       <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% url 'serve_published_project_zip' project.slug project.version %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
       <div id="files-panel" class="card">

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -251,7 +251,11 @@
   {% endif %}
 
   <h2 id="files">Files</h2>
-  {% if project.access_policy %}
+  {% if file_error %}
+  <div class="alert alert-danger col-md-8" role="alert">
+    {{ file_error|safe }}
+  </div>
+  {% elif project.access_policy %}
     {% if has_access %}
       <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% url 'serve_published_project_zip' project.slug project.version %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
       <div id="files-panel" class="card">

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -341,6 +341,24 @@ class TestAccessPublished(TestMixin, TestCase):
             args=(project.slug, project.version, 'Makefile')))
         self.assertEqual(response.status_code, 200)
 
+    @prevent_request_warnings
+    def test_nonexistent(self):
+        """
+        Test access to a non-existent project.
+        """
+        response = self.client.get(reverse(
+            'published_project_latest', args=('fnord',)))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
+            'published_project', args=('fnord', '1.0')))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
+            'published_project_subdir', args=('fnord', '1.0', 'data')))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
+            'serve_published_project_file', args=('fnord', '1.0', 'Makefile')))
+        self.assertEqual(response.status_code, 404)
+
 
 class TestState(TestMixin, TestCase):
     """

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -271,7 +271,7 @@ class TestAccessPublished(TestMixin, TestCase):
         response = self.client.get(reverse(
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         response = self.client.get(reverse(
             'published_project_subdir',
             args=(project.slug, project.version, 'timeseries')))
@@ -286,7 +286,7 @@ class TestAccessPublished(TestMixin, TestCase):
         response = self.client.get(reverse(
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         response = self.client.get(reverse(
             'published_project_subdir',
             args=(project.slug, project.version, 'timeseries')))
@@ -297,7 +297,7 @@ class TestAccessPublished(TestMixin, TestCase):
         response = self.client.get(reverse(
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         response = self.client.get(reverse(
             'published_project_subdir',
             args=(project.slug, project.version, 'timeseries')))

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -316,6 +316,10 @@ class TestAccessPublished(TestMixin, TestCase):
             args=(project.slug, project.version, 'admissions.csv')))
         self.assertEqual(response.status_code, 200)
         response = self.client.get(reverse(
+            'serve_published_project_file',
+            args=(project.slug, project.version, 'fnord.txt')))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
             'published_project_subdir',
             args=(project.slug, project.version, 'timeseries')))
         self.assertEqual(response.status_code, 200)

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -57,10 +57,18 @@ class TestAccessPresubmission(TestMixin, TestCase):
         self.client.login(username='george@mit.edu', password='Tester11!')
         for view in PROJECT_VIEWS:
             response = self.client.get(reverse(view, args=(project.slug,)))
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.status_code, 403)
         response = self.client.get(reverse('serve_active_project_file',
             args=(project.slug, 'notes/notes.txt')))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
+
+        # Visit non-existent project
+        for view in PROJECT_VIEWS:
+            response = self.client.get(reverse(view, args=('fnord',)))
+            self.assertEqual(response.status_code, 403)
+        response = self.client.get(reverse('serve_active_project_file',
+            args=('fnord', 'notes/notes.txt')))
+        self.assertEqual(response.status_code, 403)
 
     @prevent_request_warnings
     def test_project_authors(self):
@@ -163,7 +171,7 @@ class TestAccessPresubmission(TestMixin, TestCase):
         response = self.client.post(reverse(
             'project_access', args=(project.slug,)),
             data={'access_policy':0, 'license':open_data_license.id})
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     @prevent_request_warnings
     def test_project_files(self):
@@ -235,7 +243,7 @@ class TestAccessPresubmission(TestMixin, TestCase):
         response = self.client.post(reverse(
             'project_files', args=(project.slug,)),
             data={'create_folder':'', 'folder_name':'new-folder-valid'})
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
 
 class TestAccessPublished(TestMixin, TestCase):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -264,6 +264,14 @@ class TestAccessPublished(TestMixin, TestCase):
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
         self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
+            'published_project_subdir',
+            args=(project.slug, project.version, 'timeseries')))
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(reverse(
+            'published_project_subdir',
+            args=(project.slug, project.version, 'fnord')))
+        self.assertEqual(response.status_code, 403)
 
         # Non-credentialed user
         self.client.login(username='aewj@mit.edu', password='Tester11!')
@@ -271,6 +279,10 @@ class TestAccessPublished(TestMixin, TestCase):
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
         self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
+            'published_project_subdir',
+            args=(project.slug, project.version, 'timeseries')))
+        self.assertEqual(response.status_code, 403)
 
         # Credentialed user that has not signed dua
         self.client.login(username='rgmark@mit.edu', password='Tester11!')
@@ -278,6 +290,10 @@ class TestAccessPublished(TestMixin, TestCase):
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
         self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse(
+            'published_project_subdir',
+            args=(project.slug, project.version, 'timeseries')))
+        self.assertEqual(response.status_code, 403)
 
         # Sign the dua and get file again
         response = self.client.post(reverse('sign_dua',
@@ -291,6 +307,14 @@ class TestAccessPublished(TestMixin, TestCase):
             'serve_published_project_file',
             args=(project.slug, project.version, 'admissions.csv')))
         self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse(
+            'published_project_subdir',
+            args=(project.slug, project.version, 'timeseries')))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse(
+            'published_project_subdir',
+            args=(project.slug, project.version, 'fnord')))
+        self.assertEqual(response.status_code, 404)
 
     def test_open(self):
         """

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1095,11 +1095,9 @@ def published_files_panel(request, project_slug, version):
             version=version)
 
     if project.has_access(request.user):
-        display_files, display_dirs = project.get_directory_content(
-            subdir=subdir)
-        # Breadcrumbs
-        dir_breadcrumbs = utility.get_dir_breadcrumbs(subdir)
-        parent_dir = os.path.split(subdir)[0]
+        (display_files, display_dirs, dir_breadcrumbs, parent_dir,
+         file_error) = get_project_file_info(project=project, subdir=subdir)
+
         files_panel_url = reverse('published_files_panel',
             args=(project.slug, project.version))
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1107,8 +1107,11 @@ def serve_published_project_file(request, project_slug, version,
     Works for open and protected. Not needed for open.
 
     """
-    project = PublishedProject.objects.get(slug=project_slug,
-        version=version)
+    try:
+        project = PublishedProject.objects.get(slug=project_slug,
+            version=version)
+    except ObjectDoesNotExist:
+        raise Http404()
     if project.has_access(request.user):
         file_path = os.path.join(project.file_root(), full_file_name)
         try:
@@ -1126,8 +1129,11 @@ def serve_published_project_zip(request, project_slug, version):
     Works for open and protected. Not needed for open.
 
     """
-    project = PublishedProject.objects.get(slug=project_slug,
-        version=version)
+    try:
+        project = PublishedProject.objects.get(slug=project_slug,
+            version=version)
+    except ObjectDoesNotExist:
+        raise Http404()
     if project.has_access(request.user):
         try:
             return physionet.serve_file(project.zip_name(full=True))
@@ -1140,8 +1146,11 @@ def published_project_license(request, project_slug, version):
     """
     Displays a published project's license
     """
-    project = PublishedProject.objects.get(slug=project_slug,
-        version=version)
+    try:
+        project = PublishedProject.objects.get(slug=project_slug,
+            version=version)
+    except ObjectDoesNotExist:
+        raise Http404()
     license = project.license
     license_content = project.license_content(fmt='html')
 
@@ -1154,8 +1163,11 @@ def published_project_latest(request, project_slug):
     """
     Redirect to latest project version
     """
-    version = PublishedProject.objects.get(slug=project_slug,
-        is_latest_version=True).version
+    try:
+        version = PublishedProject.objects.get(slug=project_slug,
+            is_latest_version=True).version
+    except ObjectDoesNotExist:
+        raise Http404()
     return redirect('published_project', project_slug=project_slug,
         version=version)
 
@@ -1164,7 +1176,11 @@ def published_project(request, project_slug, version, subdir=''):
     """
     Displays a published project
     """
-    project = PublishedProject.objects.get(slug=project_slug, version=version)
+    try:
+        project = PublishedProject.objects.get(slug=project_slug,
+                                               version=version)
+    except ObjectDoesNotExist:
+        raise Http404()
 
     authors = project.authors.all().order_by('display_order')
     for a in authors:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1115,7 +1115,7 @@ def serve_published_project_file(request, project_slug, version,
             return physionet.serve_file(file_path)
         except IsADirectoryError:
             return redirect(request.path + '/')
-    raise Http404()
+    raise PermissionDenied()
 
 
 def serve_published_project_zip(request, project_slug, version):
@@ -1128,7 +1128,7 @@ def serve_published_project_zip(request, project_slug, version):
         version=version)
     if project.has_access(request.user):
         return physionet.serve_file(project.zip_name(full=True))
-    raise Http404()
+    raise PermissionDenied()
 
 
 def published_project_license(request, project_slug, version):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1203,6 +1203,8 @@ def published_project(request, project_slug, version, subdir=''):
             'display_files':display_files, 'display_dirs':display_dirs,
             'files_panel_url':files_panel_url, 'subdir':subdir,
             'file_error':file_error}}
+    elif subdir:
+        status = 403
     else:
         status = 200
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -275,7 +275,11 @@ def remove_author(request, author_id, project, authors):
     Remove an author from a project
     Helper function for `project_authors`.
     """
-    rm_author = Author.objects.get(id=author_id)
+    rm_author = Author.objects.filter(id=author_id)
+    if rm_author:
+        rm_author = rm_author.get() 
+    else:
+        raise Http404()
 
     if rm_author in authors:
         # Reset the corresponding author if necessary
@@ -299,7 +303,11 @@ def cancel_invitation(request, invitation_id, project):
     Cancel an author invitation for a project.
     Helper function for `project_authors`.
     """
-    invitation = AuthorInvitation.objects.get(id=invitation_id)
+    invitation = AuthorInvitation.objects.filter(id=invitation_id)
+    if invitation:
+        invitation = invitation.get()
+    else:
+        raise Http404()
     if invitation.project == project:
         invitation.delete()
         messages.success(request, 'The invitation has been cancelled')
@@ -480,7 +488,12 @@ def edit_metadata_item(request, project_slug):
 
     """
     user = request.user
-    project = ActiveProject.objects.get(slug=project_slug)
+    project = ActiveProject.objects.filter(slug=project_slug)
+    if project:
+        project = project.get()
+    else:
+        raise Http404()
+
     is_submitting = bool(project.authors.filter(user=user, is_submitting=True))
 
     if not (is_submitting and project.author_editable()) and not (project.copyeditable() and user == project.editor):
@@ -614,7 +627,11 @@ def load_license(request, project_slug):
     access form's current access policy choice. Called via ajax.
     """
     user = request.user
-    project = ActiveProject.objects.get(slug=project_slug)
+    project = ActiveProject.objects.filter(slug=project_slug)
+    if project:
+        project = project.get()
+    else:
+        raise Http404()
     form = forms.AccessMetadataForm(include_credentialed=request.user.is_admin,
         instance=project)
     form.set_license_queryset(access_policy=int(request.GET['access_policy']))
@@ -1017,8 +1034,11 @@ def rejected_submission_history(request, project_slug):
     Submission history for a rejected project
     """
     user = request.user
-    project = ArchivedProject.objects.get(slug=project_slug, archive_reason=3)
-
+    project = ArchivedProject.objects.filter(slug=project_slug, archive_reason=3)
+    if project:
+        project = project.get() 
+    else:
+        raise Http404()
     if user.is_admin or project.authors.filter(user=user):
         edit_logs = project.edit_logs.all()
         for e in edit_logs:
@@ -1056,8 +1076,11 @@ def published_submission_history(request, project_slug, version):
     Submission history for a published project
     """
     user = request.user
-    project = PublishedProject.objects.get(slug=project_slug, version=version)
-
+    project = PublishedProject.objects.filter(slug=project_slug, version=version)
+    if project:
+        project = project.get() 
+    else:
+        raise Http404()
     if user.is_admin or project.authors.filter(user=user):
         edit_logs = project.edit_logs.all()
         for e in edit_logs:
@@ -1074,8 +1097,13 @@ def published_files_panel(request, project_slug, version):
     Return the main file panel for the published project, for all access
     policies. Called via ajax.
     """
-    project = PublishedProject.objects.get(slug=project_slug,
+    project = PublishedProject.objects.filter(slug=project_slug,
         version=version)
+    if project:
+        project = project.get() 
+    else:
+        raise Http404()
+
     subdir = request.GET['subdir']
 
     if not request.is_ajax():
@@ -1234,7 +1262,11 @@ def sign_dua(request, project_slug, version):
     Both restricted and credentialed policies.
     """
     user = request.user
-    project = PublishedProject.objects.get(slug=project_slug, version=version)
+    project = PublishedProject.objects.filter(slug=project_slug, version=version)
+    if project:
+        project = project.get() 
+    else:
+        raise Http404()
 
     if not project.access_policy or project.has_access(user):
         return redirect('published_project',

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -726,7 +726,7 @@ def project_files_panel(request, project_slug, **kwargs):
         move_items_form, delete_items_form) = get_file_forms(project, subdir)
 
     return render(request, 'project/edit_files_panel.html',
-        {'project':project, 'subdir':subdir,
+        {'project':project, 'subdir':subdir, 'file_error':file_error,
          'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
          'display_files':display_files, 'display_dirs':display_dirs,
          'upload_files_form':upload_files_form,
@@ -832,7 +832,7 @@ def project_files(request, project_slug, subdir='', **kwargs):
         'create_folder_form':create_folder_form,
         'rename_item_form':rename_item_form, 'move_items_form':move_items_form,
         'delete_items_form':delete_items_form, 'is_submitting':is_submitting,
-        'dir_breadcrumbs':dir_breadcrumbs})
+        'dir_breadcrumbs':dir_breadcrumbs, 'file_error':file_error})
 
 
 @project_auth(auth_mode=2)
@@ -865,7 +865,7 @@ def preview_files_panel(request, project_slug, **kwargs):
     files_panel_url = reverse('preview_files_panel', args=(project.slug,))
 
     return render(request, 'project/files_panel.html',
-        {'project':project, 'subdir':subdir,
+        {'project':project, 'subdir':subdir, 'file_error':file_error,
          'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
          'display_files':display_files, 'display_dirs':display_dirs,
          'files_panel_url':files_panel_url})
@@ -1107,7 +1107,7 @@ def published_files_panel(request, project_slug, version):
             {'project':project, 'subdir':subdir,
              'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
              'display_files':display_files, 'display_dirs':display_dirs,
-             'files_panel_url':files_panel_url})
+             'files_panel_url':files_panel_url, 'file_error':file_error})
 
 
 def serve_published_project_file(request, project_slug, version,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1115,6 +1115,8 @@ def serve_published_project_file(request, project_slug, version,
             return physionet.serve_file(file_path)
         except IsADirectoryError:
             return redirect(request.path + '/')
+        except FileNotFoundError:
+            raise Http404()
     raise PermissionDenied()
 
 
@@ -1127,7 +1129,10 @@ def serve_published_project_zip(request, project_slug, version):
     project = PublishedProject.objects.get(slug=project_slug,
         version=version)
     if project.has_access(request.user):
-        return physionet.serve_file(project.zip_name(full=True))
+        try:
+            return physionet.serve_file(project.zip_name(full=True))
+        except FileNotFoundError:
+            raise Http404()
     raise PermissionDenied()
 
 

--- a/physionet-django/templates/403.html
+++ b/physionet-django/templates/403.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block title %}
+403: Forbidden Access
+{% endblock %}
+
+{% block content %}
+<div class="container" align='center'>
+  <h1>Forbidden Access<br />(403)</h1>
+  <br /><br />
+  <p>You dont have access to see this page.</p>
+  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Forbidden%20Access%20attempt%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AI%20Received%20an%20error%20of%20forbidden%20in%20{{request.get_full_path_info}}">contact@physionet.org</a>  </p>
+
+</div>
+{% endblock %}
+
+
+Forbidden%20Access%20attempt%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AI%20Received%20an%20error%20of%20forbidden%20in%20{{request.get_full_path_info}}


### PR DESCRIPTION
These changes address a few (fairly minor, but important to usability) issues:

- In general, if the user doesn't have permission to access a project/file, return a 403 Forbidden response instead of 404 Not Found.

- If user requests a project that doesn't exist, return a 404 Not Found instead of 500 Internal Server Error.

- If the project exists and user has permission to access it, but the content (sub-)directory doesn't exist or isn't readable, display the project information, but show an error message in place of the list of files.  In particular, if we're using a snapshot of the production database on the staging server, but not all project directories exist, it's still nice to be able to view the main project pages.

(As I mention in one of the commit messages, the visual design of the error message could be improved.)
