### PR TITLE
Improvements to 404 mail message

### DIFF
--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -12,7 +12,11 @@
   <br /><br />
   <p>It might be located at: <a href="https://archive.physionet.org{{ request.get_full_path_info }}">https://archive.physionet.org{{ request.get_full_path_info }}</a>.
 
-  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body=Dear%20Physionet%20Team%2C%0A%0AThe%20following%20URL%20is%20missing%20from%20the%20website.%0A%0A{{ request.get_full_path_info|urlencode }}">contact@physionet.org</a>  </p>
+  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body={% filter urlencode %}Dear Physionet Team,
+
+The following URL is missing from the website.
+
+{{ request.get_full_path_info }}{% endfilter %}">contact@physionet.org</a>  </p>
 
 
 </div>

--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -12,7 +12,7 @@
   <br /><br />
   <p>It might be located at: <a href="https://archive.physionet.org{{ request.get_full_path_info }}">https://archive.physionet.org{{ request.get_full_path_info }}</a>.
 
-  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body={% filter urlencode %}Dear Physionet Team,
+  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body={% filter urlencode %}Dear PhysioNet Team,
 
 The following URL is missing from the website.
 

--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -16,7 +16,7 @@
 
 The following URL is missing from the website.
 
-{{ request.get_full_path_info }}{% endfilter %}">contact@physionet.org</a>  </p>
+{{ request.get_raw_uri }}{% endfilter %}">contact@physionet.org</a>  </p>
 
 
 </div>

--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -12,7 +12,7 @@
   <br /><br />
   <p>It might be located at: <a href="https://archive.physionet.org{{ request.get_full_path_info }}">https://archive.physionet.org{{ request.get_full_path_info }}</a>.
 
-  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20in%20physionet.org&body={% filter urlencode %}Dear PhysioNet Team,
+  <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20on%20physionet.org&body={% filter urlencode %}Dear PhysioNet Team,
 
 The following URL is missing from the website.
 

--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -14,9 +14,12 @@
 
   <p>If you think this is an error, please email us at: <a href="mailto:contact@physionet.org?subject=Missing%20URL%20on%20physionet.org&body={% filter urlencode %}Dear PhysioNet Team,
 
-The following URL is missing from the website.
-
-{{ request.get_raw_uri }}{% endfilter %}">contact@physionet.org</a>  </p>
+The following URL is missing from the website:
+{{ request.get_raw_uri }}
+{% if request.META.HTTP_REFERER %}
+This URL is linked from:
+{{ request.META.HTTP_REFERER }}
+{% endif %}{% endfilter %}">contact@physionet.org</a>  </p>
 
 
 </div>


### PR DESCRIPTION
When you visit a URL such as https://physionet.org/foo, the error page includes a mailto link to contact the administrators.  Currently that message looks like this:

    To: contact@physionet.org
    Subject: Missing URL in physionet.org
    
    Dear Physionet Team,
    
    The following URL is missing from the website.
    
    /foo

This makes some minor changes to spelling and grammar, and also adds the Referer if known:

    To: contact@physionet.org
    Subject: Missing URL on physionet.org
    
    Dear PhysioNet Team,
    
    The following URL is missing from the website:
    https://physionet.org/foo
    
    This URL is linked from:
    https://example.com/asdfghjk

