### PR TITLE
Display help text for credentialing form on mouseover, instead of on click

### DIFF
--- a/physionet-django/static/custom/js/enable-tooltip.js
+++ b/physionet-django/static/custom/js/enable-tooltip.js
@@ -1,0 +1,4 @@
+// Enables tooltips
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})

--- a/physionet-django/templates/descriptive_inline_form_snippet.html
+++ b/physionet-django/templates/descriptive_inline_form_snippet.html
@@ -6,7 +6,7 @@
       {% if field.field.required %}
         <a style="color:red"> *</a>
       {% endif %}
-      <i class="fas fa-question-circle" data-toggle="popover" data-placement="right" data-content="{{ field.help_text }}" data-html="true" onmouseover="" style="cursor: pointer;"></i>
+      <i class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title="{{ field.help_text }}" data-html="true" style="cursor: pointer;"></i>
     </label>
     <div class='col-md-9'>
       {{ field }}

--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -71,6 +71,6 @@
 
 
 {% block local_js_bottom %}
-<script src="{% static 'custom/js/enable-popover.js' %}"></script>
+<script src="{% static 'custom/js/enable-tooltip.js' %}"></script>
 <script src="{% static 'user/js/credential-form-control.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Currently, viewing the help text on the credentialing form at http://localhost:8000/credential-application/ requires the user to click on the "?" icon. As requested by KP, this update instead displays the text on mouseover. I think this is an improvement and should perhaps be implemented site wide.

![Screen Shot 2019-09-03 at 16 33 47](https://user-images.githubusercontent.com/822601/64206569-ac0d8a80-ce68-11e9-9fbd-71a61ababb06.png)

