### PR TITLE
Altered error for urls with @ to 404

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -2,7 +2,6 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
-from django.http import Http404
 
 def validate_filename(value):
     """
@@ -35,8 +34,6 @@ def validate_subdir(value):
     or empty. No consecutive dots or fwd slashes.
     """
     if not re.fullmatch(r'[\w\-\./]*', value) or '..' in value or value.startswith('/') or '//' in value:
-        if '@' in value:
-            raise Http404()
         raise ValidationError('Invalid path')
 
 

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -2,7 +2,7 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
-
+from django.http import Http404
 
 def validate_filename(value):
     """
@@ -35,6 +35,8 @@ def validate_subdir(value):
     or empty. No consecutive dots or fwd slashes.
     """
     if not re.fullmatch(r'[\w\-\./]*', value) or '..' in value or value.startswith('/') or '//' in value:
+        if '@' in value:
+            raise Http404()
         raise ValidationError('Invalid path')
 
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -9,7 +9,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import (ObjectDoesNotExist, PermissionDenied,
+    ValidationError)
 from django.db import transaction
 from django.forms import (formset_factory, inlineformset_factory,
     modelformset_factory)
@@ -733,6 +734,8 @@ def get_project_file_info(project, subdir):
         file_error = 'Directory not found'
     except OSError:
         file_error = 'Unable to read directory'
+    except ValidationError:
+        raise Http404()
 
     # Breadcrumbs
     dir_breadcrumbs = utility.get_dir_breadcrumbs(subdir)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -730,12 +730,10 @@ def get_project_file_info(project, subdir):
         display_files, display_dirs = project.get_directory_content(
             subdir=subdir)
         file_error = None
-    except FileNotFoundError:
+    except (FileNotFoundError, ValidationError):
         file_error = 'Directory not found'
     except OSError:
         file_error = 'Unable to read directory'
-    except ValidationError:
-        raise Http404()
 
     # Breadcrumbs
     dir_breadcrumbs = utility.get_dir_breadcrumbs(subdir)


### PR DESCRIPTION
Altered the error for invalid paths.
If the path contains a `@` it will return a 404 error instead of a 500 Invalid path.  