### PR TITLE
Fix the "Return to the admin console" link

### DIFF
--- a/physionet-django/console/templates/console/unsubmitted_projects.html
+++ b/physionet-django/console/templates/console/unsubmitted_projects.html
@@ -20,7 +20,7 @@
         <tbody>
         {% for project in projects %}
           <tr>
-            <td><a href="{% url 'project_preview' project.slug %}">{{ project.title }}</a></td>
+            <td><a href="{% url 'project_preview' project.slug %}?Admin=True">{{ project.title }}</a></td>
             <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
             <td>{{ project.creation_datetime|date }}</td>
           </tr>

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -18,7 +18,7 @@
 <div class="container">
   {% if 'Admin' in request.GET %}
     <p><a class="btn btn-secondary"
-        href="{{ request.META.HTTP_REFERER }}" role="button">
+        href="{% url 'submission_info' project.slug %}" role="button">
         <i class="fas fa-angle-left"></i> Return to the admin console</a></p>
   {% else %}
     <p><a class="btn btn-secondary"


### PR DESCRIPTION
Make this link work correctly and point to the submitted-project info page.
