### PR TITLE
Fix syntax of mailto template

### DIFF
--- a/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
@@ -1,5 +1,4 @@
-{% autoescape off %}
-Dear Prof. {{ application.reference_name }},
+{% autoescape off %}Dear Prof. {{ application.reference_name }},
 
 {{ applicant_name }} has requested access to restricted-access clinical data maintained by PhysioNet, listing you as her/his supervisor and summarizing his/her research project as follows:
 

--- a/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
@@ -1,4 +1,4 @@
-{% autoescape off %}{% filter wordwrap:70 %}
+{% autoescape off %}
 Dear Prof. {{ application.reference_name }},
 
 {{ applicant_name }} has requested access to restricted-access clinical data maintained by PhysioNet, listing you as her/his supervisor and summarizing his/her research project as follows:
@@ -8,3 +8,4 @@ Dear Prof. {{ application.reference_name }},
 Are you {{ applicant_name }}'s supervisor for this project, and is the summary accurate?
 
 {{ signature }}
+{% endautoescape %}


### PR DESCRIPTION
Syntax of templates was broken in pull #692 and partially fixed in #695.  This fixes the syntax of the other template.
