### PR TITLE
wget access for restricted published projects

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -86,6 +86,10 @@ server {
     location /protected/ {
         internal;
         alias   /data/pn-media/; # note the trailing slash
+
+        location /protected/published-projects/ {
+            autoindex on;
+        }
     }
 
     listen 443 ssl; # managed by Certbot

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -86,6 +86,10 @@ server {
     location /protected/ {
         internal;
         alias   /data/pn-media/; # note the trailing slash
+
+        location /protected/published-projects/ {
+            autoindex on;
+        }
     }
 
     listen 443 ssl; # managed by Certbot

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -292,6 +292,7 @@
               {% endif %}
             {% endfor %}
           {% endif %}
+          <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np --user {{ user }} --ask-password https://{{ current_site }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
           </ul>
 {# ZIP END #}
         </p>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -292,7 +292,7 @@
               {% endif %}
             {% endfor %}
           {% endif %}
-          <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np --user {{ user }} --ask-password https://{{ current_site }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
+          <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np --user {{ user }} --ask-password {{ url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
           </ul>
 {# ZIP END #}
         </p>
@@ -331,7 +331,7 @@
             {% endif %}
           {% endfor %}
         {% endif %}
-          <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np http://{{ current_site }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
+          <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np {{ url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
         </ul>
 {# ZIP END #}
       </p>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -271,6 +271,8 @@
       {% if has_access %}
         <p>Total uncompressed size: {{ main_size }}.
 {# ZIP START #}
+          <h5>Access the files</h5>
+          <ul>
           {% if project.compressed_storage_size %}
             <li><a href="{% url 'serve_published_project_zip' project.slug project.version %}">Download the ZIP file</a> ({{ compressed_size }})</li>
           {% endif %}
@@ -290,6 +292,7 @@
               {% endif %}
             {% endfor %}
           {% endif %}
+          </ul>
 {# ZIP END #}
         </p>
         <div id="files-panel" class="card">

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -397,6 +397,21 @@ class TestAccessPublished(TestMixin, TestCase):
             HTTP_AUTHORIZATION=_basic_auth('rgmark@mit.edu', 'Tester11!'))
         self.assertEqual(response.status_code, 200)
 
+        # Download archive using wget
+        response = self.client.get(
+            reverse('serve_published_project_zip',
+                    args=(project.slug, project.version)),
+            secure=True,
+            HTTP_USER_AGENT='Wget/1.18')
+        self.assertEqual(response.status_code, 401)
+        response = self.client.get(
+            reverse('serve_published_project_zip',
+                    args=(project.slug, project.version)),
+            secure=True,
+            HTTP_USER_AGENT='Wget/1.18',
+            HTTP_AUTHORIZATION=_basic_auth('rgmark@mit.edu', 'Tester11!'))
+        self.assertEqual(response.status_code, 200)
+
     def test_open(self):
         """
         Test access to an open project.

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1292,6 +1292,7 @@ def serve_published_project_file(request, project_slug, version,
     Works for open and protected. Not needed for open.
 
     """
+    utility.check_http_auth(request)
     try:
         project = PublishedProject.objects.get(slug=project_slug,
             version=version)
@@ -1313,7 +1314,8 @@ def serve_published_project_file(request, project_slug, version,
             return redirect(request.path + '/')
         except (NotADirectoryError, FileNotFoundError):
             raise Http404()
-    raise PermissionDenied()
+
+    return utility.require_http_auth(request)
 
 
 def display_published_project_file(request, project_slug, version,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1438,12 +1438,14 @@ def published_project(request, project_slug, version, subdir=''):
 
     has_access = project.has_access(user) or has_passphrase
     current_site = get_current_site(request)
+    url_prefix = notification.get_url_prefix(request)
     all_project_versions = PublishedProject.objects.filter(
         slug=project_slug).order_by('version_order')
     context = {'project': project, 'authors': authors,
                'references': references, 'publication': publication,
                'topics': topics, 'languages': languages, 'contact': contact,
                'has_access': has_access, 'current_site': current_site,
+               'url_prefix': url_prefix,
                'news': news, 'all_project_versions': all_project_versions,
                'parent_projects':parent_projects, 'data_access':data_access,
                'messages':messages.get_messages(request)}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1356,6 +1356,7 @@ def serve_published_project_zip(request, project_slug, version):
     Works for open and protected. Not needed for open.
 
     """
+    utility.check_http_auth(request)
     try:
         project = PublishedProject.objects.get(slug=project_slug,
             version=version)
@@ -1373,7 +1374,8 @@ def serve_published_project_zip(request, project_slug, version):
             return serve_file(project.zip_name(full=True))
         except FileNotFoundError:
             raise Http404()
-    raise PermissionDenied()
+
+    return utility.require_http_auth(request)
 
 
 def published_project_license(request, project_slug, version):


### PR DESCRIPTION
These changes allow you to use 'wget' to download files from a
restricted project (assuming you have already been granted access.)
An example command line is added to the "Files" section.

Note that *recursive* downloading requires a change to the nginx
configuration.

I also played around with having similar access for active projects
(and I would *really* like to have WFDB access to active projects,
too!)... but I've pretty well convinced myself that this is
incompatible with the present "redirect_to_login" logic, so I will
address that in a separate pull request.
