### PR TITLE
Enable django site mechanism

### DIFF
--- a/physionet-django/physionet/fixtures/sites.json
+++ b/physionet-django/physionet/fixtures/sites.json
@@ -1,0 +1,18 @@
+[
+    {
+        "model": "sites.Site",
+        "pk": 1,
+        "fields": {
+            "name": "PhysioNet",
+            "domain": "alpha.physionet.org"
+        }
+    },
+    {
+        "model": "sites.Site",
+        "pk": 2,
+        "fields": {
+            "name": "PhysioNet-staging",
+            "domain": "staging.physionet.org"
+        }
+    }
+]

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -8,6 +8,9 @@ from .base import *
 DEBUG = False
 
 ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
+SITE_ID = 1
+INSTALLED_APPS += ['django.contrib.sites']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -8,6 +8,8 @@ from .base import *
 DEBUG = True
 
 ALLOWED_HOSTS = ['staging.physionet.org', 'physionet-staging.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
+SITE_ID = 2
+INSTALLED_APPS += ['django.contrib.sites']
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
As discussed in issue #595, there are various places where the
server's hostname is displayed to the user.

We want to use a single canonical hostname; e.g. we don't want
notification emails to be different depending on whether the person
who triggered them was logged into https://alpha.physionet.org/,
https://physionet.org/, or https://www.physionet.org/.

The canonical hostname for production is set to alpha.physionet.org.
We will of course want to change that later, which is easy.

This should be straightforward, but test it on staging to be sure it
won't break anything.
