### PR TITLE
Add autocomplete when selecting parent projects

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -29,6 +29,8 @@ SECRET_KEY = config('SECRET_KEY')
 # Application definition
 
 INSTALLED_APPS = [
+    'dal',
+    'dal_select2',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -17,6 +17,8 @@ from project.models import (Affiliation, Author, AuthorInvitation, ActiveProject
 from project import utility
 from project import validators
 
+from dal import autocomplete
+
 
 INVITATION_CHOICES = (
     (1, 'Accept'),
@@ -529,7 +531,7 @@ class DiscoveryForm(forms.ModelForm):
         required=False)
     parent_projects = forms.ModelMultipleChoiceField(
         queryset=PublishedProject.objects.all().order_by(Lower('title'),
-        'version_order'), widget=forms.SelectMultiple(attrs={'size':'10'}),
+        'version_order'), widget=autocomplete.ModelSelect2Multiple(url='project-autocomplete'),
         help_text='The existing PhysioNet project(s) this resource was derived from. Hold ctrl to select multiple.',
         required=False)
 

--- a/physionet-django/project/templates/project/metadata_inline_form_snippet.html
+++ b/physionet-django/project/templates/project/metadata_inline_form_snippet.html
@@ -26,3 +26,4 @@
 {% for field in form.hidden_fields %}
   {{ field }}
 {% endfor %}
+{{ form.media }}

--- a/physionet-django/project/urls.py
+++ b/physionet-django/project/urls.py
@@ -19,6 +19,9 @@ urlpatterns = [
         views.published_submission_history,
         name='published_submission_history'),
 
+    path('project-autocomplete/', views.ProjectAutocomplete.as_view(),
+        name='project-autocomplete'),
+
     # Individual project pages
     path('<project_slug>/', views.project_overview_redirect,
         name='project_overview_redirect'),

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -31,6 +31,8 @@ from user.forms import ProfileForm, AssociatedEmailChoiceForm
 from user.models import User
 from console.utility import add_email_bucket_access
 
+from dal import autocomplete
+
 
 def project_auth(auth_mode=0, post_auth_mode=0):
     """
@@ -691,6 +693,16 @@ def project_discovery(request, project_slug, **kwargs):
          'publication_formset':publication_formset,
          'topic_formset':topic_formset, 'add_item_url':edit_url,
          'remove_item_url':edit_url, 'is_submitting':is_submitting})
+
+
+class ProjectAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        qs = PublishedProject.objects.all()
+
+        if self.q:
+            qs = qs.filter(title__icontains=self.q)
+
+        return qs
 
 
 def get_file_forms(project, subdir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sqlparse==0.2.4
 zxcvbn-python==4.4.18
 google-cloud-storage==1.14.0
 uWSGI==2.0.18
+django-autocomplete-light==3.3.4


### PR DESCRIPTION
- pip package `django-autocomplete-light` is required
- `dal` and `dal_select2` dependencies added to settings
- Adds `projects/project-autocomplete/` url which serves a json of published projects
- The `Parent Projects` field in the `Project Discovery` section when submitting a project now uses autocomplete #452 