### PR TITLE
Move log when user connect to the signal

### DIFF
--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -410,6 +410,7 @@ def update_user_login(sender, **kwargs):
     else:
         ip = request.META.get('REMOTE_ADDR')
     UserLogin.objects.create(user=user, ip=ip)
+    logger.info('User logged in {0}'.format(user.email))
 
 signals.user_logged_in.connect(update_user_login, sender=User)
 
@@ -572,7 +573,6 @@ class DualAuthModelBackend():
         try:
             user = get_user_model().objects.get(**kwargs)
             if user.check_password(password):
-                logger.info('User logged in {0}'.format(user.email))
                 return user
         except User.DoesNotExist:
             logger.error('Unsuccessful authentication {0}'.format(username.lower()))


### PR DESCRIPTION
There is an unknown bug that is filling the log file with repetitions of
"User logged in email"

This is wrong because there are thousands of repetitions of the same 6
people.

Here I move the logging to the signal that happens after the connection is done.