### PR TITLE
Fix crash when trying to access a regular file as a directory

### DIFF
--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -29,17 +29,19 @@ def display_project_file(request, project, file_path):
     file_path is the name of the file relative to project.file_root().
     """
 
+    abs_path = os.path.join(project.file_root(), file_path)
     try:
-        abs_path = os.path.join(project.file_root(), file_path)
-        with open(abs_path, 'rb') as infile:
-            if file_path.endswith('.csv.gz'):
-                cls = GzippedCSVFileView
-            else:
-                (_, suffix) = os.path.splitext(file_path)
-                cls = _suffixes.get(suffix, TextFileView)
-            view = cls(project, file_path, infile)
-            return view.render(request)
+        infile = open(abs_path, 'rb')
     except IsADirectoryError:
         return redirect(request.path + '/')
     except (FileNotFoundError, NotADirectoryError):
         raise Http404()
+
+    with infile:
+        if file_path.endswith('.csv.gz'):
+            cls = GzippedCSVFileView
+        else:
+            (_, suffix) = os.path.splitext(file_path)
+            cls = _suffixes.get(suffix, TextFileView)
+        view = cls(project, file_path, infile)
+        return view.render(request)

--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -41,5 +41,5 @@ def display_project_file(request, project, file_path):
             return view.render(request)
     except IsADirectoryError:
         return redirect(request.path + '/')
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         raise Http404()

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -52,6 +52,18 @@ class TestAccessPresubmission(TestMixin, TestCase):
         response = self.client.get(reverse('serve_active_project_file',
             args=(project.slug, 'notes/notes.txt')))
         self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('display_active_project_file',
+            args=(project.slug, 'notes')))
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(reverse('display_active_project_file',
+            args=(project.slug, 'notes/notes.txt')))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('display_active_project_file',
+            args=(project.slug, 'notes/notes.txt/fnord')))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse('display_active_project_file',
+            args=(project.slug, 'fnord')))
+        self.assertEqual(response.status_code, 404)
 
         # Visit as project coauthor
         self.client.login(username='aewj@mit.edu', password='Tester11!')
@@ -312,6 +324,10 @@ class TestAccessPublished(TestMixin, TestCase):
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
         self.assertEqual(response.status_code, 403)
         response = self.client.get(reverse(
+            'display_published_project_file',
+            args=(project.slug, project.version, 'SHA256SUMS.txt')))
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(reverse(
             'published_project_subdir',
             args=(project.slug, project.version, 'timeseries')))
         self.assertEqual(response.status_code, 403)
@@ -348,6 +364,10 @@ class TestAccessPublished(TestMixin, TestCase):
             data={'agree':''})
         response = self.client.get(reverse(
             'serve_published_project_file',
+            args=(project.slug, project.version, 'SHA256SUMS.txt')))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse(
+            'display_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
         self.assertEqual(response.status_code, 200)
         response = self.client.get(reverse(
@@ -424,6 +444,18 @@ class TestAccessPublished(TestMixin, TestCase):
         response = self.client.get(reverse('serve_published_project_file',
             args=(project.slug, project.version, 'Makefile')))
         self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('display_published_project_file',
+            args=(project.slug, project.version, 'Makefile')))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('display_published_project_file',
+            args=(project.slug, project.version, 'doc')))
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(reverse('display_published_project_file',
+            args=(project.slug, project.version, 'fnord')))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse('display_published_project_file',
+            args=(project.slug, project.version, 'Makefile/fnord')))
+        self.assertEqual(response.status_code, 404)
 
     @prevent_request_warnings
     def test_nonexistent(self):


### PR DESCRIPTION
These changes fix a crash that occurs when trying to preview a non-existent file, such as:

https://physionet.org/content/ptbdb/1.0.0/patient001/s0010_re.xyz/ws

(where 's0010_re.xyz' is an existing file, not a directory, so this raises NotADirectoryError rather than FileNotFoundError).

In addition, restructure display_project_file to be more careful with exceptions, and add some tests.

Thanks to @alistairewj for reporting (?) this issue. :P
