### PR TITLE
fixed news for a empty year or random number in url

### DIFF
--- a/physionet-django/notification/views.py
+++ b/physionet-django/notification/views.py
@@ -4,6 +4,8 @@ from django.db.models import Min, Max
 
 from .models import News
 
+from datetime import date
+
 def news(request, max_items=20):
     """
     Redirect to news for current year
@@ -24,10 +26,14 @@ def news(request, max_items=20):
 
 
 def news_year(request, year):
+    """
+    Get all the news of a specific year
+    """
+    if int(year) < 1999 or int(year) > date.today().year:
+        return redirect('news')
+
     news_pieces = News.objects.filter(publish_datetime__year=int(year)) \
                               .order_by('-publish_datetime')
-    if not news_pieces:
-        return redirect('news')
 
     minmax = News.objects.all().aggregate(min=Min('publish_datetime'),
                                           max=Max('publish_datetime'))

--- a/physionet-django/notification/views.py
+++ b/physionet-django/notification/views.py
@@ -4,7 +4,6 @@ from django.db.models import Min, Max
 
 from .models import News
 
-
 def news(request, max_items=20):
     """
     Redirect to news for current year
@@ -14,7 +13,11 @@ def news(request, max_items=20):
     # The year range of all the PN news in existence.
     minmax = News.objects.all().aggregate(min=Min('publish_datetime'),
                                           max=Max('publish_datetime'))
-    news_years = list(range(minmax['max'].year, minmax['min'].year-1, -1))
+    if news_pieces:
+        news_years = list(range(minmax['max'].year, minmax['min'].year-1, -1))
+    else:
+        news_years = news_pieces
+
     return render(request, 'notification/news.html',
                   {'year': 'Latest', 'news_pieces': news_pieces,
                    'news_years': news_years})
@@ -23,6 +26,8 @@ def news(request, max_items=20):
 def news_year(request, year):
     news_pieces = News.objects.filter(publish_datetime__year=int(year)) \
                               .order_by('-publish_datetime')
+    if not news_pieces:
+        return redirect('news')
 
     minmax = News.objects.all().aggregate(min=Min('publish_datetime'),
                                           max=Max('publish_datetime'))


### PR DESCRIPTION
Fixes broken page when a person types a year that doesn't exist in the news url and redirects to latest news year.