### PR TITLE
change all the alpha.physionet.org for physionet.org

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -6,7 +6,7 @@ upstream django {
 
 ## configuration of the server
 server {
-    server_name alpha.physionet.org physionet-production.ecg.mit.edu;
+    server_name physionet.org alpha.physionet.org physionet-production.ecg.mit.edu;
 
     charset     utf-8;
 
@@ -106,7 +106,7 @@ server {
 
 server {
     listen      80;
-    server_name alpha.physionet.org physionet-production.ecg.mit.edu;
+    server_name physionet.org alpha.physionet.org physionet-production.ecg.mit.edu;
 
     #### Public data ####
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -740,7 +740,8 @@ def complete_credential_applications(request):
             if process_credential_form.is_valid():
                 application = process_credential_form.save()
                 notification.process_credential_complete(request, application, comments=False)
-                mailto = notification.mailto_process_credential_complete(application)
+                mailto = notification.mailto_process_credential_complete(
+                    request, application)
                 return render(request, 'console/generate_response_email.html',
                     {'application' : application, 'mailto': mailto})
             else:
@@ -752,7 +753,7 @@ def complete_credential_applications(request):
 
     for application in applications:
         application.mailto = notification.mailto_process_credential_complete(
-            application, comments=False)
+            request, application, comments=False)
         if CredentialApplication.objects.filter(reference_email=application.reference_email,
             reference_contact_datetime__isnull=False):
             # If the reference has been contacted before, mark it so

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -449,7 +449,7 @@ def mailto_supervisor(request, application):
     return mailto
 
 
-def mailto_process_credential_complete(application, comments=True):
+def mailto_process_credential_complete(request, application, comments=True):
     """
     Notify user of credentialing decision
     """

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -419,8 +419,10 @@ def mailto_reference(request, application):
             'footer': email_footer()
         })
 
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@alpha.physionet.org&body={2}".format(application.reference_email,
-      parse.quote(subject), parse.quote(body), parse.quote('"'+application.reference_name+'"'), application.id)
+    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@{5}&body={2}".format(
+        application.reference_email, parse.quote(subject), parse.quote(body),
+        parse.quote('"'+application.reference_name+'"'), application.id, 
+        get_current_site(request))
     return mailto
 
 def mailto_supervisor(request, application):
@@ -440,8 +442,10 @@ def mailto_supervisor(request, application):
             'footer': email_footer()
         })
 
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@alpha.physionet.org&body={2}".format(application.reference_email,
-      parse.quote(subject), parse.quote(body), parse.quote('"'+application.reference_name+'"'), application.id)
+    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@a{5}&body={2}".format(
+        application.reference_email, parse.quote(subject), parse.quote(body),
+        parse.quote('"'+application.reference_name+'"'), application.id,
+        get_current_site(request))
     return mailto
 
 
@@ -463,8 +467,10 @@ def mailto_process_credential_complete(application, comments=True):
           application.responder_comments, body)
     else:
         body = 'Dear {0},\n\n{1}'.format(application.first_names, body)
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@alpha.physionet.org&body={2}".format(application.user.email,
-      parse.quote(subject), parse.quote(body), parse.quote('"'+application.get_full_name()+'"'), application.id)
+    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@a{5}&body={2}".format(
+        application.user.email, parse.quote(subject), parse.quote(body), 
+        parse.quote('"'+application.get_full_name()+'"'), application.id,
+        get_current_site(request))
     return mailto
 
 def mailto_administrators(project, error):

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -7,7 +7,7 @@ from .base import *
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org', '18.13.52.205']
+ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
 SITE_ID = 1
 INSTALLED_APPS += ['django.contrib.sites']
 

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -7,7 +7,7 @@ from .base import *
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
+ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org', '18.13.52.205']
 SITE_ID = 1
 INSTALLED_APPS += ['django.contrib.sites']
 
@@ -30,11 +30,11 @@ EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
 
-DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@alpha.physionet.org>'
-CONTACT_EMAIL = 'PhysioNet Contact <contact@alpha.physionet.org>'
-SERVER_EMAIL = 'PhysioNet System <root@alpha.physionet.org>'
+DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@physionet.org>'
+CONTACT_EMAIL = 'PhysioNet Contact <contact@physionet.org>'
+SERVER_EMAIL = 'PhysioNet System <root@physionet.org>'
 
-ADMINS = [('PhysioNet Technical', 'technical@alpha.physionet.org')]
+ADMINS = [('PhysioNet Technical', 'technical@physionet.org')]
 
 DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'demo-files')
 


### PR DESCRIPTION
This PR is to replace all the places where alpha.physionet.org appears in django.
In the mailto notification email, I just replace alpha for the output of "get_current_site(request)"
which should receive either alpha or physionet.org 