### PR TITLE
Fixed bug on non-numerical news urls

### DIFF
--- a/physionet-django/notification/urls.py
+++ b/physionet-django/notification/urls.py
@@ -5,6 +5,6 @@ from . import views
 
 urlpatterns = [
     path('news/', views.news, name='news'),
-    path('news/<year>/', views.news_year, name='news_year'),
+    path('news/<int:year>/', views.news_year, name='news_year'),
     path('feed.xml', views.news_rss, name='news_rss'),
 ]

--- a/physionet-django/notification/views.py
+++ b/physionet-django/notification/views.py
@@ -29,7 +29,7 @@ def news_year(request, year):
     """
     Get all the news of a specific year
     """
-    if int(year) < 1999 or int(year) > date.today().year:
+    if year < 1999 or year > date.today().year:
         return redirect('news')
 
     news_pieces = News.objects.filter(publish_datetime__year=int(year)) \


### PR DESCRIPTION
There is a bug right now that assumes all news item will have a year, and break for non numerical 4 digit numbers.

For example
https://alpha.physionet.org/news/a/