### PR TITLE
License should be a required field

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -908,8 +908,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
 
         # Metadata
         for attr in ActiveProject.REQUIRED_FIELDS[self.resource_type]:
-            text = unescape(strip_tags(getattr(self, attr)))
-            if not text or text.isspace():
+            value = getattr(self, attr)
+            text = unescape(strip_tags(str(value)))
+            if value is None or not text or text.isspace():
                 l = self.LABELS[self.resource_type][attr] if attr in self.LABELS[self.resource_type] else attr.title().replace('_', ' ')
                 self.integrity_errors.append('Missing required field: {0}'.format(l))
 


### PR DESCRIPTION
It should not be possible to submit a project without a license being selected.

Prior to 772f91485b986b85e749e849fd1014c9b2c745c8 this was enforced (because None is false), but following that commit it was broken (because None, when converted to a string, is non-empty.)

This should fix it; sorry for my goof. :)
