### PR TITLE
Update to "credentialing approved" email by request

### DIFF
--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -2,7 +2,11 @@
 Dear {{ applicant_name }},
 
 {% if application.status == 2 %}
-We are pleased to say that your application for credentialed access to PhysioNet has been accepted. You are now a credentialed user with the ability to access restricted-access PhysioNet databases upon agreeing to the terms of usage.
+Thank you for your interest in the PhysioNet Clinical Databases. We are pleased to say that your application for credentialed access has been approved. You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access MIMIC-III by following the steps below:
+
+- Go to the project page at http://{{ domain }}{% url 'published_project_latest' 'mimiciii' %}
+- Find the “Files” section in the project description
+- Click “Sign the data use agreement” to agree to the terms of usage
 {% else %}
 Thank you for applying for credentialed access to PhysioNet. Your application was not approved. This may be for one of the following reasons:
 
@@ -13,7 +17,7 @@ Thank you for applying for credentialed access to PhysioNet. Your application wa
 - Your research summary did not include sufficient information, or was in some other way inadequate.
 
 {% if comments %}
-The following comments were also added to your application.
+The following comments were also added to your application:
 {{ application.responder_comments }}
 
 {% endif %}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -6,7 +6,7 @@ Thank you for your interest in the PhysioNet Clinical Databases. We are pleased 
 
 - Go to the project page at http://{{ domain }}{% url 'published_project_latest' 'mimiciii' %}
 - Find the “Files” section in the project description
-- Click “Sign the data use agreement” to agree to the terms of usage
+- Click “Sign the data use agreement” to agree to the terms of usage for this dataset
 {% else %}
 Thank you for applying for credentialed access to PhysioNet. Your application was not approved. This may be for one of the following reasons:
 


### PR DESCRIPTION
This is a minor update to the "Your credentialing is approved email" (requested by KP/RGM). The change clarifies how a database can be accessed now that credentialing is complete. The original text read:

> Dear NAME,
> 
> We are pleased to say that your application for credentialed access to PhysioNet has been accepted.  You are now a credentialed user with the ability to access restricted-access PhysioNet databases upon agreeing to the terms of usage. 
> 
> Regards,
> 
> SIGNATURE

The new text (approved by RGM) reads:

> Dear NAME,
> 
> Thank you for your interest in the PhysioNet Clinical Databases. We are pleased to say that your application for credentialed access has been approved. You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access MIMIC-III by following the steps below:
> 
> - Go to the project page at http://localhost:8000/content/mimiciii/
> - Find the “Files” section in the project description
> - Click “Sign the data use agreement” to agree to the terms of usage
> 
> Regards,
> 
> SIGNATURE