### PR TITLE
Enforce a strict ordering of authors at database level

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -30,7 +30,7 @@ class CorrespondingAuthorForm(forms.Form):
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.project = project
-        project_authors = project.authors.all()
+        project_authors = project.authors.all().order_by('display_order')
         self.fields['author'].queryset = project_authors
         self.fields['author'].initial = project_authors.get(is_corresponding=True)
         self.fields['author'].empty_label = None

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -419,7 +419,8 @@ class Metadata(models.Model):
             user = self.authors.get(is_submitting=True).user
             return user.email, user.get_full_name
         else:
-            users = [a.user for a in self.authors.all()]
+            authors = self.authors.all().order_by('display_order')
+            users = [a.user for a in authors]
             return ((u.email, u.get_full_name()) for u in users)
 
     def corresponding_author(self):
@@ -475,7 +476,8 @@ class Metadata(models.Model):
         content. Takes the selected license and fills in the year and
         copyright holder.
         """
-        author_names = ', '.join(a.get_full_name() for a in self.authors.all()) + '.'
+        authors = self.authors.all().order_by('display_order')
+        author_names = ', '.join(a.get_full_name() for a in authors) + '.'
 
         if fmt == 'text':
             content = self.license.text_content
@@ -807,7 +809,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             self.integrity_errors.append('Outstanding storage request')
 
         # Authors
-        for author in self.authors.all():
+        for author in self.authors.all().order_by('display_order'):
             if not author.get_full_name():
                 self.integrity_errors.append('Author {0} has not fill in name'.format(author.user.username))
             if not author.affiliations.all():
@@ -1280,12 +1282,13 @@ class PublishedProject(Metadata, SubmissionInfo):
         if self.is_legacy:
             return ''
 
+        authors = self.authors.all().order_by('display_order')
         if self.doi:
             return '{} ({}). {}. PhysioNet. doi:{}'.format(
-                ', '.join(a.initialed_name() for a in self.authors.all()),
+                ', '.join(a.initialed_name() for a in authors),
                 self.publish_datetime.year, self.title, self.doi)
         return '{} ({}). {}. PhysioNet.'.format(
-            ', '.join(a.initialed_name() for a in self.authors.all()),
+            ', '.join(a.initialed_name() for a in authors),
             self.publish_datetime.year, self.title)
 
     def remove(self, force=False):

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -161,7 +161,8 @@ class Author(BaseAuthor):
         on_delete=models.SET_NULL)
 
     class Meta:
-        unique_together = (('user', 'content_type', 'object_id',),)
+        unique_together = (('user', 'content_type', 'object_id',),
+                           ('display_order', 'content_type', 'object_id'))
 
     def get_full_name(self):
         """
@@ -211,7 +212,8 @@ class PublishedAuthor(BaseAuthor):
         related_name='authors', db_index=True, on_delete=models.CASCADE)
 
     class Meta:
-        unique_together = (('user', 'project'),)
+        unique_together = (('user', 'project'),
+                           ('display_order', 'project'))
 
     def get_full_name(self):
         return ' '.join([self.first_names, self.last_name])

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -997,7 +997,7 @@ def project_submission(request, project_slug, **kwargs):
                     notification.authors_approved_notify(request, project)
                 else:
                     messages.success(request, 'You have approved the publication of your project.')
-                authors = project.authors.all()
+                authors = project.authors.all().order_by('display_order')
             else:
                 messages.error(request, 'Invalid')
 


### PR DESCRIPTION
For each project, there should be an unambiguous order in which authors' names are displayed.  (Notwithstanding issue #369, we need to display them in some order... well, unless we go with averaging the ASCII values, I suppose.)

This should enforce that ordering at the database level.  Making this a separate pull request from #422 because it requires testing & applying a migration.
