### PR TITLE
Add the 'derived projects' functionality.

### DIFF
--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -111,8 +111,22 @@
 
     <!-- Sidebar Column -->
     <div class="col-md-4" style="padding-right: 0;">
-
+      {% if parent_projects %}
       <div class="card">
+        <h5 class="card-header">Parent Projects</h5>
+        <div class="card-body">
+            {{ project.title }} was derived from:
+            <ul>
+              {% for pp in parent_projects %}
+                <li><a href="{% url 'published_project' pp.slug pp.version %}">{{ pp }}</a></li>
+              {% endfor %}
+            </ul>
+            Please cite them when using this project.
+        </div>
+      </div>
+      {% endif %}
+
+      <div class="card my-4">
         <h5 class="card-header">Access</h5>
         <div class="card-body">
           <p>
@@ -175,20 +189,6 @@
             </p>
         </div>
       </div>
-
-      {% if parent_projects %}
-      <div class="card my-4">
-        <h5 class="card-header">Related Projects</h5>
-        <div class="card-body">
-            {{ project.title }} was derived from:
-            <ul>
-              {% for pp in parent_projects %}
-                <li><a href="{% url 'published_project' pp.slug pp.version %}">{{ pp }}</a></li>
-              {% endfor %}
-            </ul>
-        </div>
-      </div>
-      {% endif %}
 
     </div>
     <!-- /.sidebar -->

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -77,15 +77,19 @@
     <div class="col-md-8" style="padding-left: 0;">
 
     <div class="alert alert-secondary">
-    {% if not project.is_legacy %}
+
     <strong>When using this resource, please cite:</strong>
       <p>[Your citation will appear here]</p>
+
+    {% if publication %}
+      <strong>In addition, please cite the original publication:</strong>
+      <p><a href="{{ publication.url }}" target="_blank">{{ publication.citation }}</a></p>
     {% endif %}
 
     <strong>Please also include the standard citation for PhysioNet:</strong>
-      <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, 
-      Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and 
-      PhysioNet: Components of a New Research Resource for Complex Physiologic 
+      <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG,
+      Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and
+      PhysioNet: Components of a New Research Resource for Complex Physiologic
       Signals (2003). Circulation. 101(23):e215-e220.</p>
     </div>
 
@@ -160,25 +164,32 @@
           {% endif %}
         </div>
       </div>
-      {% if publications %}
-      <div class="card my-4">
-        <h5 class="card-header">Related Publication</h5>
-        <div class="card-body">
-          <p><a href="{{ publications.0.url }}" target="_blank">{{ publications.0.citation }}</a></p>
-        </div>
-      </div>
-      {% endif %}
 
       <div class="card my-4">
         <h5 class="card-header">Corresponding Author</h5>
         <div class="card-body">
             <p>
-            {{ corresponding_author.get_full_name }}, 
-            {{ corresponding_author.text_affiliations }}, 
+            {{ corresponding_author.get_full_name }},
+            {{ corresponding_author.text_affiliations }},
             {{ corresponding_author.corresponding_email }}
             </p>
         </div>
       </div>
+
+      {% if parent_projects %}
+      <div class="card my-4">
+        <h5 class="card-header">Related Projects</h5>
+        <div class="card-body">
+            {{ project.title }} was derived from:
+            <ul>
+              {% for pp in parent_projects %}
+                <li><a href="{% url 'published_project' pp.slug pp.version %}">{{ pp }}</a></li>
+              {% endfor %}
+            </ul>
+        </div>
+      </div>
+      {% endif %}
+
     </div>
     <!-- /.sidebar -->
   </div>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -56,6 +56,11 @@
         <p>{{ project.citation_text }}</p>
       {% endif %}
 
+      {% if publication %}
+        <strong>{% if project.is_legacy %}When using this resource{% else %}Additionally{% endif %}, please cite the original publication:</strong>
+        <p><a href="{{ publication.url }}" target="_blank">{{ publication.citation }}</a></p>
+      {% endif %}
+
       <strong>Please include the standard citation for PhysioNet:</strong>
       <p>Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG,
       Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and
@@ -200,22 +205,13 @@
         </div>
       </div>
 
-      {% if publication %}
-      <div class="card my-4">
-        <h5 class="card-header">Related Publication</h5>
-        <div class="card-body">
-          <p><a href="{{ publication.url }}" target="_blank">{{ publication.citation }}</a></p>
-        </div>
-      </div>
-      {% endif %}
-
       <div class="card my-4">
         <h5 class="card-header">Corresponding Author</h5>
         <div class="card-body">
           {% if user.is_authenticated %}
             <p>
-              {{ contact.name }},
-              {{ contact.affiliations }},
+              {{ contact.name }}<br>
+              {{ contact.affiliations }}.<br>
               {{ contact.email }}
             </p>
           {% else %}
@@ -231,6 +227,30 @@
           <li class="list-group-item"><a href="{% url 'published_project' project.slug project.version %}">{{ project.version }}</a> - {{ project.publish_datetime|date }}</li>
           {% endfor %}
         </ul>
+      </div>
+      {% endif %}
+
+      {% if parent_projects or derived_projects %}
+      <div class="card my-4">
+        <h5 class="card-header">Related Projects</h5>
+        <div class="card-body">
+          {% if parent_projects %}
+            {{ project.title }} was derived from:
+            <ul>
+              {% for pp in parent_projects %}
+                <li><a href="{% url 'published_project' pp.slug pp.version %}">{{ pp }}</a></li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+          {% if derived_projects %}
+            The following projects are derivations:
+            <ul>
+              {% for dp in derived_projects %}
+                <li><a href="{% url 'published_project' dp.slug dp.version %}">{{ dp }}</a></li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
       </div>
       {% endif %}
     </div>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -142,6 +142,21 @@
       </div>
       {% endif %}
 
+      {% if parent_projects %}
+      <div class="card my-4">
+        <h5 class="card-header">Parent Projects</h5>
+        <div class="card-body">
+            {{ project.title }} was derived from:
+            <ul>
+              {% for pp in parent_projects %}
+                <li><a href="{% url 'published_project' pp.slug pp.version %}">{{ pp }}</a></li>
+              {% endfor %}
+            </ul>
+            Please cite them when using this project.
+        </div>
+      </div>
+      {% endif %}
+
       <div class="card my-4">
         <h5 class="card-header">Share</h5>
         <div class="card-body">
@@ -230,29 +245,6 @@
       </div>
       {% endif %}
 
-      {% if parent_projects or derived_projects %}
-      <div class="card my-4">
-        <h5 class="card-header">Related Projects</h5>
-        <div class="card-body">
-          {% if parent_projects %}
-            {{ project.title }} was derived from:
-            <ul>
-              {% for pp in parent_projects %}
-                <li><a href="{% url 'published_project' pp.slug pp.version %}">{{ pp }}</a></li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-          {% if derived_projects %}
-            The following projects are derivations:
-            <ul>
-              {% for dp in derived_projects %}
-                <li><a href="{% url 'published_project' dp.slug dp.version %}">{{ dp }}</a></li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </div>
-      </div>
-      {% endif %}
     </div>
     <!-- /.sidebar -->
   </div>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1213,7 +1213,8 @@ def published_project(request, project_slug, version, subdir=''):
     languages = project.programming_languages.all()
     contact = Contact.objects.get(project=project)
     news = project.news.all().order_by('-publish_datetime')
-
+    parent_projects = project.parent_projects.all()
+    derived_projects = project.derived_publishedprojects.all()
 
     has_access = project.has_access(request.user)
     current_site = get_current_site(request)
@@ -1223,7 +1224,9 @@ def published_project(request, project_slug, version, subdir=''):
                'references': references, 'publication': publication,
                'topics': topics, 'languages': languages, 'contact': contact,
                'has_access': has_access, 'current_site': current_site,
-               'news': news, 'all_project_versions': all_project_versions}
+               'news': news, 'all_project_versions': all_project_versions,
+               'parent_projects':parent_projects,
+               'derived_projects':derived_projects}
 
     # The file and directory contents
     if has_access:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -898,8 +898,9 @@ def project_preview(request, project_slug, subdir='', **kwargs):
     corresponding_author.text_affiliations = ', '.join(a.name for a in corresponding_author.affiliations.all())
 
     references = project.references.all()
-    publications = project.publications.all()
+    publication = project.publications.all().first()
     topics = project.topics.all()
+    parent_projects = project.parent_projects.all()
     languages = project.programming_languages.all()
 
     passes_checks = project.check_integrity()
@@ -918,10 +919,10 @@ def project_preview(request, project_slug, subdir='', **kwargs):
         'display_files':display_files, 'display_dirs':display_dirs,
         'authors':authors, 'corresponding_author':corresponding_author,
         'invitations':invitations, 'references':references,
-        'publications':publications, 'topics':topics, 'languages':languages,
+        'publication':publication, 'topics':topics, 'languages':languages,
         'passes_checks':passes_checks, 'dir_breadcrumbs':dir_breadcrumbs,
         'files_panel_url':files_panel_url, 'subdir':subdir,
-        'file_error':file_error})
+        'file_error':file_error, 'parent_projects':parent_projects})
 
 
 @project_auth(auth_mode=2)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1215,7 +1215,7 @@ def published_project(request, project_slug, version, subdir=''):
     contact = Contact.objects.get(project=project)
     news = project.news.all().order_by('-publish_datetime')
     parent_projects = project.parent_projects.all()
-    derived_projects = project.derived_publishedprojects.all()
+    # derived_projects = project.derived_publishedprojects.all()
 
     has_access = project.has_access(request.user)
     current_site = get_current_site(request)
@@ -1226,8 +1226,7 @@ def published_project(request, project_slug, version, subdir=''):
                'topics': topics, 'languages': languages, 'contact': contact,
                'has_access': has_access, 'current_site': current_site,
                'news': news, 'all_project_versions': all_project_versions,
-               'parent_projects':parent_projects,
-               'derived_projects':derived_projects}
+               'parent_projects':parent_projects}
 
     # The file and directory contents
     if has_access:

--- a/physionet-django/static/custom/css/settings.css
+++ b/physionet-django/static/custom/css/settings.css
@@ -15,7 +15,7 @@ footer {
     max-width: 200px;
 }
 
-input, select, django-ckeditor-widget textarea {
+input, select, django-ckeditor-widget, textarea {
   display: block;
   width: 100%;
   padding: 0.5rem 0.75rem;
@@ -97,8 +97,8 @@ input::placeholder {
   }
 
   .pg-edit{
-    width: 40%; 
-    margin-left: 60%; 
+    width: 40%;
+    margin-left: 60%;
     margin-top: -25px;
   }
 }


### PR DESCRIPTION
 Fixes #347

When submitting projects, you now have the ability to select parent project(s) that the current one is derived from. The parent/child projects will show in published projects.

Other changes:
- Show related publication at the top to cite
- Fix comma in css
- Make textbox for 'short_description' field bigger.