### PR TITLE
Fix lightwave resizing error

### DIFF
--- a/physionet-django/lightwave/static/lightwave/js/lightwave.js
+++ b/physionet-django/lightwave/static/lightwave/js/lightwave.js
@@ -1656,7 +1656,8 @@ function summarize(annotator) {
 
 // Handle browser window resize events
 function resize_lightwave() {
-    m = document.getElementById("viewport").getScreenCTM();
+    var vp = document.getElementById("viewport");
+    m = (vp ? vp.getScreenCTM() : null);
     set_sw_width(dt_sec);
     $('#helpframe').attr('height', $(window).height() - 180 + 'px');
     show_plot(); // redraw signal window if resized


### PR DESCRIPTION
Fix a (mostly harmless) error in lightwave when the window is resized (issue #435).
