### PR TITLE
Update templates to reflect changes in #708

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -1,18 +1,18 @@
 {# Status section #}
 
 <p><strong>Status:</strong><br>
-Application Date: {{ application.application_datetime|date }}<br>
+Application date: {{ application.application_datetime|date }}<br>
 
 {% if application.reference_contact_datetime %}
-  Reference Contact Date: {{ application.reference_contact_datetime|date }}<br>
+  Reference contact date: {{ application.reference_contact_datetime|date }}<br>
   {% if application.reference_response_datetime %}
-    Reference Response Date: {{ application.reference_response_datetime|date }}<br>
-    Reference Verified: {{ application.get_reference_response_display }}<br>
+    Reference response date: {{ application.reference_response_datetime|date }}<br>
+    Reference verified: {{ application.get_reference_response_display }}<br>
   {% endif %}
 {% endif %}
 
 {% if application.decision_datetime %}
-  Decision Date: {{ application.decision_datetime|date }}<br>
+  Decision date: {{ application.decision_datetime|date }}<br>
 {% endif %}
 
 Decision: {% if application.status %}{{ application.get_status_display }}{% else %}<i class="fas fa-clock"></i> Pending{% endif %}<br>
@@ -26,15 +26,15 @@ Decision: {% if application.status %}{{ application.get_status_display }}{% else
 <p><strong>Personal details:</strong><br>
 User: <a href="{% url 'public_profile' application.user.username %}">{{ application.user.username }}</a><br>
 
-My first (given) name(s): {{ application.first_names }}<br>
+First name(s): {{ application.first_names }}<br>
 
-My last (family) name(s): {{ application.last_name }}<br>
+Family name(s): {{ application.last_name }}<br>
 
 Suffix (e.g., Jr.), if applicable: {{ application.suffix }}<br>
 
 My PhysioNet email: {{ application.user.email }}<br>
 
-Organization Name: {{ application.organization_name }}<br>
+Organization name: {{ application.organization_name }}<br>
 
 Job title or position: {{ application.job_title }}<br>
 
@@ -50,37 +50,23 @@ Webpage: {% if application.webpage %}<a href="{{ application.webpage }}" target=
 
 {# Training #}
 
-<p><strong>Training:</strong><br>
+<p><strong>CITI completion report:</strong><br>
 
-Human studies training course (name of course): {{ application.training_course_name }}<br>
-
-Date completed: {{ application.training_completion_date }}<br>
-
-Training Completion Report: <a href="{% url 'training_report' application.slug %}" target="_blank">File</a><br></p>
-
-{% if application.course_category %}
-  <p><strong>Course:</strong><br>
-  
-  Course Category: {{ application.get_course_category_display }}<br>
-
-  Course Info: {{ application.course_info }}<br></p>
-{% endif %}
+Training report: <a href="{% url 'training_report' application.slug %}" target="_blank">View file</a><br></p>
 
 {# Reference #}
 
 <p><strong>Reference:</strong><br>
 
-Reference Category: {{ application.get_reference_category_display }}<br>
+Reference category: {{ application.get_reference_category_display }}<br>
 
-Reference's Name: {{ application.reference_name }}<br>
+Reference name: {{ application.reference_name }}<br>
 
-Reference's Email: {{ application.reference_email }}<br>
+Reference email: {{ application.reference_email }}<br>
 
-Reference's job title or position: {{ application.reference_title }}</p>
+Reference job title or position: {{ application.reference_title }}</p>
 
 
-Researcher's Category: {{ application.get_researcher_category_display }}<br>
+Researcher category: {{ application.get_researcher_category_display }}<br>
 
-Project of interest: {{ application.project_of_interest }}<br>
-
-Research Summary: {{ application.research_summary }}<br></p>
+Research topic: {{ application.research_summary }}<br></p>

--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -5,13 +5,7 @@
       <a href='{{ application.mailto }}' style="padding-right: 1.5rem;">
 	Send e-mail to applicant
       </a>  {{ application.user.email }} <br>
-      Database requested: {{ application.project_of_interest }}<br>
       Researcher's Category: {{ application.get_researcher_category_display }}<br>
-      Project(s) of interest: {{ application.project_of_interest }}<br>
-      {% if application.course_category %}
-      Course Category: {{ application.get_course_category_display }}<br>
-      Course Info: {{ application.course_info }}<br>
-      {% endif %}
     </p>
     <form action="" method="post" class="form-signin"> <!-- empty action generates error! -->
       <p>

--- a/physionet-django/console/templates/console/complete_application_display_table.html
+++ b/physionet-django/console/templates/console/complete_application_display_table.html
@@ -27,12 +27,6 @@ Country: {{ application.get_country_display }}<br>
 
 Webpage: {{ application.webpage }}<br></p>
 
-{# Training #}
-
-<p>Human studies training course (name of course): {{ application.training_course_name }}<br>
-
-Date completed: {{ application.training_completion_date }}<br>
-
 {# Reference #}
 
 <p>Reference Category: {{ application.get_reference_category_display }}<br>
@@ -44,6 +38,6 @@ Reference's Email: {{ application.reference_email }}<br>
 Reference's job title or position: {{ application.reference_title }}</p>
 
 
-<p>Research Summary: {{ application.research_summary }}<br>
+<p>Research Topic: {{ application.research_summary }}<br>
 
 Date of this agreement: {{application.application_datetime}}<br></p>

--- a/physionet-django/user/templates/user/application_display_table.html
+++ b/physionet-django/user/templates/user/application_display_table.html
@@ -56,18 +56,10 @@
     </tr>
     <tr>
       <td>Webpage</td>
-      <td><a href="{{ application.webpage }}" target="_blank">{{ application.webpage }}</a></td>
+      <td>{% if application.webpage|length > 0 %}<a href="{{ application.webpage }}" target="_blank">{{ application.webpage }}{% endif %}</a></td>
     </tr>
     <tr>
-      <th colspan='2' class="bg-light">Training Course</th>
-    </tr>
-    <tr>
-      <td>Training Course Name</td>
-      <td>{{ application.training_course_name }}</td>
-    </tr>
-    <tr>
-      <td>Training Completion Date</td>
-      <td>{{ application.training_completion_date }}</td>
+      <th colspan='2' class="bg-light">CITI Completion Report</th>
     </tr>
     <tr>
       <td>Training Completion Report</td>
@@ -93,29 +85,11 @@
       <td>{{ application.reference_title }}</td>
     </tr>
     <tr>
-      <th colspan='2' class="bg-light">Course Survey</th>
-    </tr>
-    {% if application.course_category %}
-      <tr>
-        <td>Course Info</td>
-        <td>{{ application.course_info }}</td>
-      </tr>
-    {% else %}
-      <tr>
-        <td>Course Info</td>
-        <td>{{ application.get_course_category_display }}</td>
-      </tr>
-    {% endif %}
-    <tr>
-      <th colspan='2' class="bg-light">Research Area</th>
+      <th colspan='2' class="bg-light">Research</th>
     </tr>
     <tr>
-      <td>Research Summary</td>
+      <td>Research Topic</td>
       <td>{{ application.research_summary }}</td>
-    </tr>
-    <tr>
-      <td>Project Of Interest</td>
-      <td>{{ application.project_of_interest }}</td>
     </tr>
 
     <tr>


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/708 we updated the form for applying for credentialed access to databases. Several fields/sections were removed, including:

- Training report name and completion date
- Course survey (whether the applicant was applying for access as part of a course)
- Project of interest in the "research" section

This pull request updates the templates for completed submissions, so that these fields are not displayed.