### PR TITLE
Fixes the test error in the console

### DIFF
--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -155,12 +155,11 @@ def remove_items(items, ignore_missing=True):
     """
     for item in items:
         try:
-            if  os.path.islink(item):
-                os.unlink(item)
-            elif os.path.isdir(item):
-                shutil.rmtree(item)
-            else:
-                os.remove(item)
+            os.unlink(item)
+        except OSError as e:
+            if e.errno not in (errno.EISDIR, errno.EPERM):
+                raise
+            shutil.rmtree(item)
         except FileNotFoundError:
             if not ignore_missing:
                 raise

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -156,13 +156,13 @@ def remove_items(items, ignore_missing=True):
     for item in items:
         try:
             os.unlink(item)
+        except FileNotFoundError:
+            if not ignore_missing:
+                raise
         except OSError as e:
             if e.errno not in (errno.EISDIR, errno.EPERM):
                 raise
             shutil.rmtree(item)
-        except FileNotFoundError:
-            if not ignore_missing:
-                raise
 
 def clear_directory(directory):
     """

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -152,9 +152,14 @@ def list_items(directory, return_separate=True):
 def remove_items(items, ignore_missing=True):
     """
     Delete the list of (full file path) files/directories.
+
+    Args:
+      items: Is a list of files or directories to delete.
+      ignore_missing: Flag to ignore missing files or directories.
     """
-    for item in items:
+    while items:
         try:
+            item = items.pop()
             os.unlink(item)
         except FileNotFoundError:
             if not ignore_missing:
@@ -163,6 +168,8 @@ def remove_items(items, ignore_missing=True):
             if e.errno not in (errno.EISDIR, errno.EPERM):
                 raise
             shutil.rmtree(item)
+        except (TypeError, AttributeError):
+            raise
 
 def clear_directory(directory):
     """

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -155,9 +155,12 @@ def remove_items(items, ignore_missing=True):
     """
     for item in items:
         try:
-            os.remove(item)
-        except IsADirectoryError:
-            shutil.rmtree(item)
+            if  os.path.islink(item):
+                os.unlink(item)
+            elif os.path.isdir(item):
+                shutil.rmtree(item)
+            else:
+                os.remove(item)
         except FileNotFoundError:
             if not ignore_missing:
                 raise

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -157,19 +157,21 @@ def remove_items(items, ignore_missing=True):
       items: Is a list of files or directories to delete.
       ignore_missing: Flag to ignore missing files or directories.
     """
-    while items:
-        try:
-            item = items.pop()
-            os.unlink(item)
-        except FileNotFoundError:
-            if not ignore_missing:
-                raise
-        except OSError as e:
-            if e.errno not in (errno.EISDIR, errno.EPERM):
-                raise
-            shutil.rmtree(item)
-        except (TypeError, AttributeError):
-            raise
+    if isinstance(items,(tuple,list)):
+        for item in items:
+            try:
+                os.unlink(item)
+            except FileNotFoundError:
+                if not ignore_missing:
+                    raise
+            except OSError as e:
+                if e.errno not in (errno.EISDIR, errno.EPERM):
+                    raise
+                shutil.rmtree(item)
+    else:
+        LOGGER.info("Non list/tuple entered in remove items. The 'item' entered \
+         was: {0}".format(items))
+        raise TypeError
 
 def clear_directory(directory):
     """


### PR DESCRIPTION
There was a 40 != 25 error in a test of the console. The error I received was while trying to delete the file, the except returned a “PermissionError” instead of a “IsADirectoryError”.

Here I now check if it’s a link because of versions, and then unlink.
OR, if it’s a folder, and delete the folder with its content.
Last if it’s a file, and then delete it.