### PR TITLE
Altered django to 2.1.10 for CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bleach==3.1.0
 coverage==4.4.2
-Django==2.1.9
+Django==2.1.10
 django-background-tasks==1.2.0
 django-ckeditor==5.7.1
 django-debug-toolbar==1.9.1


### PR DESCRIPTION
There is a security vulnerability in 2.1.9. Here we change to 2.1.10 temporary while I check the differences in 2.2.3.