### PR TITLE
Avoid breaking footer CSS in lightwave

### DIFF
--- a/physionet-django/lightwave/static/lightwave/css/lightwave.css
+++ b/physionet-django/lightwave/static/lightwave/css/lightwave.css
@@ -12,8 +12,6 @@ table, tbody, thead, tfoot {
 th, td {
 	padding: 0.25em;
 }
-.container { border:2px solid #ccc; width:90%; height: 100px;
-             overflow-y: scroll; }
 .dtable { table-layout: fixed; }
 div.notice { width: 90%; margin: auto; padding: 2em; background: #cdf; }
 #tabs {


### PR DESCRIPTION
This fixes half of issue #433, and avoids putting the footer into a scrolled box.

The other half of issue #433 (stretching content to fill window) needs more careful thought.
