### PR TITLE
Fixing second user bug

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -853,7 +853,7 @@ def past_credential_applications(request):
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
 def credentialed_user_info(request, username):
-    c_user = User.objects.get(username=username)
+    c_user = User.objects.get(username__iexact=username)
     application = CredentialApplication.objects.get(user=c_user, status=2)
     return render(request, 'console/credentialed_user_info.html',
         {'c_user':c_user, 'application':application})

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -227,8 +227,8 @@ def public_profile(request, username):
     """
     A user's public profile
     """
-    if User.objects.filter(username=username).exists():
-        public_user = User.objects.get(username=username)
+    if User.objects.filter(username__iexact=username).exists():
+        public_user = User.objects.get(username__iexact=username)
         public_email = public_user.associated_emails.filter(is_public=True).first()
     else:
         raise Http404()
@@ -242,7 +242,7 @@ def profile_photo(request, username):
     """
     Serve a user's profile photo
     """
-    user = User.objects.get(username=username)
+    user = User.objects.get(username__iexact=username)
     return utility.serve_file(user.profile.photo.path)
 
 def register(request):


### PR DESCRIPTION
On registration the username was being forced to lower case.
I removed that, and changed the defined user get queries to
be case insensite.

Now admin is the same as Admin.

The thing to note here is that for future code, we need to
use "User.objects.get(username__iexact="
instead of "User.objects.get(username="