### PR TITLE
Fix section header IDs, and other small things

### DIFF
--- a/physionet-django/project/templates/project/challenge_content.html
+++ b/physionet-django/project/templates/project/challenge_content.html
@@ -2,11 +2,11 @@
 {{ project.abstract|safe }}
 <hr>
 
-<h2 id="background">Objective</h2>
+<h2 id="objective">Objective</h2>
 {{ project.background|safe }}
 <hr>
 
-<h2 id="methods">Participation</h2>
+<h2 id="participation">Participation</h2>
 {{ project.methods|safe }}
 <hr>
 
@@ -14,7 +14,7 @@
 {{ project.content_description|safe }}
 <hr>
 
-<h2 id="usage-notes">Evaluation</h2>
+<h2 id="evaluation">Evaluation</h2>
 {{ project.usage_notes|safe }}
 <hr>
 

--- a/physionet-django/project/templates/project/challenge_content.html
+++ b/physionet-django/project/templates/project/challenge_content.html
@@ -38,7 +38,7 @@
   <h2 id="references">References</h2>
   <ol>
   {% for reference in references %}
-    <li style="word-break: break-all;">{{ reference.description }}</li>
+    <li>{{ reference.description }}</li>
   {% endfor %}
   </ol>
   <hr>

--- a/physionet-django/project/templates/project/challenge_content_preview.html
+++ b/physionet-django/project/templates/project/challenge_content_preview.html
@@ -1,4 +1,4 @@
-<h2>Abstract</h2>
+<h2 id="abstract">Abstract</h2>
 {% if project.abstract %}
   {{ project.abstract|safe }}
 {% else %}
@@ -6,7 +6,7 @@
 {% endif %}
 <hr>
 
-<h2>Objective</h2>
+<h2 id="objective">Objective</h2>
 {% if project.background %}
   {{ project.background|safe }}
 {% else %}
@@ -14,7 +14,7 @@
 {% endif %}
 <hr>
 
-<h2>Participation</h2>
+<h2 id="participation">Participation</h2>
 {% if project.methods %}
   {{ project.methods|safe }}
 {% else %}
@@ -22,7 +22,7 @@
 {% endif %}
 <hr>
 
-<h2>Data Description</h2>
+<h2 id="description">Data Description</h2>
 {% if project.content_description %}
   {{ project.content_description|safe }}
 {% else %}
@@ -31,24 +31,24 @@
 <hr>
 
 {% if project.usage_notes %}
-  <h2>Evaluation</h2>
+  <h2 id="evaluation">Evaluation</h2>
   {{ project.usage_notes|safe }}
   <hr>
 {% endif %}
 
 {% if project.release_notes %}
-  <h2>Release Notes</h2>
+  <h2 id="release-notes">Release Notes</h2>
   {{ project.release_notes|safe }}
   <hr>
 {% endif %}
 
 {% if project.acknowledgements %}
-  <h2>Acknowledgements</h2>
+  <h2 id="acknowledgements">Acknowledgements</h2>
   {{ project.acknowledgements|safe }}
   <hr>
 {% endif %}
 
-<h2>Conflicts of Interest</h2>
+<h2 id="conflicts-of-interest">Conflicts of Interest</h2>
 {% if project.conflicts_of_interest %}
   {{ project.conflicts_of_interest|safe }}
 {% else %}
@@ -57,7 +57,7 @@
 <hr>
 
 {% if references %}
-  <h2>References</h2>
+  <h2 id="references">References</h2>
   <ol>
     {% for reference in references %}
       <li>{{ reference.description }}</li>

--- a/physionet-django/project/templates/project/database_content.html
+++ b/physionet-django/project/templates/project/database_content.html
@@ -38,7 +38,7 @@
   <h2 id="references">References</h2>
   <ol>
   {% for reference in references %}
-    <li style="word-break: break-all;">{{ reference.description }}</li>
+    <li>{{ reference.description }}</li>
   {% endfor %}
   </ol>
   <hr>

--- a/physionet-django/project/templates/project/database_content_preview.html
+++ b/physionet-django/project/templates/project/database_content_preview.html
@@ -1,4 +1,4 @@
-<h2>Abstract</h2>
+<h2 id="abstract">Abstract</h2>
 {% if project.abstract %}
   {{ project.abstract|safe }}
 {% else %}
@@ -6,7 +6,7 @@
 {% endif %}
 <hr>
 
-<h2>Background</h2>
+<h2 id="background">Background</h2>
 {% if project.background %}
   {{ project.background|safe }}
 {% else %}
@@ -14,7 +14,7 @@
 {% endif %}
 <hr>
 
-<h2>Methods</h2>
+<h2 id="methods">Methods</h2>
 {% if project.methods %}
   {{ project.methods|safe }}
 {% else %}
@@ -22,7 +22,7 @@
 {% endif %}
 <hr>
 
-<h2>Data Description</h2>
+<h2 id="description">Data Description</h2>
 {% if project.content_description %}
   {{ project.content_description|safe }}
 {% else %}
@@ -31,24 +31,24 @@
 <hr>
 
 {% if project.usage_notes %}
-  <h2>Usage Notes</h2>
+  <h2 id="usage-notes">Usage Notes</h2>
   {{ project.usage_notes|safe }}
   <hr>
 {% endif %}
 
 {% if project.release_notes %}
-  <h2>Release Notes</h2>
+  <h2 id="release-notes">Release Notes</h2>
   {{ project.release_notes|safe }}
   <hr>
 {% endif %}
 
 {% if project.acknowledgements %}
-  <h2>Acknowledgements</h2>
+  <h2 id="acknowledgements">Acknowledgements</h2>
   {{ project.acknowledgements|safe }}
   <hr>
 {% endif %}
 
-<h2>Conflicts of Interest</h2>
+<h2 id="conflicts-of-interest">Conflicts of Interest</h2>
 {% if project.conflicts_of_interest %}
   {{ project.conflicts_of_interest|safe }}
 {% else %}
@@ -57,7 +57,7 @@
 <hr>
 
 {% if references %}
-  <h2>References</h2>
+  <h2 id="references">References</h2>
   <ol>
     {% for reference in references %}
       <li>{{ reference.description }}</li>

--- a/physionet-django/project/templates/project/database_content_preview.html
+++ b/physionet-django/project/templates/project/database_content_preview.html
@@ -30,11 +30,13 @@
 {% endif %}
 <hr>
 
+<h2 id="usage-notes">Usage Notes</h2>
 {% if project.usage_notes %}
-  <h2 id="usage-notes">Usage Notes</h2>
   {{ project.usage_notes|safe }}
-  <hr>
+{% else %}
+  <p style="color:red"><strong>* Required field missing</strong></p>
 {% endif %}
+<hr>
 
 {% if project.release_notes %}
   <h2 id="release-notes">Release Notes</h2>

--- a/physionet-django/project/templates/project/model_content.html
+++ b/physionet-django/project/templates/project/model_content.html
@@ -42,7 +42,7 @@
   <h2 id="references">References</h2>
   <ol>
   {% for reference in references %}
-    <li style="word-break: break-all;">{{ reference.description }}</li>
+    <li>{{ reference.description }}</li>
   {% endfor %}
   </ol>
   <hr>

--- a/physionet-django/project/templates/project/model_content_preview.html
+++ b/physionet-django/project/templates/project/model_content_preview.html
@@ -1,4 +1,4 @@
-<h2>Abstract</h2>
+<h2 id="abstract">Abstract</h2>
 {% if project.abstract %}
   {{ project.abstract|safe }}
 {% else %}
@@ -6,7 +6,7 @@
 {% endif %}
 <hr>
 
-<h2>Background</h2>
+<h2 id="background">Background</h2>
 {% if project.background %}
   {{ project.background|safe }}
 {% else %}
@@ -14,7 +14,7 @@
 {% endif %}
 <hr>
 
-<h2>Model Description</h2>
+<h2 id="description">Model Description</h2>
 {% if project.content_description %}
   {{ project.content_description|safe }}
 {% else %}
@@ -22,7 +22,7 @@
 {% endif %}
 <hr>
 
-<h2>Technical Implementation</h2>
+<h2 id="implementation">Technical Implementation</h2>
 {% if project.methods %}
   {{ project.methods|safe }}
 {% else %}
@@ -30,7 +30,7 @@
 {% endif %}
 <hr>
 
-<h2>Installation and Requirements</h2>
+<h2 id="installation">Installation and Requirements</h2>
 {% if project.installation %}
   {{ project.installation|safe }}
 {% else %}
@@ -38,7 +38,7 @@
 {% endif %}
 <hr>
 
-<h2>Usage Notes</h2>
+<h2 id="usage-notes">Usage Notes</h2>
 {% if project.usage_notes %}
   {{ project.usage_notes|safe }}
 {% else %}
@@ -47,18 +47,18 @@
 <hr>
 
 {% if project.release_notes %}
-  <h2>Release Notes</h2>
+  <h2 id="release-notes">Release Notes</h2>
   {{ project.release_notes|safe }}
   <hr>
 {% endif %}
 
 {% if project.acknowledgements %}
-  <h2>Acknowledgements</h2>
+  <h2 id="acknowledgements">Acknowledgements</h2>
   {{ project.acknowledgements|safe }}
   <hr>
 {% endif %}
 
-<h2>Conflicts of Interest</h2>
+<h2 id="conflicts-of-interest">Conflicts of Interest</h2>
 {% if project.conflicts_of_interest %}
   {{ project.conflicts_of_interest|safe }}
 {% else %}
@@ -67,7 +67,7 @@
 <hr>
 
 {% if references %}
-  <h2>References</h2>
+  <h2 id="references">References</h2>
   <ol>
     {% for reference in references %}
       <li>{{ reference.description }}</li>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -139,10 +139,10 @@
             <a class="dropdown-item" href="#files">Files</a>
           {% elif project.resource_type == 2 %}
             <a class="dropdown-item" href="#abstract">Abstract</a>
-            <a class="dropdown-item" href="#background">Objective</a>
-            <a class="dropdown-item" href="#methods">Participation</a>
+            <a class="dropdown-item" href="#objective">Objective</a>
+            <a class="dropdown-item" href="#participation">Participation</a>
             <a class="dropdown-item" href="#description">Data Description</a>
-            <a class="dropdown-item" href="#usage-notes">Evaluation</a>
+            <a class="dropdown-item" href="#evaluation">Evaluation</a>
             <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
             <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
             <a class="dropdown-item" href="#references">References</a>

--- a/physionet-django/project/templates/project/software_content.html
+++ b/physionet-django/project/templates/project/software_content.html
@@ -44,7 +44,7 @@
   <h2 id="references">References</h2>
   <ol>
   {% for reference in references %}
-    <li style="word-break: break-all;">{{ reference.description }}</li>
+    <li>{{ reference.description }}</li>
   {% endfor %}
   </ol>
   <hr>

--- a/physionet-django/project/templates/project/software_content_preview.html
+++ b/physionet-django/project/templates/project/software_content_preview.html
@@ -1,4 +1,4 @@
-<h2>Abstract</h2>
+<h2 id="abstract">Abstract</h2>
 {% if project.abstract %}
   {{ project.abstract|safe }}
 {% else %}
@@ -6,7 +6,7 @@
 {% endif %}
 <hr>
 
-<h2>Background</h2>
+<h2 id="background">Background</h2>
 {% if project.background %}
   {{ project.background|safe }}
 {% else %}
@@ -14,7 +14,7 @@
 {% endif %}
 <hr>
 
-<h2>Software Description</h2>
+<h2 id="description">Software Description</h2>
 {% if project.content_description %}
   {{ project.content_description|safe }}
 {% else %}
@@ -24,13 +24,13 @@
 
 
 {% if project.methods %}
-  <h2>Technical Implementation</h2>
+  <h2 id="implementation">Technical Implementation</h2>
   {{ project.methods|safe }}
   <hr>
 {% endif %}
 
 
-<h2>Installation and Requirements</h2>
+<h2 id="installation">Installation and Requirements</h2>
 {% if project.installation %}
   {{ project.installation|safe }}
 {% else %}
@@ -38,7 +38,7 @@
 {% endif %}
 <hr>
 
-<h2>Usage Notes</h2>
+<h2 id="usage-notes">Usage Notes</h2>
 {% if project.usage_notes %}
   {{ project.usage_notes|safe }}
 {% else %}
@@ -47,18 +47,18 @@
 <hr>
 
 {% if project.release_notes %}
-  <h2>Release Notes</h2>
+  <h2 id="release-notes">Release Notes</h2>
   {{ project.release_notes|safe }}
   <hr>
 {% endif %}
 
 {% if project.acknowledgements %}
-  <h2>Acknowledgements</h2>
+  <h2 id="acknowledgements">Acknowledgements</h2>
   {{ project.acknowledgements|safe }}
   <hr>
 {% endif %}
 
-<h2>Conflicts of Interest</h2>
+<h2 id="conflicts-of-interest">Conflicts of Interest</h2>
 {% if project.conflicts_of_interest %}
   {{ project.conflicts_of_interest|safe }}
 {% else %}
@@ -67,7 +67,7 @@
 <hr>
 
 {% if references %}
-  <h2>References</h2>
+  <h2 id="references">References</h2>
   <ol>
     {% for reference in references %}
       <li>{{ reference.description }}</li>


### PR DESCRIPTION
This fixes the section header IDs in challenge pages (we also need to fix an internal link to #background in the challenge-2019 page.)

Also, add IDs to project previews (issue #588), show Usage Notes as required (it is required, it just wasn't displayed as such in database previews), and don't do weird word breaking in References.

