### PR TITLE
Consistent URL for 2019 Challenge

### DIFF
--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -27,7 +27,7 @@
     of challenges, inviting participants to tackle clinically interesting
     problems that are either unsolved or not well-solved.</p>
   <ul>
-    <li><a href="{% url 'published_project_latest' '2019-challenge' %}">2019</a>: Early Prediction of Sepsis from Clinical Data.</li>
+    <li><a href="{% url 'published_project_latest' 'challenge-2019' %}">2019</a>: Early Prediction of Sepsis from Clinical Data.</li>
     <li><a href="{% url 'published_project_latest' 'challenge-2018' %}">2018</a>: You Snooze, You Win.</li>
     <li><a href="{% url 'published_project_latest' 'challenge-2017' %}">2017</a>: AF Classification from a Short Single Lead ECG Recording.</li>
     <li><a href="{% url 'published_project_latest' 'challenge-2016' %}">2016</a>: Classification of Normal/Abnormal Heart Sound Recordings.</li>


### PR DESCRIPTION
Follow up on: https://github.com/MIT-LCP/physionet-build/pull/647.

The URL for the 2019 Challenge has been updated for consistency with previous years: https://alpha.physionet.org/content/challenge-2019

> Right now on you can access the challenges by this URL:http://physionet.org/challenge/2018 and if you pre-pend the word alpha to the hostname, you would get the same... http://alpha.physionet.org/challenge/2018 and both url's would resolve, but if we do it for the 2019 it fails.

This is now fixed (http://alpha.physionet.org/challenge/2019 resolves to the 2019 challenge content).

