### PR TITLE
Changed all usernames to lowercase

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -137,7 +137,7 @@ class UsernameChangeForm(forms.ModelForm):
         self.old_file_root = self.instance.file_root()
         if User.objects.filter(username__iexact=self.cleaned_data['username']):
             raise forms.ValidationError("A user with that username already exists.")
-        return self.cleaned_data['username']
+        return self.cleaned_data['username'].lower()
 
     def save(self):
         """
@@ -221,7 +221,7 @@ class RegistrationForm(forms.ModelForm):
         "Record the original username in case it is needed"
         if User.objects.filter(username__iexact=self.cleaned_data['username']):
             raise forms.ValidationError("A user with that username already exists.")
-        return self.cleaned_data['username']
+        return self.cleaned_data['username'].lower()
 
 
     def clean_password2(self):


### PR DESCRIPTION
There is a problem with the username login when the person added the username as a capitalized letter. This is because Django by default on login turns the input to lower.

Here we set the default for usernames to lower case.