### PR TITLE
Deprecate static indexes

### DIFF
--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -26,7 +26,7 @@ PhysioNet
       </p>
       <br>
       <div>
-        <a href="{% url 'database_overview' %}">Data</a>
+        <a href="{% url 'database_index' %}">Data</a>
         <a href="{% url 'software_overview' %}">Software</a>
         <a href="{% url 'challenge_overview' %}">Challenges</a>
         <a href="{% url 'tutorial_overview' %}">Tutorials</a>


### PR DESCRIPTION
The landing page buttons redirect to the search page with this change.