### PR TITLE
Better zip and sha256sum

### DIFF
--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -168,10 +168,8 @@ def zip_dir(zip_name, target_dir, enclosing_folder=''):
         target_dir = target_dir.rstrip('/')
 
     with zipfile.ZipFile(zip_name, 'w') as zipf:
-        for root, dirs, files in os.walk(target_dir):
-            for file in files:
-                # Do not include the path to the target directory when
-                # writing files in the zip
-                zipf.write(os.path.join(root, file),
-                    arcname=os.path.join(enclosing_folder,
-                    root[len(target_dir)+1:], file))
+        for path in sorted_tree_files(target_dir):
+            # Do not include the path to the target directory when
+            # writing files in the zip
+            zipf.write(os.path.join(target_dir, path),
+                       arcname=os.path.join(enclosing_folder, path))

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -167,7 +167,8 @@ def zip_dir(zip_name, target_dir, enclosing_folder=''):
     if target_dir.endswith('/'):
         target_dir = target_dir.rstrip('/')
 
-    with zipfile.ZipFile(zip_name, 'w') as zipf:
+    with zipfile.ZipFile(zip_name, 'w',
+                         compression=zipfile.ZIP_DEFLATED) as zipf:
         for path in sorted_tree_files(target_dir):
             # Do not include the path to the target directory when
             # writing files in the zip

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -413,16 +413,20 @@ class NewProjectVersionForm(forms.ModelForm):
         os.mkdir(project.file_root())
         current_file_root = project.file_root()
         older_file_root = self.latest_project.file_root()
-        files = utility.get_tree_files(older_file_root, full_path=False)
-        for file in files:
-            destination = os.path.join(current_file_root, file)
-            if not os.path.exists(os.path.dirname(destination)):
+        for (directory, subdirs, files) in os.walk(older_file_root):
+            rel_dir = os.path.relpath(directory, older_file_root)
+            destination = os.path.join(current_file_root, rel_dir)
+            for d in subdirs:
                 try:
-                    os.makedirs(os.path.dirname(destination))
-                except OSError as exc: # Guard against race condition
-                    if exc.errno != errno.EEXIST:
-                        raise
-            os.link(os.path.join(older_file_root, file),  destination)
+                    os.mkdir(os.path.join(destination, d))
+                except FileExistsError:
+                    pass
+            for f in files:
+                try:
+                    os.link(os.path.join(directory, f),
+                            os.path.join(destination, f))
+                except FileExistsError:
+                    pass
 
         return project
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1256,8 +1256,13 @@ class PublishedProject(Metadata, SubmissionInfo):
         with open(fname, 'w') as outfile:
             for f in sorted_tree_files(self.file_root()):
                 if f != 'SHA256SUMS.txt':
-                    outfile.write('{} {}\n'.format(
-                        hashlib.sha256(open(os.path.join(self.file_root(), f), 'rb').read()).hexdigest(), f))
+                    h = hashlib.sha256()
+                    with open(os.path.join(self.file_root(), f), 'rb') as fp:
+                        block = fp.read(h.block_size)
+                        while block:
+                            h.update(block)
+                            block = fp.read(h.block_size)
+                    outfile.write('{} {}\n'.format(h.hexdigest(), f))
 
         self.set_storage_info()
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -23,12 +23,12 @@ from django.utils.html import strip_tags
 from django.utils.text import slugify
 
 from project.utility import (get_tree_size, get_file_info, get_directory_info,
-                             list_items, StorageInfo, get_tree_files,
-                             list_files, clear_directory)
+                             list_items, StorageInfo, list_files,
+                             clear_directory)
 from project.validators import (validate_doi, validate_subdir,
                                 validate_version, validate_slug)
 from user.validators import validate_alphaplus, validate_alphaplusplus
-from physionet.utility import zip_dir
+from physionet.utility import (sorted_tree_files, zip_dir)
 
 
 class SafeHTMLField(ckeditor.fields.RichTextField):
@@ -1253,11 +1253,11 @@ class PublishedProject(Metadata, SubmissionInfo):
         if os.path.isfile(fname):
             os.remove(fname)
 
-        files = get_tree_files(self.file_root(), full_path=False)
         with open(fname, 'w') as outfile:
-            for f in files:
-                outfile.write('{} {}\n'.format(
-                    hashlib.sha256(open(os.path.join(self.file_root(), f), 'rb').read()).hexdigest(), f))
+            for f in sorted_tree_files(self.file_root()):
+                if f != 'SHA256SUMS.txt':
+                    outfile.write('{} {}\n'.format(
+                        hashlib.sha256(open(os.path.join(self.file_root(), f), 'rb').read()).hexdigest(), f))
 
         self.set_storage_info()
 


### PR DESCRIPTION
Here are some improvements to the generation of zip archives and
SHA256SUMS files.

Zip archives should be compressed, and files should be stored in
order (issue #564).

SHA256SUMS.txt should be written in order (issue #556) and files
should not be slurped into memory.

We also avoid reading the entire directory tree at once, which
should improve performance for large databases.

All of these changes should be independent of pull #554.

Once this is done, we should also re-generate zip files and
SHA256SUMS files for existing published projects.
