### PR TITLE
Fix up field names in prefixed forms

### DIFF
--- a/physionet-django/project/templates/project/metadata_inline_form_snippet.html
+++ b/physionet-django/project/templates/project/metadata_inline_form_snippet.html
@@ -1,7 +1,7 @@
 {% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
-    <label class="col-md-2" for="{{ field.name }}">
+    <label class="col-md-2" for="{{ field.html_name }}">
       {{ field.label|title }}
       {% if field.help_text|slice:"0:1" == "*" %}
         <a style="color:red"> *</a>

--- a/physionet-django/templates/descriptive_inline_form_snippet.html
+++ b/physionet-django/templates/descriptive_inline_form_snippet.html
@@ -1,7 +1,7 @@
 {% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
-    <label class="col-md-3" for="{{ field.name }}">
+    <label class="col-md-3" for="{{ field.html_name }}">
       {{ field.label|title }}
       {% if field.field.required %}
         <a style="color:red"> *</a>

--- a/physionet-django/templates/form_snippet.html
+++ b/physionet-django/templates/form_snippet.html
@@ -1,6 +1,6 @@
 {% for field in form.visible_fields %}
   <div class="form-group">
-    <label for="{{ field.name }}" title="{{ field.help_text }}">{{ field.label|safe }}
+    <label for="{{ field.html_name }}" title="{{ field.help_text }}">{{ field.label|safe }}
     </label> {{ field }}
     {% for error in field.errors %}
       <div class="alert alert-danger">

--- a/physionet-django/templates/inline_form_snippet.html
+++ b/physionet-django/templates/inline_form_snippet.html
@@ -1,6 +1,6 @@
 {% for field in form.visible_fields %}
   <div class="form-group row">
-    <label class="col-md-2" for="{{ field.name }}" title="{{ field.help_text }}">{{ field.label }}
+    <label class="col-md-2" for="{{ field.html_name }}" title="{{ field.help_text }}">{{ field.label }}
     </label>
     <div class='col-md-10'>
       {{ field }}


### PR DESCRIPTION
A minor issue with pull #551: 'field.name' isn't always the name of the field.  Weird, right?
