### PR TITLE
Moved pagination to another file and cleaned past credentialed applications

### DIFF
--- a/physionet-django/console/templates/console/pagination.html
+++ b/physionet-django/console/templates/console/pagination.html
@@ -3,7 +3,7 @@
     <ul class="pagination">
       <li><a href="?{{ querystring }}page=1">&laquo;</a></li>
       {% if pagination.has_previous %}
-        <li><a href="?{{ querystring }}page={{ users.previous_page_number }}">&lsaquo;</a></li>
+        <li><a href="?{{ querystring }}page={{ pagination.previous_page_number }}">&lsaquo;</a></li>
       {% else %}
         <li class="disabled"><span>&lsaquo;</span></li>
       {% endif %}

--- a/physionet-django/console/templates/console/pagination.html
+++ b/physionet-django/console/templates/console/pagination.html
@@ -1,9 +1,9 @@
 {% if pagination.has_other_pages %}
   <div style="text-align: center;">
     <ul class="pagination">
-      <li><a href="?{{ querystring }}page=1">&laquo;</a></li>
+      <li><a href="?{{ querystring }}&page=1">&laquo;</a></li>
       {% if pagination.has_previous %}
-        <li><a href="?{{ querystring }}page={{ pagination.previous_page_number }}">&lsaquo;</a></li>
+        <li><a href="?{{ querystring }}&page={{ pagination.previous_page_number }}">&lsaquo;</a></li>
       {% else %}
         <li class="disabled"><span>&lsaquo;</span></li>
       {% endif %}
@@ -13,17 +13,17 @@
           {% if pagination.number == num %}
             <li class="active"><span>{{ num }} <span class="sr-only">(current)</span></span></li>
           {% else %}
-            <li><a href="?{{ querystring }}page={{ num }}">{{ num }}</a></li>
+            <li><a href="?{{ querystring }}&page={{ num }}">{{ num }}</a></li>
           {% endif %}
         {% endif %}
         {% endwith %}
       {% endfor %}
       {% if pagination.has_next %}
-        <li><a href="?{{ querystring }}page={{ pagination.next_page_number }}">&rsaquo;</a></li>
+        <li><a href="?{{ querystring }}&page={{ pagination.next_page_number }}">&rsaquo;</a></li>
       {% else %}
         <li class="disabled"><span>&rsaquo;</span></li>
       {% endif %}
-      <li><a href="?{{ querystring }}page={{ pagination.paginator.num_pages }}">&raquo;</a></li>
+      <li><a href="?{{ querystring }}&page={{ pagination.paginator.num_pages }}">&raquo;</a></li>
     </ul>
   </div>
 {% endif %}

--- a/physionet-django/console/templates/console/pagination.html
+++ b/physionet-django/console/templates/console/pagination.html
@@ -1,0 +1,29 @@
+{% if pagination.has_other_pages %}
+  <div style="text-align: center;">
+    <ul class="pagination">
+      <li><a href="?{{ querystring }}page=1">&laquo;</a></li>
+      {% if pagination.has_previous %}
+        <li><a href="?{{ querystring }}page={{ users.previous_page_number }}">&lsaquo;</a></li>
+      {% else %}
+        <li class="disabled"><span>&lsaquo;</span></li>
+      {% endif %}
+      {% for i in i|ljust:10 %}
+        {% with num=forloop.counter|add:pagination.number|add:"-4" %}
+        {% if num > 0 and num <= pagination.paginator.num_pages %}
+          {% if pagination.number == num %}
+            <li class="active"><span>{{ num }} <span class="sr-only">(current)</span></span></li>
+          {% else %}
+            <li><a href="?{{ querystring }}page={{ num }}">{{ num }}</a></li>
+          {% endif %}
+        {% endif %}
+        {% endwith %}
+      {% endfor %}
+      {% if pagination.has_next %}
+        <li><a href="?{{ querystring }}page={{ pagination.next_page_number }}">&rsaquo;</a></li>
+      {% else %}
+        <li class="disabled"><span>&rsaquo;</span></li>
+      {% endif %}
+      <li><a href="?{{ querystring }}page={{ pagination.paginator.num_pages }}">&raquo;</a></li>
+    </ul>
+  </div>
+{% endif %}

--- a/physionet-django/console/templates/console/past_credential_applications.html
+++ b/physionet-django/console/templates/console/past_credential_applications.html
@@ -9,9 +9,7 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
-      {% with s=s_applications|length l=l_applications|length %}
-        <a class="nav-link active" id="s-tab" data-toggle="tab" href="#s-apps" role="tab" aria-controls="s-apps" aria-selected="true">Successful Applications <span class="badge badge-pill badge-info">{{ s|add:l }}</a>
-      {% endwith %}
+        <a class="nav-link active" id="s-tab" data-toggle="tab" href="#s-apps" role="tab" aria-controls="s-apps" aria-selected="true">Successful Applications <span class="badge badge-pill badge-info">{{ approved_applications|length }}</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" id="u-tab" data-toggle="tab" href="#u-apps" role="tab" aria-controls="u-apps" aria-selected="false">Unsuccessful Applications <span class="badge badge-pill badge-info">{{ u_applications|length }}</span></a>
@@ -23,7 +21,7 @@
     <div class="tab-content">
       {# Successful applications #}
       <div class="tab-pane fade show active" id="s-apps" role="tabpanel" aria-labelledby="s-tab">
-        {% if s_applications or l_applications %}
+        {% if approved_applications %}
           <div class="table-responsive">
             <table class="table table-bordered">
               <thead>
@@ -38,44 +36,36 @@
                 </tr>
               </thead>
               <tbody>
-              {% for application in s_applications %}
+              {% for user in approved_applications %}
                 <tr>
-                {% with user=application.user %}
-                  <td><a href="{% url 'public_profile' user.username %}">{{ user.get_full_name }}</td>
-                  <td>{{ user.email }}</td>
-                  <td>{{ application.application_datetime|date }}</td>
-                  <td>{{ application.decision_datetime|date }}</td>
-                  <td>{{ application.responder.get_full_name }}</td>
-                  <td><a href="{% url 'view_credential_application' application.slug %}">View</a></td>
-                  <td>
-                    <form action="" method="post">
-                    {% csrf_token %}
-                      <button class="btn btn-danger" name="remove_credentialing" value="{{ application.id }}" type="submit">
-                        Remove Credentialing
-                      </button>
-                    </form>
-                  </td>
-                {% endwith %}
-                </tr>
-              {% endfor %}
-              {% for application in l_applications %}
-                <tr>
-                {% with user=application.migrated_user %}
                   <td><a href="{% url 'public_profile' user.username %}">{{ user.get_full_name }}</td>
                   <td>{{ user.email }}</td>
                   <td>{{ user.credential_datetime|date }}</td>
-                  <td>Legacy</td>
-                  <td>Legacy</td>
-                  <td>Legacy</td>
-                  <td>
-                    <form action="" method="post">
-                    {% csrf_token %}
-                      <button class="btn btn-danger" name="remove_credentialing" value="{{ application.email }}" type="submit">
-                        Remove Credentialing
-                      </button>
-                    </form>
-                  </td>
-                {% endwith %}
+                  {% if user.credential_applications.count %}
+                    <td>{{ user.credential_applications.last.decision_datetime|date }}</td>
+                    <td>{{ user.credential_applications.last.responder.get_full_name }}</td>
+                    <td><a href="{ % url 'view_credential_application' user.credential_applications.last.slug % }">View</a></td>
+                    <td>
+                      <form action="" method="post">
+                      {% csrf_token %}
+                        <button class="btn btn-danger" name="remove_credentialing" value="{{ user.credential_applications.last.id }}" type="submit">
+                          Remove Credentialing
+                        </button>
+                      </form>
+                    </td>
+                  {% else %}
+                    <td>Legacy</td>
+                    <td>Legacy</td>
+                    <td>Legacy</td>
+                    <td>
+                      <form action="" method="post">
+                      {% csrf_token %}
+                        <button class="btn btn-danger" name="remove_credentialing" value="{{ application.email }}" type="submit">
+                          Remove Credentialing
+                        </button>
+                      </form>
+                    </td>
+                  {% endif %}
                 </tr>
               {% endfor %}
               </tbody>

--- a/physionet-django/console/templates/console/past_credential_applications.html
+++ b/physionet-django/console/templates/console/past_credential_applications.html
@@ -9,7 +9,9 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
-        <a class="nav-link active" id="s-tab" data-toggle="tab" href="#s-apps" role="tab" aria-controls="s-apps" aria-selected="true">Successful Applications <span class="badge badge-pill badge-info">{{ approved_applications|length }}</a>
+      {% with s=s_applications|length l=l_applications|length %}
+        <a class="nav-link active" id="s-tab" data-toggle="tab" href="#s-apps" role="tab" aria-controls="s-apps" aria-selected="true">Successful Applications <span class="badge badge-pill badge-info">{{ s|add:l }}</a>
+      {% endwith %}
       </li>
       <li class="nav-item">
         <a class="nav-link" id="u-tab" data-toggle="tab" href="#u-apps" role="tab" aria-controls="u-apps" aria-selected="false">Unsuccessful Applications <span class="badge badge-pill badge-info">{{ u_applications|length }}</span></a>
@@ -21,7 +23,7 @@
     <div class="tab-content">
       {# Successful applications #}
       <div class="tab-pane fade show active" id="s-apps" role="tabpanel" aria-labelledby="s-tab">
-        {% if approved_applications %}
+        {% if s_applications or l_applications %}
           <div class="table-responsive">
             <table class="table table-bordered">
               <thead>
@@ -36,36 +38,44 @@
                 </tr>
               </thead>
               <tbody>
-              {% for user in approved_applications %}
+              {% for application in s_applications %}
                 <tr>
+                {% with user=application.user %}
+                  <td><a href="{% url 'public_profile' user.username %}">{{ user.get_full_name }}</td>
+                  <td>{{ user.email }}</td>
+                  <td>{{ application.application_datetime|date }}</td>
+                  <td>{{ application.decision_datetime|date }}</td>
+                  <td>{{ application.responder.get_full_name }}</td>
+                  <td><a href="{% url 'view_credential_application' application.slug %}">View</a></td>
+                  <td>
+                    <form action="" method="post">
+                    {% csrf_token %}
+                      <button class="btn btn-danger" name="remove_credentialing" value="{{ application.id }}" type="submit">
+                        Remove Credentialing
+                      </button>
+                    </form>
+                  </td>
+                {% endwith %}
+                </tr>
+              {% endfor %}
+              {% for application in l_applications %}
+                <tr>
+                {% with user=application.migrated_user %}
                   <td><a href="{% url 'public_profile' user.username %}">{{ user.get_full_name }}</td>
                   <td>{{ user.email }}</td>
                   <td>{{ user.credential_datetime|date }}</td>
-                  {% if user.credential_applications.count %}
-                    <td>{{ user.credential_applications.last.decision_datetime|date }}</td>
-                    <td>{{ user.credential_applications.last.responder.get_full_name }}</td>
-                    <td><a href="{ % url 'view_credential_application' user.credential_applications.last.slug % }">View</a></td>
-                    <td>
-                      <form action="" method="post">
-                      {% csrf_token %}
-                        <button class="btn btn-danger" name="remove_credentialing" value="{{ user.credential_applications.last.id }}" type="submit">
-                          Remove Credentialing
-                        </button>
-                      </form>
-                    </td>
-                  {% else %}
-                    <td>Legacy</td>
-                    <td>Legacy</td>
-                    <td>Legacy</td>
-                    <td>
-                      <form action="" method="post">
-                      {% csrf_token %}
-                        <button class="btn btn-danger" name="remove_credentialing" value="{{ application.email }}" type="submit">
-                          Remove Credentialing
-                        </button>
-                      </form>
-                    </td>
-                  {% endif %}
+                  <td>Legacy</td>
+                  <td>Legacy</td>
+                  <td>Legacy</td>
+                  <td>
+                    <form action="" method="post">
+                    {% csrf_token %}
+                      <button class="btn btn-danger" name="remove_credentialing" value="{{ application.email }}" type="submit">
+                        Remove Credentialing
+                      </button>
+                    </form>
+                  </td>
+                {% endwith %}
                 </tr>
               {% endfor %}
               </tbody>

--- a/physionet-django/console/templates/console/users.html
+++ b/physionet-django/console/templates/console/users.html
@@ -5,7 +5,7 @@
 {% block title %}PhysioNet Users{% endblock %}
 
 {% block local_css %}
-<link rel="stylesheet" type="text/css" href="{% static 'search/css/content-index.css' %}">
+<link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/physionet-django/console/templates/console/users.html
+++ b/physionet-django/console/templates/console/users.html
@@ -57,35 +57,7 @@
           {% include 'console/users_list.html' %}
         </tbody>
       </table>
-      {% if users.has_other_pages %}
-        <div style="text-align: center;">
-          <ul class="pagination">
-            <li><a href="?page=1">&laquo;</a></li>
-            {% if users.has_previous %}
-              <li><a href="?page={{ users.previous_page_number }}">&lsaquo;</a></li>
-            {% else %}
-              <li class="disabled"><span>&lsaquo;</span></li>
-            {% endif %}
-            {% for i in i|ljust:10 %}
-              {% with num=forloop.counter|add:users.number|add:"-4" %}
-              {% if num > 0 and num <= users.paginator.num_pages %}
-                {% if users.number == num %}
-                  <li class="active"><span>{{ num }} <span class="sr-only">(current)</span></span></li>
-                {% else %}
-                  <li><a href="?page={{ num }}">{{ num }}</a></li>
-                {% endif %}
-              {% endif %}
-              {% endwith %}
-            {% endfor %}
-            {% if users.has_next %}
-              <li><a href="?page={{ users.next_page_number }}">&rsaquo;</a></li>
-            {% else %}
-              <li class="disabled"><span>&rsaquo;</span></li>
-            {% endif %}
-            <li><a href="?page={{ users.paginator.num_pages }}">&raquo;</a></li>
-          </ul>
-        </div>
-      {% endif %}
+      {% include "console/pagination.html" with pagination=users %}
     </div>
   </div>
 </div>

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -6,6 +6,7 @@ from google.api_core.exceptions import BadRequest
 from googleapiclient.discovery import build
 from google.cloud import storage
 from django.conf import settings
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 import logging
 
@@ -162,4 +163,13 @@ def create_directory_service(user_email):
     credentials = credentials.create_delegated(user_email)
     return build('admin', 'directory_v1', credentials=credentials)
 
+
+def paginate(request, to_paginate, maximun):
+    """
+    Function to paginate the arguments. 
+    """
+    page = request.GET.get('page', 1)
+    paginator = Paginator(to_paginate, maximun)
+    paginated = paginator.get_page(page)
+    return paginated
 

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -6,7 +6,6 @@ from google.api_core.exceptions import BadRequest
 from googleapiclient.discovery import build
 from google.cloud import storage
 from django.conf import settings
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 import logging
 
@@ -172,4 +171,3 @@ def paginate(request, to_paginate, maximun):
     paginator = Paginator(to_paginate, maximun)
     paginated = paginator.get_page(page)
     return paginated
-

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -814,6 +814,9 @@ def past_credential_applications(request):
     Inactive credential applications. Split into successful and
     unsuccessful.
     """
+    l_applications = LegacyCredential.objects.filter(migrated=True, migrated_user__is_credentialed=True).order_by('-migration_date')
+    s_applications = CredentialApplication.objects.filter(status=2).order_by('-application_datetime')
+    u_applications = CredentialApplication.objects.filter(status=1).order_by('-application_datetime')
     if request.method == 'POST':
         if 'remove_credentialing' in request.POST:
             if request.POST['remove_credentialing'].isdigit():
@@ -855,13 +858,10 @@ def past_credential_applications(request):
                 c_application.status = 0
                 c_application.save()
 
-    rejected_applications = CredentialApplication.objects.filter(status=1).order_by('-application_datetime')
-
-    approved_applications = User.objects.filter(is_credentialed=True).order_by('-credential_datetime')
-
     return render(request, 'console/past_credential_applications.html',
-        {'approved_applications':approved_applications,
-         'rejected_applications':rejected_applications})
+        {'s_applications':s_applications,
+         'u_applications':u_applications,
+         'l_applications':l_applications})
 
 
 @login_required

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -19,6 +19,7 @@ from background_task import background
 
 from notification.models import News
 import notification.utility as notification
+from physionet.utility import paginate
 import project.forms as project_forms
 from project.models import (ActiveProject, ArchivedProject, StorageRequest,
     Reference, Topic, Publication, PublishedProject,
@@ -634,7 +635,7 @@ def users(request):
     List of users
     """
     all_users = User.objects.all().order_by('username')
-    users = utility.paginate(request, all_users, 100)
+    users = paginate(request, all_users, 100)
 
     return render(request, 'console/users.html', {'users': users})
 
@@ -673,7 +674,7 @@ def users_inactive(request):
         last_login__lt=timezone.now() + timezone.timedelta(days=-90))
         ).order_by('username')
 
-    inactive_users = utility.paginate(request, all_inactive_users, 100)
+    inactive_users = paginate(request, all_inactive_users, 100)
 
     return render(request, 'console/users.html', {'users': inactive_users})
 

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -6,6 +6,7 @@ import tempfile
 from django.conf import settings
 from django.http import HttpResponse, Http404
 from django.utils.html import format_html
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 CONTENT_TYPE = {
     '.html': 'text/html',
@@ -223,3 +224,21 @@ def zip_dir(zip_name, target_dir, enclosing_folder=''):
             os.remove(tmp_zip_name)
         except FileNotFoundError:
             pass
+
+
+def paginate(request, to_paginate, maximum):
+    """
+    Function to split an array into pages of a specified size.
+
+    Parameters
+    ----------
+    request : HTTP request to get the desired page if not defaults to 1.
+    to_paginate : Array to paginate.
+    maximum : Maximum ammount of elments in a page.
+
+    Returns a page in the array.
+    """
+    page = request.GET.get('page', 1)
+    paginator = Paginator(to_paginate, maximum)
+    paginated = paginator.get_page(page)
+    return paginated

--- a/physionet-django/search/static/search/css/content-index.css
+++ b/physionet-django/search/static/search/css/content-index.css
@@ -8,59 +8,6 @@
 	flex: unset;
 }
 
-.pagination{
-	display: inline-block;
-	text-align: left;
-}
-
-.pagination li{
-	width: 2.6em;
-	height: 2.6em;
-	text-align: center;
-	line-height: 2.6em;
-	margin-right: -5.5px;
-	margin-bottom: -1px;
-	display: inline-block;
-	box-sizing: border-box;
-	border: 1px solid silver;
-}
-
-.pagination a:hover{
-	text-decoration: none;
-}
-
-.pagination li:first-of-type{
-	border-left: 1px solid silver;
-	border-radius: 5px 0 0 5px;
-}
-
-.pagination li:last-of-type{
-	border-radius: 0 5px 5px 0;
-}
-
-.pagination li.active{
-	color: white;
-	background-color: #343a40;
-	border: 1px solid #343a40;
-}
-
-.pagination .disabled{
-	color: silver;
-}
-
-.pagination li:nth-of-type(1n+10) {
-  display: none;
-}
-
-
-.pagination li:nth-last-of-type(2){
-	display: inline-block;
-}
-
-.pagination li:last-of-type{
-	display: inline-block;
-}
-
 .search-options, .search-options select{
 	font-size: 0.8rem;
 }

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -8,6 +8,7 @@ PhysioNet Index
 {% block local_css %}
 <link rel="stylesheet" type="text/css" href="{% static 'search/css/content-index.css' %}">
 <link rel="stylesheet" type="text/css" href="{% static 'custom/css/form-control-input.css' %}">
+<link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/physionet-django/search/templates/search/content_index.html
+++ b/physionet-django/search/templates/search/content_index.html
@@ -42,35 +42,9 @@ PhysioNet Index
       <br>
       {% if projects|length < 1 %} No results {% endif %}
       {% include "search/content_list.html" %}
-      {% if projects.has_other_pages %}
-        <div style="text-align: center;">
-          <ul class="pagination">
-            <li><a href="?{{ querystring }}page=1">&laquo;</a></li>
-            {% if projects.has_previous %}
-              <li><a href="?{{ querystring }}page={{ users.previous_page_number }}">&lsaquo;</a></li>
-            {% else %}
-              <li class="disabled"><span>&lsaquo;</span></li>
-            {% endif %}
-            {% for i in i|ljust:10 %}
-              {% with num=forloop.counter|add:projects.number|add:"-4" %}
-              {% if num > 0 and num <= projects.paginator.num_pages %}
-                {% if projects.number == num %}
-                  <li class="active"><span>{{ num }} <span class="sr-only">(current)</span></span></li>
-                {% else %}
-                  <li><a href="?{{ querystring }}page={{ num }}">{{ num }}</a></li>
-                {% endif %}
-              {% endif %}
-              {% endwith %}
-            {% endfor %}
-            {% if projects.has_next %}
-              <li><a href="?{{ querystring }}page={{ projects.next_page_number }}">&rsaquo;</a></li>
-            {% else %}
-              <li class="disabled"><span>&rsaquo;</span></li>
-            {% endif %}
-            <li><a href="?{{ querystring }}page={{ projects.paginator.num_pages }}">&raquo;</a></li>
-          </ul>
-        </div>
-      {% endif %}
+
+      {% include "console/pagination.html" with pagination=projects %}
+
     </div>
 </div>
 {% endblock %}

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -11,7 +11,7 @@ from django.http import Http404
 
 from search import forms
 from project.models import PublishedProject, PublishedTopic
-from console.utility import paginate
+from physionet.utility import paginate
 
 def topic_search(request):
     """
@@ -152,9 +152,14 @@ def content_index(request, resource_type=None):
     # PAGINATION
     projects = paginate(request, published_projects, 10)
 
-    querystring = re.sub(r'\&*page=\d*', '', request.GET.urlencode())
-    if querystring != '':
-        querystring += '&'
+    params = request.GET.copy()
+    # Remove the page argument from the querystring if it exists
+    try:
+        params.pop('page')
+    except KeyError:
+        pass
+
+    querystring = params.urlencode()
 
     return render(request, 'search/content_index.html',
                   {'form_order': form_order,

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -1,20 +1,17 @@
 import pdb
 import re
+import operator
+from functools import reduce
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.shortcuts import render, redirect, reverse
-
-from . import forms
-from project.models import PublishedProject, PublishedTopic
-
-import operator
-from functools import reduce
 from django.db.models import Q, Count, Case, When, Value, IntegerField, Sum
-
-from django.core.paginator import Paginator
 from django.conf import settings
 from django.http import Http404
 
+from search import forms
+from project.models import PublishedProject, PublishedTopic
+from console.utility import paginate
 
 def topic_search(request):
     """
@@ -153,12 +150,7 @@ def content_index(request, resource_type=None):
                                      topic=topic)
 
     # PAGINATION
-    page = request.GET.get('page', 1)
-    paginator = Paginator(published_projects, 10)
-    try:
-        projects = paginator.page(page)
-    except:
-        projects = paginator.page(1)
+    projects = paginate(request, published_projects, 10)
 
     querystring = re.sub(r'\&*page=\d*', '', request.GET.urlencode())
     if querystring != '':

--- a/physionet-django/static/custom/css/pagination.css
+++ b/physionet-django/static/custom/css/pagination.css
@@ -1,0 +1,52 @@
+.pagination{
+	display: inline-block;
+	text-align: left;
+}
+
+.pagination li{
+	width: 2.6em;
+	height: 2.6em;
+	text-align: center;
+	line-height: 2.6em;
+	margin-right: -5.5px;
+	margin-bottom: -1px;
+	display: inline-block;
+	box-sizing: border-box;
+	border: 1px solid silver;
+}
+
+.pagination a:hover{
+	text-decoration: none;
+}
+
+.pagination li:first-of-type{
+	border-left: 1px solid silver;
+	border-radius: 5px 0 0 5px;
+}
+
+.pagination li:last-of-type{
+	border-radius: 0 5px 5px 0;
+}
+
+.pagination li.active{
+	color: white;
+	background-color: #343a40;
+	border: 1px solid #343a40;
+}
+
+.pagination .disabled{
+	color: silver;
+}
+
+.pagination li:nth-of-type(1n+10) {
+  display: none;
+}
+
+
+.pagination li:nth-last-of-type(2){
+	display: inline-block;
+}
+
+.pagination li:last-of-type{
+	display: inline-block;
+}


### PR DESCRIPTION
Here remove the try except and use the built ‘get_page’ in as suggested.
I moved it to another file, and just call the function instead of having the same thing in multiple places.

Also, I cleaned the past credential applications page. Now we don’t use 2 variables to differentiate legacy and new applications.

I was going to add pagination here, but it’s a bit more complicated because of the tab. To add pagination, the pages has to be separated.