### PR TITLE
Don't crash when lightwave 'action' parameter is missing

### DIFF
--- a/physionet-django/lightwave/views.py
+++ b/physionet-django/lightwave/views.py
@@ -129,7 +129,7 @@ def lightwave_server(request):
     """
     Request LightWAVE data for a published database.
     """
-    if request.GET['action'] == 'dblist':
+    if request.GET.get('action', '') == 'dblist':
         projects = PublishedProject.objects.filter(
             has_wfdb=True, access_policy=0, deprecated_files=False).order_by(
             'title', '-version_order')


### PR DESCRIPTION
If a user (or more likely a confused crawler) accesses /lightwave/server without a query string, it should show an error message, but it shouldn't crash and throw a 500 error.

Actually, the server will currently display a rather unhelpful error message in this case:

    lightwave: can't open /home/physionet/html/lightwave/doc/about.txt

...so we should also fix that to point to the correct location (/data/pn-static/lightwave/doc/about.txt).  I think that requires recompiling the server.
