### PR TITLE
Allow QueryBuilder to use Basic Authentication

### DIFF
--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -338,6 +338,7 @@ def grant_gcp_group_access(user, project, data_access, request):
 HTTP_AUTH_USER_AGENT = re.compile('|'.join((
     'Wget/',
     'libwfdb/',
+    'QueryBuilder',
 )))
 
 


### PR DESCRIPTION
Here we add a custom user agent string to be used for the Query Builder authentication.