### PR TITLE
Fix error in the js control for the credentialing form

### DIFF
--- a/physionet-django/user/static/user/js/credential-form-control.js
+++ b/physionet-django/user/static/user/js/credential-form-control.js
@@ -1,27 +1,5 @@
 course_category_input = document.getElementById("id_application-course_category");
 
-function controlCourses() {
-  // Control the course name/number selection based on course category
-  course_name_input = document.getElementById("id_application-course_info");
-  if (course_category_input.value == "0") {
-    course_name_input.selectedIndex = 0;
-    course_name_input.disabled = true;
-    course_name_input.hidden = true;
-    course_name_input.required = false;
-    $('label[for="course_info"]').hide();
-  }
-  else {
-    course_name_input.disabled = false;
-    course_name_input.hidden = false;
-    course_name_input.required = true;
-    $('label[for="course_info"]').show ();
-  }
-}
-
-course_category_input.onload = controlCourses();
-course_category_input.onchange = controlCourses;
-
-
 researcher_category_input = document.getElementById("id_application-researcher_category");
 
 function controlReference() {


### PR DESCRIPTION
Currently, the credentialing form at http://localhost:8000/credential-application/ raises the following js error:

```
credential-form-control.js:6 Uncaught TypeError: Cannot read property 'value' of null
    at controlCourses (credential-form-control.js:6)
    at credential-form-control.js:21
```

The error is raised because the course survey section was removed in https://github.com/MIT-LCP/physionet-build/pull/708. This pull request fixes the error by removing the form control function for the section.