### PR TITLE
"Fix" content type for feed.xml

### DIFF
--- a/physionet-django/notification/views.py
+++ b/physionet-django/notification/views.py
@@ -47,4 +47,5 @@ def news_rss(request, max_items=100):
     news_pieces = News.objects.order_by('-publish_datetime')[:max_items]
     feed_date = news_pieces[0].publish_datetime
     return render(request, 'notification/news_rss.xml',
-                  {'feed_date': feed_date, 'news_pieces': news_pieces})
+                  {'feed_date': feed_date, 'news_pieces': news_pieces},
+                  content_type='text/xml; charset=UTF-8')


### PR DESCRIPTION
Change content type for the RSS feed to text/xml.  It probably "should" be application/rss+xml but text/xml seems to be more widely used & supported.
