### PR TITLE
Fix share page breaking in resized window

### DIFF
--- a/physionet-django/templates/about/publish.html
+++ b/physionet-django/templates/about/publish.html
@@ -9,7 +9,6 @@ Publish
 
 {% block local_css %}
 <link rel="stylesheet" type="text/css" href="{% static 'custom/css/publish.css' %}">
-<link rel="stylesheet" type="text/css" href="{% static 'custom/css/settings.css' %}"/>
 {% endblock %}
 
 


### PR DESCRIPTION
Removes unused css that was breaking the page when it was resized. 