### PR TITLE
Consistent order history (new to old). Fixes #611

### DIFF
--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -1,7 +1,7 @@
 {# Submission timeline for a project under submission #}
 <ul class="list-group list-group-flush">
 
-    <!-- break -->
+    <!-- author approval -->
     {# Awaiting authors to approve final project #}
     {% if project.submission_status == 50 %}
       <li class="list-group-item">
@@ -42,6 +42,8 @@
           </div>
         </div>
       </li>
+
+    <!-- editor approval -->
     {% elif project.submission_status == 60 %}
       <li class="list-group-item">
         <div class="row">
@@ -57,7 +59,7 @@
       </li>
     {% endif %}
 
-  <!-- break -->
+  <!-- copyediting -->
   {# Waiting for revisions #}
   {% if project.submission_status == 30 %}
     <li class="list-group-item">
@@ -128,7 +130,7 @@
       {% endfor %}
     {% endif %}
 
-  <!-- break -->
+  <!-- resubmissions -->
   {# At this point, there may have been any number of submissions #}
   {% for e in edit_logs reversed %}
     <li class="list-group-item">
@@ -176,7 +178,7 @@
     {% endif %}
   {% endfor %}
 
-  <!-- break -->
+  <!-- editor assigned -->
   {# Waiting for editor #}
   {% if project.submission_status == 10 %}
   <li class="list-group-item">
@@ -195,7 +197,7 @@
   </li>
   {% endif %}
 
-  <!-- break -->
+  <!-- submitted -->
   {# Submitted #}
   <li class="list-group-item">
     <div class="row">

--- a/physionet-django/project/templates/project/published_submission_history.html
+++ b/physionet-django/project/templates/project/published_submission_history.html
@@ -9,9 +9,10 @@
 
 {% block content %}
 <div class="container">
-  <h1>Submission History - {{ project }}</h1>
+  <h1>{{ project }}</h1>
   <hr>
   <div class="card mb-3">
+    <div class="card-header">Submission Timeline (New to Old)</div>
     {% include "project/static_submission_timeline.html" %}
   </div>
   <p><a href="{% url 'project_home' %}">Return to Project Home</a></p>

--- a/physionet-django/project/templates/project/rejected_submission_history.html
+++ b/physionet-django/project/templates/project/rejected_submission_history.html
@@ -9,9 +9,10 @@
 
 {% block content %}
 <div class="container">
-  <h1>Submission History - {{ project }}</h1>
+  <h1>{{ project }}</h1>
   <hr>
   <div class="card mb-3">
+    <div class="card-header">Submission Timeline (New to Old)</div>
     {% include "project/static_submission_timeline.html" %}
   </div>
   <p><a href="{% url 'project_home' %}">Return to Project Home</a></p>

--- a/physionet-django/project/templates/project/static_submission_timeline.html
+++ b/physionet-django/project/templates/project/static_submission_timeline.html
@@ -1,24 +1,57 @@
 {# Submission timeline for a non-changing project. Used for rejected archived and published projects #}
 {# This assumes all edits and copyedits have been complete #}
+
 <ul class="list-group list-group-flush">
-  <li class="list-group-item">
-    <div class="row">
-      <div class="col-md-2">{{ project.submission_datetime|date }}</div>
-      <div class="col-md-10">
-        <p>The project was submitted for review.</p>
-        {% if project.author_comments %}
-          <p>The submitting author included the following comments:</p>
-          <a class="editor-comments">{{ project.author_comments|linebreaks }}</a>
-        {% endif %}
+
+  {% if published %}
+
+    <!-- published date -->
+    <li class="list-group-item">
+      <div class="row">
+        <div class="col-md-2">{{ project.publish_datetime|date }}</div>
+        <div class="col-md-10">The project was published.</div>
       </div>
-    </div>
-  </li>
-  <li class="list-group-item">
-    <div class="row">
-      <div class="col-md-2">{{ project.editor_assignment_datetime|date }}</div>
-      <div class="col-md-10">The project was assigned the editor: {{ project.editor.disp_name_email }}
-    </div>
-  </li>
+    </li>
+
+    <!-- author approval -->
+    <li class="list-group-item">
+      <div class="row">
+        <div class="col-md-2">{{ project.author_approval_datetime|date }}</div>
+        <div class="col-md-10">All authors approved the final project for publication.
+      </div>
+    </li>
+
+    <!-- copyediting -->
+    {# There may have been any number of copyedits #}
+    {% for c in copyedit_logs reversed %}
+
+      {% if c.is_reedit %}
+        <li class="list-group-item">
+          <div class="row">
+            <div class="col-md-2">{{ c.start_datetime|date }}</div>
+            <div class="col-md-10">The editor reopened the submission for copyediting.</div>
+          </div>
+        </li>
+      {% endif %}
+
+      <li class="list-group-item">
+        <div class="row">
+          <div class="col-md-2">{{ c.complete_datetime|date }}</div>
+          <div class="col-md-10">
+            <p>The editor finished copyediting the submission.</p>
+            {% if c.made_changes %}
+              <p>The editor comments regarding the changes made are as follows:</p>
+              <a class="editor-comments">{{ c.changelog_summary|linebreaks }}</a>
+            {% else %}
+              <p>No changes were made during the copyedit.</p>
+            {% endif %}
+          </div>
+        </div>
+      </li>
+    {% endfor %}
+  {% endif %}
+
+  <!-- resubmissions -->
   {# There may have been any number of submissions #}
   {% for e in edit_logs %}
     {% if e.is_resubmission %}
@@ -34,6 +67,7 @@
         </div>
       </li>
     {% endif %}
+
     <li class="list-group-item">
       <div class="row">
         <div class="col-md-2">{{ e.decision_datetime|date }}</div>
@@ -58,44 +92,27 @@
       </div>
     </li>
   {% endfor %}
-  {# End here if the project was rejected instead of published #}
-  {% if published %}
-    {# There may have been any number of copyedits #}
-    {% for c in copyedit_logs %}
-      {% if c.is_reedit %}
-        <li class="list-group-item">
-          <div class="row">
-            <div class="col-md-2">{{ c.start_datetime|date }}</div>
-            <div class="col-md-10">The editor reopened the submission for copyediting.</div>
-          </div>
-        </li>
-      {% endif %}
-      <li class="list-group-item">
-        <div class="row">
-          <div class="col-md-2">{{ c.complete_datetime|date }}</div>
-          <div class="col-md-10">
-            <p>The editor finished copyediting the submission.</p>
-            {% if c.made_changes %}
-              <p>The editor comments regarding the changes made are as follows:</p>
-              <a class="editor-comments">{{ c.changelog_summary|linebreaks }}</a>
-            {% else %}
-              <p>No changes were made during the copyedit.</p>
-            {% endif %}
-          </div>
-        </div>
-      </li>
-    {% endfor %}
-    <li class="list-group-item">
-      <div class="row">
-        <div class="col-md-2">{{ project.author_approval_datetime|date }}</div>
-        <div class="col-md-10">All authors approved the final project for publication.
+
+  <!-- editor assigned -->
+  <li class="list-group-item">
+    <div class="row">
+      <div class="col-md-2">{{ project.editor_assignment_datetime|date }}</div>
+      <div class="col-md-10">The project was assigned the editor: {{ project.editor.disp_name_email }}
+    </div>
+  </li>
+
+  <!-- submitted -->
+  <li class="list-group-item">
+    <div class="row">
+      <div class="col-md-2">{{ project.submission_datetime|date }}</div>
+      <div class="col-md-10">
+        <p>The project was submitted for review.</p>
+        {% if project.author_comments %}
+          <p>The submitting author included the following comments:</p>
+          <a class="editor-comments">{{ project.author_comments|linebreaks }}</a>
+        {% endif %}
       </div>
-    </li>
-    <li class="list-group-item">
-      <div class="row">
-        <div class="col-md-2">{{ project.publish_datetime|date }}</div>
-        <div class="col-md-10">The project was published.</div>
-      </div>
-    </li>
-  {% endif %}
+    </div>
+  </li>
+
 </ul>


### PR DESCRIPTION
Changes the submission history for published/rejected projects for consistency. Order is now new to old.

![Screen Shot 2019-07-24 at 10 39 56](https://user-images.githubusercontent.com/822601/61803171-b36c5d80-adff-11e9-92c8-c14700444d31.png)
