### PR TITLE
Order projects in the "add news" form

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -339,6 +339,8 @@ class NewsForm(forms.ModelForm):
     """
     To add and edit news items
     """
+    project = forms.ModelChoiceField(queryset=PublishedProject.objects.order_by('title'))
+
     class Meta:
         model = News
         fields = ('title', 'content', 'url', 'project')


### PR DESCRIPTION
Projects are unordered in the form that we use for adding news items (https://staging.physionet.org/console/news/add/), as shown below:

![Screen Shot 2019-09-04 at 15 18 28](https://user-images.githubusercontent.com/822601/64284296-492ef880-cf27-11e9-837f-92a10a5155a4.png)

This fixes that, by ordering items in the menu by title. 

