### PR TITLE
Fixed typo in email

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -442,7 +442,7 @@ def mailto_supervisor(request, application):
             'footer': email_footer()
         })
 
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@a{5}&body={2}".format(
+    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@{5}&body={2}".format(
         application.reference_email, parse.quote(subject), parse.quote(body),
         parse.quote('"'+application.reference_name+'"'), application.id,
         get_current_site(request))
@@ -467,7 +467,7 @@ def mailto_process_credential_complete(request, application, comments=True):
           application.responder_comments, body)
     else:
         body = 'Dear {0},\n\n{1}'.format(application.first_names, body)
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@a{5}&body={2}".format(
+    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@{5}&body={2}".format(
         application.user.email, parse.quote(subject), parse.quote(body), 
         parse.quote('"'+application.get_full_name()+'"'), application.id,
         get_current_site(request))


### PR DESCRIPTION
Removing extra a from the emails that are generated in the mailto for references and supervisors. 