### PR TITLE
Bottom spacing in the content list

### DIFF
--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -13,11 +13,13 @@
           {% endfor %}
       </p>
     {% endif %}
-    {% if not published_project.short_description %}
-      {{ published_project.abstract|safe|truncatechars_html:250 }}
-    {% else %}
-      {{ published_project.short_description }}
-    {% endif %}
+    <div style="margin-bottom: 1rem;">
+      {% if not published_project.short_description %}
+        {{ published_project.abstract|safe|truncatechars_html:250 }}
+      {% else %}
+        {{ published_project.short_description }}
+      {% endif %}
+    </div>
     <p class="text-muted">
       {% for topic in published_project.topics.all %}
         {{ topic|topic_badge|safe }}


### PR DESCRIPTION
The content list in both home and find pages is without any spacing between the short description and the project tags, as can be easily noticed either on staging or production.

This is not clear when you are on dev or in some projects because they already contain `<p>` tags in the short description.

Here I wrap it in a `<div>` with bottom margin to fix the issue.