### PR TITLE
Remove most uses of target=_blank

### DIFF
--- a/physionet-django/notification/templates/notification/news.html
+++ b/physionet-django/notification/templates/notification/news.html
@@ -28,7 +28,7 @@
           <div class="card-body">
             <ul class="list-unstyled mb-0">
               <li>
-                <a href="https://github.com/MIT-LCP/" target="_blank" style="text-decoration: none; color: #000000;"><i class="fab fa-github"></i> Github</a>
+                <a href="https://github.com/MIT-LCP/" style="text-decoration: none; color: #000000;"><i class="fab fa-github"></i> Github</a>
               </li>
             </ul>
           </div>

--- a/physionet-django/project/templates/project/project_license_preview.html
+++ b/physionet-django/project/templates/project/project_license_preview.html
@@ -8,7 +8,7 @@ License for {{ project }}
 
 {% block content %}
 <div class="container">
-  <h1 class="text-center">{{ license.name }} <a href="{{ license.home_page }}" target="_blank"><i class="fas fa-external-link-alt"></i></a></h1>
+  <h1 class="text-center">{{ license.name }} <a href="{{ license.home_page }}"><i class="fas fa-external-link-alt"></i></a></h1>
   <hr>
   {{ license_content|safe }}
   <br>

--- a/physionet-django/project/templates/project/project_overview.html
+++ b/physionet-django/project/templates/project/project_overview.html
@@ -28,7 +28,7 @@
 
 {% include "about/preparation_checklist.html" %}
 <p>The full publishing process is described in the
-   <a href="{% url 'about_publish' %}#guidelines" target="_blank"> author
+   <a href="{% url 'about_publish' %}#guidelines"> author
 guidelines</a>.</p>
 <hr>
 <h3>Quality Guidelines</h3>

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -16,6 +16,10 @@
 
 {% block content %}
 <div class="container">
+  <p><a class="btn btn-secondary"
+        href="{% url 'project_overview' project.slug %}" role="button">
+      <i class="fas fa-angle-left"></i> Return to project overview</a></p>
+
   {% if messages %}
     {% if passes_checks %}
       <div class="alert alert-success alert-dismissible">

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -83,7 +83,7 @@
 
     {% if publication %}
       <strong>In addition, please cite the original publication:</strong>
-      <p><a href="{{ publication.url }}" target="_blank">{{ publication.citation }}</a></p>
+      <p><a href="{{ publication.url }}">{{ publication.citation }}</a></p>
     {% endif %}
 
     <strong>Please also include the standard citation for PhysioNet:</strong>
@@ -141,7 +141,7 @@
             <strong>License (for files):</strong>
             <br>
             {% if project.license %}
-              <a href="{% url 'project_license_preview' project.slug %}" target="_blank">{{ project.license }}</a>
+              <a href="{% url 'project_license_preview' project.slug %}">{{ project.license }}</a>
             {% else %}
               <a style="color:red"><strong>* Required field missing</strong></a>
             {% endif %}
@@ -176,7 +176,7 @@
 
           {% if project.project_home_page %}
             <p><strong>Project Website:</strong><br>
-            <a href="{{ project.project_home_page }}" target="_blank"><i class="fas fa-external-link-alt"></i> {{ project.project_home_page }}</a>
+            <a href="{{ project.project_home_page }}"><i class="fas fa-external-link-alt"></i> {{ project.project_home_page }}</a>
             </p>
           {% endif %}
         </div>
@@ -198,7 +198,7 @@
   </div>
   <h2>Files</h2>
   {% if project.has_wfdb %}
-    <p><a href="{% url 'lightwave_project_home' project.slug %}?db={{ project.slug }}" target="_blank"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
+    <p><a href="{% url 'lightwave_project_home' project.slug %}?db={{ project.slug }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
   {% endif %}
   <div id="files-panel" class="card">
     {% include "project/files_panel.html" %}

--- a/physionet-django/project/templates/project/project_proofread.html
+++ b/physionet-django/project/templates/project/project_proofread.html
@@ -26,7 +26,7 @@
 {% endif %}
 <hr>
 <div class="btn-container-rsp">
-	<a id="view_preview" class="btn btn-primary btn-rsp" href="{% url 'project_preview' project.slug %}" role="button" target="_blank">View Project Preview</a>
+	<a id="view_preview" class="btn btn-primary btn-rsp" href="{% url 'project_preview' project.slug %}" role="button">View Project Preview</a>
 </div>
 
 {% endblock %}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -58,7 +58,7 @@
 
       {% if publication %}
         <strong>{% if project.is_legacy %}When using this resource{% else %}Additionally{% endif %}, please cite the original publication:</strong>
-        <p><a href="{{ publication.url }}" target="_blank">{{ publication.citation }}</a></p>
+        <p><a href="{{ publication.url }}">{{ publication.citation }}</a></p>
       {% endif %}
 
       <strong>Please include the standard citation for PhysioNet:</strong>
@@ -163,11 +163,11 @@
       <div class="card my-4">
         <h5 class="card-header">Share</h5>
         <div class="card-body">
-            <a class="btn btn-sm share-email sharebtn" href="mailto:?subject={{ project.title|urlencode }}&body={{ request.build_absolute_uri }}" target="_blank" role="button" title="Share with email"><i class="far fa-envelope"></i></a>
-            <a class="btn btn-sm facebook sharebtn" href="http://www.facebook.com/sharer.php?u={{ request.build_absolute_uri }}" target="_blank" role="button" title="Share on Facebook"><i class="fab fa-facebook"></i></a>
-            <a class="btn btn-sm linkedin sharebtn" href="https://www.linkedin.com/shareArticle?url={{ request.build_absolute_uri }}" target="_blank" role="button" title="Share on LinkedIn"><i class="fab fa-linkedin"></i></a>
-            <a class="btn btn-sm reddit sharebtn" href="https://www.reddit.com/submit?url={{ request.build_absolute_uri }}&title={{ project.title|urlencode }}" target="_blank" role="button" title="Share on Reddit"><i class="fab fa-reddit"></i></a>
-            <a class="btn btn-sm twitter sharebtn" href="https://twitter.com/intent/tweet?text={{ project.title|urlencode }}. {{ request.build_absolute_uri }}" target="_blank" role="button" title="Share on Twitter"><i class="fab fa-twitter"></i></a>
+            <a class="btn btn-sm share-email sharebtn" href="mailto:?subject={{ project.title|urlencode }}&body={{ request.build_absolute_uri }}" role="button" title="Share with email"><i class="far fa-envelope"></i></a>
+            <a class="btn btn-sm facebook sharebtn" href="http://www.facebook.com/sharer.php?u={{ request.build_absolute_uri }}" role="button" title="Share on Facebook"><i class="fab fa-facebook"></i></a>
+            <a class="btn btn-sm linkedin sharebtn" href="https://www.linkedin.com/shareArticle?url={{ request.build_absolute_uri }}" role="button" title="Share on LinkedIn"><i class="fab fa-linkedin"></i></a>
+            <a class="btn btn-sm reddit sharebtn" href="https://www.reddit.com/submit?url={{ request.build_absolute_uri }}&title={{ project.title|urlencode }}" role="button" title="Share on Reddit"><i class="fab fa-reddit"></i></a>
+            <a class="btn btn-sm twitter sharebtn" href="https://twitter.com/intent/tweet?text={{ project.title|urlencode }}. {{ request.build_absolute_uri }}" role="button" title="Share on Twitter"><i class="fab fa-twitter"></i></a>
         </div>
       </div>
 
@@ -182,7 +182,7 @@
           <p>
             <strong>License (for files):</strong>
             <br>
-            <a href="{% url 'published_project_license' project.slug project.version %}" target="_blank">{{ project.license }}</a>
+            <a href="{% url 'published_project_license' project.slug project.version %}">{{ project.license }}</a>
           </p>
         </div>
       </div>
@@ -192,7 +192,7 @@
           {% if project.doi %}
           <p><strong>DOI:</strong>
             <br>
-            <a href="http://dx.doi.org/{{ project.doi }}" target="_blank">{{ project.doi }}</a>
+            <a href="http://dx.doi.org/{{ project.doi }}">{{ project.doi }}</a>
           </p>
           {% endif %}
 
@@ -217,7 +217,7 @@
           {% if project.project_home_page %}
             <p><strong>Project Website:</strong>
               <br>
-              <a href="{{ project.project_home_page }}" target="_blank"><i class="fas fa-external-link-alt"></i> {{ project.project_home_page }}</a>
+              <a href="{{ project.project_home_page }}"><i class="fas fa-external-link-alt"></i> {{ project.project_home_page }}</a>
             </p>
           {% endif %}
         </div>
@@ -285,7 +285,7 @@
     {% else %}
       <p>Total uncompressed size: {{ main_size }}.{% if project.compressed_storage_size %}<a class="btn btn-success btn-sm btn-rsp" href="{% static project.zip_url %}" style="float:right">Download Zip ({{ compressed_size }})</a>{% endif %}</p>
       {% if project.has_wfdb %}
-        <p><a href="{% url 'lightwave_home' %}?db={{ project.slug }}/{{ project.version }}" target="_blank"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
+        <p><a href="{% url 'lightwave_home' %}?db={{ project.slug }}/{{ project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
       {% endif %}
       <div id="files-panel" class="card">
         {% include "project/files_panel.html" %}

--- a/physionet-django/project/templates/project/published_project_license.html
+++ b/physionet-django/project/templates/project/published_project_license.html
@@ -8,7 +8,7 @@ License for {{ project }}
 
 {% block content %}
 <div class="container">
-  <h1 class="text-center">{{ license.name }} <a href="{{ license.home_page }}" target="_blank"><i class="fas fa-external-link-alt"></i></a></h1>
+  <h1 class="text-center">{{ license.name }} <a href="{{ license.home_page }}"><i class="fas fa-external-link-alt"></i></a></h1>
   <hr>
   {{ license_content|safe }}
   <hr>

--- a/physionet-django/templates/about/about_content.html
+++ b/physionet-django/templates/about/about_content.html
@@ -733,34 +733,31 @@
 
   <h5 id="othertutorial">Other resources</h5>
   <ul>
-    <li><a
-href="http://ecg.bidmc.harvard.edu/"
-target="_blank">ECG Wave-Maven</a>.  This is a self-assessment program on
+    <li><a href="http://ecg.bidmc.harvard.edu/">ECG Wave-Maven</a>.
+This is a self-assessment program on
 interpretation of 12-lead diagnostic ECGs, with over 400 case studies.  Use the
 program to test your diagnostic abilities, or browse through the cases in
 reference mode.  <i>ECG Wave-Maven</i> was developed at Harvard Medical School
 and Boston's Beth Israel Deaconess Medical Center.  Its creators have written a
-<a href="http://www.med-ed-online.org/t0000030.htm" target="_blank">paper</a>
+<a href="http://www.med-ed-online.org/t0000030.htm">paper</a>
 describing the goals and technology behind the program, and a survey of its use
 during its first 17 months of operation.</li>
 
-<li><a href="http://ecg.utah.edu/" target="_blank">The Alan
+<li><a href="http://ecg.utah.edu/">The Alan
 E. Lindsay ECG Learning Center in Cyberspace</a>.  A comprehensive
 introduction to clinical electrocardiography, developed at LDS Hospital, Salt
 Lake City.</li>
 
-<li><a
-href="http://www.mpipks-dresden.mpg.de/~tisean/TISEAN_2.1/docs/tutorial/exercises.html"
-target="_blank">A guided tour through TISEAN: Exercises with data sets</a>.
+<li><a href="http://www.mpipks-dresden.mpg.de/~tisean/TISEAN_2.1/docs/tutorial/exercises.html">A
+guided tour through TISEAN: Exercises with data sets</a>.
 This tutorial introduces a large package of software for nonlinear time series
 analysis developed by Rainer Hegger, Holger Kantz, and Thomas Schreiber
 (Institut f&uuml;r Physikalische und Theoretische Chemie, Universit&auml;t
 Frankfurt (Main) and Max-Planck-Institut f&uuml;r Physik komplexer Systeme,
 Dresden).</li>
 
-<li><a href="http://www.openeering.com/scilab_tutorials"
-target="_blank">Openeering</a>.  This site offers tutorials on <a
-href="http://www.scilab.org/" target="_blank">Scilab</a> (an
+<li><a href="http://www.openeering.com/scilab_tutorials">Openeering</a>.
+This site offers tutorials on <a href="http://www.scilab.org/">Scilab</a> (an
 open-source programming environment developed at INRIA for "numerical
 computations in a user-friendly environment") and how to use it with
 PhysioBank data and PhysioToolkit software.  Scilab is similar to Matlab, but

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -1,7 +1,7 @@
 <section id="physionet">
   <h1>PhysioNet</h1>
   <br>
-  <p>PhysioNet is a unique resource for research and education, offering free access to large collections of physiological data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/" target="_blank">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. PhysioNet is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. For an overview of PhysioNet resources, see our <a href="{% url 'content_overview' %}">content overview</a> or search our content.</p>
+  <p>PhysioNet is a unique resource for research and education, offering free access to large collections of physiological data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. PhysioNet is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. For an overview of PhysioNet resources, see our <a href="{% url 'content_overview' %}">content overview</a> or search our content.</p>
 </section>
 
 <br>
@@ -98,12 +98,11 @@ scientists, physicists, mathematicians, biomedical researchers,
 clinicians, and educators at
 Boston's <a href="http://reylab.bidmc.harvard.edu/"
 target="_blank">Beth Israel Deaconess Medical
-Center</a>/<a href="http://www.med.harvard.edu" target="_blank">Harvard
-Medical School</a>, <a href="http://polymer.bu.edu/"
-target="_blank">Boston
+Center</a>/<a href="http://www.med.harvard.edu">Harvard
+Medical School</a>, <a href="http://polymer.bu.edu/">Boston
 University</a>, and <a href="http://www.medicine.mcgill.ca/physio/glasslab/"
-target="_blank" title="Prof. Leon Glass, of the Center for Nonlinear Dynamics at McGill University">McGill University</a>, all working together with the
-<a href="http://lcp.mit.edu/" target="_blank">MIT</a> group. Many of us
+title="Prof. Leon Glass, of the Center for Nonlinear Dynamics at McGill University">McGill University</a>, all working together with the
+<a href="http://lcp.mit.edu/">MIT</a> group. Many of us
 have worked together for 20 years or even longer on problems relating
 to characterizing and understanding the dynamics of human physiology,
 the implications of dynamical change in diagnosis and treatment of

--- a/physionet-django/templates/about/challenge_quality_guidelines.html
+++ b/physionet-django/templates/about/challenge_quality_guidelines.html
@@ -4,6 +4,6 @@
   <li>Any challenge files are provided in an open format.</li>
   <li>Any challenge files are machine readable.</li>
   <li>All the information needed for reuse is present.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html" target="_blank">protected health information</a> is contained.</li>
+  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
   <li>The content is suitable for PhysioNet.</li>
 </ul>

--- a/physionet-django/templates/about/citi_course.html
+++ b/physionet-django/templates/about/citi_course.html
@@ -11,7 +11,7 @@
   <p>In order to become a <a href="{% url 'edit_credentialing' %}">credentialed</a> PhysioNet user and access the restricted-access clinical databases, you must complete a suitable training program in human research subject protections and HIPAA regulations. We recommend the Collaborative Institutional Training Initiative (CITI) Program's “Data or Specimens Only Research” course. Follow the instructions below to access and complete the training course:</p>
 
   <ol>
-    <li>If your institution is affiliated with the CITI program, please log in to the CITI site using your institutional portal. Otherwise, visit the CITI program site: <a href="https://www.citiprogram.org/" target="_blank">https://www.citiprogram.org/</a>, create an account if you don’t already have one, and log in.</li>
+    <li>If your institution is affiliated with the CITI program, please log in to the CITI site using your institutional portal. Otherwise, visit the CITI program site: <a href="https://www.citiprogram.org/">https://www.citiprogram.org/</a>, create an account if you don’t already have one, and log in.</li>
     <li>Once you are logged in to the CITI site, open the tab “Click here to affiliate with another institution” and click on the link <em>(fig 1)</em>). Select your organizational affiliation as “Massachusetts Institute of Technology Affiliates”.</li>
     <li>After affiliating with MIT, follow the links to add a Massachusetts Institute of Technology Affiliates course <em>(fig 2)</em>. In the Human Subjects training category, select the “Data or Specimens Only Research” course <em>(fig 3)</em>. Answer the other questions as appropriate and submit the form.</li>
     <li>Complete the course. This may take a few hours.</li>

--- a/physionet-django/templates/about/data_quality_guidelines.html
+++ b/physionet-django/templates/about/data_quality_guidelines.html
@@ -4,6 +4,6 @@
   <li>The data files are provided in an open format.</li>
   <li>The data files are machine readable.</li>
   <li>All the information needed for reuse is present.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html" target="_blank">protected health information</a> is contained.</li>
+  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
   <li>The content is suitable for PhysioNet.</li>
 </ul>

--- a/physionet-django/templates/about/license_content.html
+++ b/physionet-django/templates/about/license_content.html
@@ -9,7 +9,7 @@ License Content
 
 {% block content %}
 <div class="container">
-  <h1 class="text-center">{{ license.name }} <a href="{{ license.home_page }}" target="_blank"><i class="fas fa-external-link-alt"></i></a></h1>
+  <h1 class="text-center">{{ license.name }} <a href="{{ license.home_page }}"><i class="fas fa-external-link-alt"></i></a></h1>
   <hr>
   {{ license.html_content|safe }}
   <br>

--- a/physionet-django/templates/about/licenses.html
+++ b/physionet-django/templates/about/licenses.html
@@ -7,7 +7,7 @@
 		<li>
 		  {{ license.name }}
       <br>
-      <a href="{% url 'license_content' license.slug %}">License</a> - <a href="{{ license.home_page }}" target="_blank">Home page <i class="fas fa-external-link-alt"></i></a>
+      <a href="{% url 'license_content' license.slug %}">License</a> - <a href="{{ license.home_page }}">Home page <i class="fas fa-external-link-alt"></i></a>
 		</li>
   	{% endfor %}
   	</ul>

--- a/physionet-django/templates/about/model_quality_guidelines.html
+++ b/physionet-django/templates/about/model_quality_guidelines.html
@@ -4,6 +4,6 @@
   <li>The model is provided in an open format.</li>
   <li>Files are machine readable.</li>
   <li>All the information needed for reuse is present.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html" target="_blank">protected health information</a> is contained.</li>
+  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
   <li>The content is suitable for PhysioNet.</li>
 </ul>

--- a/physionet-django/templates/about/software_content.html
+++ b/physionet-django/templates/about/software_content.html
@@ -77,7 +77,7 @@ formats</li>
 
 <h2>Other</h2>
 <ul>
-<li><a href="#chall" id="challnote">Physionet/CinC Challenge Software Archive</a>. Software contributions from successful entrants of past <a href="https://archive.physionet.org/challenge/" target="_blank">PhysioNet/CinC challenges</a>. The listed software has been successfully tested at least once during the year of the entry. Unless the link opens to a physiotoolkit page, the software is treated as an archive and is <b>not supported by Physionet</b>. Older challenges may have fewer or no contributions, but the rest of this software index page may contain relevant tools not directly contributed for the challenges.</li>
+<li><a href="#chall" id="challnote">Physionet/CinC Challenge Software Archive</a>. Software contributions from successful entrants of past <a href="https://archive.physionet.org/challenge/">PhysioNet/CinC challenges</a>. The listed software has been successfully tested at least once during the year of the entry. Unless the link opens to a physiotoolkit page, the software is treated as an archive and is <b>not supported by Physionet</b>. Older challenges may have fewer or no contributions, but the rest of this software index page may contain relevant tools not directly contributed for the challenges.</li>
 <li><a href="#misc">Miscellaneous software</a>. Build shell scripts (batch files) using these mini-applications</li>
 </ul>
 
@@ -1225,7 +1225,7 @@ a Matlab interface to the WFDB library</a></td>
 
 
 <tr><td><a href="https://archive.physionet.org/challenge/2008/">2008</a></td>
-<td><a href="https://archive.physionet.org/challenge/2008/sources/" onclick="window.open('https://physionet.org/physiotools/TWAnalyser/')" target="_blank">Contributions</a></td>
+<td><a href="https://archive.physionet.org/challenge/2008/sources/" onclick="window.open('https://physionet.org/physiotools/TWAnalyser/')">Contributions</a></td>
 <td>Detecting and quantifying T-wave alternans.</td>
 </tr>
 

--- a/physionet-django/templates/about/software_quality_guidelines.html
+++ b/physionet-django/templates/about/software_quality_guidelines.html
@@ -2,7 +2,7 @@
   <li>The project follows good practice in software development.</li>
   <li>The software is adequately described.</li>
   <li>The software is provided in an open format.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html" target="_blank">protected health information</a> is contained.</li>
+  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
   <li>All the information needed for reuse is present.</li>
   <li>The content is suitable for PhysioNet.</li>
 </ul>

--- a/physionet-django/templates/about/timeline.html
+++ b/physionet-django/templates/about/timeline.html
@@ -64,7 +64,7 @@ PhysioNet Timeline
                 <h4 class="subheading">Computing in Cardiology</h4>
               </div>
               <div class="timeline-body">
-                <p>Members of the PhysioNet team at MIT were preparing to host <a href="http://www.cinc.org/" target="_blank">Computing in Cardiology</a> 2000, and created the first PhysioNet/CinC Challenge to be launched as part of that meeting. They hoped to introduce PhysioNet to international colleagues, by encouraging participation in an activity that made effective use of PhysioNet's resources to stimulate rapid progress on an unsolved problem of practical clinical significance. More than a dozen teams participated in the challenge of detecting sleep apnea from the ECG alone, and an <a href="#">annual tradition</a> was born.</p>
+                <p>Members of the PhysioNet team at MIT were preparing to host <a href="http://www.cinc.org/">Computing in Cardiology</a> 2000, and created the first PhysioNet/CinC Challenge to be launched as part of that meeting. They hoped to introduce PhysioNet to international colleagues, by encouraging participation in an activity that made effective use of PhysioNet's resources to stimulate rapid progress on an unsolved problem of practical clinical significance. More than a dozen teams participated in the challenge of detecting sleep apnea from the ECG alone, and an <a href="#">annual tradition</a> was born.</p>
               </div>
             </div>
           </li>
@@ -78,7 +78,7 @@ PhysioNet Timeline
                 <h4 class="subheading">New Web Platform</h4>
               </div>
               <div class="timeline-body">
-                <p>New members of the LCP build a modernized, dynamic PhysioNet platform using <a href="https://www.djangoproject.com/" target="_blank">Django</a>. <a href="https://github.com/MIT-LCP/physionet-build/" target="_blank">Development</a> is continually ongoing to improve the site's capabilities.</p>
+                <p>New members of the LCP build a modernized, dynamic PhysioNet platform using <a href="https://www.djangoproject.com/">Django</a>. <a href="https://github.com/MIT-LCP/physionet-build/">Development</a> is continually ongoing to improve the site's capabilities.</p>
               </div>
             </div>
           </li>

--- a/physionet-django/templates/about/tutorial_content.html
+++ b/physionet-django/templates/about/tutorial_content.html
@@ -253,7 +253,7 @@ materials:
 Books describing the major components of
 <a href="http://archive.physionet.org/physiotools/">PhysioToolkit</a> are also available here.
 Printed copies of some of these books may be purchased from
-the <a href="http://www.lulu.com/spotlight/physionet/" target="_blank">PhysioNet
+the <a href="http://www.lulu.com/spotlight/physionet/">PhysioNet
 Bookstore</a>.  These books incorporate both tutorial and reference
 material:</p>
 <ul>
@@ -318,11 +318,11 @@ interpretation of 12-lead diagnostic ECGs, with over 400 case studies.  Use the
 program to test your diagnostic abilities, or browse through the cases in
 reference mode.  ECG Wave-Maven was developed at Harvard Medical School
 and Boston's Beth Israel Deaconess Medical Center.  Its creators have written a
-<a href="http://www.med-ed-online.org/t0000030.htm" target="_blank">paper</a>
+<a href="http://www.med-ed-online.org/t0000030.htm">paper</a>
 describing the goals and technology behind the program, and a survey of its use
 during its first 17 months of operation.</li>
 
-<li><a href="http://ecg.utah.edu/" target="_blank">The Alan
+<li><a href="http://ecg.utah.edu/">The Alan
 E. Lindsay ECG Learning Center in Cyberspace</a>.  A comprehensive
 introduction to clinical electrocardiography, developed at LDS Hospital, Salt
 Lake City.</li>

--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -72,7 +72,7 @@ Profile for {{ public_user.username }}
             Website:
           </div>
           <div class="col-md-10">
-            <a href="{{ profile.website }}" target="_blank" rel="nofollow">{{ profile.website }}</a>
+            <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
This started out with me being irritated that when I want to edit a project, and also see a preview of the result in a separate tab:
 - I'm viewing /projects/hgiavnfvklg/metadata/ (tab #1)
 - I middle-click the "Proofread" button, which opens /projects/hgiavnfvklg/proofread/ in tab #2
 - I click the "View Project Preview" button, which opens /projects/hgiavnfvklg/preview/ in tab #3
Tab #2 is completely worthless and only serves to get in my way.

But in any case, target=_blank is an annoyance in general.  Most web browsers give you a way to open a link in a new tab/window if that's what you want to do.  Most browsers *don't* give you a way to open a link in the current tab/window if target=_blank is specified.

I've left alone pages in the console, which users don't see and I don't much care about for now; and I've left alone links on some pages with complex forms, where clicking the link might result in data loss.  (target=_blank is still probably not the best way to deal with this issue.  And note that the prime example - the Metadata page - doesn't follow this pattern.)
