### PR TITLE
renamed reverse url

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -94,11 +94,11 @@
         </ul>
       </li>
 
-      {% url 'project_access' as project_access %}      
+      {% url 'protected_project_access' as protected_project_access %}      
       <!-- project access -->
       {% url 'storage_requests' as storage_requests %}
-      <li class="nav-item {% if request.path == project_access %}active{% endif %}" data-toggle="tooltip" data-placement="right">
-        <a id="nav_project_access" class="nav-link" href="{% url 'project_access' %}">
+      <li class="nav-item {% if request.path == protected_project_access %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+        <a id="nav_protected_project_access" class="nav-link" href="{% url 'protected_project_access' %}">
           <i class="fa fa-fw fa-universal-access"></i>
           <span class="nav-link-text">Access</span>
         </a>

--- a/physionet-django/console/templates/console/project_access_manage.html
+++ b/physionet-django/console/templates/console/project_access_manage.html
@@ -5,7 +5,7 @@
 {% block title %}View credentialed project members{% endblock %}
 
 {% block content %}
-<p><a href="{% url 'project_access' %}">Back to project access</a></p>
+<p><a href="{% url 'protected_project_access' %}">Back to project access</a></p>
 <div class="card mb-3">
   <div class="card-header">
     {{ c_project }} <span class="badge badge-pill badge-info">{{ project_members|length }}</span>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path('rejected-submissions/', views.rejected_submissions,
         name='rejected_submissions'),
     path('project-access', views.project_access,
-        name='project_access'),
+        name='protected_project_access'),
     path('project-access-manage/<pid>/', views.project_access_manage,
         name='project_access_manage'),
     path('published-projects/<project_slug>/<version>/',


### PR DESCRIPTION
The name for the URL 'project_access' was used already. It should have given errors before, but for some reason it worked fine. 

Here I rename the URL reverse.