### PR TITLE
Created service for background tasks

### DIFF
--- a/deploy/common/etc/systemd/system/django-background-tasks.service
+++ b/deploy/common/etc/systemd/system/django-background-tasks.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Command that runs Django background tasks
+After=emperor.uwsgi.service
+
+[Service]
+Environment=DJANGO_SETTINGS_MODULE=physionet.settings.production
+ExecStart=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py process_tasks --log-std
+Restart=always
+KillSignal=SIGQUIT
+Type=simple
+StandardError=syslog
+NotifyAccess=all
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/common/etc/systemd/system/django-background-tasks.service
+++ b/deploy/common/etc/systemd/system/django-background-tasks.service
@@ -6,7 +6,7 @@ After=emperor.uwsgi.service
 Environment=DJANGO_SETTINGS_MODULE=physionet.settings.production
 ExecStart=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py process_tasks --log-std
 Restart=always
-KillSignal=SIGQUIT
+KillSignal=SIGINT
 Type=simple
 StandardError=syslog
 NotifyAccess=all


### PR DESCRIPTION
I created a service for the background tasks to run automatically. The service SHOULD start after the uwsgi service. It will log the output to the system log.
Can be managed by:
- systemctl COMMAND django-background-tasks.service

This address #604