### PR TITLE
Stricter filename validation, and warning messages

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -144,8 +144,8 @@ class CreateFolderForm(ActiveProjectFilesForm):
     """
     Form for creating a new folder in a directory
     """
-    folder_name = forms.CharField(max_length=50, required=False,
-        validators=[validators.validate_filename])
+    folder_name = forms.CharField(max_length=validators.MAX_FILENAME_LENGTH,
+        required=False, validators=[validators.validate_filename])
 
     def clean(self):
         """
@@ -204,8 +204,8 @@ class RenameItemForm(EditItemsForm):
     """
     # The name is 'items' to override the parent class field.
     items = forms.ChoiceField(required=False)
-    new_name = forms.CharField(max_length=50, required=False,
-        validators=[validators.validate_filename])
+    new_name = forms.CharField(max_length=validators.MAX_FILENAME_LENGTH,
+        required=False, validators=[validators.validate_filename])
 
     field_order = ['subdir', 'items', 'new_name']
 

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -30,6 +30,13 @@
         </div>
       </div>
       {% else %}
+        {% if file_warning %}
+          <div class="card-body">
+            <div class="alert alert-warning" role="alert">
+              {{ file_warning|safe }}
+            </div>
+          </div>
+        {% endif %}
       <table class="files-panel">
         <col class="files-panel-name"></col>
         <col class="files-panel-size"></col>

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -24,8 +24,10 @@
         {% endspaceless %}
       </div>
       {% if file_error %}
-      <div class="alert alert-danger col-md-8" role="alert">
-        {{ file_error|safe }}
+      <div class="card-body">
+        <div class="alert alert-danger" role="alert">
+          {{ file_error|safe }}
+        </div>
       </div>
       {% else %}
       <table class="files-panel">

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -9,15 +9,15 @@
       <div class="card-header">
         Folder Navigation:
         {% spaceless %}
-          <span class="path-breadcrumbs">
+          <span class="dir-breadcrumbs">
             {% for breadcrumb in dir_breadcrumbs %}
               {% if forloop.counter == dir_breadcrumbs|length %}
-                <span class="path-breadcrumb-self">{{ breadcrumb.name }}</span>
+                <span class="dir-breadcrumb-self">{{ breadcrumb.name }}</span>
               {% else %}
                 <a href="{{ breadcrumb.rel_path }}#files-panel"
                    onclick="return navigateDir('{{ breadcrumb.full_subdir }}')"
-                   class="path-breadcrumb-up">{{ breadcrumb.name }}</a>
-                <span class="path-breadcrumb-sep">/</span>
+                   class="dir-breadcrumb-up">{{ breadcrumb.name }}</a>
+                <span class="dir-breadcrumb-sep">/</span>
               {% endif %}
             {% endfor %}
           </span>

--- a/physionet-django/project/templates/project/files_panel.html
+++ b/physionet-django/project/templates/project/files_panel.html
@@ -16,9 +16,11 @@
   {% endspaceless %}
 </div>
 {% if file_error %}
-  <div class="alert alert-danger col-md-8" role="alert">
+<div class="card-body">
+  <div class="alert alert-danger" role="alert">
     {{ file_error|safe }}
   </div>
+</div>
 {% else %}
 <table class="files-panel">
   <col class="files-panel-name"></col>

--- a/physionet-django/project/templates/project/files_panel.html
+++ b/physionet-django/project/templates/project/files_panel.html
@@ -22,6 +22,13 @@
   </div>
 </div>
 {% else %}
+  {% if file_warning %}
+    <div class="card-body">
+      <div class="alert alert-warning" role="alert">
+        {{ file_warning|safe }}
+      </div>
+    </div>
+  {% endif %}
 <table class="files-panel">
   <col class="files-panel-name"></col>
   <col class="files-panel-size"></col>

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -3,6 +3,8 @@ import re
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
+MAX_FILENAME_LENGTH = 50
+
 _good_name_pattern = re.compile(r'\w+([\w\-\.]*\w+)?', re.ASCII)
 _bad_name_pattern = re.compile(r'^(?:con|nul|aux|prn|com\d|lpt\d)(?:\.|$)',
                                re.ASCII|re.IGNORECASE)
@@ -16,6 +18,11 @@ def validate_filename(value):
     allowed = ['h', 'hi1', 'hi1.txt', '1.1', 'hi1.x', 'hi_1', '1-hi.1']
     disallowed = ['', '!', 'hi!', '.hi', 'hi.', 'hi..hi', '.', '..']
     """
+    if len(value) > MAX_FILENAME_LENGTH:
+        raise ValidationError(
+            'Invalid file name "%(filename)s". '
+            'File names may be at most %(limit)s characters long.',
+            params={'filename': value, 'limit': MAX_FILENAME_LENGTH})
     if not _good_name_pattern.fullmatch(value):
         raise ValidationError(
             'Invalid file name "%(filename)s". '

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -3,6 +3,11 @@ import re
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
+_good_name_pattern = re.compile(r'\w+([\w\-\.]*\w+)?', re.ASCII)
+_bad_name_pattern = re.compile(r'^(?:con|nul|aux|prn|com\d|lpt\d)(?:\.|$)',
+                               re.ASCII|re.IGNORECASE)
+
+
 def validate_filename(value):
     """
     Validate file/folder names.
@@ -11,7 +16,9 @@ def validate_filename(value):
     allowed = ['h', 'hi1', 'hi1.txt', '1.1', 'hi1.x', 'hi_1', '1-hi.1']
     disallowed = ['', '!', 'hi!', '.hi', 'hi.', 'hi..hi', '.', '..']
     """
-    if not re.fullmatch(r'\w+([\w\-\.]*\w+)?', value) or '..' in value:
+    if (not _good_name_pattern.fullmatch(value)
+            or _bad_name_pattern.match(value)
+            or '..' in value):
         raise ValidationError('Invalid filename: "%(filename)s" ' \
             'Filenames may only contain letters, numbers, dashes, underscores, ' \
             'and dots. They may not contain adjacent dots, begin with, ' \

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -16,13 +16,24 @@ def validate_filename(value):
     allowed = ['h', 'hi1', 'hi1.txt', '1.1', 'hi1.x', 'hi_1', '1-hi.1']
     disallowed = ['', '!', 'hi!', '.hi', 'hi.', 'hi..hi', '.', '..']
     """
-    if (not _good_name_pattern.fullmatch(value)
-            or _bad_name_pattern.match(value)
-            or '..' in value):
-        raise ValidationError('Invalid filename: "%(filename)s" ' \
-            'Filenames may only contain letters, numbers, dashes, underscores, ' \
-            'and dots. They may not contain adjacent dots, begin with, ' \
-            'or end with a dot.', params={'filename':value})
+    if not _good_name_pattern.fullmatch(value):
+        raise ValidationError(
+            'Invalid file name "%(filename)s". '
+            'File names may only contain letters, numbers, dashes (-), dots '
+            '(.), and underscores (_). They may not begin or end with a dot '
+            'or dash.',
+            params={'filename': value})
+    if '..' in value:
+        raise ValidationError(
+            'Invalid file name "%(filename)s". '
+            'File names may not contain two consecutive dots.',
+            params={'filename': value})
+    if _bad_name_pattern.match(value):
+        raise ValidationError(
+            'Invalid file name "%(filename)s". '
+            'File names CON, NUL, AUX, PRN, COM0-COM9, LPT0-LPT9, or any of '
+            'these followed by a dot and file extension, are not allowed.',
+            params={'filename': value})
 
 
 def validate_doi(value):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -815,6 +815,8 @@ def project_files_panel(request, project_slug, **kwargs):
 
     (display_files, display_dirs, dir_breadcrumbs, parent_dir,
      file_error) = get_project_file_info(project=project, subdir=subdir)
+    file_warning = get_project_file_warning(display_files, display_dirs,
+                                              subdir)
 
     (upload_files_form, create_folder_form, rename_item_form,
         move_items_form, delete_items_form) = get_file_forms(project, subdir)
@@ -823,6 +825,7 @@ def project_files_panel(request, project_slug, **kwargs):
         {'project':project, 'subdir':subdir, 'file_error':file_error,
          'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
          'display_files':display_files, 'display_dirs':display_dirs,
+         'file_warning':file_warning,
          'upload_files_form':upload_files_form,
          'create_folder_form':create_folder_form,
          'rename_item_form':rename_item_form,
@@ -914,6 +917,8 @@ def project_files(request, project_slug, subdir='', **kwargs):
 
     (display_files, display_dirs, dir_breadcrumbs, _,
      file_error) = get_project_file_info(project=project, subdir=subdir)
+    file_warning = get_project_file_warning(display_files, display_dirs,
+                                              subdir)
 
     return render(request, 'project/project_files.html', {'project':project,
         'individual_size_limit':utility.readable_size(
@@ -926,7 +931,8 @@ def project_files(request, project_slug, subdir='', **kwargs):
         'create_folder_form':create_folder_form,
         'rename_item_form':rename_item_form, 'move_items_form':move_items_form,
         'delete_items_form':delete_items_form, 'is_submitting':is_submitting,
-        'dir_breadcrumbs':dir_breadcrumbs, 'file_error':file_error})
+        'dir_breadcrumbs':dir_breadcrumbs, 'file_error':file_error,
+        'file_warning':file_warning})
 
 
 @project_auth(auth_mode=2)
@@ -957,12 +963,14 @@ def preview_files_panel(request, project_slug, **kwargs):
     (display_files, display_dirs, dir_breadcrumbs, parent_dir,
      file_error) = get_project_file_info(project=project, subdir=subdir)
     files_panel_url = reverse('preview_files_panel', args=(project.slug,))
+    file_warning = get_project_file_warning(display_files, display_dirs,
+                                              subdir)
 
     return render(request, 'project/files_panel.html',
         {'project':project, 'subdir':subdir, 'file_error':file_error,
          'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
          'display_files':display_files, 'display_dirs':display_dirs,
-         'files_panel_url':files_panel_url})
+         'files_panel_url':files_panel_url, 'file_warning':file_warning})
 
 
 @project_auth(auth_mode=2)
@@ -995,6 +1003,8 @@ def project_preview(request, project_slug, subdir='', **kwargs):
     (display_files, display_dirs, dir_breadcrumbs, _,
      file_error) = get_project_file_info(project=project, subdir=subdir)
     files_panel_url = reverse('preview_files_panel', args=(project.slug,))
+    file_warning = get_project_file_warning(display_files, display_dirs,
+                                              subdir)
 
     return render(request, 'project/project_preview.html', {'project':project,
         'display_files':display_files, 'display_dirs':display_dirs,
@@ -1003,7 +1013,8 @@ def project_preview(request, project_slug, subdir='', **kwargs):
         'publication':publication, 'topics':topics, 'languages':languages,
         'passes_checks':passes_checks, 'dir_breadcrumbs':dir_breadcrumbs,
         'files_panel_url':files_panel_url, 'subdir':subdir,
-        'file_error':file_error, 'parent_projects':parent_projects})
+        'file_error':file_error, 'file_warning':file_warning,
+        'parent_projects':parent_projects})
 
 
 @project_auth(auth_mode=2)


### PR DESCRIPTION
These changes address a few things:

- Non-ASCII file names are problematic (we are fortunate, I suppose, to be supporting only English. :/)  Disallow them.

- On certain popular operating systems, you can't create or access files called "con" or "aux.dat" (at least not via the normal filesystem API.)  Disallow these names.

- Limit file names to 50 characters (an arbitrary number, but the rename function already had a limit of 50.)

- If existing file names don't meet these criteria, a warning message is displayed in the edit and preview pages.

(Note: functions for *manipulating* existing files - rename, move, delete - will still probably work, because they don't validate their argument using validate_filename - they validate it by checking that it matches one of the known existing filenames.  This is not the best design, but *probably* is not a security issue.)

- If *two* existing filenames in the same directory differ only in case, show a warning message about that.  On certain popular operating systems, you can't have two filenames that differ only in case.

This is related to issue #483 but not a complete solution.  At some point during the publication process, there should be a *complete* scan and auto-reject, but like computing hashes (see issue #519) this needs to be done asynchronously.  So I'm ignoring that part for now.

