### PR TITLE
Add the newly published 2019 challenge to the hardcoded challenge index

### DIFF
--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -27,7 +27,7 @@
     of challenges, inviting participants to tackle clinically interesting
     problems that are either unsolved or not well-solved.</p>
   <ul>
-    <!-- <li><a href="{% url 'published_project_latest' 'challenge-2019' %}">2019</a>: Early Prediction of Sepsis from Clinical Data.</li> -->
+    <li><a href="{% url 'published_project_latest' '2019-challenge' %}">2019</a>: Early Prediction of Sepsis from Clinical Data.</li>
     <li><a href="{% url 'published_project_latest' 'challenge-2018' %}">2018</a>: You Snooze, You Win.</li>
     <li><a href="{% url 'published_project_latest' 'challenge-2017' %}">2017</a>: AF Classification from a Short Single Lead ECG Recording.</li>
     <li><a href="{% url 'published_project_latest' 'challenge-2016' %}">2016</a>: Classification of Normal/Abnormal Heart Sound Recordings.</li>


### PR DESCRIPTION
The 2019 PhysioNet Challenge is now listed at: https://alpha.physionet.org/content/2019-challenge/1.0.0/. This is a minor change to add the challenge to the hardcoded page at: https://alpha.physionet.org/about/challenge/