### PR TITLE
Better error message for unauthorized file preview

### DIFF
--- a/physionet-django/project/templates/project/file_view_unauthorized.html
+++ b/physionet-django/project/templates/project/file_view_unauthorized.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}{{ project.title }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+  <h1>{{ project.title }} {{ project.version }}</h1>
+  <div class="card">
+    <div class="card-header">
+      File:
+      {% spaceless %}
+        <span class="dir-breadcrumbs">
+          {% for breadcrumb in breadcrumbs %}
+            {% if forloop.last %}
+              <span class="dir-breadcrumb-self">{{ breadcrumb.name }}</span>
+            {% elif forloop.first %}
+              <a href="{{ breadcrumb.rel_path }}#files-panel"
+                 class="dir-breadcrumb-up">{{ breadcrumb.name }}</a>
+              <span class="dir-breadcrumb-sep">/</span>
+            {% else %}
+              <span class="dir-breadcrumb-up">{{ breadcrumb.name }}</a>
+              <span class="dir-breadcrumb-sep">/</span>
+            {% endif %}
+          {% endfor %}
+        </span>
+      {% endspaceless %}
+    </div>
+    <div class="card-body">
+      {% include "project/published_project_unauthorized.html" %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -296,9 +296,7 @@
           {% include "project/files_panel.html" %}
         </div>
       {% else %}
-      <div class="alert alert-danger col-md-8" role="alert">
-        This is a restricted-access resource. To access the files, you must {% if project.access_policy == 2 and not user.is_credentialed %}be a <a href="{% url 'edit_credentialing' %}">credentialed user</a> and {% endif %}<a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project.
-      </div>
+        {% include "project/published_project_unauthorized.html" %}
       {% endif %}
     {% else %}
       <p>Total uncompressed size: {{ main_size }}.

--- a/physionet-django/project/templates/project/published_project_unauthorized.html
+++ b/physionet-django/project/templates/project/published_project_unauthorized.html
@@ -1,0 +1,8 @@
+<div class="alert alert-danger col-md-8" role="alert">
+  This is a restricted-access resource. To access the files, you must
+  {% if project.access_policy == 2 and not user.is_credentialed %}
+  be a <a href="{% url 'edit_credentialing' %}">credentialed user</a> and
+  {% endif %}
+  <a href="{% url 'sign_dua' project.slug project.version %}">sign the
+    data use agreement</a> for the project.
+</div>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1288,9 +1288,16 @@ def display_published_project_file(request, project_slug, version,
         raise Http404()
     if project.has_access(request.user):
         return display_project_file(request, project, full_file_name)
-    if not request.user.is_authenticated:
-        return redirect_to_login(request.get_full_path())
-    raise PermissionDenied()
+
+    # Display error message: "you must [be a credentialed user and]
+    # sign the data use agreement"
+    breadcrumbs = utility.get_dir_breadcrumbs(full_file_name, directory=False)
+    context = {
+        'project': project,
+        'breadcrumbs': breadcrumbs,
+    }
+    return render(request, 'project/file_view_unauthorized.html',
+                  context, status=403)
 
 
 def serve_published_project_zip(request, project_slug, version):


### PR DESCRIPTION
If you visit a published file preview (e.g. /content/demoeicu/2.0.0/SHA256SUMS.txt), currently:

- if you are not logged in, it bounces you to a login page

- after logging in, if you are not authorized to view the project, it displays a generic error message

Instead of this, display an error message similar to what is shown in the files panel of the main project page, explaining that you need to be credentialed and sign the DUA.
