### PR TITLE
Added a way to not store private information in tracebacks

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.views.decorators.debug import sensitive_post_parameters
 
 from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
@@ -251,6 +252,7 @@ def profile_photo(request, username):
     user = User.objects.get(username__iexact=username)
     return utility.serve_file(user.profile.photo.path)
 
+@sensitive_post_parameters('password1', 'password2')
 def register(request):
     """
     User registration page


### PR DESCRIPTION
Django has a neat way to handle protected information.

It can be done with either of the following:
 - sensitive_variables
 - sensitive_post_parameters

In this case I use post because the variables are in a post
request and I dont touch them.

The traceback will replace the specified fields for ***
E.g.
email =3D 'felipe.torres.cs@gmail.com'
username =3D 'ftorres'
first_names =3D 'Felipe'
last_name =3D 'F=C3=A1bregas'
password1 =3D '********************'
password2 =3D '********************'