### PR TITLE
Fix the "share project" buttons on published projects

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -140,11 +140,11 @@
       <div class="card my-4">
         <h5 class="card-header">Share</h5>
         <div class="card-body">
-            <a class="btn btn-sm share-email sharebtn" href="mailto:?subject={{ project.title }}&body={{ page_url }}" target="_blank" role="button" title="Share with email"><i class="far fa-envelope"></i></a>
-            <a class="btn btn-sm facebook sharebtn" href="http://www.facebook.com/sharer.php?u={{ page_url }}" target="_blank" role="button" title="Share on Facebook"><i class="fab fa-facebook"></i></a>
-            <a class="btn btn-sm linkedin sharebtn" href="https://www.linkedin.com/shareArticle?url={{ page_url }}" target="_blank" role="button" title="Share on LinkedIn"><i class="fab fa-linkedin"></i></a>
-            <a class="btn btn-sm reddit sharebtn" href="https://www.reddit.com/submit?url={{ page_url }}&title={{ project.title }}" target="_blank" role="button" title="Share on Reddit"><i class="fab fa-reddit"></i></a>
-            <a class="btn btn-sm twitter sharebtn" href="https://twitter.com/intent/tweet?text={{ project.title }}. {{ page_url }}" target="_blank" role="button" title="Share on Twitter"><i class="fab fa-twitter"></i></a>
+            <a class="btn btn-sm share-email sharebtn" href="mailto:?subject={{ project.title|urlencode }}&body={{ request.build_absolute_uri }}" target="_blank" role="button" title="Share with email"><i class="far fa-envelope"></i></a>
+            <a class="btn btn-sm facebook sharebtn" href="http://www.facebook.com/sharer.php?u={{ request.build_absolute_uri }}" target="_blank" role="button" title="Share on Facebook"><i class="fab fa-facebook"></i></a>
+            <a class="btn btn-sm linkedin sharebtn" href="https://www.linkedin.com/shareArticle?url={{ request.build_absolute_uri }}" target="_blank" role="button" title="Share on LinkedIn"><i class="fab fa-linkedin"></i></a>
+            <a class="btn btn-sm reddit sharebtn" href="https://www.reddit.com/submit?url={{ request.build_absolute_uri }}&title={{ project.title|urlencode }}" target="_blank" role="button" title="Share on Reddit"><i class="fab fa-reddit"></i></a>
+            <a class="btn btn-sm twitter sharebtn" href="https://twitter.com/intent/tweet?text={{ project.title|urlencode }}. {{ request.build_absolute_uri }}" target="_blank" role="button" title="Share on Twitter"><i class="fab fa-twitter"></i></a>
         </div>
       </div>
 


### PR DESCRIPTION
Two minor changes:
- Add `urlencode` for `project.title` references where it occurs within a `href` (fixes w3c validation error)
- replace `page_url` with `request.build_absolute_uri` to get the full project url for sharing.