### PR TITLE
Move table captions to the top

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -36,6 +36,9 @@ table {
   border-bottom: 1px solid #dfdfdf;
   margin: 1em auto;
 }
+table > caption {
+  caption-side: top;
+}
 thead, tbody, tfoot {
   border-top: 1px solid #dfdfdf;
 }


### PR DESCRIPTION
Display the 'caption' tag at the top of a table rather than at the bottom.

