### PR TITLE
Minor change to HTML template to fix order in submission log. Relates to #611

### DIFF
--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -45,14 +45,14 @@
     {% elif project.submission_status == 60 %}
       <li class="list-group-item">
         <div class="row">
-          <div class="col-md-2">{{ project.author_approval_datetime|date }}</div>
-          <div class="col-md-10">All authors approved the final project for publication.
+          <div class="col-md-2">Currently</div>
+          <div class="col-md-10"><i class="far fa-clock"></i> Waiting for editor to publish submission.</div>
         </div>
       </li>
       <li class="list-group-item">
         <div class="row">
-          <div class="col-md-2">Currently</div>
-          <div class="col-md-10"><i class="far fa-clock"></i> Waiting for editor to publish submission.</div>
+          <div class="col-md-2">{{ project.author_approval_datetime|date }}</div>
+          <div class="col-md-10">All authors approved the final project for publication.
         </div>
       </li>
     {% endif %}


### PR DESCRIPTION
The final step in the submission log is listed out of sequence:

![Screen Shot 2019-07-24 at 10 03 24](https://user-images.githubusercontent.com/822601/61800375-e7914f80-adfa-11e9-93c2-5ad1695b75e0.png)

This changes fixes the order:

![Screen Shot 2019-07-24 at 10 03 10](https://user-images.githubusercontent.com/822601/61800363-e3fdc880-adfa-11e9-8f8b-f0d195b4d780.png)


