### PR TITLE
Improve resilience of file management forms

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -292,12 +292,12 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
 
     authors, author_emails, storage_info, edit_logs, copyedit_logs, latest_version = project.info_card()
 
-    (upload_files_form, create_folder_form, rename_item_form,
-        move_items_form, delete_items_form) = get_file_forms(project=project,
-        subdir=subdir)
-
     (display_files, display_dirs, dir_breadcrumbs, _,
      file_error) = get_project_file_info(project=project, subdir=subdir)
+
+    (upload_files_form, create_folder_form, rename_item_form,
+     move_items_form, delete_items_form) = get_file_forms(
+         project=project, subdir=subdir, display_dirs=display_dirs)
 
     edit_url = reverse('edit_metadata_item', args=[project.slug])
 

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -4,6 +4,7 @@ import pdb
 import re
 
 from django import forms
+from django.forms.utils import ErrorList
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 from django.db.models.functions import Lower
 from django.template.defaultfilters import slugify
@@ -135,10 +136,11 @@ class UploadFilesForm(ActiveProjectFilesForm):
         """
         Upload the files
         """
+        errors = ErrorList()
         for file in self.files.getlist('file_field'):
             utility.write_uploaded_file(file=file,
                 write_file_path=os.path.join(self.file_dir, file.name))
-        return 'Your files have been uploaded'
+        return 'Your files have been uploaded', errors
 
 
 class CreateFolderForm(ActiveProjectFilesForm):
@@ -166,8 +168,9 @@ class CreateFolderForm(ActiveProjectFilesForm):
         """
         Create the folder
         """
+        errors = ErrorList()
         os.mkdir(os.path.join(self.file_dir, self.cleaned_data['folder_name']))
-        return 'Your folder has been created'
+        return 'Your folder has been created', errors
 
 
 class EditItemsForm(ActiveProjectFilesForm):
@@ -195,8 +198,9 @@ class EditItemsForm(ActiveProjectFilesForm):
         """
         Delete the items
         """
+        errors = ErrorList()
         utility.remove_items([os.path.join(self.file_dir, i) for i in self.cleaned_data['items']])
-        return 'Your items have been deleted'
+        return 'Your items have been deleted', errors
 
 
 class RenameItemForm(EditItemsForm):
@@ -229,9 +233,10 @@ class RenameItemForm(EditItemsForm):
         """
         Rename the items
         """
+        errors = ErrorList()
         os.rename(os.path.join(self.file_dir, self.cleaned_data['items']),
             os.path.join(self.file_dir, self.cleaned_data['new_name']))
-        return 'Your item has been renamed'
+        return 'Your item has been renamed', errors
 
 
 class MoveItemsForm(EditItemsForm):
@@ -307,9 +312,10 @@ class MoveItemsForm(EditItemsForm):
         """
         Move the items into the selected directory
         """
+        errors = ErrorList()
         utility.move_items([os.path.join(self.file_dir, i) for i in self.cleaned_data['items']],
             os.path.join(self.file_dir, self.cleaned_data['destination_folder']))
-        return 'Your items have been moved'
+        return 'Your items have been moved', errors
 
 
 class CreateProjectForm(forms.ModelForm):

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -190,7 +190,14 @@ class DeleteItemsForm(EditItemsForm):
         Delete the items
         """
         errors = ErrorList()
-        utility.remove_items([os.path.join(self.file_dir, i) for i in self.cleaned_data['items']])
+        for item in self.cleaned_data['items']:
+            path = os.path.join(self.file_dir, item)
+            try:
+                utility.remove_items([path])
+            except OSError as e:
+                errors.append(format_html(
+                    'Unable to delete <i>{}</i>',
+                    os.path.relpath(e.filename or path, self.file_dir)))
         return 'Your items have been deleted', errors
 
 

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -250,7 +250,7 @@ class MoveItemsForm(EditItemsForm):
         if subdir is not None:
             choices = [(d.name, d.name) for d in display_dirs]
             if subdir:
-                choices.insert(0, ('../', '*Parent Directory*'))
+                choices.insert(0, ('../', '(Parent directory)'))
             self.fields['destination_folder'].widget.choices = choices
 
     def clean(self):

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -240,26 +240,18 @@ class MoveItemsForm(EditItemsForm):
     """
     destination_folder = forms.Field(required=False, widget=forms.Select)
 
-    def __init__(self, project, subdir=None, *args, **kwargs):
+    def __init__(self, project, subdir=None, display_dirs=None,
+                 *args, **kwargs):
         """
         Set the choices for the destination folder
         """
         super(MoveItemsForm, self).__init__(project, *args, **kwargs)
         # The choices are only set here for get requests
         if subdir is not None:
-            c = MoveItemsForm.get_destination_choices(project, subdir)
-            self.fields['destination_folder'].widget.choices = c
-
-    def get_destination_choices(project, subdir):
-        """
-        Return allowed destination choices
-        """
-        existing_subdirs = utility.list_directories(
-            os.path.join(project.file_root(), subdir))
-        subdir_choices = [(s, s) for s in existing_subdirs]
-        if subdir:
-            subdir_choices = [('../', '*Parent Directory*')] + subdir_choices
-        return subdir_choices
+            choices = [(d.name, d.name) for d in display_dirs]
+            if subdir:
+                choices.insert(0, ('../', '*Parent Directory*'))
+            self.fields['destination_folder'].widget.choices = choices
 
     def clean(self):
         """

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -193,7 +193,7 @@ class DeleteItemsForm(EditItemsForm):
         for item in self.cleaned_data['items']:
             path = os.path.join(self.file_dir, item)
             try:
-                utility.remove_items([path])
+                utility.remove_items([path], ignore_missing=False)
             except OSError as e:
                 errors.append(format_html(
                     'Unable to delete <i>{}</i>',

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -143,26 +143,20 @@ class CreateFolderForm(ActiveProjectFilesForm):
     folder_name = forms.CharField(max_length=validators.MAX_FILENAME_LENGTH,
         required=False, validators=[validators.validate_filename])
 
-    def clean(self):
-        """
-        Check for name clash with existing files/folders in the directory
-        """
-        if self.errors:
-            return
-
-        folder_name = self.cleaned_data['folder_name']
-        self.taken_names = utility.list_items(self.file_dir, return_separate=False)
-
-        if folder_name in self.taken_names:
-            raise forms.ValidationError('Item named: "%(taken_name)s" already exists in current folder.',
-                code='clashing_name', params={'taken_name':folder_name})
-
     def perform_action(self):
         """
         Create the folder
         """
         errors = ErrorList()
-        os.mkdir(os.path.join(self.file_dir, self.cleaned_data['folder_name']))
+        name = self.cleaned_data['folder_name']
+        try:
+            os.mkdir(os.path.join(self.file_dir, name))
+        except FileExistsError:
+            errors.append(format_html(
+                'Item named <i>{}</i> already exists', name))
+        except OSError:
+            errors.append(format_html(
+                'Unable to create <i>{}</i>', name))
         return 'Your folder has been created', errors
 
 

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -175,9 +175,7 @@ class CreateFolderForm(ActiveProjectFilesForm):
 
 class EditItemsForm(ActiveProjectFilesForm):
     """
-    Inherited form for manipulating existing files/directories.
-    Rename, edit, delete. This is also the form for deleting items.
-
+    Abstract form for manipulating existing files/directories.
     """
     # This field's choices depend on the `subdir` field
     items = forms.MultipleChoiceField()
@@ -193,6 +191,12 @@ class EditItemsForm(ActiveProjectFilesForm):
         existing_items = utility.list_items(self.file_dir, return_separate=False)
         self.fields['items'].choices = tuple((item, item) for item in existing_items)
         return self.cleaned_data['subdir']
+
+
+class DeleteItemsForm(EditItemsForm):
+    """
+    Form for deleting existing files/directories.
+    """
 
     def perform_action(self):
         """

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -150,7 +150,7 @@ def move_items(items, target_folder):
     Move items (full path) into target folder (full path)
     """
     for item in items:
-        os.rename(item, os.path.join(target_folder, os.path.split(item)[-1]))
+        rename_file(item, os.path.join(target_folder, os.path.split(item)[-1]))
 
 def get_file_info(file_path):
     "Given a file path, get the information used to display it"

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -102,7 +102,7 @@ class StorageInfo():
 
 def list_files(directory):
     "List files in a directory"
-    return sorted([f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f)) and not f.endswith('~')])
+    return sorted([f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))])
 
 
 def list_directories(directory):

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -116,15 +116,18 @@ def list_items(directory, return_separate=True):
     else:
         return sorted(list_files(directory)+list_directories(directory))
 
-def remove_items(items):
+def remove_items(items, ignore_missing=True):
     """
     Delete the list of (full file path) files/directories.
     """
     for item in items:
-        if os.path.isfile(item):
+        try:
             os.remove(item)
-        elif os.path.isdir(item):
+        except IsADirectoryError:
             shutil.rmtree(item)
+        except FileNotFoundError:
+            if not ignore_missing:
+                raise
 
 def clear_directory(directory):
     """

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -102,19 +102,35 @@ class StorageInfo():
 
 def list_files(directory):
     "List files in a directory"
-    return sorted([f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))])
+    files = []
+    for ent in os.scandir(directory):
+        if not ent.is_dir():
+            files.append(ent.name)
+    return sorted(files)
 
 
 def list_directories(directory):
     "List directories in a directory"
-    return sorted([d for d in os.listdir(directory) if os.path.isdir(os.path.join(directory, d))])
+    dirs = []
+    for ent in os.scandir(directory):
+        if ent.is_dir():
+            dirs.append(ent.name)
+    return sorted(dirs)
+
 
 def list_items(directory, return_separate=True):
     "List files and directories in a directory. Return separate or combine lists"
     if return_separate:
-        return (list_files(directory), list_directories(directory))
+        dirs = []
+        files = []
+        for ent in os.scandir(directory):
+            if ent.is_dir():
+                dirs.append(ent.name)
+            else:
+                files.append(ent.name)
+        return (sorted(files), sorted(dirs))
     else:
-        return sorted(list_files(directory)+list_directories(directory))
+        return sorted(os.listdir(directory))
 
 def remove_items(items, ignore_missing=True):
     """

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -1,4 +1,5 @@
 import datetime
+import errno
 import os
 import shutil
 import pdb
@@ -130,6 +131,19 @@ def clear_directory(directory):
     Delete all files and folders in a directory.
     """
     remove_items(os.path.join(directory, i) for i in os.listdir(directory))
+
+def rename_file(old_path, new_path):
+    """
+    Rename a file, without overwriting an existing file.
+
+    If the destination path already exists, this will attempt to raise
+    a FileExistsError.  This is not guaranteed to work correctly in
+    all cases.
+    """
+    if os.path.exists(new_path):
+        raise FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST),
+                              old_path, new_path)
+    os.rename(old_path, new_path)
 
 def move_items(items, target_folder):
     """

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -43,6 +43,22 @@ def validate_filename(value):
             params={'filename': value})
 
 
+def validate_filename_or_parent(value):
+    """
+    Check if string is either a valid file base name, or '../'.
+    """
+    if value != '../':
+        validate_filename(value)
+
+
+def validate_oldfilename(value):
+    """
+    Check if string is potentially a file base name.
+    """
+    if '/' in value or value == '' or value == '.' or value == '..':
+        raise ValidationError('Not a valid file base name.')
+
+
 def validate_doi(value):
     """
     Validate a doi. Currently pn is assigned the 10.13026 prefix

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -720,14 +720,15 @@ class ProjectAutocomplete(autocomplete.Select2QuerySetView):
         return qs
 
 
-def get_file_forms(project, subdir):
+def get_file_forms(project, subdir, display_dirs):
     """
     Get the file processing forms
     """
     upload_files_form = forms.UploadFilesForm(project=project)
     create_folder_form = forms.CreateFolderForm(project=project)
     rename_item_form = forms.RenameItemForm(project=project)
-    move_items_form = forms.MoveItemsForm(project=project, subdir=subdir)
+    move_items_form = forms.MoveItemsForm(project=project, subdir=subdir,
+                                          display_dirs=display_dirs)
     delete_items_form = forms.DeleteItemsForm(project=project)
 
     return (upload_files_form, create_folder_form, rename_item_form,
@@ -819,7 +820,8 @@ def project_files_panel(request, project_slug, **kwargs):
                                               subdir)
 
     (upload_files_form, create_folder_form, rename_item_form,
-        move_items_form, delete_items_form) = get_file_forms(project, subdir)
+     move_items_form, delete_items_form) = get_file_forms(
+         project=project, subdir=subdir, display_dirs=display_dirs)
 
     return render(request, 'project/edit_files_panel.html',
         {'project':project, 'subdir':subdir, 'file_error':file_error,
@@ -915,14 +917,15 @@ def project_files(request, project_slug, subdir='', **kwargs):
                                                     is_active=True).first()
     # Forms
     storage_request_form = forms.StorageRequestForm(project=project) if (not storage_request and is_submitting) else None
-    (upload_files_form, create_folder_form, rename_item_form,
-        move_items_form, delete_items_form) = get_file_forms(project=project,
-        subdir=subdir)
 
     (display_files, display_dirs, dir_breadcrumbs, _,
      file_error) = get_project_file_info(project=project, subdir=subdir)
     file_warning = get_project_file_warning(display_files, display_dirs,
                                               subdir)
+
+    (upload_files_form, create_folder_form, rename_item_form,
+     move_items_form, delete_items_form) = get_file_forms(
+         project=project, subdir=subdir, display_dirs=display_dirs)
 
     return render(request, 'project/project_files.html', {'project':project,
         'individual_size_limit':utility.readable_size(

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -728,7 +728,7 @@ def get_file_forms(project, subdir):
     create_folder_form = forms.CreateFolderForm(project=project)
     rename_item_form = forms.RenameItemForm(project=project)
     move_items_form = forms.MoveItemsForm(project=project, subdir=subdir)
-    delete_items_form = forms.EditItemsForm(project=project)
+    delete_items_form = forms.DeleteItemsForm(project=project)
 
     return (upload_files_form, create_folder_form, rename_item_form,
             move_items_form, delete_items_form)
@@ -874,7 +874,7 @@ def process_files_post(request, project):
         form = forms.MoveItemsForm(project=project, data=request.POST)
         subdir = process_items(request, form)
     elif 'delete_items' in request.POST:
-        form = forms.EditItemsForm(project=project, data=request.POST)
+        form = forms.DeleteItemsForm(project=project, data=request.POST)
         subdir = process_items(request, form)
 
     return subdir

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -842,7 +842,11 @@ def process_items(request, form):
     Helper function for `project_files`.
     """
     if form.is_valid():
-        messages.success(request, form.perform_action())
+        success_msg, errors = form.perform_action()
+        if errors:
+            messages.error(request, errors)
+        else:
+            messages.success(request, success_msg)
         return form.cleaned_data['subdir']
     else:
         messages.error(request, utility.get_form_errors(form))


### PR DESCRIPTION
Various changes are made here to the file management forms.  In
general:

- Handle exceptions when manipulating files, and display an
  appropriate error message.

- When multiple operations are requested, do as much as possible,
  rather than stopping when one operation fails.

- Don't read the same directory more than once.

This fixes issue #524 along with other issues.

