### PR TITLE
Minor update to the wording for credentialing decision time

### DIFF
--- a/physionet-django/user/templates/user/edit_credentialing.html
+++ b/physionet-django/user/templates/user/edit_credentialing.html
@@ -14,7 +14,8 @@
 {% if user.is_credentialed %}
   <p><i class="fas fa-check" style="color:green"></i> Your account was successfully credentialed on {{ user.credential_datetime }}</p>
 {% elif current_application %}
-  <p><i class="fa fa-clock"></i> Your credentialing application was submitted on {{ current_application.application_datetime }}. We will respond shortly.</p>
+  <p><i class="fa fa-clock"></i> Your credentialing application was submitted on {{ current_application.application_datetime }}.</p>
+  <p>We aim to reach a decision within two weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.</p>
 {% else %}
   <p>Your account is not credentialed. You may <a href="{% url 'credential_application' %}">apply for access</a>.</p>
   <p><strong>If your account on the old PhysioNet site is already credentialed</strong>, please add the email address from the old site to this account. Your credentialed status will be automatically transferred when your email is verified.</p>


### PR DESCRIPTION
When a user submits the form at http://127.0.0.1:8000/settings/credentialing/ to request credentialed access, they see the following message: 

> Your credentialing application was submitted on Sept. 16, 2019, 1:58 p.m.. We will respond shortly.

Delays are almost always a result of an unresponsive reference, so this changes the wording to:

> Your credentialing application was submitted on Sept. 16, 2019, 1:58 p.m..
>
> We aim to reach a decision within two weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.

