### PR TITLE
Better styling for static pages

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -535,3 +535,12 @@ table.files-panel {
 a, code{
   word-break: break-word;
 }
+
+.indented-box{
+  margin-left: 0.75em;
+  padding-left: 25px;
+  margin-top: 25px;
+  border-left: 1px solid;
+  border-image: linear-gradient(to bottom, silver 0%, silver 60%, transparent 100%) 1% 100%;
+          
+}

--- a/physionet-django/templates/about/about.html
+++ b/physionet-django/templates/about/about.html
@@ -33,14 +33,11 @@ About
     </div><div class="main-content">
       <div>{% include "about/about_physionet.html" %}</div>
       <br>
-      <hr>
-      <br>
       {% include "message_snippet.html" %}
       <h1 id="contact">Contact us</h1>
-      <br>
-      <div>{% include "about/contact.html" %}</div>
-      <br>
-      <hr>
+      <div class="indented-box">
+        <div>{% include "about/contact.html" %}</div>
+      </div>
     </div>
   </div>
 </div>

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -1,113 +1,101 @@
 <section id="physionet">
-  <h1>PhysioNet: Brief Introduction</h1>
-  <br>
-  <p>PhysioNet, the moniker of the <em>Research Resource for Complex Physiologic Signals</em>, was established in 1999 under the auspices of the National Institutes of Health (NIH), as described further below. The PhysioNet Resource’s original and ongoing missions were to conduct and catalyze for biomedical research and education, in part by offering free access to large collections of physiological and clinical data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. Members of PhysioNet’s team are actively involved in innovative work on analysis of physiologic signals, both from basic and translational perspectives.</p>
-  <p>The PhysioNet platform is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. The other core laboratory of the PhysioNet Resource is the <a href="http://reylab.bidmc.harvard.edu/">Margret and H.A. Rey Institute for Nonlinear Dynamics</a> at Beth Israel Deaconess Medical Center.</p>
+    <h1>PhysioNet: Brief Introduction</h1>
+  <div class="indented-box">
+    <p>PhysioNet, the moniker of the <em>Research Resource for Complex Physiologic Signals</em>, was established in 1999 under the auspices of the National Institutes of Health (NIH), as described further below. The PhysioNet Resource’s original and ongoing missions were to conduct and catalyze for biomedical research and education, in part by offering free access to large collections of physiological and clinical data and related open-source software. In cooperation with the annual <a href="http://www.cinc.org/">Computing in Cardiology</a> conference, PhysioNet also hosts an annual series of challenges, focusing research on unsolved problems in clinical and basic science. Members of PhysioNet’s team are actively involved in innovative work on analysis of physiologic signals, both from basic and translational perspectives.</p>
+    <p>The PhysioNet platform is managed by members of the <a href="https://lcp.mit.edu/">MIT Laboratory for Computational Physiology</a>. The other core laboratory of the PhysioNet Resource is the <a href="http://reylab.bidmc.harvard.edu/">Margret and H.A. Rey Institute for Nonlinear Dynamics</a> at Beth Israel Deaconess Medical Center.</p>
+  </div>
 </section>
-
 <br>
-<hr>
-
 <section id="resource">
-<h1>A Community Resource</h1>
+  <h1>A Community Resource</h1>
+  <div class="indented-box">
+    <p>The PhysioNet resource has three closely interdependent components:</p>
+    <ul>
+      <li>
+        <p>An  <a href="{% url 'database_overview' %}">extensive archive</a> ("PhysioBank") of well-characterized digital recordings of physiologic signals, time series, and related
+          data for use by the biomedical research community. PhysioNet includes collections of cardiopulmonary, neural, and other biomedical signals from healthy subjects and patients
+          with a variety of conditions with major public health implications, including sudden
+          cardiac death, congestive heart failure, epilepsy, gait disorders, sleep apnea, and aging.
+          These collections include data from a wide range of studies, as developed and contributed by members of the research community. PhysioNet also includes clinical and imaging data related to critical care.</p>
+      </li>
+      <li>
+        <p>A large and growing <a href="{% url 'software_overview' %}">library of software</a> ("PhysioToolkit") for physiologic signal processing and analysis, detection of
+        physiologically significant events using both classical techniques and novel methods based on statistical physics and nonlinear dynamics, interactive display and characterization of signals, creation of new databases, simulation of physiologic and other signals, quantitative evaluation and comparison of analysis methods, and analysis of nonequilibrium and nonstationary processes.</p>
+      </li>
+      <li>
+        <p>A  <a href="{% url 'tutorial_overview' %}">collection of popular tutorials and educational materials</a>,  offering expert guidance in approaches for exploring and analysing health data
+          and physiologic signals. A unifying theme for these resources
+          is a focus on the extraction of “hidden” information from biomedical data,
+          providing information that may have diagnostic or prognostic value in medicine,
+          or explanatory or predictive power in basic research.</p>
+      </li>
+    </ul>
+    <p>
+    PhysioNet, as noted, is not only the name of the Research Resource for Complex Physiologic Signals, but also of its web site, <a href="https://physionet.org/">physionet.org</a>. The website was established by the Resource as its mechanism for free and open
+    dissemination and exchange of recorded biomedical signals and open-source
+    software for analyzing them, by providing facilities for cooperative analysis
+    of data and evaluation of proposed new algorithms.  In addition to providing
+    free electronic access to data and software, the PhysioNet web site offers service and training via on-line
+    tutorials to assist users at entry and more advanced levels.  In cooperation
+    with the annual <a href=http://www.cinc.org/ target="other">Computing in
+    Cardiology</a> conference, PhysioNet hosts an annual series
+    of <a href="{% url 'challenge_overview' %}">challenges</a>, in which researchers and students
+    address unsolved problems of clinical or basic scientific interest using data
+    and software provided by PhysioNet.</p>
 
-<p>The PhysioNet resource has three closely interdependent components:</p>
-
-<ul>
-<li>
-<p>An  <a href="{% url 'database_overview' %}">extensive archive</a> ("PhysioBank") of well-characterized digital recordings of physiologic signals, time series, and related
-  data for use by the biomedical research community. PhysioNet includes collections of cardiopulmonary, neural, and other biomedical signals from healthy subjects and patients
-  with a variety of conditions with major public health implications, including sudden
-  cardiac death, congestive heart failure, epilepsy, gait disorders, sleep apnea, and aging.
-  These collections include data from a wide range of studies, as developed and contributed by members of the research community. PhysioNet also includes clinical and imaging data related to critical care.</p>
-</li>
-
-<li>
-<p>A large and growing <a href="{% url 'software_overview' %}">library of software</a> ("PhysioToolkit") for physiologic signal processing and analysis, detection of
- physiologically significant events using both classical techniques and novel methods based on statistical physics and nonlinear dynamics, interactive display and characterization of signals, creation of new databases, simulation of physiologic and other signals, quantitative evaluation and comparison of analysis methods, and analysis of nonequilibrium and nonstationary processes.</p>
-</li>
-
-<li>
-<p>A  <a href="{% url 'tutorial_overview' %}">collection of popular tutorials and educational materials</a>,  offering expert guidance in approaches for exploring and analysing health data
-  and physiologic signals. A unifying theme for these resources
-  is a focus on the extraction of “hidden” information from biomedical data,
-  providing information that may have diagnostic or prognostic value in medicine,
-  or explanatory or predictive power in basic research.</p>
-</li>
-
-</ul>
-
-<p>
-PhysioNet, as noted, is not only the name of the Research Resource for Complex Physiologic Signals, but also of its web site, <a href="https://physionet.org/">physionet.org</a>. The website was established by the Resource as its mechanism for free and open
-dissemination and exchange of recorded biomedical signals and open-source
-software for analyzing them, by providing facilities for cooperative analysis
-of data and evaluation of proposed new algorithms.  In addition to providing
-free electronic access to data and software, the PhysioNet web site offers service and training via on-line
-tutorials to assist users at entry and more advanced levels.  In cooperation
-with the annual <a href=http://www.cinc.org/ target="other">Computing in
-Cardiology</a> conference, PhysioNet hosts an annual series
-of <a href="{% url 'challenge_overview' %}">challenges</a>, in which researchers and students
-address unsolved problems of clinical or basic scientific interest using data
-and software provided by PhysioNet.</p>
-
-<p>
-All data and software included in PhysioNet are carefully reviewed.  We invite you to participate in the ongoing review process.  By sharing common data sets, and software in source form, the research community benefits from access to materials that have been rigorously
-scrutinized by many investigators.  We further invite researchers to contribute
-data and software for review and possible inclusion in our resource collection.  Please review our
-<a href="{% url 'about_publish' %}">guidelines for contributors</a> before submitting
-material.</p>
+    <p>
+    All data and software included in PhysioNet are carefully reviewed.  We invite you to participate in the ongoing review process.  By sharing common data sets, and software in source form, the research community benefits from access to materials that have been rigorously
+    scrutinized by many investigators.  We further invite researchers to contribute
+    data and software for review and possible inclusion in our resource collection.  Please review our
+    <a href="{% url 'about_publish' %}">guidelines for contributors</a> before submitting
+    material.</p>
+  </div>
 </section>
-
 <br>
-<hr>
-
 <section id="history">
   <h1>PhysioNet: Brief Historical Background</h1>
-  <br>
-<p>Beginning in the mid-1970s, members of the PhysioNet team who were then working on some of the first microcomputer-based instruments for cardiac arrhythmia monitoring foresaw the usefulness of establishing shared databases of well-characterized ECG recordings, as a basis for evaluation, iterative improvement, and objective comparison of algorithms for automated arrhythmia analysis. A five-year effort culminated in the publication of the MIT-BIH Arrhythmia Database in 1980, which soon became the standard reference collection of its type, used by over 500 academic, hospital, and industry researchers and developers worldwide during the 1980s and 1990s. Other databases of ECGs and eventually other physiologic signals followed. By 1999, the MIT group distributed CD-ROMs containing 11 such collections, and had participated in the development of several others. Over the same period, other members of the PhysioNet team helped pioneer the development of concepts and computational tools from nonlinear dynamics (including fractals and complex systems) to biomedicine and in creating and sharing ECG/Holter databases of patients with chronic heart failure and healthy controls.</p>
+  <div class="indented-box">
+    <p>Beginning in the mid-1970s, members of the PhysioNet team who were then working on some of the first microcomputer-based instruments for cardiac arrhythmia monitoring foresaw the usefulness of establishing shared databases of well-characterized ECG recordings, as a basis for evaluation, iterative improvement, and objective comparison of algorithms for automated arrhythmia analysis. A five-year effort culminated in the publication of the MIT-BIH Arrhythmia Database in 1980, which soon became the standard reference collection of its type, used by over 500 academic, hospital, and industry researchers and developers worldwide during the 1980s and 1990s. Other databases of ECGs and eventually other physiologic signals followed. By 1999, the MIT group distributed CD-ROMs containing 11 such collections, and had participated in the development of several others. Over the same period, other members of the PhysioNet team helped pioneer the development of concepts and computational tools from nonlinear dynamics (including fractals and complex systems) to biomedicine and in creating and sharing ECG/Holter databases of patients with chronic heart failure and healthy controls.</p>
 
-<p>PhysioNet was formally established in 1999 as the outreach component of the <em>Research Resource for Complex Physiologic Signals</em>, a cooperative project initiated by a diverse group of computer scientists, physicists, mathematicians, biomedical researchers, clinicians, and educators at
-<a href="http://reylab.bidmc.harvard.edu/"
-target="_blank">Boston's Beth Israel Deaconess Medical Center</a>/<a href="https://hms.harvard.edu/">Harvard Medical School</a> and <a href="https://lcp.mit.edu/">MIT</a>. Over the years, colleagues from Boston University, the University of Massachusetts Medical Center and McGill University have played seminal roles in the founding and development of the PhysioNet Resource. Many of us have worked together for 20 years or even longer on problems relating to characterizing and understanding the dynamics of human physiology, the implications of dynamical change in diagnosis and treatment of pathophysiology, novel and robust techniques for physiologic monitoring in ambulatory subjects and critical care patients, and applications of model-based reasoning to medical decision support in intensive care. The MIT group contributed its 11 databases, and the software it had developed for exploring and analyzing them, to establish PhysioBank and PhysioToolkit. Free availability of these resources via the Internet catalyzed an even greater explosion of interest in them, as researchers and students worldwide who had no previous access to such data or software began new programs of research, and specialists began comparing their methods. The initial contributions were quickly supplemented by additional collections of data and software from collaborators, and soon after, from many researchers worldwide. PhysioBank and PhysioToolkit have grown to many times their original sizes, and most of the growth has been thanks to the hard work and generosity of an international community of researchers.</p>
+    <p>PhysioNet was formally established in 1999 as the outreach component of the <em>Research Resource for Complex Physiologic Signals</em>, a cooperative project initiated by a diverse group of computer scientists, physicists, mathematicians, biomedical researchers, clinicians, and educators at
+    <a href="http://reylab.bidmc.harvard.edu/"
+    target="_blank">Boston's Beth Israel Deaconess Medical Center</a>/<a href="https://hms.harvard.edu/">Harvard Medical School</a> and <a href="https://lcp.mit.edu/">MIT</a>. Over the years, colleagues from Boston University, the University of Massachusetts Medical Center and McGill University have played seminal roles in the founding and development of the PhysioNet Resource. Many of us have worked together for 20 years or even longer on problems relating to characterizing and understanding the dynamics of human physiology, the implications of dynamical change in diagnosis and treatment of pathophysiology, novel and robust techniques for physiologic monitoring in ambulatory subjects and critical care patients, and applications of model-based reasoning to medical decision support in intensive care. The MIT group contributed its 11 databases, and the software it had developed for exploring and analyzing them, to establish PhysioBank and PhysioToolkit. Free availability of these resources via the Internet catalyzed an even greater explosion of interest in them, as researchers and students worldwide who had no previous access to such data or software began new programs of research, and specialists began comparing their methods. The initial contributions were quickly supplemented by additional collections of data and software from collaborators, and soon after, from many researchers worldwide. PhysioBank and PhysioToolkit have grown to many times their original sizes, and most of the growth has been thanks to the hard work and generosity of an international community of researchers.</p>
 
-<p>At the time PhysioNet was established, members of the PhysioNet team at MIT were preparing to host Computers in Cardiology (CinC) 2000. We hoped to introduce PhysioNet to our international colleagues who would be attending CinC, by encouraging participation in an activity that made effective use of the facilities provided by PhysioNet to stimulate rapid progress on an unsolved problem of practical clinical significance. A timely contribution of data made it possible to create the first
-<a href="/challenge/">PhysioNet/CinC Challenge</a>, which attracted the attention of more than a dozen teams to the subject of detecting sleep apnea from the ECG. Their efforts were broadly successful, they discussed their findings at CinC 2000, and an annual tradition was born. For a summary, see our <a href="{% url 'timeline' %}">timeline</a>.</p>
-<p>The novelty and impact of the Resource for industry was recognized by the granting of the 2016 Association for the Advancement of Medical Instrumentation’s highest award, the Laufman-Greatbatch prize, to PhysioNet’s founding and current joint directors.</p>
-<p>For a further description of founding of PhysioNet, see:
-  Goldberger AL, Amaral LAN, Glass L,
-    Hausdorff JM, Ivanov PCh, Mark RG,
-  Mietus JE, Moody GB, Peng C-K, Stanley HE.  PhysioBank, PhysioToolkit, and
-  PhysioNet: Components of a New Research Resource for Complex Physiologic
-  Signals.
-  <i>Circulation</i> <b>101</b>(23):e215-e220 [Circulation Electronic Pages;
-  <a href="http://circ.ahajournals.org/content/101/23/e215.full"
-  target="other">http://circ.ahajournals.org/content/101/23/e215.full</a>];
-  2000 (June 13).</p>
+    <p>At the time PhysioNet was established, members of the PhysioNet team at MIT were preparing to host Computers in Cardiology (CinC) 2000. We hoped to introduce PhysioNet to our international colleagues who would be attending CinC, by encouraging participation in an activity that made effective use of the facilities provided by PhysioNet to stimulate rapid progress on an unsolved problem of practical clinical significance. A timely contribution of data made it possible to create the first
+    <a href="/challenge/">PhysioNet/CinC Challenge</a>, which attracted the attention of more than a dozen teams to the subject of detecting sleep apnea from the ECG. Their efforts were broadly successful, they discussed their findings at CinC 2000, and an annual tradition was born. For a summary, see our <a href="{% url 'timeline' %}">timeline</a>.</p>
+    <p>The novelty and impact of the Resource for industry was recognized by the granting of the 2016 Association for the Advancement of Medical Instrumentation’s highest award, the Laufman-Greatbatch prize, to PhysioNet’s founding and current joint directors.</p>
+    <p>For a further description of founding of PhysioNet, see:
+      Goldberger AL, Amaral LAN, Glass L,
+        Hausdorff JM, Ivanov PCh, Mark RG,
+      Mietus JE, Moody GB, Peng C-K, Stanley HE.  PhysioBank, PhysioToolkit, and
+      PhysioNet: Components of a New Research Resource for Complex Physiologic
+      Signals.
+      <i>Circulation</i> <b>101</b>(23):e215-e220 [Circulation Electronic Pages;
+      <a href="http://circ.ahajournals.org/content/101/23/e215.full"
+      target="other">http://circ.ahajournals.org/content/101/23/e215.full</a>];
+      2000 (June 13).</p>
+  </div>
 </section>
-
 <br>
-<hr>
-
 <section id="funding">
   <h1>Funding</h1>
-  <br>
-  <p>PhysioNet was originally established under the auspices of the National Center for Research Resources (NCRR) of the National Institutes of Health (NIH). The NCRR was discontinued in 2011 as part of a major NIH reorganization. We now gratefully acknowledge ongoing support from the National Institute of General Medical Sciences (NIGMS) and National Institute of Biomedical Imaging and Bioengineering (NIBIB) under grant <em>R01GM10498</em>.</p>
+  <div class="indented-box">
+    <p>PhysioNet was originally established under the auspices of the National Center for Research Resources (NCRR) of the National Institutes of Health (NIH). The NCRR was discontinued in 2011 as part of a major NIH reorganization. We now gratefully acknowledge ongoing support from the National Institute of General Medical Sciences (NIGMS) and National Institute of Biomedical Imaging and Bioengineering (NIBIB) under grant <em>R01GM10498</em>.</p>
+  </div>
 </section>
-
 <br>
-<hr>
-
 <section id="citation">
   <h1>Citation of the Resource</h1>
-  <br>
-<p><strong>If you use data or software from PhysioNet in a publication, please credit the author(s) when referencing it</strong>. You can find authors' names, and in many cases their publications introducing the data or software, on the project pages for their contributions. If you are unsure how to cite a specific project, please <a href="mailto:webmaster@physionet.org?subject=citing%20software">ask us</a>!. Please also include the standard citation for PhysioNet:</p>
-  <p class="alert alert-primary" role="alert">Goldberger AL, Amaral LAN, Glass L,
-    Hausdorff JM, Ivanov PCh, Mark RG,
-  Mietus JE, Moody GB, Peng C-K, Stanley HE.  PhysioBank, PhysioToolkit, and
-  PhysioNet: Components of a New Research Resource for Complex Physiologic
-  Signals.
-  <i>Circulation</i> <b>101</b>(23):e215-e220 [Circulation Electronic Pages;
-  <a href="http://circ.ahajournals.org/content/101/23/e215.full"
-  target="other">http://circ.ahajournals.org/content/101/23/e215.full</a>];
-  2000 (June 13).</p>
+  <div class="indented-box">
+    <p><strong>If you use data or software from PhysioNet in a publication, please credit the author(s) when referencing it</strong>. You can find authors' names, and in many cases their publications introducing the data or software, on the project pages for their contributions. If you are unsure how to cite a specific project, please <a href="mailto:webmaster@physionet.org?subject=citing%20software">ask us</a>!. Please also include the standard citation for PhysioNet:</p>
+      <p class="alert alert-primary" role="alert">Goldberger AL, Amaral LAN, Glass L,
+        Hausdorff JM, Ivanov PCh, Mark RG,
+      Mietus JE, Moody GB, Peng C-K, Stanley HE.  PhysioBank, PhysioToolkit, and
+      PhysioNet: Components of a New Research Resource for Complex Physiologic
+      Signals.
+      <i>Circulation</i> <b>101</b>(23):e215-e220 [Circulation Electronic Pages;
+      <a href="http://circ.ahajournals.org/content/101/23/e215.full"
+      target="other">http://circ.ahajournals.org/content/101/23/e215.full</a>];
+      2000 (June 13).</p>
+  </div>
 </section>

--- a/physionet-django/templates/about/author_guidelines.html
+++ b/physionet-django/templates/about/author_guidelines.html
@@ -1,4 +1,4 @@
-<section id="project_descriptions">
+<section id="project_descriptions" class="indented-box">
   <h2>Choosing a project type</h2>
   <p>When submitting a project to PhysioNet you will be asked to select one of the following project types:</p>
   <ul>
@@ -8,7 +8,7 @@
   </ul>
 </section>
 
-<section id="project_draft">
+<section id="project_draft" class="indented-box">
   <h2>Creating the project metadata</h2>
   <p>To help the community to reuse your shared resources, we 
     require a detailed description. The information that you provide 
@@ -30,7 +30,7 @@
   </ul>
 </section>
 
-<section id="project_files">
+<section id="project_files" class="indented-box">
   <h2>Preparing your project files</h2>
   <p>When submitting a project, you will be asked to upload relevant data and
   software files. Please review the following guidelines when preparing your

--- a/physionet-django/templates/about/licenses.html
+++ b/physionet-django/templates/about/licenses.html
@@ -1,6 +1,7 @@
 <p>When sharing data and software, it is important to be clear about how you intend the content to be reused. To maximize reuse potential of the content, we encourage permissive, open licenses. Currently, authors submitting content to PhysioNet are able to select the following licenses.</p>
 
 {% for key, value in licenses.items %}
+<div class="indented-box">
 	<h5 id="{{ key|lower }}">{{ key }}</h5>
 	<ul>
 	{% for license in value %}
@@ -10,6 +11,6 @@
       <a href="{% url 'license_content' license.slug %}">License</a> - <a href="{{ license.home_page }}">Home page <i class="fas fa-external-link-alt"></i></a>
 		</li>
   	{% endfor %}
-  	</ul>
-  	<br>
+	</ul>
+</div>  
 {% endfor %}

--- a/physionet-django/templates/about/publish.html
+++ b/physionet-django/templates/about/publish.html
@@ -31,19 +31,15 @@ Publish
       </div>
     </div><div class="main-content">
       <h1 id="sharing">Sharing on PhysioNet</h1>
-      <br><div>{% include "about/share.html" %}</div><br>
-      <hr>
-      <br><h1 id="overview">Submission Overview</h1><br>
+      <div>{% include "about/share.html" %}</div><br>
+      <h1 id="overview">Submission Overview</h1>
       <div>{% include "about/submission_overview.html" %}</div><br>
-      <hr>
-      <br><h1 id="guidelines">Author Guidelines</h1><br>
+      <h1 id="guidelines">Author Guidelines</h1>
       <div>{% include "about/author_guidelines.html" %}</div><br>
-      <hr>
-      <br><h1 id="licenses">Licenses</h1><br>
-      <div>{% include "about/licenses.html" %}</div>
-      <hr>
-      <br><h1 id="submit">Submit your Project</h1><br>
-      <div>
+      <h1 id="licenses">Licenses</h1>
+      <div>{% include "about/licenses.html" %}</div><br>
+      <h1 id="submit">Submit your Project</h1>
+      <div class="indented-box">
           <p><a href="{% url 'create_project' %}">Click here</a> to create your project.</p>
       </div>
     </div>

--- a/physionet-django/templates/about/share.html
+++ b/physionet-django/templates/about/share.html
@@ -1,4 +1,4 @@
-<section id="pshare">
+<section id="pshare" class="indented-box">
   <p>We invite you to share your resources with the PhysioNet community. Incentives to share include:
   <ul>
     <li>Improving the discoverability of your work through increased citations.</li>

--- a/physionet-django/templates/about/submission_overview.html
+++ b/physionet-django/templates/about/submission_overview.html
@@ -1,4 +1,4 @@
-<section id="submission">
+<section id="submission" class="indented-box">
   <h2>Submission process</h2>
   <p>Submitting data and software to PhysioNet is similar to submitting an article to a journal. Briefly, the process for submitting your work for publication in PhysioNet is as follows:</p>
   <ul>
@@ -11,7 +11,7 @@
   </ul>
 </section>
 
-<section id="preparing">
+<section id="preparing" class="indented-box">
   <h2>Preparing for submission</h2>
   <p>PhysioNet helps you to ensure that your data and software is sufficiently well organized to enable reuse by the community. Before submitting your project for review, please make sure that you have:</p>
   <ul>
@@ -22,7 +22,7 @@
   </ul>
 </section>
 
-<section id="criteria">
+<section id="criteria" class="indented-box">
   <h2>Criteria for publication</h2>
   <p>Our goals are to ensure that the data is safe to share and that it is sufficiently well structured and described for it to be a valuable resource for the research community. Some of the high-level criteria that we will be considering when reviewing your project include:</p>
   <h5>Data Quality</h5>
@@ -31,7 +31,7 @@
   {% include "about/software_quality_guidelines.html" %}
 </section>
 
-<section id="editorial">
+<section id="editorial" class="indented-box">
   <h2>Editorial process</h2>
   <p>Once your project is submitted to PhysioNet, it will be reviewed by one or more content specialists. Based on this review, you will be provided with an initial editorial decision within four weeks from submission. The possible decisions are:</p>
   <ol>


### PR DESCRIPTION
This is an attempt to improve the template of the `Share` and `About` pages.

Instead of using a bunch of `<br>` and `<hr>` tags, I wrap subsections in an indented box with a left border.