### PR TITLE
files-panel: don't crash when required parameter is missing

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1104,7 +1104,9 @@ def published_files_panel(request, project_slug, version):
     else:
         raise Http404()
 
-    subdir = request.GET['subdir']
+    subdir = request.GET.get('subdir')
+    if subdir is None:
+        raise Http404()
 
     if not request.is_ajax():
         return redirect('published_project', project_slug=project_slug,


### PR DESCRIPTION
This should address issue #407.

As a general matter, it's problematic to use 'request.GET[foo]' without catching the possible exception.

(Most other instances of 'request.GET[foo]' are in functions that are only accessible to logged-in users, so normally shouldn't be triggered by spiders.  Still...)
