### PR TITLE
Changes "Rejected" to "Closed"

### DIFF
--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -198,7 +198,7 @@
             <h3>{{ project }} <a href="{% url 'rejected_submission_history' project.slug %}" class="btn btn-primary ml-1" role="button" style="float:right">Submission History</a></h3>
             <p class="list-group-item-text text-muted">
             <strong>Submitting Author: {{ project.submitting_author.get_full_name }}</strong><br>
-            <small>Created {{ project.creation_datetime|date }} Rejected {{ project.archive_datetime|date }}</small>
+            <small>Created {{ project.creation_datetime|date }} Closed {{ project.archive_datetime|date }}</small>
             </p>
           </li>
           {% endfor %}

--- a/physionet-django/project/templates/project/published_submission_history.html
+++ b/physionet-django/project/templates/project/published_submission_history.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Published Submission History - {{ project }}{% endblock %}
+{% block title %}Submission History - {{ project }}{% endblock %}
 
 {% load static %}
 

--- a/physionet-django/project/templates/project/rejected_submission_history.html
+++ b/physionet-django/project/templates/project/rejected_submission_history.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Rejected Submission History - {{ project }}{% endblock %}
+{% block title %}Submission History - {{ project }}{% endblock %}
 
 {% load static %}
 


### PR DESCRIPTION
Very minor changes to language:
 
- Soften "Rejected" to "Closed", so the project listing is displayed to the author as shown below:

<img width="253" alt="Screen Shot 2019-08-13 at 12 16 21" src="https://user-images.githubusercontent.com/822601/62958701-4841f580-bdc5-11e9-8fff-00bf4bf1ecdf.png">

- Remove "Rejected"/"Published" from the header of the submission history. It isn't necessary.
