### PR TITLE
Add ability to deprecate a published project's files

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -232,6 +232,13 @@ class DOIForm(forms.ModelForm):
         return data
 
 
+class DeprecateFilesForm(forms.Form):
+    """
+    For deprecating a project's files
+    """
+    delete_files = forms.ChoiceField(choices=YES_NO)
+
+
 class ProcessCredentialForm(forms.ModelForm):
     """
     Form to respond to a credential application

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -61,15 +61,44 @@
       <button class="btn btn-primary btn-fixed" name="set_doi" type="submit">Set DOI</button>
     </form>
     <br>
-    <h2>Special Files</h2>
+    <h2>Manage Files</h2>
     <hr>
-    <form action="" method="post">
-      {% csrf_token %}
-      <button class="btn btn-primary btn-fixed" name="make_checksum_file" type="submit">Make Checksum File</button>
-      <button class="btn btn-primary btn-fixed" name="make_zip" type="submit">Make Zip</button>
-    </form>
+    {% if project.deprecated_files %}
+      <p>This project's files are deprecated.</p>
+    {% else %}
+      <form action="" method="post">
+        {% csrf_token %}
+        <button class="btn btn-primary btn-fixed" name="make_checksum_file" type="submit">Make Checksum File</button>
+        <button class="btn btn-primary btn-fixed" name="make_zip" type="submit">Make Zip</button>
+        <button id="delete-items-button" type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#deprecate-files-modal">Deprecate Files</button>
+      </form>
+      {# Modal for deprecating files #}
+      <div class="modal fade" id="deprecate-files-modal" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="exampleModalLabel">Deprecate Files</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <form action="" method="post">
+              <div class="modal-body">
+                {% csrf_token %}
+                {{ deprecate_form }}
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-danger" name="deprecate_files" type="submit">Deprecate Files</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
     <br>
-    <h3>Google Cloud</h3>
+    <h2>Google Cloud</h2>
     <hr>
       {% if not has_credentials %}
         <p>You are missing the Google Cloud credentials.</p>

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -77,7 +77,7 @@
         <div class="modal-dialog" role="document">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title" id="exampleModalLabel">Deprecate Files</h5>
+              <h5 class="modal-title" id="exampleModalLabel">Deprecate Project Files</h5>
               <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
               </button>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -536,7 +536,7 @@ def manage_published_project(request, project_slug, version):
             deprecate_form = forms.DeprecateFilesForm(data=request.POST)
             if deprecate_form.is_valid():
                 project.deprecate_files(
-                    delete_files=deprecate_form.cleaned_data['delete_files'])
+                    delete_files=int(deprecate_form.cleaned_data['delete_files']))
                 messages.success(request, 'The project files have been deprecated.')
         elif 'bucket' in request.POST and has_credentials:
             slug = request.POST['bucket'].lower()

--- a/physionet-django/lightwave/views.py
+++ b/physionet-django/lightwave/views.py
@@ -131,7 +131,8 @@ def lightwave_server(request):
     """
     if request.GET['action'] == 'dblist':
         projects = PublishedProject.objects.filter(
-            has_wfdb=True, access_policy=0).order_by('title', '-version_order')
+            has_wfdb=True, access_policy=0, deprecated_files=False).order_by(
+            'title', '-version_order')
         dblist = '\n'.join(
             '{}/{}\t{}'.format(p.slug, p.version, p) for p in projects)
     else:

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -20,11 +20,9 @@ from django.utils.text import slugify
 
 from project.utility import (get_tree_size, get_file_info, get_directory_info,
                              list_items, StorageInfo, get_tree_files,
-                             list_files)
-
+                             list_files, clear_directory)
 from project.validators import (validate_doi, validate_subdir,
                                 validate_version, validate_slug)
-
 from user.validators import validate_alphaplus, validate_alphaplusplus
 from physionet.utility import zip_dir
 
@@ -1256,6 +1254,24 @@ class PublishedProject(Metadata, SubmissionInfo):
         # This should come last since it also zips the special files
         if make_zip:
             self.make_zip()
+
+    def remove_files(self):
+        """
+        Remove files of this project
+        """
+        clear_directory(self.file_root())
+        self.remove_zip()
+        self.set_storage_info()
+
+    def deprecate_files(self, delete_files):
+        """
+        Label the project's files as deprecated. Option of deleting
+        files.
+        """
+        self.deprecated_files = True
+        self.save()
+        if delete_files:
+            self.remove_files()
 
     def get_inspect_dir(self, subdir):
         """

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1002,7 +1002,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
 
         if self.core_project.publishedprojects.all() and len(previous_published_projects) > 0:
             for project in previous_published_projects:
-                if project.version > publiversionshed_project.version:
+                if project.version > published_project.version:
                     project.is_latest_version = True
                     published_project.is_latest_version = False
                     project.save()

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1004,7 +1004,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
 
         if self.core_project.publishedprojects.all() and len(previous_published_projects) > 0:
             for project in previous_published_projects:
-                if project.version > published_project.version:
+                if project.version > publiversionshed_project.version:
                     project.is_latest_version = True
                     published_project.is_latest_version = False
                     project.save()
@@ -1103,6 +1103,7 @@ class PublishedProject(Metadata, SubmissionInfo):
     compressed_storage_size = models.BigIntegerField(default=0)
     publish_datetime = models.DateTimeField(auto_now_add=True)
     has_other_versions = models.BooleanField(default=False)
+    deprecated_files = models.BooleanField(default=False)
     # doi = models.CharField(max_length=50, unique=True, validators=[validate_doi])
     # Temporary workaround
     doi = models.CharField(max_length=50, default='')
@@ -1112,6 +1113,7 @@ class PublishedProject(Metadata, SubmissionInfo):
     # Fields for legacy pb databases
     is_legacy = models.BooleanField(default=False)
     full_description = SafeHTMLField(default='')
+
     is_latest_version = models.BooleanField(default=True)
     # Featured content
     featured = models.BooleanField(default=False)
@@ -1286,8 +1288,11 @@ class PublishedProject(Metadata, SubmissionInfo):
 
     def has_access(self, user):
         """
-        Whether the user has access to this project
+        Whether the user has access to this project's files
         """
+        if self.deprecated_files:
+            return False
+
         if self.access_policy:
             if self.approved_users.filter(id=user.id):
                 return True

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -268,7 +268,7 @@
   <h2 id="files">Files</h2>
   {% if project.deprecated_files %}
     <div class="alert alert-danger col-md-8" role="alert">
-      The files of this project have been deprecated and are no longer available.
+      The files for this project are no longer available.
     </div>
   {% else %}
     {% if project.access_policy %}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -266,25 +266,31 @@
   {% endif %}
 
   <h2 id="files">Files</h2>
-  {% if project.access_policy %}
-    {% if has_access %}
-      <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% url 'serve_published_project_zip' project.slug project.version %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
+  {% if project.deprecated_files %}
+    <div class="alert alert-danger col-md-8" role="alert">
+      The files of this project have been deprecated and are no longer available.
+    </div>
+  {% else %}
+    {% if project.access_policy %}
+      {% if has_access %}
+        <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% url 'serve_published_project_zip' project.slug project.version %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
+        <div id="files-panel" class="card">
+          {% include "project/files_panel.html" %}
+        </div>
+      {% else %}
+      <div class="alert alert-danger col-md-8" role="alert">
+        This is a restricted-access resource. To access the files, you must {% if project.access_policy == 2 and not user.is_credentialed %}be a <a href="{% url 'edit_credentialing' %}">credentialed user</a> and {% endif %}<a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project.
+      </div>
+      {% endif %}
+    {% else %}
+      <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% static project.zip_url %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
+      {% if project.has_wfdb %}
+        <p><a href="{% url 'lightwave_home' %}?db={{ project.slug }}/{{ project.version }}" target="_blank"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
+      {% endif %}
       <div id="files-panel" class="card">
         {% include "project/files_panel.html" %}
       </div>
-    {% else %}
-    <div class="alert alert-danger col-md-8" role="alert">
-      This is a restricted-access resource. To access the files, you must {% if project.access_policy == 2 and not user.is_credentialed %}be a <a href="{% url 'edit_credentialing' %}">credentialed user</a> and {% endif %}<a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project.
-    </div>
     {% endif %}
-  {% else %}
-    <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% static project.zip_url %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
-    {% if project.has_wfdb %}
-      <p><a href="{% url 'lightwave_home' %}?db={{ project.slug }}/{{ project.version }}" target="_blank"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
-    {% endif %}
-    <div id="files-panel" class="card">
-      {% include "project/files_panel.html" %}
-    </div>
   {% endif %}
   <br>
 </div>

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -124,7 +124,12 @@ def remove_items(items):
             os.remove(item)
         elif os.path.isdir(item):
             shutil.rmtree(item)
-    return
+
+def clear_directory(directory):
+    """
+    Delete all files and folders in a directory.
+    """
+    remove_items(os.path.join(directory, i) for i in os.listdir(directory))
 
 def move_items(items, target_folder):
     """

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1116,6 +1116,8 @@ def published_files_panel(request, project_slug, version):
         return redirect('published_project', project_slug=project_slug,
             version=version)
 
+    subdir = request.GET['subdir']
+
     if project.has_access(request.user):
         (display_files, display_dirs, dir_breadcrumbs, parent_dir,
          file_error) = get_project_file_info(project=project, subdir=subdir)
@@ -1128,6 +1130,8 @@ def published_files_panel(request, project_slug, version):
              'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
              'display_files':display_files, 'display_dirs':display_dirs,
              'files_panel_url':files_panel_url, 'file_error':file_error})
+    else:
+        raise Http404()
 
 
 def serve_published_project_file(request, project_slug, version,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -11,24 +11,26 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import transaction
-from django.forms import formset_factory, inlineformset_factory, modelformset_factory
+from django.forms import (formset_factory, inlineformset_factory,
+    modelformset_factory)
 from django.http import HttpResponse, Http404, JsonResponse
 from django.shortcuts import render, redirect
 from django.template import loader
 from django.urls import reverse
 from django.utils import timezone
 
-from . import forms
-from .models import (Affiliation, Author, AuthorInvitation, ActiveProject,
-    PublishedProject, StorageRequest, Reference, ArchivedProject,
-    ProgrammingLanguage, Topic, Contact, Publication, PublishedAuthor, EditLog,
-    CopyeditLog, DUASignature, CoreProject, GCP)
-from . import utility
+from project import forms
+from project.models import (Affiliation, Author, AuthorInvitation,
+    ActiveProject, PublishedProject, StorageRequest, Reference,
+    ArchivedProject, ProgrammingLanguage, Topic, Contact, Publication,
+    PublishedAuthor, EditLog, CopyeditLog, DUASignature, CoreProject, GCP)
+from project import utility
 import notification.utility as notification
-import physionet.utility as physionet
+from physionet.utility import serve_file
 from user.forms import ProfileForm, AssociatedEmailChoiceForm
 from user.models import User
 from console.utility import add_email_bucket_access
+
 
 def project_auth(auth_mode=0, post_auth_mode=0):
     """
@@ -863,7 +865,7 @@ def serve_active_project_file(request, project_slug, file_name, **kwargs):
     """
     file_path = os.path.join(kwargs['project'].file_root(), file_name)
     try:
-        return physionet.serve_file(file_path)
+        return serve_file(file_path)
     except IsADirectoryError:
         return redirect(request.path + '/')
 
@@ -1147,7 +1149,7 @@ def serve_published_project_file(request, project_slug, version,
     if project.has_access(request.user):
         file_path = os.path.join(project.file_root(), full_file_name)
         try:
-            return physionet.serve_file(file_path)
+            return serve_file(file_path)
         except IsADirectoryError:
             return redirect(request.path + '/')
         except FileNotFoundError:
@@ -1168,7 +1170,7 @@ def serve_published_project_zip(request, project_slug, version):
         raise Http404()
     if project.has_access(request.user):
         try:
-            return physionet.serve_file(project.zip_name(full=True))
+            return serve_file(project.zip_name(full=True))
         except FileNotFoundError:
             raise Http404()
     raise PermissionDenied()

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1280,7 +1280,7 @@ def sign_dua(request, project_slug, version):
     else:
         raise Http404()
 
-    if not project.access_policy or project.has_access(user):
+    if project.deprecated_files or not project.access_policy or project.has_access(user):
         return redirect('published_project',
                         project_slug=project_slug, version=version)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1116,8 +1116,6 @@ def published_files_panel(request, project_slug, version):
         return redirect('published_project', project_slug=project_slug,
             version=version)
 
-    subdir = request.GET['subdir']
-
     if project.has_access(request.user):
         (display_files, display_dirs, dir_breadcrumbs, parent_dir,
          file_error) = get_project_file_info(project=project, subdir=subdir)

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -25,7 +25,7 @@
     </p>
     <p class="pub-details">Published: {{ published_project.publish_datetime|date }}.
       Version: {{ published_project.version }}</p>
-    {% if published_project.has_wfdb %}
+    {% if published_project.has_wfdb and not published_project.deprecated_files %}
     <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>
     {% endif %}
     <hr>


### PR DESCRIPTION
Added a new `deprecated_files` field for published projects. If True, the files are labelled as not accessible and will no longer be shown.

Importantly, the `has_access` method of the `PublishedProject` now also depends on that field.

In the manage published project view from the console, there is a button to deprecate a project's files. The dropdown allows you to optionally delete all the files too.

