### PR TITLE
Removes the "profile" link from the user menu

### DIFF
--- a/physionet-django/templates/navbar_content.html
+++ b/physionet-django/templates/navbar_content.html
@@ -45,9 +45,6 @@
         {% endif %}
         </a>
         <div class="dropdown-menu" aria-labelledby="nav_account_dropdown">
-          <a class="dropdown-item" href="{% url 'public_profile' user.username %}">
-            Profile
-          </a>
           <a class="dropdown-item" href="{% url 'user_settings' %}">
             Settings
           </a>
@@ -56,7 +53,6 @@
               Admin Console
             </a>
           {% endif %}
-          <hr>
           <a id="nav_logout" class="dropdown-item" href="{% url 'logout' %}">
             Logout
           </a>


### PR DESCRIPTION
The "settings" item in the user menu takes the user to the "edit profile" page. The "profile" item takes the user to the public profile. I find this a little confusing.

My suggestion is that we just remove the "profile" item from the menu (which this pull request does). 

If you don't like idea of doing this, then alternatives are: (1) we change the link item from "profile" to "public profile" (2) we link "profile" to the "edit profile" page.