### PR TITLE
Links and codes

### DIFF
--- a/physionet-django/project/static/project/css/project-content.css
+++ b/physionet-django/project/static/project/css/project-content.css
@@ -14,10 +14,6 @@ blockquote {
   background: #F0F0F0;
 }
 
-a{
-  word-break: break-word;
-}
-
 @media (min-width: 768px){
   .btn-right{
     float: right;

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -525,3 +525,7 @@ table.files-panel {
   text-align: center;
   width: 1.25em;
 }
+
+a, code{
+  word-break: break-word;
+}


### PR DESCRIPTION
Links and code snippets should be set to `word-break: break-word` site-wide, as both can contain long paths that would result in undesirable scrolling in small window sizes. 

Breaking words in these cases to avoid this shouldn't be a problem.