### PR TITLE
Fix username and training_report URL in credential console

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -1,6 +1,30 @@
+{# Status section #}
+
+<p><strong>Status:</strong><br>
 Application Date: {{ application.application_datetime|date }}<br>
 
-User: <a href="{% url 'public_profile' user.username %}">{{ user }}</a><br>
+{% if application.reference_contact_datetime %}
+  Reference Contact Date: {{ application.reference_contact_datetime|date }}<br>
+  {% if application.reference_response_datetime %}
+    Reference Response Date: {{ application.reference_response_datetime|date }}<br>
+    Reference Verified: {{ application.get_reference_response_display }}<br>
+  {% endif %}
+{% endif %}
+
+{% if application.decision_datetime %}
+  Decision Date: {{ application.decision_datetime|date }}<br>
+{% endif %}
+
+Decision: {% if application.status %}{{ application.get_status_display }}{% else %}<i class="fas fa-clock"></i> Pending{% endif %}<br>
+
+{% if application.responder_comments %}
+  Admin Comments:<br> {{ application.responder_comments|linebreaks }}<br>
+{% endif %}</p>
+
+{# Personal details #}
+
+<p><strong>Personal details:</strong><br>
+User: <a href="{% url 'public_profile' application.user.username %}">{{ application.user.username }}</a><br>
 
 First Names: {{ application.first_names }}<br>
 
@@ -18,6 +42,10 @@ Country: {{ application.get_country_display }}<br>
 
 {% if application.webpage %}Webpage: <a href="{{ application.webpage }}" target="_blank">{{ application.webpage }}</a><br>{% endif %}
 
+{# Training #}
+
+<p><strong>Training:</strong><br>
+
 Training Course Name: {{ application.training_course_name }}<br>
 
 Training Completion Date: {{ application.training_completion_date }}<br>
@@ -28,7 +56,11 @@ Course Category: {{ application.get_course_category_display }}<br>
 
 {% if application.course_info %}
   Course Info: {{ application.course_info }}<br>
-{% endif %}
+{% endif %}</p>
+
+{# Reference #}
+
+<p><strong>Reference:</strong><br>
 
 Reference Category: {{ application.get_reference_category_display }}<br>
 
@@ -36,26 +68,4 @@ Reference Name: {{ application.reference_name }}<br>
 
 Reference Email: {{ application.reference_email }}<br>
 
-Reference Title: {{ application.reference_title }}<br>
-
-{% if application.reference_contact_datetime %}
-
-  Reference Contact Date: {{ application.reference_contact_datetime|date }}<br>
-
-  {% if application.reference_response_datetime %}
-    Reference Response Date: {{ application.reference_response_datetime|date }}<br>
-    Reference Verified: {{ application.get_reference_response_display }}<br>
-  {% endif %}
-
-{% endif %}
-
-{% if application.decision_datetime %}
-  Decision Date: {{ application.decision_datetime|date }}<br>
-{% endif %}
-<hr>
-Decision: {% if application.status %}{{ application.get_status_display }}{% else %}<i class="fas fa-clock"></i> Pending{% endif %}<br>
-
-{% if application.responder_comments %}
-  Admin Comments:<br>
-  {{ application.responder_comments|linebreaks }}<br>
-{% endif %}
+Reference Title: {{ application.reference_title }}</p>

--- a/physionet-django/console/templates/console/complete_credential_applications.html
+++ b/physionet-django/console/templates/console/complete_credential_applications.html
@@ -28,15 +28,15 @@
             </thead>
             <tbody>
             {% for application in applications %}
-              <tr class="header" id='application_{{application.user.email}}'>
+              <tr class="header" id='application_{{ application.user.email }}'>
                 <td>{{forloop.counter}}</td>
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'public_profile' application.user.username %}">{{ application.user.username }}</td>
                 <td>{{ application.user.get_full_name }}</td>
                 <td>{{ application.user.email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
                 <td>{{ application.reference_contact_datetime|date }}</td>
                 <td>{{ application.reference_response_datetime|date }}</td>
-                <td><a href="#application_{{application.id}}">Process</a></td>
+                <td><a href="#application_{{ application.id }}">Process</a></td>
               </tr>
             {% endfor %}
             </tbody>
@@ -45,7 +45,7 @@
         {% for application in applications %}
           <div class="card mb-4">
             <div class="card-header">
-              <h1 style='font-size:25px;' id='application_{{application.id}}'>Process Credential Application - {{ application.user.get_full_name }}</h1>
+              <h1 style='font-size:25px;' id='application_{{ application.id }}'>Process Credential Application - {{ application.user.get_full_name }}</h1>
             </div>
             <div class="card-body">
               <div class='mb-2'>
@@ -79,7 +79,7 @@
                               <p>The reference has not been contacted.</p>
                               <form action="" method="post" class="form-signin">
                               {% csrf_token %}
-                                <button class="btn btn-primary btn-lg" name="contact_reference" value="{{application.id}}" type="submit">Contact Reference</button>
+                                <button class="btn btn-primary btn-lg" name="contact_reference" value="{{ application.id }}" type="submit">Contact Reference</button>
                               </form>
                             {% endif %}
                             {# Reference already responded #}
@@ -100,7 +100,7 @@
                             <form action="" method="post" class="form-signin">
                               {% csrf_token %}
                               {% include "form_snippet.html" with form=process_credential_form %}
-                              <button class="btn btn-primary btn-lg" name="process_application" value="{{application.id}}" type="submit">Submit Response</button>
+                              <button class="btn btn-primary btn-lg" name="process_application" value="{{ application.id }}" type="submit">Submit Response</button>
                             </form>
                           </div>
                         </div>

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -618,7 +618,7 @@ class CredentialApplication(models.Model):
         (2, 'Accept')
     )
 
-    # Where the applications' files are kept
+    # Location for storing files associated with the application
     FILE_ROOT = os.path.join(settings.MEDIA_ROOT, 'credential-applications')
 
     slug = models.SlugField(max_length=20, unique=True, db_index=True)
@@ -676,7 +676,7 @@ class CredentialApplication(models.Model):
         blank=True)
 
     def file_root(self):
-        "Where the application's files are stored"
+        """Location for storing files associated with the application"""
         return os.path.join(CredentialApplication.FILE_ROOT, self.slug)
 
     def get_full_name(self):

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -410,9 +410,18 @@ def training_report(request, application_slug):
     """
     Serve a training report file
     """
-    application = CredentialApplication.objects.get(slug=application_slug)
+    try:
+        application = CredentialApplication.objects.get(slug=application_slug)
+    except ObjectDoesNotExist:
+        raise Http404()
+
     if request.user == application.user or request.user.is_admin:
-        return utility.serve_file(request, application.training_completion_report.path)
+        try:
+            return utility.serve_file(application.training_completion_report.path)
+        except FileNotFoundError:
+            raise Http404()
+
+    raise PermissionDenied()
 
 
 # @login_required


### PR DESCRIPTION
Fixes a couple of issues with the credentialing form on the admin console:
- correctly display the username of the applicant.
- fix the url of the completion report.

Also reorganizes the template slightly to:
- display headers for the content (status; personal details; training etc).
- moves status information to the top of the card.