### PR TITLE
Fix encoding of mailto URLs within 403.html and 404.html

### DIFF
--- a/physionet-django/templates/403.html
+++ b/physionet-django/templates/403.html
@@ -11,7 +11,7 @@
   <h1>Forbidden Access<br />(403)</h1>
   <br /><br />
   <p>You dont have access to see this page.</p>
-  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Forbidden%20Access%20attempt%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AI%20Received%20an%20error%20of%20forbidden%20in%20{{request.get_full_path_info}}">contact@physionet.org</a>  </p>
+  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Forbidden%20Access%20attempt%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AI%20Received%20an%20error%20of%20forbidden%20in%20{{ request.get_full_path_info|urlencode }}">contact@physionet.org</a>  </p>
 
 </div>
 {% endblock %}

--- a/physionet-django/templates/403.html
+++ b/physionet-django/templates/403.html
@@ -15,6 +15,3 @@
 
 </div>
 {% endblock %}
-
-
-Forbidden%20Access%20attempt%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AI%20Received%20an%20error%20of%20forbidden%20in%20{{request.get_full_path_info}}

--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -12,7 +12,7 @@
   <br /><br />
   <p>It might be located at: <a href="https://archive.physionet.org{{ request.get_full_path_info }}">https://archive.physionet.org{{ request.get_full_path_info }}</a>.
 
-  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AThe%20following%20URL%20is%20missing%20from%20the%20website.%0A%0A{{request.get_full_path_info}}">contact@physionet.org</a>  </p>
+  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AThe%20following%20URL%20is%20missing%20from%20the%20website.%0A%0A{{ request.get_full_path_info|urlencode }}">contact@physionet.org</a>  </p>
 
 
 </div>


### PR DESCRIPTION
If I visit:

https://physionet.org/foo/bar/?asdf=ghjk&cc=nobody@example.com

it displays a mailto link which, when clicked, generates a message:

```
To: contact@physionet.org
Cc: nobody@example.com
Subject: Missing URL in physionet.org

Dear Physionet Team,

The following URL is missing from the website.

/foo/bar/?asdf=ghjk
```

(which is a silly example, but if there are actually links pointing to old resources with query strings - e.g., ATM - this could be important.)

Fix this by encoding the message properly.
