### PR TITLE
Fix credentialing error and rename variable

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -956,7 +956,7 @@ def download_credentialed_users(request):
     # Create the HttpResponse object with the appropriate CSV header.
     project_access = DUASignature.objects.filter(project__access_policy = 2)
     added = []
-    List = [['First name', 'Last name', 'E-mail', 'Institution', 'Country', 
+    columns = [['First name', 'Last name', 'E-mail', 'Institution', 'Country', 
     'MIMIC approval date', 'eICU approval date', 
     'General research area for which the data will be used']]
     for person in project_access:
@@ -967,14 +967,14 @@ def download_credentialed_users(request):
         elif 'eicu' in person.project.slug:
             eicu_signature_date = person.sign_datetime
         if person.user.id in added:
-            for indx, item in enumerate(List):
+            for indx, item in enumerate(columns):
                 if item[2] == person.user.email and item[5] == None:
-                    List[indx][5] = mimic_signature_date
+                    columns[indx][5] = mimic_signature_date
                 elif item[2] == person.user.email and item[6] == None:
-                    List[indx][6] = eicu_signature_date
+                    columns[indx][6] = eicu_signature_date
         else:
             if application:
-                List.append([person.user.profile.first_names,
+                columns.append([person.user.profile.first_names,
                     person.user.profile.last_name, person.user.email,
                     application.organization_name, application.country,
                     mimic_signature_date, eicu_signature_date,
@@ -982,7 +982,7 @@ def download_credentialed_users(request):
                 added.append(person.user.id)
             else:
                 legacy = LegacyCredential.objects.get(migrated_user_id=person.user.id)
-                List.append([person.user.profile.first_names,
+                columns.append([person.user.profile.first_names,
                     person.user.profile.last_name, person.user.email,
                     'Legacy User', legacy.country,
                     legacy.mimic_approval_date, legacy.eicu_approval_date,
@@ -992,7 +992,7 @@ def download_credentialed_users(request):
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="credentialed_users.csv"'
     writer = csv.writer(response)
-    for item in List:
+    for item in columns:
         writer.writerow(item)
 
     return response

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -380,6 +380,7 @@ def credential_application(request):
             files=request.FILES, prefix="application")
         reference_form = forms.ReferenceCAF(data=request.POST, prefix="application")
         course_form = forms.CourseCAF(data=request.POST, require_courses=False, prefix="application")
+        research_form = forms.ResearchCAF(data=request.POST, require_courses=False, prefix="application")
         
         form = CredentialApplicationForm(user=user, data=request.POST,
             files=request.FILES,  prefix="application")
@@ -398,6 +399,7 @@ def credential_application(request):
         training_form = forms.TrainingCAF(prefix="application")
         reference_form = forms.ReferenceCAF(prefix="application")
         course_form = forms.CourseCAF(prefix="application")
+        research_form = forms.CourseCAF(prefix="application")
 
         form = None
 


### PR DESCRIPTION
The credentialing page was returning an error because the `research_form` was not being initialized.

Also, rename the variable `List` to `columns`