### PR TITLE
Update django-ckeditor to 5.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bleach==3.1.0
 coverage==4.4.2
 Django==2.1.7
 django-background-tasks==1.2.0
-django-ckeditor==5.6.1
+django-ckeditor==5.7.1
 django-debug-toolbar==1.9.1
 django-js-asset==0.1.1
 djangorestframework==3.9.1


### PR DESCRIPTION
Update the django-ckeditor package to version 5.7.1, which includes CKEditor version 4.11.4.
