### PR TITLE
Fix css for search on the console navbar

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -211,7 +211,7 @@
     <form class="form-inline" action="{% url 'content_index' %}">
         <input name="topic" class="search-input" type="text" placeholder="Search">
         <span class="input-group-btn">
-          <button id="search-button" type="submit" class="btn btn-search my-2 my-sm-0" type="button"><i class="fa fa-search"></i></button>
+          <button id="search-button" type="submit" class="btn-search my-2 my-sm-0" type="button"><i class="fa fa-search"></i></button>
         </span>
     </form>
   </div>


### PR DESCRIPTION
Fix the problem where the search icon on the console navbar had a different css styling than the rest of the website.