### PR TITLE
Better "sticky footer"

### DIFF
--- a/physionet-django/lightwave/templates/lightwave/lw-bottom.html
+++ b/physionet-django/lightwave/templates/lightwave/lw-bottom.html
@@ -1,2 +1,4 @@
+</main>
 {% include "footer.html" %}
 {% include "base_js_bottom.html" %}
+</div>{# .flexbody #}

--- a/physionet-django/lightwave/templates/lightwave/lw-top.html
+++ b/physionet-django/lightwave/templates/lightwave/lw-top.html
@@ -1,3 +1,5 @@
+<div class="flexbody">
 {% include "navbar.html" %}
 <input type="hidden" name="default_server" value="{{ lightwave_server_url }}">
 <input type="hidden" name="default_scribe" value="{{ lightwave_scribe_url }}">
+<main>

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -294,12 +294,22 @@ a{
     border: unset;
 }
 
-.container{
-  padding: 40px 30px;
+.flexbody {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
 }
 
-body > .container{
-  min-height: calc(80% - 64px);
+.flexbody > * {
+  flex-shrink: 0;
+}
+
+.flexbody > main {
+  flex: 1 0 auto;
+}
+
+main {
+  margin: 1rem 0rem;
 }
 
 .row{

--- a/physionet-django/templates/base.html
+++ b/physionet-django/templates/base.html
@@ -1,4 +1,3 @@
-<!-- The base template used for the site -->
 <!DOCTYPE html>
 {% load static %}
 <html lang="en">

--- a/physionet-django/templates/base.html
+++ b/physionet-django/templates/base.html
@@ -13,15 +13,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
 
-  <body>
+  {% block body %}
+  <body class="flexbody">
     {% include "navbar.html" %}
 
-    {% block content %}{% endblock %}
+    <main>{% block content %}{% endblock %}</main>
 
     {% include 'footer.html' %}
 
     {% include "base_js_bottom.html" %}
     {% block local_js_bottom %}{% endblock %}
   </body>
-
+  {% endblock %}
 </html>

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -12,8 +12,11 @@ PhysioNet
 <link rel="stylesheet" type="text/css" href="{% static 'custom/css/home.css' %}"/>
 {% endblock %}
 
+{# avoid using flexbody style #}
+{% block body %}
+<body>
+  {% include "navbar.html" %}
 
-{% block content %}
   <div class="main-header">
     <div class="center">
       <h1>PhysioNet</h1>
@@ -71,5 +74,8 @@ PhysioNet
       <div class="more"><a class="btn btn-outline-dark" href="{% url 'news' %}">More news</a></div>
     </div>
   </div>
-  <!-- /.container -->
+
+  {% include "footer.html" %}
+  {% include "base_js_bottom.html" %}
+</body>
 {% endblock %}


### PR DESCRIPTION
Use the CSS3 flex property to allocate unused vertical space to the main content, instead of setting an ad-hoc min-height value.

(See https://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/ for more than you wanted to know about the flex property.)

Moreover, set rules on the 'main' element rather than overloading the 'container' class.

This should fix the remainder of issue #433.
