### PR TITLE
Fix handling of /.well-known/ for certbot

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -78,11 +78,6 @@ server {
         include     uwsgi_params;
     }
 
-    location /.well-known {
-        root /physionet/;
-        allow all;
-    }
-
     location /protected/ {
         internal;
         alias   /data/pn-media/; # note the trailing slash
@@ -111,6 +106,12 @@ server {
 server {
     listen      80;
     server_name physionet.org alpha.physionet.org physionet-production.ecg.mit.edu;
+
+    # ACME authentication for certificates
+    location /.well-known {
+        root /physionet/;
+        allow all;
+    }
 
     #### Public data ####
 

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -78,11 +78,6 @@ server {
         include     uwsgi_params;
     }
 
-    location /.well-known {
-        root /physionet/;
-        allow all;
-    }
-
     location /protected/ {
         internal;
         alias   /data/pn-media/; # note the trailing slash
@@ -111,6 +106,12 @@ server {
 server {
     listen      80;
     server_name staging.physionet.org physionet-staging.ecg.mit.edu;
+
+    # ACME authentication for certificates
+    location /.well-known {
+        root /physionet/;
+        allow all;
+    }
 
     #### Public data ####
 


### PR DESCRIPTION
In order to renew certificates, 'certbot' needs to be able to authenticate itself to the certificate authority by creating files in /.well-known/acme-challenge/.

These files are served over HTTP, not (as far as I'm aware) over HTTPS.  The process is roughly:

1. certbot generates a private key and certificate signing request, and sends the CSR to the certificate authority (Let's Encrypt)
2. the CA says "place this file at http://staging.physionet.org/.well-known/acme-challenge/"
3. certbot writes that file to /physionet/.well-known/acme-challenge/
4. CA downloads the file over HTTP
5. CA signs the certificate and sends it back
6. certbot saves the certificate and cleans up temporary files

Thus, for step 3/4, the directory /physionet/.well-known/acme-challenge/ must be accessible via nginx over HTTP.

(certbot has several other modes for authenticating itself, and it's quite possible that with "nginx" mode everything would just work automatically, but the idea of telling certbot to automatically monkey with the web server configuration makes me rather nervous.)

Tested just now on the staging server.
