### PR TITLE
Avoid recursively scanning project directories in console

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -647,13 +647,20 @@ class UnpublishedProject(models.Model):
         """
         return os.path.join(self.__class__.FILE_ROOT, self.slug)
 
-    def get_storage_info(self):
+    def get_storage_info(self, force_calculate=True):
         """
         Return an object containing information about the project's
         storage usage.
+
+        If force_calculate is true, calculate the size by recursively
+        scanning the directory tree.  This is deprecated.
         """
+        if force_calculate:
+            used = self.storage_used()
+        else:
+            used = None
         return StorageInfo(allowance=self.core_project.storage_allowance,
-            used=self.storage_used(), include_remaining=True)
+                           used=used, include_remaining=True)
 
     def get_previous_slug(self):
         """
@@ -1400,12 +1407,16 @@ class PublishedProject(Metadata, SubmissionInfo):
         else:
             return True
 
-    def get_storage_info(self):
+    def get_storage_info(self, force_calculate=True):
         """
         Return an object containing information about the project's
         storage usage. Main, compressed, total files, and allowance.
+
+        This function always returns the cached information stored in
+        the model.  The force_calculate argument has no effect.
         """
-        main, compressed = self.storage_used()
+        main = self.main_storage_size
+        compressed = self.compressed_storage_size
         return StorageInfo(allowance=self.core_project.storage_allowance,
             used=main+compressed, include_remaining=False, main_used=main,
             compressed_used=compressed)

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -517,13 +517,13 @@ class Metadata(models.Model):
             else:
                 return authors
 
-    def info_card(self, include_emails=True):
+    def info_card(self, include_emails=True, force_calculate=False):
         """
         Get all the information needed for the project info card
         seen by an admin
         """
         authors, author_emails = self.get_author_info(include_emails=include_emails)
-        storage_info = self.get_storage_info()
+        storage_info = self.get_storage_info(force_calculate=force_calculate)
         edit_logs = self.edit_logs.all()
         for e in edit_logs:
             e.set_quality_assurance_results()

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -43,9 +43,7 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     """
 
     published_project = PublishedProject.objects.get(id=pid)
-    # Create special files if there are files. Should always be the case.
-    if bool(published_project.storage_used):
-        published_project.make_special_files(make_zip=make_zip)
+    published_project.make_special_files(make_zip=make_zip)
 
     published_project.set_storage_info()
 

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -81,25 +81,32 @@ class StorageInfo():
     """
     Object for storing display information about a project's storage.
     """
-    def __init__(self, allowance, used, include_remaining,
+    def __init__(self, allowance, used, include_remaining=True,
         main_used=None, compressed_used=None):
         """
         Initialize fields with optional args for published and
         unpublished projects
+
+        The include_remaining argument has no effect and is kept for
+        compatibility.
         """
         self.allowance = allowance
         self.readable_allowance = readable_size(allowance)
 
         # Total used
         self.used = used
-        self.readable_used = readable_size(used)
-
-        if include_remaining:
-            remaining = allowance - used
-            self.remaining = remaining
-            self.readable_remaining = readable_size(remaining)
-            self.p_used = round(used *100 / allowance)
-            self.p_remaining = round(remaining *100 / allowance)
+        if used is None:
+            self.readable_used = 'unknown'
+            self.remaining = None
+            self.readable_remaining = 'unknown'
+            self.p_used = '?'
+            self.p_remaining = '?'
+        else:
+            self.readable_used = readable_size(used)
+            self.remaining = allowance - used
+            self.readable_remaining = readable_size(self.remaining)
+            self.p_used = round(used * 100 / allowance)
+            self.p_remaining = round(self.remaining * 100 / allowance)
 
         if main_used is not None:
             self.main_used = main_used

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -202,22 +202,6 @@ def get_tree_size(path):
             total += entry.stat(follow_symlinks=False).st_size
     return total
 
-def get_tree_files(path, full_path=True):
-    """
-    Return list of files from a base path
-    """
-    files = []
-    for entry in os.scandir(path):
-        if entry.is_dir(follow_symlinks=False):
-            files += get_tree_files(entry.path, full_path=True)
-        else:
-            files.append(entry.path)
-    # Strip the original path if desired
-    if not full_path:
-        if not path.endswith('/'):
-            path += '/'
-        files = [f[len(path):] for f in files]
-    return files
 
 def readable_size(num, suffix='B'):
     "Display human readable size of byte number"


### PR DESCRIPTION
There are still a few places that perform a complete recursive
directory scan as part of a page load.  We want to avoid such things,
especially if they enable external authors to break the admin console.

(Just for fun: I tried invoking 'get_tree_size' on one-tenth of
the MIMIC-III Waveform Database.  It took about 90 seconds.)

This fixes two of those issues:

- 'manage_published_project' wants to display the complete size of a
  (published) project.  Instead of calculating the size, just use the
  stored 'main_storage_size' (which is calculated by set_storage_info
  at the time the project is published.)

- 'submission_info' (and 'edit_submission' and 'copyedit_submission'
  and 'awaiting_authors' and 'publish_submission') wants to display
  the complete size of an active project.  For the time being, I've
  changed this to say "unknown".

(This is a kludge and I promise it will eventually be fixed!  But for
the time being, I don't think it's crucial to have disk usage
displayed there, and it's more important to allow us to review huge
projects without using even uglier kludges on the server.)

The issues that (I know) are still unfixed are:

* 'project_files' will still do a complete scan every time the page is
  loaded.

* UploadFilesForm will still do a complete scan every time one or more
  files are uploaded.

* NewProjectVersionForm will still copy over the directory structure
  synchronously.

I am ignoring those issues for now because... well, the system still
doesn't have any good mechanism that external contributors can use to
easily upload a project containing millions of files.  If it only
inconveniences me and Alistair, we can deal with that. :)
