### PR TITLE
Follow DataCite recommendation for displaying DOIs

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -199,7 +199,7 @@
           {% if project.doi %}
           <p><strong>DOI:</strong>
             <br>
-            <a href="http://dx.doi.org/{{ project.doi }}">{{ project.doi }}</a>
+            <a href="https://doi.org/{{ project.doi }}">https://doi.org/{{ project.doi }}</a>
           </p>
           {% endif %}
 


### PR DESCRIPTION
DataCite's guidelines for displaying DOIs are at:
https://support.datacite.org/docs/datacite-doi-display-guidelines

The guidelines suggest that:
- "DataCite DOIs should always be displayed as a complete URL using the form: https://doi.org/10.7939/r3qz22k64"
- the "dx" should be dropped from the domain name portion of DOI links
- use the secure HTTPS rather than HTTP

This pull request updates our project pages (e.g. https://alpha.physionet.org/content/eicu-crd/) to follow these guidelines.

 