### PR TITLE
add published projects to public profile

### DIFF
--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -84,7 +84,7 @@ Profile for {{ public_user.username }}
         <div class="row mb-1">
           <ul>
             {% for project in projects %}
-            <li><a href="{% url 'published_project' project.slug project.version %}">{{ project.citation_text }}</a>
+            <li><a href="{% url 'published_project' project.slug project.version %}">{{ project.citation_text }}</a> (v{{ project.version }})
             {% endfor %}
           </ul>
         </div>

--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -24,6 +24,7 @@ Profile for {{ public_user.username }}
       <a class="btn btn-primary btn-rsp" style="vertical-align: top" href="{% url 'edit_profile' %}" role="button">Settings</a>
       {% endif %}
       <hr>
+      <h3>Profile</h3>
       <div class="row mb-1">
         <div class="col-md-2">
           Name:
@@ -76,6 +77,19 @@ Profile for {{ public_user.username }}
           </div>
         </div>
       {% endif %}
+      
+      {% if projects %}
+      <br />
+      <h3>Contributions</h3>
+        <div class="row mb-1">
+          <ul>
+            {% for project in projects %}
+            <li><a href="{% url 'published_project' project.slug project.version %}">{{ project.citation_text }}</a>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
     </div>
   </div>
   <br>

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -24,7 +24,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
 from physionet import utility
-from project.models import Author, License
+from project.models import Author, License, PublishedProject
 from notification.utility import (process_credential_complete,
                                   credential_application_request,
                                   get_url_prefix)
@@ -240,9 +240,14 @@ def public_profile(request, username):
     else:
         raise Http404()
 
+    # get list of projects
+    projects = PublishedProject.objects.filter(authors__user__username__iexact=username,
+        is_latest_version=True).order_by('-publish_datetime')
+
+
     return render(request, 'user/public_profile.html', {
         'public_user':public_user, 'profile':public_user.profile,
-        'public_email':public_email})
+        'public_email':public_email, 'projects':projects})
 
 
 def profile_photo(request, username):

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -241,7 +241,7 @@ def public_profile(request, username):
         raise Http404()
 
     # get list of projects
-    projects = PublishedProject.objects.filter(authors__user__username__iexact=username,
+    projects = PublishedProject.objects.filter(authors__user=public_user,
         is_latest_version=True).order_by('-publish_datetime')
 
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -241,8 +241,7 @@ def public_profile(request, username):
         raise Http404()
 
     # get list of projects
-    projects = PublishedProject.objects.filter(authors__user=public_user,
-        is_latest_version=True).order_by('-publish_datetime')
+    projects = PublishedProject.objects.filter(authors__user=public_user).order_by('-publish_datetime')
 
 
     return render(request, 'user/public_profile.html', {


### PR DESCRIPTION
The public profile page for physionet users (e.g. http://localhost:8000/users/rgmark/) is fairly sparse at the moment. This is a minor change to display published projects on the page. Example screenshot below:

![Screen Shot 2019-09-03 at 13 50 54](https://user-images.githubusercontent.com/822601/64196659-575f1500-ce52-11e9-8a17-a8dab84e4ddf.png)

I would like to improve the way that citation details are displayed across the website, and will do this in a separate pull request.