### PR TITLE
Fix anonymous authentication and add DUA

### DIFF
--- a/physionet-django/project/templates/project/anonymous_login.html
+++ b/physionet-django/project/templates/project/anonymous_login.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container">
+<div class="container text-center">
   {% include "message_snippet.html" %}
   <form action="{% url 'anonymous_login' anonymous_url %}" method="post">
     {% csrf_token %}
@@ -18,7 +18,7 @@
       {{ form.passphrase }}
     </div>
     {% if license.dua_html_content %}
-      <div class="card">
+      <div class="card text-left">
         <div class="card-header">
           Data Use Agreement (DUA)
         </div>
@@ -32,7 +32,7 @@
         <strong>{{ error|escape }}</strong>
       </div>
     {% endfor %}
-    <button id="login" class="btn btn-lg btn-success btn-block w-25 mx-auto" type="submit">
+    <button id="login" class="btn btn-lg btn-success btn-rsp" type="submit">
       {% if license.dua_html_content %}
         Accept and log in
       {% else %}

--- a/physionet-django/project/templates/project/anonymous_login.html
+++ b/physionet-django/project/templates/project/anonymous_login.html
@@ -11,16 +11,34 @@
 {% block content %}
 <div class="container">
   {% include "message_snippet.html" %}
-  <form action="{% url 'anonymous_login' anonymous_url %}" method="post" class="form-signin">
-    <h2 class="form-signin-heading">Reviewer Login</h2>
+  <form action="{% url 'anonymous_login' anonymous_url %}" method="post">
     {% csrf_token %}
-    {{ form.passphrase }}
+    <div class="form-signin">
+      <h2 class="form-signin-heading text-center">Reviewer Login</h2>
+      {{ form.passphrase }}
+    </div>
+    {% if license.dua_html_content %}
+      <div class="card">
+        <div class="card-header">
+          Data Use Agreement (DUA)
+        </div>
+        <div class="card-body">
+          {{ license.dua_html_content|safe }}
+        </div>
+      </div>
+    {% endif %}
     {% for error in form.non_field_errors %}
       <div class="alert alert-danger">
         <strong>{{ error|escape }}</strong>
       </div>
     {% endfor %}
-    <button id="login" class="btn btn-lg btn-primary btn-block" type="submit">Log In</button>
+    <button id="login" class="btn btn-lg btn-success btn-block w-25 mx-auto" type="submit">
+      {% if license.dua_html_content %}
+        Accept and log in
+      {% else %}
+        Log in
+      {% endif %}
+    </button>
   </form>
 </div>
 {% endblock %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1267,7 +1267,7 @@ def published_files_panel(request, project_slug, version):
 
     # Anonymous access authentication
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
-    has_passphrase = project.get_anonymous_url == an_url
+    has_passphrase = project.get_anonymous_url() == an_url
 
     if project.has_access(user) or has_passphrase:
         (display_files, display_dirs, dir_breadcrumbs, parent_dir,
@@ -1302,7 +1302,7 @@ def serve_published_project_file(request, project_slug, version,
 
     # Anonymous access authentication
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
-    has_passphrase = project.get_anonymous_url == an_url
+    has_passphrase = project.get_anonymous_url() == an_url
 
     if project.has_access(user) or has_passphrase:
         file_path = os.path.join(project.file_root(), full_file_name)
@@ -1332,7 +1332,7 @@ def display_published_project_file(request, project_slug, version,
 
     # Anonymous access authentication
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
-    has_passphrase = project.get_anonymous_url == an_url
+    has_passphrase = project.get_anonymous_url() == an_url
 
     if project.has_access(user) or has_passphrase:
         return display_project_file(request, project, full_file_name)
@@ -1364,7 +1364,7 @@ def serve_published_project_zip(request, project_slug, version):
 
     # Anonymous access authentication
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
-    has_passphrase = project.get_anonymous_url == an_url
+    has_passphrase = project.get_anonymous_url() == an_url
 
     if project.has_access(user) or has_passphrase:
         try:
@@ -1430,7 +1430,7 @@ def published_project(request, project_slug, version, subdir=''):
 
     # Anonymous access authentication
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
-    has_passphrase = project.get_anonymous_url == an_url
+    has_passphrase = project.get_anonymous_url() == an_url
 
     has_access = project.has_access(user) or has_passphrase
     current_site = get_current_site(request)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1582,4 +1582,4 @@ def anonymous_login(request, anonymous_url):
             messages.error(request, 'Submission unsuccessful. See form for errors.')
 
     return render(request, 'project/anonymous_login.html', {'anonymous_url': anonymous_url,
-                  'form': form})
+                  'form': form, 'license':project.license})


### PR DESCRIPTION
This fixes anonymous authentication for published project not working because of missing parenthesis on a function call.

Also, it adds the DUA in the anonymous login page, as long as it is provided by the license chosen for the project requested. 