### PR TITLE
Fix copyedit submission

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -260,7 +260,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
     copyedit_form = forms.CopyeditForm(instance=copyedit_log)
 
     if request.method == 'POST':
-        if 'edit_metadata' in request.POST:
+        if 'edit_content' in request.POST:
             description_form = project_forms.ContentForm(
                 resource_type=project.resource_type, data=request.POST,
                 instance=project)


### PR DESCRIPTION
Fixes error when saving updated metadata during the copyediting phase (thanks @elfeto for spotting the problem).

```
Internal Server Error: /console/submitted-projects/wowRrDwxO1FW0XJjiZGz/copyedit/

UnboundLocalError at /console/submitted-projects/wowRrDwxO1FW0XJjiZGz/copyedit/
local variable 'subdir' referenced before assignment

Request Method: POST
Request URL: https://alpha.physionet.org/console/submitted-projects/wowRrDwxO1FW0XJjiZGz/copyedit/
Django Version: 2.2.3
Python Executable: /physionet/python-env/physionet/bin/uwsgi
Python Version: 3.7.3
Python Path: ['.', '', '/physionet/python-env/physionet/lib/python37.zip', '/physionet/python-env/physionet/lib/python3.7', '/physionet/python-env/physionet/lib/python3.7/lib-dynload', '/usr/lib/python3.7', '/physionet/python-env/physionet/lib/python3.7/site-packages']
Server time: Wed, 24 Jul 2019 21:56:39 -0400
Installed Applications:
['dal',
 'dal_select2',
 'django.contrib.admin',
 'django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.messages',
 'django.contrib.staticfiles',
 'ckeditor',
 'background_task',
 'user',
 'project',
 'console',
 'export',
 'notification',
 'search',
 'lightwave']
Installed Middleware:
['django.middleware.security.SecurityMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware']


Traceback:

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  115.                 response = self.process_exception_by_middleware(e, request)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
  21.                 return view_func(request, *args, **kwargs)

File "./console/views.py" in handling_view
  72.             return base_view(request, *args, **kwargs)

File "./console/views.py" in copyedit_submission
  311.             subdir = process_files_post(request, project)

File "./project/views.py" in process_files_post
  886.     return subdir

Exception Type: UnboundLocalError at /console/submitted-projects/wowRrDwxO1FW0XJjiZGz/copyedit/
Exception Value: local variable 'subdir' referenced before assignment
Request information:
```