### PR TITLE
Add short description to project info card

### DIFF
--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -39,6 +39,9 @@
           Storage: {{ storage_info.readable_main_used }} uncompressed, {{ storage_info.readable_compressed_used }} compressed, {{ storage_info.readable_used }} total, {{ storage_info.readable_allowance }} allowance.<br>
           Version: {{ project.version }}{% if project.is_latest_version %} (latest){% else %}<br>Latest Published Version: <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>{% endif %}
         </p>
+        <p class="card-text">
+          Description: {{ project.short_description }}
+        </p>
         <p>
           <button class="btn btn-primary" onclick="copyToClipboard('{{ author_emails }}')">Copy Author Emails</button>
         </p>

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -26,6 +26,9 @@
           Version: {{ project.version }}
           {% if project.version_order %}<br>Latest Published Version: <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>{% endif %}
         </p>
+        <p class="card-text">
+          Description: {{ project.short_description }}
+        </p>
         <p><a class="btn btn-lg btn-primary" href="{% url 'project_preview' project.slug %}?Admin=True" role="button">
           View Project Preview</a>
           <button class="btn btn-lg btn-primary" onclick="copyToClipboard('{{ author_emails }}')">Copy Author Emails</button>


### PR DESCRIPTION
The project's short description is not visible anywhere in the published project page itself, or in the project preview.  Add it to the "submission info card" shown in the console so that editors can easily review it.
