### PR TITLE
Fix breadcrumb links in project file preview

### DIFF
--- a/physionet-django/project/fileviews/base.py
+++ b/physionet-django/project/fileviews/base.py
@@ -53,7 +53,7 @@ class FileView:
                 and not hasattr(self.project, 'publish_datetime')):
             base_url = reverse('project_files', args=(self.project.slug,))
             for b in breadcrumbs:
-                b.rel_path = os.path.join(base_url, b.full_subdir)
+                b.rel_path = os.path.join(base_url, b.full_subdir, '')
 
         response = render(request, template, {
             'breadcrumbs': breadcrumbs,


### PR DESCRIPTION
File previews that are linked from the file management page will show breadcrumb links pointing back to the file management page.  For example (if logged in as rgmark):

    http://localhost:8000/projects/SHuKI1APLrwWCqxSQnSk/preview/subject-100/100.hea?return=files

shows a link `subject-100` which points to:

    /projects/SHuKI1APLrwWCqxSQnSk/files/subject-100#files-panel

but this should instead be:

    /projects/SHuKI1APLrwWCqxSQnSk/files/subject-100/#files-panel

(with a trailing slash); the former URL works on a development server but does not currently work on staging/production.

Fixes issue #752.
