### PR TITLE
Add admin functionality to edit published projects and related items.

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -268,7 +268,7 @@ class TopicForm(forms.Form):
                     'numbers, spaces, underscores, and hyphens only, and '
                     'begin with a letter or number.')
 
-        self.topic_list = [t.lower() for t in topics]
+        self.topic_descriptions = [t.lower() for t in topics]
         return data
 
 

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -232,6 +232,46 @@ class DOIForm(forms.ModelForm):
         return data
 
 
+class TopicForm(forms.Form):
+    """
+    Form to set tags for a published project
+    """
+    topics = forms.CharField(required=False, max_length=800,
+        label='Comma delimited topics')
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+    def set_initial(self):
+        """
+        Set the initial topics char field from the project's existing
+        topics.
+        """
+        self.fields['topics'].initial = ','.join(
+            t.description for t in self.project.topics.all())
+
+    def clean_topics(self):
+        data = self.cleaned_data['topics']
+        # It is allowed to be blank, but not have multiple items
+        # that include a blank
+        if data == '':
+            return data
+
+        topics = data.split(',')
+        if len(topics) != len(set(topics)):
+            raise forms.ValidationError('Topics must be unique')
+
+        for t in topics:
+            if not re.fullmatch(r'[\w][\w\ -]*', t):
+                raise forms.ValidationError('Each topic must contain letters, '
+                    'numbers, spaces, underscores, and hyphens only, and '
+                    'begin with a letter or number.')
+
+        self.topic_list = [t.lower() for t in topics]
+        return data
+
+
 class DeprecateFilesForm(forms.Form):
     """
     For deprecating a project's files

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -258,7 +258,8 @@ class TopicForm(forms.Form):
         if data == '':
             return data
 
-        topics = data.split(',')
+        topics = [x.strip() for x in data.split(',')]
+
         if len(topics) != len(set(topics)):
             raise forms.ValidationError('Topics must be unique')
 

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -61,6 +61,15 @@
       <button class="btn btn-primary btn-fixed" name="set_doi" type="submit">Set DOI</button>
     </form>
     <br>
+
+    <h2>Manage Topics</h2>
+    <form action="" method="post">
+      {% csrf_token %}
+      {% include "form_snippet.html" with form=topic_form %}
+      <button class="btn btn-primary btn-fixed" name="set_topics" type="submit">Set Topics</button>
+    </form>
+    <br>
+
     <h2>Manage Files</h2>
     <hr>
     {% if project.deprecated_files %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -515,6 +515,8 @@ def manage_published_project(request, project_slug, version):
     user = request.user
     project = PublishedProject.objects.get(slug=project_slug, version=version)
     doi_form = forms.DOIForm(instance=project)
+    topic_form = forms.TopicForm(project=project)
+    topic_form.set_initial()
     deprecate_form = None if project.deprecated_files else forms.DeprecateFilesForm()
     has_credentials = os.path.exists(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
 
@@ -524,6 +526,13 @@ def manage_published_project(request, project_slug, version):
             if doi_form.is_valid():
                 doi_form.save()
                 messages.success(request, 'The DOI has been set')
+            else:
+                messages.error(request, 'Invalid submission. See form below.')
+        elif 'set_topics' in request.POST:
+            topic_form = forms.TopicForm(project=project, data=request.POST)
+            if topic_form.is_valid():
+                # Set the topics
+                messages.success(request, 'The topics have been set')
             else:
                 messages.error(request, 'Invalid submission. See form below.')
         elif 'make_checksum_file' in request.POST:
@@ -566,7 +575,7 @@ def manage_published_project(request, project_slug, version):
         {'project':project, 'authors':authors, 'author_emails':author_emails,
          'storage_info':storage_info, 'edit_logs':edit_logs,
          'copyedit_logs':copyedit_logs, 'latest_version':latest_version,
-         'published':True, 'doi_form':doi_form,
+         'published':True, 'doi_form':doi_form, 'topic_form':topic_form,
          'deprecate_form':deprecate_form, 'has_credentials':has_credentials})
 
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -531,6 +531,7 @@ def manage_published_project(request, project_slug, version):
         elif 'set_topics' in request.POST:
             topic_form = forms.TopicForm(project=project, data=request.POST)
             if topic_form.is_valid():
+                project.set_topics(topic_form.topic_descriptions)
                 # Set the topics
                 messages.success(request, 'The topics have been set')
             else:

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -587,7 +587,7 @@ def users(request):
     """
     List of users
     """
-    users = User.objects.all()
+    users = User.objects.all().order_by('username')
     return render(request, 'console/users.html', {'users':users})
 
 @login_required
@@ -597,7 +597,8 @@ def inactive_users(request):
     List of users
     """
     inactive_users = User.objects.filter(is_active=False) | User.objects.filter(
-        last_login__lt=timezone.now() + timezone.timedelta(days=-90))
+        last_login__lt=timezone.now() + timezone.timedelta(days=-90)).order_by(
+        'username')
 
     return render(request, 'console/users.html', {'users':inactive_users})
 
@@ -608,8 +609,7 @@ def admin_users(request):
     """
     List of users
     """
-    admin_users = User.objects.filter(is_admin=True)
-    users = User.objects.all()
+    admin_users = User.objects.filter(is_admin=True).order_by('username')
     return render(request, 'console/admin_users.html', {
         'admin_users':admin_users})
 

--- a/physionet-django/project/admin.py
+++ b/physionet-django/project/admin.py
@@ -11,24 +11,68 @@ class LicenseAdmin(admin.ModelAdmin):
     prepopulated_fields = {'slug': ('name',)}
 
 
-admin.site.register(models.Author)
-admin.site.register(models.AuthorInvitation)
-admin.site.register(models.CoreProject)
-admin.site.register(models.License, LicenseAdmin)
-admin.site.register(models.ActiveProject)
-admin.site.register(models.Reference)
-admin.site.register(models.PublishedProject)
-admin.site.register(models.PublishedTopic)
-admin.site.register(models.ProgrammingLanguage)
-admin.site.register(models.Topic)
-
-
-
-
 class LegacyProjectModelAdmin(admin.ModelAdmin):
     formfield_overrides = {
         CharField: {'widget': TextInput(attrs={'size':'200'})},
         TextField: {'widget': Textarea(attrs={'rows':4, 'cols':40})},
     }
 
+
+class PublishedPublicationInline(admin.TabularInline):
+    """
+    Used to add/edit the publication of a published project
+    """
+    model = models.PublishedPublication
+    max_num = 1
+
+
+class PublishedAuthorInline(admin.StackedInline):
+    """
+    Used to add/edit the authors of a published project
+    """
+    model = models.PublishedAuthor
+
+
+class ContactInline(admin.TabularInline):
+    """
+    Used to add/edit the contact of a published project
+    """
+    model = models.Contact
+
+
+class PublishedProjectAdmin(admin.ModelAdmin):
+    fields = ('title', 'abstract', 'background', 'methods',
+        'content_description', 'usage_notes', 'installation',
+        'acknowledgements', 'conflicts_of_interest', 'release_notes',
+        'short_description', 'project_home_page', 'doi')
+
+    readonly_fields = ('publish_datetime',)
+    inlines = [PublishedPublicationInline, ContactInline,
+        PublishedAuthorInline]
+    list_display = ('title', 'version', 'is_legacy', 'publish_datetime')
+
+
+class PublishedAffiliationInline(admin.TabularInline):
+    """
+    Used to add/edit affiliations of published authors
+    """
+    model = models.PublishedAffiliation
+    max_num = 3
+
+
+class PublishedAuthorAdmin(admin.ModelAdmin):
+    list_display = ('project', 'user')
+    inlines = [PublishedAffiliationInline]
+
+
+admin.site.register(models.ActiveProject)
+admin.site.register(models.AuthorInvitation)
+admin.site.register(models.CoreProject)
 admin.site.register(models.LegacyProject, LegacyProjectModelAdmin)
+admin.site.register(models.License, LicenseAdmin)
+admin.site.register(models.PublishedAuthor, PublishedAuthorAdmin)
+admin.site.register(models.PublishedProject, PublishedProjectAdmin)
+admin.site.register(models.PublishedTopic)
+admin.site.register(models.ProgrammingLanguage)
+admin.site.register(models.Reference)
+admin.site.register(models.Topic)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1396,11 +1396,11 @@ class PublishedProject(Metadata, SubmissionInfo):
         existing_descriptions = [t.description for t in self.topics.all()]
 
         # Add these topics
-        for td in set(topic_descriptions) - set(existing_descriptions)
+        for td in set(topic_descriptions) - set(existing_descriptions):
             self.add_topic(td)
 
         # Remove these topics
-        for td in set(existing_descriptions) - set(topic_descriptions)
+        for td in set(existing_descriptions) - set(topic_descriptions):
             self.remove_topic(td)
 
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -297,8 +297,8 @@ class Contact(models.Model):
     name = models.CharField(max_length=120)
     affiliations = models.CharField(max_length=150)
     email = models.EmailField(max_length=255)
-    project = models.ForeignKey('project.PublishedProject',
-        related_name='contacts', on_delete=models.CASCADE)
+    project = models.OneToOneField('project.PublishedProject',
+        related_name='contact', on_delete=models.CASCADE)
 
 
 class BasePublication(models.Model):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1223,7 +1223,7 @@ def published_project(request, project_slug, version, subdir=''):
     publication = project.publications.all().first()
     topics = project.topics.all()
     languages = project.programming_languages.all()
-    contact = Contact.objects.get(project=project)
+    contact = project.contact
     news = project.news.all().order_by('-publish_datetime')
     parent_projects = project.parent_projects.all()
     # derived_projects = project.derived_publishedprojects.all()


### PR DESCRIPTION
- The django admin panel (not the console we built) is now configured to be able to edit published projects and published authors correctly.
  - From a published_project, you can edit the relevant metadata, and its related publication, contact info, and set up to several authors. Unfortunately to set the affiliations of these authors, you'll have to go to the author object after you create it.
  - From the PublishedAuthor objects you create from the step above, you can directly set up to 3 affiliations.
- Refactor the code for tagging published projects. Call new functions in `ActiveProject.publish`
- Now in the `manage published project` page, there is a form to set comma separated topics for published projects. This both adds and deletes. To test this, open the published project, and open this in a new tab: http://127.0.0.1:8000/search/all-topics/ to check out the count, as you keep changing that comma delimited string.
