### PR TITLE
Install dependencies in a less insecure way

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,108 @@
-bleach==3.1.0
-coverage==4.4.2
-Django==2.2.3
-django-background-tasks==1.2.0
-django-ckeditor==5.7.1
-django-debug-toolbar==1.9.1
-django-js-asset==0.1.1
-djangorestframework==3.9.1
-html2text==2018.1.9
-Pillow==5.2.0
-psycopg2-binary==2.7.4
-python-decouple==3.1
-pytz==2017.2
-requests==2.21.0
-selenium==3.141.0
-sqlparse==0.2.4
-zxcvbn-python==4.4.18
-google-cloud-storage==1.14.0
-uWSGI==2.0.18
-django-autocomplete-light==3.3.4
+#### Requirements for running the server ####
+
+bleach==3.1.0 \
+ --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16
+chardet==3.0.4 \
+ --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+Django==2.2.3 \
+ --hash=sha256:6e974d4b57e3b29e4882b244d40171d6a75202ab8d2402b8e8adbd182e25cf0c
+django-autocomplete-light==3.3.4 \
+ --hash=sha256:cff0b1cad0e233e49c8cce08dff22868951123cbb79a7c1768eda78845044568
+django-background-tasks==1.2.0 \
+ --hash=sha256:35a9a54961f3e4486ab2f9482d1e8ac63ab4f47e5e0b7e654a22f7002299ffae
+django-ckeditor==5.7.1 \
+ --hash=sha256:0147f8905dc64747e45157a185feedee4e39973fa4b571c9c82ad10d9d4b8974
+djangorestframework==3.9.1 \
+ --hash=sha256:a4138613b67e3a223be6c97f53b13d759c5b90d2b433bad670b8ebf95402075f
+google-cloud-storage==1.14.0 \
+ --hash=sha256:a3115c22a71e2f172fade72c7b7b797a071f3ac9b66043191fc84c214ba0c671
+html2text==2018.1.9 \
+ --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662
+python-decouple==3.1 \
+ --hash=sha256:1317df14b43efee4337a4aa02914bf004f010cd56d6c4bd894e6474ec8c4fe2d
+pytz==2017.2 \
+ --hash=sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67
+uWSGI==2.0.18 \
+ --hash=sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583
+zxcvbn-python==4.4.18 \
+ --hash=sha256:a9beaf3fde32957ea13f979f5dd61c0023af0da7d3e1cb9bbc0c000770be12f6
+
+#### Requirements for development and testing ####
+
+coverage==4.4.2 \
+ --hash=sha256:9721f1b7275d3112dc7ccf63f0553c769f09b5c25a26ee45872c7f5c09edf6c1\
+ --hash=sha256:309d91bd7a35063ec7a0e4d75645488bfab3f0b66373e7722f23da7f5b0f34cc
+django-debug-toolbar==1.9.1 \
+ --hash=sha256:4af2a4e1e932dadbda197b18585962d4fc20172b4e5a479490bc659fe998864d
+requests==2.21.0 \
+ --hash=sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b
+
+#### Unknown - are these needed? ####
+
+Pillow==5.2.0 \
+ --hash=sha256:8194d913ca1f459377c8a4ed8f9b7ad750068b8e0e3f3f9c6963fcc87a84515f\
+ --hash=sha256:b3ef168d4d6fd4fa6685aef7c91400f59f7ab1c0da734541f7031699741fb23f
+psycopg2-binary==2.7.4 \
+ --hash=sha256:9305d7cbc802aaefac5c75a3df725f2654797369f32b18d4d0adb382dfab6c09\
+ --hash=sha256:de4f88f823037a71ea5ef3c1041d96b8a68d73343133edda684fd42f575bd9d7
+selenium==3.141.0 \
+ --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c
+
+#### Indirect requirements ####
+
+# required by bleach 3.1.0
+webencodings==0.5.1 \
+ --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
+six==1.12.0 \
+ --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
+
+# required by Django 2.2.3
+sqlparse==0.2.4 \
+ --hash=sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4
+
+# required by django-ckeditor 5.7.1
+django-js-asset==0.1.1 \
+ --hash=sha256:0dd2c5f64f2b24eb8a7270a6a59cb914a03f205335bd0eb6207bf61cf7410828
+
+# required by django-background-tasks 1.2.0
+django-compat==1.0.15 \
+ --hash=sha256:3ac9a3bedc56b9365d9eb241bc5157d0c193769bf995f9a78dc1bc24e7c2331b
+
+# required by google-cloud-storage 1.14.0
+google-cloud-core==0.29.1 \
+ --hash=sha256:9bee63e0991be9801a4baf0b7841cf54f86c6e7fec922f45ea74cd4032ed4ee4
+google-api-core==1.13.0 \
+ --hash=sha256:72a1c8966bdbd70a72de32760368aec399fe6a5c2a6675d9476cb9ae27046de7
+google-resumable-media==0.3.2 \
+ --hash=sha256:2dae98ee716efe799db3578a7b902fbf5592fc5c77d3c0906fc4ef9b1b930861
+
+# required by google-api-core 1.13.0
+protobuf==3.9.0 \
+ --hash=sha256:05c36022fef3c7d3562ac22402965c0c2b9fe8421f459bb377323598996e407f\
+ --hash=sha256:72edcbacd0c73eef507d2ff1af99a6c27df18e66a3ff4351e401182e4de62b03
+google-auth==1.6.3 \
+ --hash=sha256:20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed
+googleapis-common-protos==1.6.0 \
+ --hash=sha256:e61b8ed5e36b976b487c6e7b15f31bb10c7a0ca7bd5c0e837f4afab64b53a0c6
+setuptools==41.0.1 \
+ --hash=sha256:c7769ce668c7a333d84e17fe8b524b1c45e7ee9f7908ad0a73e1eda7e6a5aebf
+
+# required by google-auth 1.6.3
+cachetools==3.1.1 \
+ --hash=sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae
+pyasn1-modules==0.2.5 \
+ --hash=sha256:f309b6c94724aeaf7ca583feb1cc70430e10d7551de5e36edfc1ae6909bcfb3c
+rsa==4.0 \
+ --hash=sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66
+
+# required by pyasn1-modules 0.2.5
+pyasn1==0.4.5 \
+ --hash=sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e
+
+# required by requests 2.21.0
+certifi==2019.6.16 \
+ --hash=sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939
+idna==2.8 \
+ --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
+urllib3==1.24.3 \
+ --hash=sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,9 @@ google-cloud-storage==1.14.0 \
  --hash=sha256:a3115c22a71e2f172fade72c7b7b797a071f3ac9b66043191fc84c214ba0c671
 html2text==2018.1.9 \
  --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662
+Pillow==5.2.0 \
+ --hash=sha256:8194d913ca1f459377c8a4ed8f9b7ad750068b8e0e3f3f9c6963fcc87a84515f\
+ --hash=sha256:b3ef168d4d6fd4fa6685aef7c91400f59f7ab1c0da734541f7031699741fb23f
 python-decouple==3.1 \
  --hash=sha256:1317df14b43efee4337a4aa02914bf004f010cd56d6c4bd894e6474ec8c4fe2d
 pytz==2017.2 \
@@ -36,15 +39,6 @@ django-debug-toolbar==1.9.1 \
  --hash=sha256:4af2a4e1e932dadbda197b18585962d4fc20172b4e5a479490bc659fe998864d
 requests==2.21.0 \
  --hash=sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b
-
-#### Unknown - are these needed? ####
-
-Pillow==5.2.0 \
- --hash=sha256:8194d913ca1f459377c8a4ed8f9b7ad750068b8e0e3f3f9c6963fcc87a84515f\
- --hash=sha256:b3ef168d4d6fd4fa6685aef7c91400f59f7ab1c0da734541f7031699741fb23f
-psycopg2-binary==2.7.4 \
- --hash=sha256:9305d7cbc802aaefac5c75a3df725f2654797369f32b18d4d0adb382dfab6c09\
- --hash=sha256:de4f88f823037a71ea5ef3c1041d96b8a68d73343133edda684fd42f575bd9d7
 selenium==3.141.0 \
  --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -2,7 +2,7 @@
 language: python
 
 python:
-  - 3.6
+  - 3.7
 
 # use this to control what branches get built.
 # http://docs.shippable.com/ci/advancedOptions/branches/


### PR DESCRIPTION
Add package hashes to 'requirements.txt' so that packages will be
verified before being installed.

(I haven't verified that these packages are *legitimate*, but I have
checked that these are the hashes of the files currently hosted at
files.pythonhosted.org.  Trust-on-first-use is not particularly good
but it's better than "trust everyone all the time". :/)

pip3 will enforce these, and refuse to install packages that don't
match the listed hash(es).  When updating to a new version, obviously,
the hashes will need to be changed as well.
