### PR TITLE
Less logging when files are not found

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -66,6 +66,7 @@ server {
 
     error_log /var/log/nginx/physionet_error.log warn;
     access_log /var/log/nginx/physionet_access.log;
+    log_not_found off;
 
     # Finally, send all non-media requests to the Django server.
     location / {
@@ -166,6 +167,7 @@ server {
 
     error_log /var/log/nginx/physionet_error.log warn;
     access_log /var/log/nginx/physionet_access.log;
+    log_not_found off;
 
     location / {
         return 301 https://$host$request_uri;

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -66,6 +66,7 @@ server {
 
     error_log /var/log/nginx/physionet_error.log warn;
     access_log /var/log/nginx/physionet_access.log;
+    log_not_found off;
 
     # Finally, send all non-media requests to the Django server.
     location / {
@@ -166,6 +167,7 @@ server {
 
     error_log /var/log/nginx/physionet_error.log warn;
     access_log /var/log/nginx/physionet_access.log;
+    log_not_found off;
 
     location / {
         return 301 https://$host$request_uri;


### PR DESCRIPTION
When a file is to be served by nginx, and the file is not found (as opposed to being handled by django and returning a 404 status), currently two error messages are logged:

* In physionet_access.log:

    18.18.42.15 - - [26/Sep/2019:16:05:00 -0400] "GET /files/mitdb/1.0.0/fnord HTTP/1.1" 404 169 "-" "curl/7.52.1"

* In physionet_error.log:

    2019/09/26 16:05:00 [error] 22759#22759: *19023959 open() "/data/pn-static/published-projects/mitdb/1.0.0/fnord" failed (2: No such file or directory), client: 18.18.42.15, server: physionet.org, request: "GET /files/mitdb/1.0.0/fnord HTTP/1.1", upstream: "uwsgi://unix:///physionet/deploy/physionet.sock", host: "physionet.org"

The latter messages flood the log (because we see a LOT of 404s) and make it hard to find real errors.  Although they do give slightly more information about why the request failed, that information isn't particularly useful to us.

Disable this behavior, so these errors will still be logged in physionet_access.log but not in physionet_error.log.
