### PR TITLE
Allow N/A response to QA form. ref #546

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -29,6 +29,13 @@ YES_NO = (
     (0, 'No')
 )
 
+YES_NO_NA = (
+    ('', '-----------'),
+    (1, 'Yes'),
+    (0, 'No'),
+    ('', 'N/A')
+)
+
 
 class AssignEditorForm(forms.Form):
     """
@@ -65,15 +72,15 @@ class EditSubmissionForm(forms.ModelForm):
         labels = EditLog.COMMON_LABELS
 
         widgets = {
-            'soundly_produced':forms.Select(choices=YES_NO),
-            'well_described':forms.Select(choices=YES_NO),
-            'open_format':forms.Select(choices=YES_NO),
-            'data_machine_readable':forms.Select(choices=YES_NO),
-            'reusable':forms.Select(choices=YES_NO),
-            'no_phi':forms.Select(choices=YES_NO),
-            'pn_suitable':forms.Select(choices=YES_NO),
-            'editor_comments':forms.Textarea(),
-            'decision':forms.Select(choices=SUBMISSION_RESPONSE_CHOICES)
+            'soundly_produced': forms.Select(choices=YES_NO_NA),
+            'well_described': forms.Select(choices=YES_NO_NA),
+            'open_format': forms.Select(choices=YES_NO_NA),
+            'data_machine_readable': forms.Select(choices=YES_NO_NA),
+            'reusable': forms.Select(choices=YES_NO_NA),
+            'no_phi': forms.Select(choices=YES_NO_NA),
+            'pn_suitable': forms.Select(choices=YES_NO_NA),
+            'editor_comments': forms.Textarea(),
+            'decision': forms.Select(choices=SUBMISSION_RESPONSE_CHOICES)
         }
 
     def __init__(self, resource_type, *args, **kwargs):

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -29,11 +29,12 @@ YES_NO = (
     (0, 'No')
 )
 
-YES_NO_NA = (
+# See also RESPONSE_LABEL in project/models.py
+YES_NO_UNDETERMINED = (
     ('', '-----------'),
     (1, 'Yes'),
     (0, 'No'),
-    ('', 'N/A')
+    (None, 'Undetermined')
 )
 
 
@@ -51,6 +52,7 @@ class AssignEditorForm(forms.Form):
         if ActiveProject.objects.get(id=pid) not in ActiveProject.objects.filter(submission_status=10):
             raise forms.ValidationError('Incorrect project selected.')
         return pid
+
 
 class EditSubmissionForm(forms.ModelForm):
     """
@@ -72,13 +74,13 @@ class EditSubmissionForm(forms.ModelForm):
         labels = EditLog.COMMON_LABELS
 
         widgets = {
-            'soundly_produced': forms.Select(choices=YES_NO_NA),
-            'well_described': forms.Select(choices=YES_NO_NA),
-            'open_format': forms.Select(choices=YES_NO_NA),
-            'data_machine_readable': forms.Select(choices=YES_NO_NA),
-            'reusable': forms.Select(choices=YES_NO_NA),
-            'no_phi': forms.Select(choices=YES_NO_NA),
-            'pn_suitable': forms.Select(choices=YES_NO_NA),
+            'soundly_produced': forms.Select(choices=YES_NO_UNDETERMINED),
+            'well_described': forms.Select(choices=YES_NO_UNDETERMINED),
+            'open_format': forms.Select(choices=YES_NO_UNDETERMINED),
+            'data_machine_readable': forms.Select(choices=YES_NO_UNDETERMINED),
+            'reusable': forms.Select(choices=YES_NO_UNDETERMINED),
+            'no_phi': forms.Select(choices=YES_NO_UNDETERMINED),
+            'pn_suitable': forms.Select(choices=YES_NO_UNDETERMINED),
             'editor_comments': forms.Textarea(),
             'decision': forms.Select(choices=SUBMISSION_RESPONSE_CHOICES)
         }

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1712,14 +1712,19 @@ class EditLog(models.Model):
 
         resource_type = self.project.resource_type
         NO_YES = ('No', 'Yes')
-        # The quality assurance fields we want.
-        # Retrieve their labels and results.
+
+        # Retrieve their labels and results for our resource type
         quality_assurance_fields = self.__class__.QUALITY_ASSURANCE_FIELDS[resource_type]
+
         # Create the labels dictionary for this resource type
         labels = {**self.__class__.COMMON_LABELS, **self.__class__.LABELS[resource_type]}
 
-        self.quality_assurance_results = ['{}: {}'.format(
-            labels[f], NO_YES[getattr(self, f)]) for f in quality_assurance_fields]
+        # Our QA response is either Yes, No, or N/A.
+        self.quality_assurance_results = []
+        for f in quality_assurance_fields:
+            qa_str = '{} {}'.format(labels[f],
+                NO_YES[getattr(self, f)] if isinstance(getattr(self, f), bool) else 'N/A')
+            self.quality_assurance_results.append(qa_str)
 
 
 class CopyeditLog(models.Model):

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1721,7 +1721,6 @@ class EditLog(models.Model):
         # Create the labels dictionary for this resource type
         labels = {**self.__class__.COMMON_LABELS, **self.__class__.LABELS[resource_type]}
 
-        # Our QA response is either Yes, No, or N/A.
         self.quality_assurance_results = []
         for f in quality_assurance_fields:
             qa_str = '{} {}'.format(labels[f], RESPONSE_LABEL[getattr(self, f)])

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1711,7 +1711,9 @@ class EditLog(models.Model):
             return
 
         resource_type = self.project.resource_type
-        NO_YES = ('No', 'Yes')
+
+        # See also YES_NO_UNDETERMINED in console/forms.py
+        RESPONSE_LABEL = {True: 'Yes', False: 'No', None: 'Undetermined'}
 
         # Retrieve their labels and results for our resource type
         quality_assurance_fields = self.__class__.QUALITY_ASSURANCE_FIELDS[resource_type]
@@ -1722,8 +1724,7 @@ class EditLog(models.Model):
         # Our QA response is either Yes, No, or N/A.
         self.quality_assurance_results = []
         for f in quality_assurance_fields:
-            qa_str = '{} {}'.format(labels[f],
-                NO_YES[getattr(self, f)] if isinstance(getattr(self, f), bool) else 'N/A')
+            qa_str = '{} {}'.format(labels[f], RESPONSE_LABEL[getattr(self, f)])
             self.quality_assurance_results.append(qa_str)
 
 


### PR DESCRIPTION
When reviewing a project, the editor is required to select Yes/No for a list of questions before selecting "Accept"; "Reject" or "Revisions accepted". Sometimes these responses are not appropriate (e.g. we might not want to check whether files are machine readable if there are much larger issues that need to be resolved first). This change allows the editor to select N/A as an alternative to yes/no.