### PR TITLE
More robust construction of mailto links

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -455,11 +455,12 @@ def mailto_reference(request, application):
             'footer': email_footer()
         })
 
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@{5}&body={2}".format(
-        application.reference_email, parse.quote(subject), parse.quote(body),
-        parse.quote('"'+application.reference_name+'"'), application.id, 
-        get_current_site(request))
-    return mailto
+    to = formataddr((application.reference_name,
+                     application.reference_email))
+    bcc = 'credential-reference+{0}@{1}'.format(
+        application.id, get_current_site(request))
+    return mailto_url(to, subject=subject, bcc=bcc, body=body)
+
 
 def mailto_supervisor(request, application):
     """
@@ -478,11 +479,11 @@ def mailto_supervisor(request, application):
             'footer': email_footer()
         })
 
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@{5}&body={2}".format(
-        application.reference_email, parse.quote(subject), parse.quote(body),
-        parse.quote('"'+application.reference_name+'"'), application.id,
-        get_current_site(request))
-    return mailto
+    to = formataddr((application.reference_name,
+                     application.reference_email))
+    bcc = 'credential-reference+{0}@{1}'.format(
+        application.id, get_current_site(request))
+    return mailto_url(to, subject=subject, bcc=bcc, body=body)
 
 
 def mailto_process_credential_complete(request, application, comments=True):
@@ -503,11 +504,13 @@ def mailto_process_credential_complete(request, application, comments=True):
           application.responder_comments, body)
     else:
         body = 'Dear {0},\n\n{1}'.format(application.first_names, body)
-    mailto = "mailto:{3}%3C{0}%3E?subject={1}&bcc=credential-reference+{4}@{5}&body={2}".format(
-        application.user.email, parse.quote(subject), parse.quote(body), 
-        parse.quote('"'+application.get_full_name()+'"'), application.id,
-        get_current_site(request))
-    return mailto
+
+    to = formataddr((application.get_full_name(),
+                     application.user.email))
+    bcc = 'credential-reference+{0}@{1}'.format(
+        application.id, get_current_site(request))
+    return mailto_url(to, subject=subject, bcc=bcc, body=body)
+
 
 def mailto_administrators(project, error):
     """

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -14,6 +14,32 @@ from project.models import License
 RESPONSE_ACTIONS = {0:'rejected', 1:'accepted'}
 
 
+def mailto_url(*recipients, **params):
+    """
+    Generate a 'mailto:' URL.
+
+    The recipient address(es) are specified as positional arguments.
+    Additional header fields (such as 'subject') and the special
+    pseudo-header 'body' may be specified as keyword arguments.
+
+    Note that RFC 6068 requires each recipient to be a simple address
+    ("root@example.org"), while the older RFC 2368 permits the full
+    RFC 822 mailbox syntax ("Root <root@example.org>").  Many, but not
+    all, clients will accept the latter syntax.
+
+    >>> mailto_url('alice@example.com', 'bob@example.com')
+    'mailto:alice@example.com,bob@example.com'
+
+    >>> mailto_url('fred&wilma@example.org', subject='Hello world')
+    'mailto:fred%26wilma@example.org?subject=Hello%20world'
+    """
+    encoded_addrs = (parse.quote(addr, safe='@') for addr in recipients)
+    url = 'mailto:' + ','.join(encoded_addrs)
+    if params:
+        url += '?' + parse.urlencode(params, quote_via=parse.quote)
+    return url
+
+
 def send_contact_message(contact_form):
     """
     Send a message to the contact email

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -239,7 +239,7 @@
             <p>
               {{ contact.name }}<br>
               {{ contact.affiliations }}.<br>
-              {{ contact.email }}
+              {% mailto_link contact.email subject=project %}
             </p>
           {% else %}
             <em>You must be logged in to view the contact information.</em>

--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -1,6 +1,9 @@
 from django import template
 from django.shortcuts import reverse
+from django.utils.html import format_html
 from django.utils.http import urlencode
+
+from notification.utility import mailto_url
 
 
 register = template.Library()
@@ -121,3 +124,19 @@ def show_all_author_info(author):
     return author_popover(author, show_submitting=True, show_email=True,
                           show_corresponding=True)
 
+
+@register.simple_tag(name='mailto_link')
+def mailto_link(*recipients, **params):
+    """
+    Format an email address as an HTML link.
+
+    The recipient address(es) are specified as positional arguments.
+    Additional header fields (such as 'subject') and the special
+    pseudo-header 'body' may be specified as keyword arguments.
+
+    For example, {% mailto_link "alice@example.com" %}
+    yields "<a href="mailto:alice@example.com">alice@example.com</a>".
+    """
+    url = mailto_url(*recipients, **params)
+    label = ', '.join(recipients)
+    return format_html('<a href="{0}">{1}</a>', url, label)


### PR DESCRIPTION
In the credentialing pages we construct various 'mailto' links, so
that we can contact applicants and their references using a predefined
message template that can be edited as needed.

In place of the (somewhat ad-hoc and difficult to read) code that was
previously used to construct these mailto links, a new 'mailto_url'
function is defined that performs the appropriate escaping.

This will produce a slightly different URL, but it should be
functionally equivalent.

In addition, in published project pages, show the corresponding
author's email address as a mailto link.
