### PR TITLE
Assorted email style fixes

### DIFF
--- a/physionet-django/notification/templates/notification/email/accept_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/accept_submission_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -16,4 +16,4 @@ After copyediting of the project and files is complete, we will be in touch agai
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/accept_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/accept_submission_notify.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-Based on the recommendations of our editors, we are delighted to accept your project entitled "{{ project.title }}" for publication on PhysioNet. 
+Based on the recommendations of our editors, we are delighted to accept your project entitled "{{ project.title }}" for publication on PhysioNet.
 
 A summary of our standard set of editorial checks is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
@@ -11,7 +11,7 @@ A summary of our standard set of editorial checks is listed below:
 Additional comments from the editorial team are listed below:
 {{ edit_log.editor_comments }}
 
-After copyediting of the project and files is complete, we will be in touch again. Then, once all authors approve of the copyedited version at: {{ url_prefix }}{% url 'project_submission' project.slug %}, the project will be ready for publication. 
+After copyediting of the project and files is complete, we will be in touch again. Then, once all authors approve of the copyedited version at {{ url_prefix }}{% url 'project_submission' project.slug %}, the project will be ready for publication.
 
 {{ signature }}
 

--- a/physionet-django/notification/templates/notification/email/accept_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/accept_submission_notify.html
@@ -11,7 +11,7 @@ A summary of our standard set of editorial checks is listed below:
 Additional comments from the editorial team are listed below:
 {{ edit_log.editor_comments }}
 
-After copyediting of the project and files is complete, we will be in touch again. Then, once all authors approve of the copyedited version at: http://{{ domain }}{% url 'project_submission' project.slug %}, the project will be ready for publication. 
+After copyediting of the project and files is complete, we will be in touch again. Then, once all authors approve of the copyedited version at: {{ url_prefix }}{% url 'project_submission' project.slug %}, the project will be ready for publication. 
 
 {{ signature }}
 

--- a/physionet-django/notification/templates/notification/email/assign_editor_notify.html
+++ b/physionet-django/notification/templates/notification/email/assign_editor_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ We are pleased to say that your project entitled "{{ project.title }}" is now un
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/author_response.html
+++ b/physionet-django/notification/templates/notification/email/author_response.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ Your invitation to {{ author_email }} to co-author your project entitled "{{ pro
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/authors_approved_notify.html
+++ b/physionet-django/notification/templates/notification/email/authors_approved_notify.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-We are pleased to say that all authors have approved the publication of your project entitled "{{ project.title }}". 
+We are pleased to say that all authors have approved the publication of your project entitled "{{ project.title }}".
 
 Thanks for submitting your work to PhysioNet. The editors will publish your project shortly.
 

--- a/physionet-django/notification/templates/notification/email/authors_approved_notify.html
+++ b/physionet-django/notification/templates/notification/email/authors_approved_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -10,4 +10,4 @@ Thanks for submitting your work to PhysioNet. The editors will publish your proj
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/cancel_submit_notify.html
+++ b/physionet-django/notification/templates/notification/email/cancel_submit_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ This is an update on the status of your project entitled "{{ project.title }}". 
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_administrators.html
+++ b/physionet-django/notification/templates/notification/email/contact_administrators.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 
 Dear Physionet Team,
 
@@ -9,4 +9,4 @@ There was an error sending the files from "{{project}}" to the GCP bucket {{proj
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ application.reference_name }},
 
-{{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/She has listed you as a reference for the application and he/she has summarized the research project as follows:
+{{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/she has listed you as a reference for the application and has summarized the research project as follows:
 
 {{application.research_summary}}
 

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -9,7 +9,7 @@ Are you familiar with {{ applicant_name }}'s research, and in your view would it
 
 If you support this application for credentialed access, please indicate your approval using the link below. If you do not support the application, please ignore this email or update us directly via the link.
 
-http://{{ domain }}{% url 'credential_reference' application.slug %}
+{{ url_prefix }}{% url 'credential_reference' application.slug %}
 
 {{ signature }}
 {% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ application.reference_name }},
 
 {{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/She has listed you as a reference for the application and he/she has summarized the research project as follows:
@@ -12,4 +12,4 @@ If you support this application for credentialed access, please indicate your ap
 http://{{ domain }}{% url 'credential_reference' application.slug %}
 
 {{ signature }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/contact_supervisor.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ application.reference_name }},
 
-{{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/She have listed you as their supervisor and he/she have summarized the research project as follows:
+{{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/she has listed you as his/her supervisor and has summarized the research project as follows:
 
 {{application.research_summary}}
 

--- a/physionet-django/notification/templates/notification/email/contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/contact_supervisor.html
@@ -9,7 +9,7 @@ Are you {{ applicant_name }}'s supervisor for this project, and is the summary a
 
 If you support this application for credentialed access, please indicate your approval using the link below. If you do not support their application, please ignore this email or update us directly via the link.
 
-http://{{ domain }}{% url 'credential_reference' application.slug %}
+{{ url_prefix }}{% url 'credential_reference' application.slug %}
 
 {{ signature }}
 {% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/contact_supervisor.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ application.reference_name }},
 
 {{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/She have listed you as their supervisor and he/she have summarized the research project as follows:
@@ -12,4 +12,4 @@ If you support this application for credentialed access, please indicate your ap
 http://{{ domain }}{% url 'credential_reference' application.slug %}
 
 {{ signature }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
+++ b/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -17,4 +17,4 @@ Please check this version carefully because it will not be possible to edit the 
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
+++ b/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
@@ -5,7 +5,7 @@ Dear {{ name }},
 
 We are pleased to say that copyediting of your project entitled {{ project.title }}" is now complete. To proceed with publication, you must now approve the project using the following link:
 
-http://{{ domain }}{% url 'project_submission' project.slug %}
+{{ url_prefix }}{% url 'project_submission' project.slug %}
 
 {% if copyedit_log.made_changes %}
 The changes made during the copyediting process are summarized below:

--- a/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
+++ b/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ editor }},
@@ -7,4 +7,4 @@ Dear {{ editor }},
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
+++ b/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
@@ -3,7 +3,7 @@
 
 Dear {{ editor }},
 
-"{{ user }}" has assigned you the role of handling editor for a project entitled "{{ project.title }}".
+{{ user }} has assigned you the role of handling editor for a project entitled "{{ project.title }}".
 {{ signature }}
 
 {{ footer }}

--- a/physionet-django/notification/templates/notification/email/invite_author.html
+++ b/physionet-django/notification/templates/notification/email/invite_author.html
@@ -5,9 +5,9 @@ Dear Colleague,
 
 You have been invited by {{ inviter_name }} ({{ inviter_email }}) to co-author a project entitled "{{ project.title }}" on {{ domain }}. Please accept or decline this request as appropriate. If you accept the invitation, you will also need to provide your affiliation.
 
-You may respond to the invitation from your project homepage (http://{{ domain }}{% url "project_home" %}). If the email address {{ target_email }} is not associated with your {{ domain }} account, please add it to your profile.
+You may respond to the invitation from your project homepage ({{ url_prefix }}{% url "project_home" %}). If the email address {{ target_email }} is not associated with your {{ domain }} account, please add it to your profile.
 
-If you do not have an account, please register here: http://{{ domain }}{% url "register" %}. Once you have registered, you will find the pending invitation on your project home page.
+If you do not have an account, please register here: {{ url_prefix }}{% url "register" %}. Once you have registered, you will find the pending invitation on your project home page.
 
 {{ signature }}
 

--- a/physionet-django/notification/templates/notification/email/invite_author.html
+++ b/physionet-django/notification/templates/notification/email/invite_author.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear Colleague,
@@ -12,4 +12,4 @@ If you do not have an account, please register here: http://{{ domain }}{% url "
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/mailto_contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_reference.html
@@ -1,4 +1,4 @@
-{% filter wordwrap:70 %}
+{% autoescape off %}{% filter wordwrap:70 %}
 Dear Prof. {{ application.reference_name }},
 
 {{ applicant_name }} has requested access to restricted-access clinical data maintained by PhysioNet, listing you as a reference and summarizing his/her research project as follows:
@@ -8,4 +8,4 @@ Dear Prof. {{ application.reference_name }},
 Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
 
 {{ signature }}
-{% endfilter %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/mailto_contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_reference.html
@@ -1,3 +1,4 @@
+{% filter wordwrap:70 %}
 Dear Prof. {{ application.reference_name }},
 
 {{ applicant_name }} has requested access to restricted-access clinical data maintained by PhysioNet, listing you as a reference and summarizing his/her research project as follows:
@@ -7,3 +8,4 @@ Dear Prof. {{ application.reference_name }},
 Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
 
 {{ signature }}
+{% endfilter %}

--- a/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
@@ -1,4 +1,4 @@
-{% filter wordwrap:70 %}
+{% autoescape off %}{% filter wordwrap:70 %}
 Dear Prof. {{ application.reference_name }},
 
 {{ applicant_name }} has requested access to restricted-access clinical data maintained by PhysioNet, listing you as her/his supervisor and summarizing his/her research project as follows:
@@ -8,4 +8,4 @@ Dear Prof. {{ application.reference_name }},
 Are you {{ applicant_name }}'s supervisor for this project, and is the summary accurate?
 
 {{ signature }}
-{% endfilter %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
@@ -1,3 +1,4 @@
+{% filter wordwrap:70 %}
 Dear Prof. {{ application.reference_name }},
 
 {{ applicant_name }} has requested access to restricted-access clinical data maintained by PhysioNet, listing you as her/his supervisor and summarizing his/her research project as follows:
@@ -7,3 +8,4 @@ Dear Prof. {{ application.reference_name }},
 Are you {{ applicant_name }}'s supervisor for this project, and is the summary accurate?
 
 {{ signature }}
+{% endfilter %}

--- a/physionet-django/notification/templates/notification/email/notify_credential_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_credential_request.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ applicant_name }},
 
 Thank you for submitting your data use agreement. If it is approved, you will be authorized to use restricted-access PhysioNet clinical databases.
@@ -11,4 +11,4 @@ It may take a week or longer to process your request. Thank you for your underst
 
 {{ footer }}
 {% include "notification/email/mailto_contact_applicant.html" with dua=dua %}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/outstanding_invitation_removal.html
+++ b/physionet-django/notification/templates/notification/email/outstanding_invitation_removal.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ Your invitation to {{ email }} to co-author your project entitled "{{ title }}" 
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ applicant_name }},
 
 {% if application.status == 2 %}
@@ -27,4 +27,4 @@ If you are able to address these issues, please open a new credentialing applica
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -4,7 +4,7 @@ Dear {{ applicant_name }},
 {% if application.status == 2 %}
 Thank you for your interest in the PhysioNet Clinical Databases. We are pleased to say that your application for credentialed access has been approved. You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access MIMIC-III by following the steps below:
 
-- Go to the project page at http://{{ domain }}{% url 'published_project_latest' 'mimiciii' %}
+- Go to the project page at {{ url_prefix }}{% url 'published_project_latest' 'mimiciii' %}
 - Find the “Files” section in the project description
 - Click “Sign the data use agreement” to agree to the terms of usage for this dataset
 {% else %}
@@ -21,7 +21,7 @@ The following comments were also added to your application:
 {{ application.responder_comments }}
 
 {% endif %}
-If you are able to address these issues, please open a new credentialing application at: http://{{ domain }}{% url 'credential_application' %}
+If you are able to address these issues, please open a new credentialing application at: {{ url_prefix }}{% url 'credential_application' %}
 {% endif %}
 
 {{ signature }}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -21,7 +21,7 @@ The following comments were also added to your application:
 {{ application.responder_comments }}
 
 {% endif %}
-If you are able to address these issues, please open a new credentialing application at: {{ url_prefix }}{% url 'credential_application' %}
+If you are able to address these issues, please open a new credentialing application at {{ url_prefix }}{% url 'credential_application' %}.
 {% endif %}
 
 {{ signature }}

--- a/physionet-django/notification/templates/notification/email/publish_notify.html
+++ b/physionet-django/notification/templates/notification/email/publish_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -10,4 +10,4 @@ We encourage you to share this link to increase your work's visibility within th
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/publish_notify.html
+++ b/physionet-django/notification/templates/notification/email/publish_notify.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at: http://{{ domain }}{% url 'published_project' published_project.slug published_project.version%}
+We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at: {{ url_prefix }}{% url 'published_project' published_project.slug published_project.version%}
 
 We encourage you to share this link to increase your work's visibility within the research community. Thanks again for choosing to publish with PhysioNet, and we look forward to working with you again in the future.
 

--- a/physionet-django/notification/templates/notification/email/publish_notify.html
+++ b/physionet-django/notification/templates/notification/email/publish_notify.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at: {{ url_prefix }}{% url 'published_project' published_project.slug published_project.version%}
+We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at {{ url_prefix }}{% url 'published_project' published_project.slug published_project.version %}.
 
 We encourage you to share this link to increase your work's visibility within the research community. Thanks again for choosing to publish with PhysioNet, and we look forward to working with you again in the future.
 

--- a/physionet-django/notification/templates/notification/email/reject_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/reject_submission_notify.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-We are writing to inform you that the review process for your project entitled "{{ project.title }}" is complete. Based on the review, our decision is that the project is not suitable for publication in its current form. 
+We are writing to inform you that the review process for your project entitled "{{ project.title }}" is complete. Based on the review, our decision is that the project is not suitable for publication in its current form.
 
 A summary of the review is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
@@ -12,7 +12,7 @@ A summary of the review is listed below:
 Additional comments by the editorial team follow below:
 {{ edit_log.editor_comments }}
 
-Your project has been closed, but we would welcome a new submission if you are able to address these issues. Thanks for submitting your work to PhysioNet and we are sorry not to be able to publish it on this occasion. 
+Your project has been closed, but we would welcome a new submission if you are able to address these issues. Thanks for submitting your work to PhysioNet and we are sorry not to be able to publish it on this occasion.
 
 {{ signature }}
 

--- a/physionet-django/notification/templates/notification/email/reject_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/reject_submission_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -17,4 +17,4 @@ Your project has been closed, but we would welcome a new submission if you are a
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/reopen_copyedit_notify.html
+++ b/physionet-django/notification/templates/notification/email/reopen_copyedit_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ The editor of your project entitled "{{ project.title }}" is copyediting the pro
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/resubmit_notify.html
+++ b/physionet-django/notification/templates/notification/email/resubmit_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ Your project entitled "{{ project.title }}" has been resubmitted to PhysioNet fo
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
+++ b/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -10,4 +10,4 @@ We would be grateful if you could review the revised submission within 7 days.
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
+++ b/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-The project you have requested revisions for: {{ project.title }} has been resubmitted for review. 
+The project you have requested revisions for, "{{ project.title }}", has been resubmitted for review.
 
 We would be grateful if you could review the revised submission within 7 days.
 

--- a/physionet-django/notification/templates/notification/email/revise_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/revise_submission_notify.html
@@ -3,9 +3,9 @@
 
 Dear {{ name }},
 
-Thank you for submitting your project entitled "{{ project.title }}" to PhysioNet. 
+Thank you for submitting your project entitled "{{ project.title }}" to PhysioNet.
 
-A summary of our standard set of editorial checks is listed below: 
+A summary of our standard set of editorial checks is listed below:
 {% for result in edit_log.quality_assurance_results %}- {{ result }}
 {% endfor %}
 We ask that you address the following comments before we proceed:

--- a/physionet-django/notification/templates/notification/email/revise_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/revise_submission_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -16,4 +16,4 @@ Once these comments have been addressed, please resubmit your project.
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/storage_response_notify.html
+++ b/physionet-django/notification/templates/notification/email/storage_response_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -12,4 +12,4 @@ The following message was included:
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/submit_notify.html
+++ b/physionet-django/notification/templates/notification/email/submit_notify.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
@@ -8,4 +8,4 @@ Thank you for submitting your project entitled "{{ project.title }}" to PhysioNe
 {{ signature }}
 
 {{ footer }}
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -65,14 +65,16 @@ def invitation_notify(request, invite_author_form, target_email):
     inviter = invite_author_form.inviter
     project = invite_author_form.project
     subject = 'Invitation to author project: {}'.format(project.title)
-    email_context = {'inviter_name':inviter.get_full_name(),
-                     'inviter_email':inviter.email,
-                     'project':project,
-                     'domain':get_current_site(request),
-                     'signature':email_signature(),
-                     'project_info':email_project_info(project),
-                     'footer':email_footer(),
-                     'target_email':target_email}
+    email_context = {
+        'inviter_name': inviter.get_full_name(),
+        'inviter_email': inviter.email,
+        'project': project,
+        'domain': get_current_site(request),
+        'signature': email_signature(),
+        'project_info': email_project_info(project),
+        'footer': email_footer(),
+        'target_email': target_email
+    }
 
     body = loader.render_to_string('notification/email/invite_author.html',
                                     email_context)
@@ -91,9 +93,14 @@ def invitation_response_notify(invitation, affected_emails):
     subject = 'Authorship invitation {} for project: {}'.format(response,
                                                                 project.title)
     email, name = project.author_contact_info(only_submitting=True)
-    email_context = {'name':name, 'project':project,
-        'response':response, 'signature':email_signature(),
-        'project_info':email_project_info(project),'footer':email_footer()}
+    email_context = {
+        'name': name,
+        'project': project,
+        'response': response,
+        'signature': email_signature(),
+        'project_info': email_project_info(project),
+        'footer': email_footer()
+    }
 
     # Send an email for each email belonging to the accepting user
     for author_email in affected_emails:
@@ -109,8 +116,12 @@ def submit_notify(project):
     Notify authors when a project is submitted
     """
     subject = 'Submission of project: {}'.format(project.title)
-    email_context = {'project':project, 'signature':email_signature(),
-        'project_info':email_project_info(project),'footer':email_footer()}
+    email_context = {
+        'project': project,
+        'signature': email_signature(),
+        'project_info': email_project_info(project),
+        'footer': email_footer()
+    }
 
     for email, name in project.author_contact_info():
         email_context['name'] = name
@@ -126,8 +137,12 @@ def resubmit_notify(project):
     Notify authors and the editor when a project is resubmitted
     """
     subject = 'Resubmission of project: {}'.format(project.title)
-    email_context = {'project':project, 'signature':email_signature(),
-        'project_info':email_project_info(project),'footer':email_footer()}
+    email_context = {
+        'project': project,
+        'signature': email_signature(),
+        'project_info': email_project_info(project),
+        'footer': email_footer()
+    }
 
     for email, name in project.author_contact_info():
         email_context['name'] = name
@@ -155,12 +170,14 @@ def assign_editor_notify(project):
 
     for email, name in project.author_contact_info():
         body = loader.render_to_string(
-            'notification/email/assign_editor_notify.html',
-            {'name':name, 'project':project,
-             'editor':project.editor,
-             'signature':email_signature(),
-             'project_info':email_project_info(project),
-             'footer':email_footer()})
+            'notification/email/assign_editor_notify.html', {
+                'name': name,
+                'project': project,
+                'editor': project.editor,
+                'signature': email_signature(),
+                'project_info': email_project_info(project),
+                'footer': email_footer()
+            })
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
@@ -173,12 +190,14 @@ def editor_notify_new_project(project, assignee):
         project.title)
 
     body = loader.render_to_string(
-        'notification/email/editor_notify_new_project.html',
-        {'project':project, 'editor':project.editor,
-         'signature':email_signature(),
-         'user':assignee.get_full_name(),
-         'project_info':email_project_info(project),
-         'footer':email_footer()})
+        'notification/email/editor_notify_new_project.html', {
+            'project': project,
+            'editor': project.editor,
+            'signature': email_signature(),
+            'user': assignee.get_full_name(),
+            'project_info': email_project_info(project),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [project.editor.email], fail_silently=False)
@@ -201,12 +220,15 @@ def edit_decision_notify(request, project, edit_log):
         template = 'notification/email/accept_submission_notify.html'
 
     for email, name in project.author_contact_info():
-        body = loader.render_to_string(template,
-            {'name':name, 'project':project, 'edit_log':edit_log,
-             'domain':get_current_site(request),
-             'signature':email_signature(),
-             'project_info':email_project_info(project),
-             'footer':email_footer()})
+        body = loader.render_to_string(template, {
+            'name': name,
+            'project': project,
+            'edit_log': edit_log,
+            'domain': get_current_site(request),
+            'signature': email_signature(),
+            'project_info': email_project_info(project),
+            'footer': email_footer()
+        })
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
@@ -220,12 +242,15 @@ def copyedit_complete_notify(request, project, copyedit_log):
 
     for email, name in project.author_contact_info():
         body = loader.render_to_string(
-            'notification/email/copyedit_complete_notify.html',
-            {'name':name, 'project':project, 'copyedit_log':copyedit_log,
-             'domain':get_current_site(request),
-             'signature':email_signature(),
-             'project_info':email_project_info(project),
-             'footer':email_footer()})
+            'notification/email/copyedit_complete_notify.html', {
+                'name': name,
+                'project': project,
+                'copyedit_log': copyedit_log,
+                'domain': get_current_site(request),
+                'signature': email_signature(),
+                'project_info': email_project_info(project),
+                'footer': email_footer()
+            })
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
@@ -239,12 +264,14 @@ def reopen_copyedit_notify(request, project):
 
     for email, name in project.author_contact_info():
         body = loader.render_to_string(
-            'notification/email/reopen_copyedit_notify.html',
-            {'name':name, 'project':project,
-             'domain':get_current_site(request),
-             'signature':email_signature(),
-             'project_info':email_project_info(project),
-             'footer':email_footer()})
+            'notification/email/reopen_copyedit_notify.html', {
+                'name': name,
+                'project': project,
+                'domain': get_current_site(request),
+                'signature': email_signature(),
+                'project_info': email_project_info(project),
+                'footer': email_footer()
+            })
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
@@ -258,12 +285,14 @@ def authors_approved_notify(request, project):
 
     for email, name in project.author_contact_info():
         body = loader.render_to_string(
-            'notification/email/authors_approved_notify.html',
-            {'name':name, 'project':project,
-             'domain':get_current_site(request),
-             'signature':email_signature(),
-             'project_info':email_project_info(project),
-             'footer':email_footer()})
+            'notification/email/authors_approved_notify.html', {
+                'name': name,
+                'project': project,
+                'domain': get_current_site(request),
+                'signature': email_signature(),
+                'project_info': email_project_info(project),
+                'footer': email_footer()
+            })
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
@@ -277,12 +306,14 @@ def publish_notify(request, published_project):
 
     for email, name in published_project.author_contact_info():
         body = loader.render_to_string(
-            'notification/email/publish_notify.html',
-            {'name':name, 'published_project':published_project,
-             'domain':get_current_site(request),
-             'signature':email_signature(),
-             'project_info':email_project_info(published_project),
-             'footer':email_footer()})
+            'notification/email/publish_notify.html', {
+                'name': name,
+                'published_project': published_project,
+                'domain': get_current_site(request),
+                'signature': email_signature(),
+                'project_info': email_project_info(published_project),
+                'footer': email_footer()
+            })
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
@@ -296,13 +327,17 @@ def storage_response_notify(storage_request):
     subject = 'Storage request {0} for project: {1}'.format(response,
         project.title)
     email, name = project.author_contact_info(only_submitting=True)
-    body = loader.render_to_string('notification/email/storage_response_notify.html',
-        {'name':name, 'project':project, 'response':response,
-         'allowance':storage_request.request_allowance,
-         'response_message':storage_request.response_message,
-         'signature':email_signature(),
-         'project_info':email_project_info(project),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/storage_response_notify.html', {
+            'name': name,
+            'project': project,
+            'response': response,
+            'allowance': storage_request.request_allowance,
+            'response_message': storage_request.response_message,
+            'signature': email_signature(),
+            'project_info': email_project_info(project),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [email], fail_silently=False)
@@ -314,11 +349,14 @@ def contact_reference(request, application):
     applicant_name = ' '.join([application.first_names, application.last_name])
     subject = 'Please verify {} for PhysioNet credentialing'.format(
         applicant_name)
-    body = loader.render_to_string('notification/email/contact_reference.html',
-        {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request),
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/contact_reference.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'domain': get_current_site(request),
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [application.reference_email], fail_silently=False)
@@ -330,11 +368,14 @@ def contact_supervisor(request, application):
     applicant_name = ' '.join([application.first_names, application.last_name])
     subject = 'Please verify {} for PhysioNet credentialing'.format(
         applicant_name)
-    body = loader.render_to_string('notification/email/contact_supervisor.html',
-        {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request),
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/contact_supervisor.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'domain': get_current_site(request),
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [application.reference_email], fail_silently=False)
@@ -346,11 +387,14 @@ def mailto_reference(request, application):
     applicant_name = application.get_full_name()
     subject = '{} -- PhysioNet clinical database access request'.format(
         applicant_name)
-    body = loader.render_to_string('notification/email/mailto_contact_reference.html',
-        {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request),
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/mailto_contact_reference.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'domain': get_current_site(request),
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@alpha.physionet.org&body={2}".format(application.reference_email,
       parse.quote(subject), parse.quote(body), parse.quote('"'+application.reference_name+'"'), application.id)
@@ -363,11 +407,14 @@ def mailto_supervisor(request, application):
     applicant_name = application.get_full_name()
     subject = '{} -- PhysioNet clinical database access request'.format(
         applicant_name)
-    body = loader.render_to_string('notification/email/mailto_contact_supervisor.html',
-        {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request),
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/mailto_contact_supervisor.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'domain': get_current_site(request),
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@alpha.physionet.org&body={2}".format(application.reference_email,
       parse.quote(subject), parse.quote(body), parse.quote('"'+application.reference_name+'"'), application.id)
@@ -381,8 +428,11 @@ def mailto_process_credential_complete(application, comments=True):
     applicant_name = application.get_full_name()
     subject = 'PhysioNet clinical database access request for {}'.format(applicant_name)
     dua = License.objects.get(slug='physionet-credentialed-health-data-license-150')
-    body = loader.render_to_string('notification/email/mailto_contact_applicant.html',
-        {'application': application, 'dua': dua.dua_text_content()}).replace('\n', '\n> ')
+    body = loader.render_to_string(
+        'notification/email/mailto_contact_applicant.html', {
+            'application': application,
+            'dua': dua.dua_text_content()
+        }).replace('\n', '\n> ')
 
     if comments:
         body = 'Dear {0},\n\n{1}\n\n{2}'.format(application.first_names, 
@@ -398,10 +448,13 @@ def mailto_administrators(project, error):
     Request verification from a credentialing applicant's reference
     """
     subject = 'Error sending files to GCP for {}'.format(project.slug)
-    body = loader.render_to_string('notification/email/contact_administrators.html',
-        {'project':project, 'error':error,
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/contact_administrators.html', {
+            'project': project,
+            'error': error,
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [settings.CONTACT_EMAIL], fail_silently=False)
@@ -413,11 +466,15 @@ def process_credential_complete(request, application, comments=True):
     applicant_name = application.get_full_name()
     response = 'rejected' if application.status == 1 else 'accepted'
     subject = 'Your application for PhysioNet credentialing'
-    body = loader.render_to_string('notification/email/process_credential_complete.html',
-        {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request), 'comments':comments,
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/process_credential_complete.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'domain': get_current_site(request),
+            'comments': comments,
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [application.user.email], fail_silently=False)
@@ -429,11 +486,15 @@ def credential_application_request(request, application):
     applicant_name = application.get_full_name()
     subject = 'PhysioNet credentialing application notification'
     dua = License.objects.get(slug='physionet-credentialed-health-data-license-150')
-    body = loader.render_to_string('notification/email/notify_credential_request.html',
-        {'application':application, 'applicant_name':applicant_name,
-         'domain':get_current_site(request), 'dua':dua.dua_text_content(),
-         'signature':email_signature(),
-         'footer':email_footer()})
+    body = loader.render_to_string(
+        'notification/email/notify_credential_request.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'domain': get_current_site(request),
+            'dua': dua.dua_text_content(),
+            'signature': email_signature(),
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [application.user.email], fail_silently=False)
@@ -443,18 +504,28 @@ def notify_gcp_access_request(data_access, user, project, new_user):
     email = user.cloud_information.gcp_email.email
     if data_access == 3:
         subject = 'PhysioNet Google Cloud Platform storage read access'
-    body = loader.render_to_string('notification/email/notify_gcp_access_request.html',
-        {'signature': email_signature(), 'data_access': data_access,
-        'user': user, 'new_user': new_user, 'footer': email_footer()})
+    body = loader.render_to_string(
+        'notification/email/notify_gcp_access_request.html', {
+            'signature': email_signature(),
+            'data_access': data_access,
+            'user': user,
+            'new_user': new_user,
+            'footer': email_footer()
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [email], fail_silently=False)
 
 def notify_aws_access_request(user, project, data_access):
     subject = 'PhysioNet Amazon Web Service storage access'
-    body = loader.render_to_string('notification/email/notify_aws_access_request.html',
-        {'user': user, 'project': project, 'signature': email_signature(),
-        'footer': email_footer(), 'data_access': data_access})
+    body = loader.render_to_string(
+        'notification/email/notify_aws_access_request.html', {
+            'user': user,
+            'project': project,
+            'signature': email_signature(),
+            'footer': email_footer(),
+            'data_access': data_access
+        })
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [user.email], fail_silently=False)

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -84,6 +84,7 @@ def invitation_notify(request, invite_author_form, target_email):
         'inviter_email': inviter.email,
         'project': project,
         'domain': get_current_site(request),
+        'url_prefix': get_url_prefix(request),
         'signature': email_signature(),
         'project_info': email_project_info(project),
         'footer': email_footer(),
@@ -239,6 +240,7 @@ def edit_decision_notify(request, project, edit_log):
             'project': project,
             'edit_log': edit_log,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'signature': email_signature(),
             'project_info': email_project_info(project),
             'footer': email_footer()
@@ -261,6 +263,7 @@ def copyedit_complete_notify(request, project, copyedit_log):
                 'project': project,
                 'copyedit_log': copyedit_log,
                 'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
                 'signature': email_signature(),
                 'project_info': email_project_info(project),
                 'footer': email_footer()
@@ -282,6 +285,7 @@ def reopen_copyedit_notify(request, project):
                 'name': name,
                 'project': project,
                 'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
                 'signature': email_signature(),
                 'project_info': email_project_info(project),
                 'footer': email_footer()
@@ -303,6 +307,7 @@ def authors_approved_notify(request, project):
                 'name': name,
                 'project': project,
                 'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
                 'signature': email_signature(),
                 'project_info': email_project_info(project),
                 'footer': email_footer()
@@ -324,6 +329,7 @@ def publish_notify(request, published_project):
                 'name': name,
                 'published_project': published_project,
                 'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
                 'signature': email_signature(),
                 'project_info': email_project_info(published_project),
                 'footer': email_footer()
@@ -368,6 +374,7 @@ def contact_reference(request, application):
             'application': application,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'signature': email_signature(),
             'footer': email_footer()
         })
@@ -387,6 +394,7 @@ def contact_supervisor(request, application):
             'application': application,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'signature': email_signature(),
             'footer': email_footer()
         })
@@ -406,6 +414,7 @@ def mailto_reference(request, application):
             'application': application,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'signature': email_signature(),
             'footer': email_footer()
         })
@@ -426,6 +435,7 @@ def mailto_supervisor(request, application):
             'application': application,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'signature': email_signature(),
             'footer': email_footer()
         })
@@ -485,6 +495,7 @@ def process_credential_complete(request, application, comments=True):
             'application': application,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'comments': comments,
             'signature': email_signature(),
             'footer': email_footer()
@@ -505,6 +516,7 @@ def credential_application_request(request, application):
             'application': application,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'dua': dua.dua_text_content(),
             'signature': email_signature(),
             'footer': email_footer()

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -26,6 +26,20 @@ def send_contact_message(contact_form):
 
 # ---------- Project App ---------- #
 
+def get_url_prefix(request):
+    """
+    Return a URL protocol and host, such as 'https://example.com'.
+
+    django.contrib.sites.shortcuts is used to look up a "canonical"
+    hostname, if one is defined.
+    """
+    site = get_current_site(request)
+    if request and not request.is_secure():
+        return 'http://' + site.domain
+    else:
+        return 'https://' + site.domain
+
+
 def email_signature():
     """
     Gets the signature for the emails

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -197,7 +197,7 @@ def assign_editor_notify(project):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
-def editor_notify_new_project(project, assignee):
+def editor_notify_new_project(project, assigner):
     """
     Notify authors when an editor is assigned
     """
@@ -209,7 +209,7 @@ def editor_notify_new_project(project, assignee):
             'project': project,
             'editor': project.editor,
             'signature': email_signature(),
-            'user': assignee.get_full_name(),
+            'user': assigner.get_full_name(),
             'project_info': email_project_info(project),
             'footer': email_footer()
         })

--- a/physionet-django/user/templates/user/email/register_email.html
+++ b/physionet-django/user/templates/user/email/register_email.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ name }},
 
 Thanks for registering for an account on {{ domain }}. Please activate your account by clicking the following activation link or by copying and pasting the link into your web browser: 
@@ -7,4 +7,4 @@ http://{{ domain }}{% url 'activate_user' uidb64=uidb64 token=token %}
 
 Regards
 The PhysioNet Team
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/user/templates/user/email/register_email.html
+++ b/physionet-django/user/templates/user/email/register_email.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ name }},
 
-Thanks for registering for an account on {{ domain }}. Please activate your account by clicking the following activation link or by copying and pasting the link into your web browser: 
+Thanks for registering for an account on {{ domain }}. Please activate your account by clicking the following activation link or by copying and pasting the link into your web browser:
 
 {{ url_prefix }}{% url 'activate_user' uidb64=uidb64 token=token %}
 

--- a/physionet-django/user/templates/user/email/register_email.html
+++ b/physionet-django/user/templates/user/email/register_email.html
@@ -3,7 +3,7 @@ Dear {{ name }},
 
 Thanks for registering for an account on {{ domain }}. Please activate your account by clicking the following activation link or by copying and pasting the link into your web browser: 
 
-http://{{ domain }}{% url 'activate_user' uidb64=uidb64 token=token %}
+{{ url_prefix }}{% url 'activate_user' uidb64=uidb64 token=token %}
 
 Regards
 The PhysioNet Team

--- a/physionet-django/user/templates/user/email/reset_password_email.html
+++ b/physionet-django/user/templates/user/email/reset_password_email.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 {% blocktrans %}You are receiving this email because you requested a password reset for your account at {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
@@ -8,4 +8,4 @@
 
 Regards
 The PhysioNet Team
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/user/templates/user/email/reset_password_email.html
+++ b/physionet-django/user/templates/user/email/reset_password_email.html
@@ -3,7 +3,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'reset_password_confirm' uidb64=uid token=token %}
+https://{{ domain }}{% url 'reset_password_confirm' uidb64=uid token=token %}
 {% endblock %}
 
 Regards

--- a/physionet-django/user/templates/user/email/unverified_email_removal.html
+++ b/physionet-django/user/templates/user/email/unverified_email_removal.html
@@ -1,8 +1,8 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ name }}
 
 The email: {{ email }} you attempted to add to your account has been un-verified for 15 days and thus removed.
 
 Regards
 The PhysioNet Team
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/user/templates/user/email/unverified_email_removal.html
+++ b/physionet-django/user/templates/user/email/unverified_email_removal.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
-Dear {{ name }}
+Dear {{ name }},
 
-The email: {{ email }} you attempted to add to your account has been un-verified for 15 days and thus removed.
+The email "{{ email }}" you attempted to add to your account has been un-verified for 15 days and thus removed.
 
 Regards
 The PhysioNet Team

--- a/physionet-django/user/templates/user/email/verify_email_email.html
+++ b/physionet-django/user/templates/user/email/verify_email_email.html
@@ -3,7 +3,7 @@ Dear {{ name }}
 
 You have requested this email to be added to your account on {{ domain }}. Please verify this email by clicking the following activation link, or copying and pasting the link into your web browser:
 
-http://{{ domain }}{% url 'verify_email' uidb64=uidb64 token=token %}
+{{ url_prefix }}{% url 'verify_email' uidb64=uidb64 token=token %}
 
 Regards
 The PhysioNet Team

--- a/physionet-django/user/templates/user/email/verify_email_email.html
+++ b/physionet-django/user/templates/user/email/verify_email_email.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
-Dear {{ name }}
+Dear {{ name }},
 
 You have requested this email to be added to your account on {{ domain }}. Please verify this email by clicking the following activation link, or copying and pasting the link into your web browser:
 

--- a/physionet-django/user/templates/user/email/verify_email_email.html
+++ b/physionet-django/user/templates/user/email/verify_email_email.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ name }}
 
 You have requested this email to be added to your account on {{ domain }}. Please verify this email by clicking the following activation link, or copying and pasting the link into your web browser:
@@ -7,4 +7,4 @@ http://{{ domain }}{% url 'verify_email' uidb64=uidb64 token=token %}
 
 Regards
 The PhysioNet Team
-{% endautoescape %}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -136,8 +136,12 @@ def add_email(request, add_email_form):
         uidb64 = force_text(urlsafe_base64_encode(force_bytes(associated_email.pk)))
         token = default_token_generator.make_token(user)
         subject = "PhysioNet Email Verification"
-        context = {'name':user.get_full_name(),
-            'domain':get_current_site(request), 'uidb64':uidb64, 'token':token}
+        context = {
+            'name': user.get_full_name(),
+            'domain': get_current_site(request),
+            'uidb64': uidb64,
+            'token': token
+        }
         body = loader.render_to_string('user/email/verify_email_email.html', context)
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
             [add_email_form.cleaned_data['email']], fail_silently=False)
@@ -262,8 +266,12 @@ def register(request):
             uidb64 = force_text(urlsafe_base64_encode(force_bytes(user.pk)))
             token = default_token_generator.make_token(user)
             subject = "PhysioNet Account Activation"
-            context = {'name':user.get_full_name(),
-                'domain':get_current_site(request), 'uidb64':uidb64, 'token':token}
+            context = {
+                'name': user.get_full_name(),
+                'domain': get_current_site(request),
+                'uidb64': uidb64,
+                'token': token
+            }
             body = loader.render_to_string('user/email/register_email.html', context)
             send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                 [form.cleaned_data['email']], fail_silently=False)

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -24,7 +24,9 @@ from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
 from physionet import utility
 from project.models import Author, License
-from notification.utility import process_credential_complete, credential_application_request
+from notification.utility import (process_credential_complete,
+                                  credential_application_request,
+                                  get_url_prefix)
 
 
 logger = logging.getLogger(__name__)
@@ -139,6 +141,7 @@ def add_email(request, add_email_form):
         context = {
             'name': user.get_full_name(),
             'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
             'uidb64': uidb64,
             'token': token
         }
@@ -269,6 +272,7 @@ def register(request):
             context = {
                 'name': user.get_full_name(),
                 'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
                 'uidb64': uidb64,
                 'token': token
             }


### PR DESCRIPTION
- Word-wrap email messages

- Use 'https' URLs instead of 'http'

- Assorted punctuation and grammar fixes

I would probably have used "they" instead of "he/she" in the "reference contact" message templates.  I'm guessing, though, that "he/she" was used deliberately to emphasize that credentialing is for a single person, not a group.

