### PR TITLE
Display a message when activating an active account

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -53,7 +53,7 @@ def activate_user(request, uidb64, token):
         email.save()
         logger.info('User activated - {0}'.format(user.email))
         context = {'title':'Activation Successful', 'isvalid':True}
-    elif user is not None and user.is_active and default_token_generator.check_token(user, token):
+    elif user is not None and user.is_active:
         context = {'title':'Activation Successful', 'isvalid':True}
     else:
         logger.warning('Invalid Activation Link')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -53,6 +53,8 @@ def activate_user(request, uidb64, token):
         email.save()
         logger.info('User activated - {0}'.format(user.email))
         context = {'title':'Activation Successful', 'isvalid':True}
+    elif user is not None and user.is_active and default_token_generator.check_token(user, token):
+        context = {'title':'Activation Successful', 'isvalid':True}
     else:
         logger.warning('Invalid Activation Link')
         context = {'title':'Invalid Activation Link', 'isvalid':False}


### PR DESCRIPTION
There are a lot of emails complaining that the account activation failed.

At the moment when the person tries to activate the account the email link is valid for only one time. After the account is active, and you use either the same link or refresh the page, it will show a link is invalid message. 

This here is replaced with a the account is already active message. 