### PR TITLE
Excludes empty references from known references

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -802,7 +802,7 @@ def complete_credential_applications(request):
         application.mailto = notification.mailto_process_credential_complete(
             request, application, comments=False)
         if CredentialApplication.objects.filter(reference_email__iexact=application.reference_email,
-            reference_contact_datetime__isnull=False):
+            reference_contact_datetime__isnull=False).exclude(reference_email=''):
             # If the reference has been contacted before, mark it so
             application.known_ref = True
         elif LegacyCredential.objects.filter(reference_email__iexact=application.reference_email).exclude(


### PR DESCRIPTION
There is a problem now that whenever the reference is empty, its
included in the credential applications form and marked as known
reference. Just the same as Legacy, here we exclude empty reference
emails.