### PR TITLE
"Decline" an invitation, don't "reject" it

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -17,9 +17,9 @@ from . import utility
 from . import validators
 
 
-RESPONSE_CHOICES = (
+INVITATION_CHOICES = (
     (1, 'Accept'),
-    (0, 'Reject')
+    (0, 'Decline')
 )
 
 class CorrespondingAuthorForm(forms.Form):
@@ -830,7 +830,7 @@ class InvitationResponseForm(forms.ModelForm):
     class Meta:
         model = AuthorInvitation
         fields = ('response',)
-        widgets = {'response':forms.Select(choices=RESPONSE_CHOICES)}
+        widgets = {'response': forms.Select(choices=INVITATION_CHOICES)}
 
     def clean(self):
         """


### PR DESCRIPTION
When a user receives an invitation to be a co-author, give them the option to "accept" or "decline" the invitation, not "accept" or "reject".  "Reject" is a very strong word that seems inappropriate in this context.
