### PR TITLE
Fixed emails sent when person requests GCP access

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
@@ -1,6 +1,6 @@
 Dear {{ user.get_full_name }},
 
-{% if data_access == 3 %}
+{% if data_access.platform == 3 %}
 You have requested access to use {{ project }} in GCP Storage.
 {% if not new_user %}
 You already have been granted access for this resource. 

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -573,7 +573,7 @@ def credential_application_request(request, application):
 def notify_gcp_access_request(data_access, user, project, new_user):
     subject = 'PhysioNet Google Cloud Platform BigQuery access'
     email = user.cloud_information.gcp_email.email
-    if data_access == 3:
+    if data_access.platform == 3:
         subject = 'PhysioNet Google Cloud Platform storage read access'
     body = loader.render_to_string(
         'notification/email/notify_gcp_access_request.html', {


### PR DESCRIPTION
There was an error where it differentiates which email to send between GCP BigQuery and Storage.
