### PR TITLE
Async files

### DIFF
--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -3,6 +3,8 @@ import pdb
 
 from django.test import TestCase
 from django.urls import reverse
+from django.test.utils import get_runner
+from background_task.tasks import tasks
 
 from project.models import (ArchivedProject, ActiveProject, PublishedProject,
     Author, AuthorInvitation, License, StorageRequest)
@@ -204,6 +206,8 @@ class TestState(TestMixin, TestCase):
         response = self.client.post(reverse(
             'publish_submission', args=(project.slug,)),
             data={'slug':custom_slug, 'doi':'10.13026/MIT505', 'make_zip':1})
+
+        self.assertTrue(bool(tasks.run_next_task()))
         self.assertTrue(bool(PublishedProject.objects.filter(slug=custom_slug)))
         self.assertFalse(bool(PublishedProject.objects.filter(slug=project_slug)))
         self.assertFalse(bool(ActiveProject.objects.filter(slug=project_slug)))

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -24,14 +24,6 @@ def send_contact_message(contact_form):
     send_mail(contact_form.cleaned_data['subject'], body, mail_from,
         [settings.CONTACT_EMAIL], fail_silently=False)
 
-
-def send_email_to_admin(subject, message):
-    """
-    Send a message to admin
-    """
-    send_mail(subject, message, settings.SERVER_EMAIL, [settings.ADMINS],
-        fail_silently=False)
-
 # ---------- Project App ---------- #
 
 def email_signature():

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -24,6 +24,14 @@ def send_contact_message(contact_form):
     send_mail(contact_form.cleaned_data['subject'], body, mail_from,
         [settings.CONTACT_EMAIL], fail_silently=False)
 
+
+def send_email_to_admin(subject, message):
+    """
+    Send a message to admin
+    """
+    send_mail(subject, message, settings.SERVER_EMAIL, [settings.ADMINS],
+        fail_silently=False)
+
 # ---------- Project App ---------- #
 
 def email_signature():

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1134,15 +1134,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             os.mkdir(published_project.project_file_root())
 
         # Move over main files
-        try:
-            os.rename(self.file_root(), published_project.file_root())
-        except FileNotFoundError:
-            send_emial_to_admin('Failed publishing files',
-                'Failed to move files of published project {0}.\
-                \nThe user publishing the project was: {1}'.format(
-                    published_project, published_project.editor.get_full_name))
-            LOGGER.info("Failed to move files of published project {}".format(
-                published_project))
+        os.rename(self.file_root(), published_project.file_root())
 
         # Set files read only and make zip file if requested
         move_files_as_readonly(published_project.id, self.file_root(),

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -35,14 +35,10 @@ from physionet.utility import (sorted_tree_files, zip_dir)
 @background()
 def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     """
-    Schedule a background task to send the files to GCP.
-    This function can be runned manually to force a re-send of all the files
-    to GCP. It only requires the Project ID.
+    Schedule a background task to set the files as read only.
     """
 
     published_project = PublishedProject.objects.get(id=pid)
-    os.rename(dir_from, dir_to)
-
     # Create special files if there are files. Should always be the case.
     if bool(published_project.storage_used):
         published_project.make_special_files(make_zip=make_zip)
@@ -50,15 +46,13 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     published_project.set_storage_info()
 
     # Make the files read only
-    file_root = published_project.file_root()
-    files = get_tree_files(file_root, full_path=False)
-    Dirs = []
-    for file in files: 
-        if os.path.dirname(os.path.join(file_root, file)) not in Dirs:
-            Dirs.append(os.path.dirname(os.path.join(file_root, file)))
-        os.chmod(os.path.join(file_root, file), stat.S_IRUSR |stat.S_IRGRP | stat.S_IROTH)
-    # for directory in Dirs:
-    #     os.chmod(directory, stat.S_IRUSR |stat.S_IRGRP | stat.S_IROTH)
+    file_root = published_project.project_file_root()
+
+    for root, dirs, files in os.walk(file_root):
+        for d in dirs:
+            os.chmod(os.path.join(root, f), 0o555)
+        for f in files:
+            os.chmod(os.path.join(root, f), 0o555)
 
 
 class SafeHTMLField(ckeditor.fields.RichTextField):
@@ -1136,7 +1130,10 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         if not os.path.isdir(published_project.project_file_root()):
             os.mkdir(published_project.project_file_root())
         
-        # Move over main files and set read only
+        # Move over main files
+        os.rename(self.file_root(), published_project.file_root())
+
+        # Set files read only and make zip file if requested
         move_files_as_readonly(published_project.id, self.file_root(),
             published_project.file_root(), make_zip)
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -51,10 +51,9 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
 
     # Make the files read only
     file_root = published_project.project_file_root()
-    folders = []
     for root, dirs, files in os.walk(file_root):
         for f in files:
-            fline = open(os.path.join(root, f), 'rb').readline().rstrip()
+            fline = open(os.path.join(root, f), 'rb').read(2)
             if fline[:2] == b'#!':
                 os.chmod(os.path.join(root, f), 0o555)
             else:

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -41,10 +41,7 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     """
 
     published_project = PublishedProject.objects.get(id=pid)
-    try:
-        os.rename(dir_from, dir_to)
-    except:
-        print('Files not there')
+    os.rename(dir_from, dir_to)
 
     # Create special files if there are files. Should always be the case.
     if bool(published_project.storage_used):
@@ -56,11 +53,9 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     file_root = published_project.file_root()
     files = get_tree_files(file_root, full_path=False)
     Dirs = []
-    print(files)
     for file in files: 
         if os.path.dirname(os.path.join(file_root, file)) not in Dirs:
             Dirs.append(os.path.dirname(os.path.join(file_root, file)))
-        print(os.path.join(file_root, file))
         os.chmod(os.path.join(file_root, file), stat.S_IRUSR |stat.S_IRGRP | stat.S_IROTH)
     # for directory in Dirs:
     #     os.chmod(directory, stat.S_IRUSR |stat.S_IRGRP | stat.S_IROTH)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -53,7 +53,7 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
 
     for root, dirs, files in os.walk(file_root):
         for d in dirs:
-            os.chmod(os.path.join(root, f), 0o555)
+            os.chmod(os.path.join(root, d), 0o555)
         for f in files:
             os.chmod(os.path.join(root, f), 0o555)
 

--- a/physionet-django/user/management/commands/resetdb.py
+++ b/physionet-django/user/management/commands/resetdb.py
@@ -74,13 +74,12 @@ def clear_media_files():
     for subdir in os.listdir(settings.MEDIA_ROOT):
         media_subdir = os.path.join(settings.MEDIA_ROOT, subdir)
         subdir_items = [os.path.join(media_subdir, item) for item in os.listdir(media_subdir) if item != '.gitkeep']
-
         for item in subdir_items:
             for root, dirs, files in os.walk(item):
                 for d in dirs:
-                    os.chmod(os.path.join(root, d), 0o775)
+                    os.chmod(os.path.join(root, d), 0o755)
                 for f in files:
-                    os.chmod(os.path.join(root, f), 0o775)
+                    os.chmod(os.path.join(root, f), 0o755)
 
             shutil.rmtree(item)
 
@@ -97,12 +96,11 @@ def clear_created_static_files():
     for subdir in ['published-projects']:
         static_subdir = os.path.join(effective_static_root, subdir)
         subdir_items = [os.path.join(static_subdir, item) for item in os.listdir(static_subdir) if item != '.gitkeep']
-
         for item in subdir_items:
             for root, dirs, files in os.walk(item):
                 for d in dirs:
-                    os.chmod(os.path.join(root, d), 0o775)
+                    os.chmod(os.path.join(root, d), 0o755)
                 for f in files:
-                    os.chmod(os.path.join(root, f), 0o775)
+                    os.chmod(os.path.join(root, f), 0o755)
 
             shutil.rmtree(item)

--- a/physionet-django/user/management/commands/resetdb.py
+++ b/physionet-django/user/management/commands/resetdb.py
@@ -99,4 +99,10 @@ def clear_created_static_files():
         subdir_items = [os.path.join(static_subdir, item) for item in os.listdir(static_subdir) if item != '.gitkeep']
 
         for item in subdir_items:
+            for root, dirs, files in os.walk(item):
+                for d in dirs:
+                    os.chmod(os.path.join(root, d), 0o775)
+                for f in files:
+                    os.chmod(os.path.join(root, f), 0o775)
+
             shutil.rmtree(item)

--- a/physionet-django/user/management/commands/resetdb.py
+++ b/physionet-django/user/management/commands/resetdb.py
@@ -76,6 +76,12 @@ def clear_media_files():
         subdir_items = [os.path.join(media_subdir, item) for item in os.listdir(media_subdir) if item != '.gitkeep']
 
         for item in subdir_items:
+            for root, dirs, files in os.walk(item):
+                for d in dirs:
+                    os.chmod(os.path.join(root, d), 0o775)
+                for f in files:
+                    os.chmod(os.path.join(root, f), 0o775)
+
             shutil.rmtree(item)
 
 def clear_created_static_files():

--- a/physionet-django/user/test_views.py
+++ b/physionet-django/user/test_views.py
@@ -11,8 +11,8 @@ from django.core import mail
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
-from .models import AssociatedEmail, User
-from .views import (activate_user, edit_emails, edit_profile,
+from user.models import AssociatedEmail, User
+from user.views import (activate_user, edit_emails, edit_profile,
     edit_password_complete, public_profile, register, user_settings,
     verify_email)
 
@@ -67,6 +67,17 @@ class TestMixin():
         """
         Remove the testing media root
         """
+        for root, dirs, files in os.walk(settings.MEDIA_ROOT):
+            for d in dirs:
+                os.chmod(os.path.join(root, d), 0o755)
+            for f in files:
+                os.chmod(os.path.join(root, f), 0o755)
+        for root, dirs, files in os.walk(self.test_static_root):
+            for d in dirs:
+                os.chmod(os.path.join(root, d), 0o755)
+            for f in files:
+                os.chmod(os.path.join(root, f), 0o755)
+
         shutil.rmtree(settings.MEDIA_ROOT)
         shutil.rmtree(self.test_static_root)
 


### PR DESCRIPTION
Here I create a background task to set the following:
- Move files on publish to new directory
- Create special files like zip file
- Set file permission as read only

Also changed the resetdb file to re-add permissions to the media, in order for it to delete the files. 

This background task will work as long as the "process_tasks" is running using `python manage.py process_tasks` in a different  terminal

Here I address #522 #521

### **NOTE. Permissions for the folders are kept the same. (Still debating if its a good idea)**