### PR TITLE
Fix author order in content list pages

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -435,6 +435,12 @@ class Metadata(models.Model):
     def submitting_author(self):
         return self.authors.get(is_submitting=True)
 
+    def author_list(self):
+        """
+        Get the project's authors in the correct display order.
+        """
+        return self.authors.all().order_by('display_order')
+
     def get_author_info(self, separate_submitting=False, include_emails=False):
         """
         Get the project's authors, setting information needed to display

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -8,7 +8,7 @@
     <h2><a href="{% url 'published_project' published_project.slug published_project.version %}" style="word-wrap: break-word;">{{ published_project.title }}</a></h2>
     {% if not published_project.is_legacy %}
       <p class="text-muted">
-          {% for author in published_project.authors.all %}
+          {% for author in published_project.author_list %}
           {{ author.get_full_name }}{% if not forloop.last %}, {% endif %}
           {% endfor %}
       </p>


### PR DESCRIPTION
Display authors in the correct order on the front page and search page.

This should finally fix issue #419.
