### PR TITLE
Clean up about page text and change links to new site

### DIFF
--- a/physionet-django/templates/about/about.html
+++ b/physionet-django/templates/about/about.html
@@ -22,7 +22,7 @@ About
         <div class="card-body">
           <ul>
             <li><a href="#physionet">PhysioNet</a></li>
-            <li><a href="#resource">Research and education</a></li>
+            <li><a href="#resource">Community resource</a></li>
             <li><a href="#history">Brief history</a></li>
             <li><a href="#funding">Funding</a></li>
             <li><a href="#research">Research</a></li>

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -46,18 +46,6 @@ comparison of analysis methods, and analysis of nonequilibrium and
   or explanatory or predictive power in basic research.</p>
 </li>
 
-<!-- <li>
-<p><a href="https://archive.physionet.org/users/"><strong>PhysioNetWorks</strong></a> is a virtual laboratory
-where you can work together with us and with colleagues anywhere in the world
-to create, evaluate, improve, document, and prepare new data and software
-  “works” for publication on PhysioNet.</p>
-<p>Unlike all other parts of the PhysioNet
-web site, access to PhysioNetWorks is password-protected. (Accounts can be obtained in a minute or two.)  PhysioNet Works provides
-reliable and secure web-accessible backup, tools for viewing and annotating
-your data interactively, and an active community of researchers
-around the world who can help you by annotating, analyzing, and reviewing your
-data, and perhaps by contributing additional relevant data. To learn more,
-start <a href="https://archive.physionet.org/users/">here</a>.</p></li> -->
 </ul>
 
 <p>

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -8,51 +8,45 @@
 <hr>
 
 <section id="resource">
-<h1>Research and Education</h1>
+<h1>A Community Resource</h1>
 
 <p>
 The PhysioNet resource, established in 1999, is intended to stimulate
 current research and new investigations in the study of complex biomedical
 and physiologic signals.  It has three closely interdependent components:</p>
 
-<ol>
+<ul>
 <li>
-<p><a href="https://archive.physionet.org/physiobank/database/"><strong>PhysioBank</strong></a> is a
-large and growing archive of well-characterized digital recordings of
+<p>An  <a href="{% url 'database_overview' %}">extensive archive</a> of well-characterized digital recordings of
 physiologic signals, time series, and related data for use by the biomedical
-  research community.</p>
-<p>PhysioBank includes collections of
+  research community. PhysioNet includes collections of
 cardiopulmonary, neural, and other biomedical signals
 from healthy subjects and patients with a variety of conditions with
 major public health implications, including sudden cardiac death,
 congestive heart failure, epilepsy, gait disorders, sleep apnea, and
 aging.  These collections include data from a wide range of studies,
   as developed and contributed by members of the research community.</p>
-<p>PhysioBank databases
-are made available under the <a href="http://opendatacommons.org/licenses/pddl/1.0/" target="other">
-  ODC Public Domain Dedication and License v1.0</a>.</p>
 </li>
 
 <li>
-<p><a href="https://archive.physionet.org/physiotools/index.shtml"><strong>PhysioToolkit</strong></a> is a large
-and growing library of software for physiologic signal processing and analysis,
+<p>A large and growing  <a href="{% url 'software_overview' %}">library of software</a> for physiologic signal processing and analysis,
 detection of physiologically significant events using both classical techniques
 and novel methods based on statistical physics and nonlinear dynamics,
 interactive display and characterization of signals, creation of new databases,
 simulation of physiologic and other signals, quantitative evaluation and
 comparison of analysis methods, and analysis of nonequilibrium and
   nonstationary processes.</p>
-<p>A unifying theme of many of the research projects that
-contribute software to PhysioToolkit is the extraction of “hidden”
-information from biomedical signals, information that may have diagnostic or
-prognostic value in medicine, or explanatory or predictive power in basic
-  research.</p>
-<p>All PhysioToolkit software is available in source form under the <a
-href="http://www.gnu.org/licenses/gpl.html" target="_blank">GNU General Public
-License (GPL)</a>. For information about the PhysioToolkit software, visit the
-<a href="https://archive.physionet.org//physiotools/software-index.shtml">PhysioTookit Software Index</a>.</p></li>
+</li>
 
 <li>
+<p>A  <a href="{% url 'tutorial_overview' %}">collection of popular tutorials and educational materials</a>,  offering expert guidance in approaches for exploring and analysing health data
+  and physiologic signals. A unifying theme for these resources 
+  is a focus on the extraction of “hidden” information from biomedical data, 
+  providing information that may have diagnostic or prognostic value in medicine, 
+  or explanatory or predictive power in basic research.</p>
+</li>
+
+<!-- <li>
 <p><a href="https://archive.physionet.org/users/"><strong>PhysioNetWorks</strong></a> is a virtual laboratory
 where you can work together with us and with colleagues anywhere in the world
 to create, evaluate, improve, document, and prepare new data and software
@@ -63,40 +57,29 @@ reliable and secure web-accessible backup, tools for viewing and annotating
 your data interactively, and an active community of researchers
 around the world who can help you by annotating, analyzing, and reviewing your
 data, and perhaps by contributing additional relevant data. To learn more,
-start <a href="https://archive.physionet.org/users/">here</a>.</p></li>
-</ol>
+start <a href="https://archive.physionet.org/users/">here</a>.</p></li> -->
+</ul>
 
 <p>
-<strong>PhysioNet</strong> is not only the name of
-the Resource, but also of its web site, <a href="https://physionet.org/">physionet.org</a>. The PhysioNet web site
-was established by the Resource as its mechanism for free and open
+PhysioNet is not only the name of
+the Resource, but also of its web site, <a href="https://physionet.org/">physionet.org</a>. The website was established by the Resource as its mechanism for free and open
 dissemination and exchange of recorded biomedical signals and open-source
 software for analyzing them, by providing facilities for cooperative analysis
 of data and evaluation of proposed new algorithms.  In addition to providing
-free electronic access to PhysioBank data and PhysioToolkit software, and
-secure workspaces for collaborative development of new data and software within
-PhysioNetWorks, the PhysioNet web site offers service and training via on-line
+free electronic access to data and software, the PhysioNet web site offers service and training via on-line
 tutorials to assist users at entry and more advanced levels.  In cooperation
 with the annual <a href=http://www.cinc.org/ target="other">Computing in
 Cardiology</a> conference, PhysioNet hosts an annual series
-of <a href="https://archive.physionet.org/challenge/">challenges</a>, in which researchers and students
+of <a href="{% url 'challenge_overview' %}">challenges</a>, in which researchers and students
 address unsolved problems of clinical or basic scientific interest using data
 and software provided by PhysioNet.</p>
 
 <p>
-All data included in PhysioBank, and all software included in PhysioToolkit,
-are carefully reviewed.  We invite you to participate in the ongoing review
-process.  By sharing common data sets, and software in source form, the
-research community benefits from access to materials that have been rigorously
+All data and software included in PhysioNet are carefully reviewed.  We invite you to participate in the ongoing review process.  By sharing common data sets, and software in source form, the research community benefits from access to materials that have been rigorously
 scrutinized by many investigators.  We further invite researchers to contribute
-data and software via PhysioNetWorks for review and possible inclusion in
-PhysioBank and PhysioToolkit.  Please review our
-<a href="https://archive.physionet.org/guidelines.shtml">guidelines for contributors</a> before submitting
+data and software for review and possible inclusion in our resource collection.  Please review our
+<a href="{% url 'about_publish' %}">guidelines for contributors</a> before submitting
 material.</p>
-
-<p>
-Links to a variety of other on-line resources likely to be of interest to
-PhysioNet visitors are listed <a href="https://archive.physionet.org/other-links.shtml">here</a>.</p>
 </section>
 
 <br>


### PR DESCRIPTION
The content at http://localhost:8000/about/ was copied from the old site for continuity, as requested. This pull request makes minor changes to the text and links to remove several back references to the archive site.