### PR TITLE
Added missing project variable to mail template

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -581,6 +581,7 @@ def notify_gcp_access_request(data_access, user, project, new_user):
             'data_access': data_access,
             'user': user,
             'new_user': new_user,
+            'project':project,
             'footer': email_footer()
         })
 


### PR DESCRIPTION
This fixes #759. 

The problem was that the project variable was not being sent to the template. Here I send it to the template and its used properly to display the GCP bucket information.