### PR TITLE
changed reference_email comparison to case-insensitive

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -777,11 +777,11 @@ def complete_credential_applications(request):
     for application in applications:
         application.mailto = notification.mailto_process_credential_complete(
             request, application, comments=False)
-        if CredentialApplication.objects.filter(reference_email=application.reference_email,
+        if CredentialApplication.objects.filter(reference_email__iexact=application.reference_email,
             reference_contact_datetime__isnull=False):
             # If the reference has been contacted before, mark it so
             application.known_ref = True
-        elif LegacyCredential.objects.filter(reference_email=application.reference_email):
+        elif LegacyCredential.objects.filter(reference_email__iexact=application.reference_email):
             application.known_ref = True
 
     return render(request, 'console/complete_credential_applications.html',


### PR DESCRIPTION
following Tom's suggestions, I added an “iexact” keyword to comparisons that check to see whether reference's e-mail address is on a list of known reference e-mail addresses.