### PR TITLE
Fixes user username change bug

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -152,8 +152,8 @@ class UsernameChangeForm(forms.ModelForm):
                 name_components[1] = new_username
                 profile.photo.name = '/'.join(name_components)
                 profile.save()
-
-            os.rename(self.old_file_root, self.instance.file_root())
+            if os.path.exists(self.old_file_root):
+                os.rename(self.old_file_root, self.instance.file_root())
 
 
 class ProfileForm(forms.ModelForm):


### PR DESCRIPTION
There is a bug that if the user has never added a picture, and tries to
change the username, it will assume that there is a user folder under
the media directory, and try to move it. Here we just check if that
path exists, and if does, then we rename to the new username.