### PR TITLE
Minor changes to credentialing application form, requested by KP

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -544,3 +544,8 @@ a, code{
   border-image: linear-gradient(to bottom, silver 0%, silver 60%, transparent 100%) 1% 100%;
           
 }
+
+.tooltip-inner {
+  text-align: left;
+  max-width: 350px;
+}

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -272,7 +272,7 @@ class PersonalCAF(forms.ModelForm):
             'organization_name', 'job_title', 'city', 'state_province',
             'zip_code', 'country', 'webpage')
         help_texts = {
-            'first_names': "First and middle names.",
+            'first_names': "First name(s).",
             'last_name': "Last (family) name.",
             'suffix': """Please leave the suffix blank if your name does not 
                 include a suffix like "Jr." or "III". Do not list degrees. 

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -410,7 +410,8 @@ class CredentialApplicationForm(forms.ModelForm):
 
         # Students and postdocs must provide their supervisor as a reference
         if data['researcher_category'] in [0, 1] and data['reference_category'] != 0:
-            raise forms.ValidationError('If you are a student or postdoc, you must provide your supervisor as a reference.')
+            raise forms.ValidationError("""If you are a student or postdoc,
+                you must provide your supervisor as a reference.""")
 
         if not self.instance and CredentialApplication.objects.filter(user=self.user, status=0):
             raise forms.ValidationError('Outstanding application exists.')

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -326,7 +326,7 @@ class ResearchCAF(forms.ModelForm):
         model = CredentialApplication
         fields = ('research_summary',)
         help_texts = {
-            'research_summary': """Brief description on your research. If you 
+            'research_summary': """Brief description of your research. If you 
                 will be using the data for a class, please include course name 
                 and number in your description.""",
         }

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -411,9 +411,9 @@ class CredentialApplicationForm(forms.ModelForm):
         # Students and postdocs must provide their supervisor as a reference
         if data['researcher_category'] in [0, 1] and (
             data['reference_category'] != 0
-            or not data['reference_name']
-            or not data['reference_email']
-            or not data['reference_title']):
+            or not data['reference_name'].strip()
+            or not data['reference_email'].strip()
+            or not data['reference_title'].strip()):
             raise forms.ValidationError("""If you are a student or postdoc,
                 you must provide your supervisor as a reference.""")
 

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -409,7 +409,11 @@ class CredentialApplicationForm(forms.ModelForm):
             return
 
         # Students and postdocs must provide their supervisor as a reference
-        if data['researcher_category'] in [0, 1] and data['reference_category'] != 0:
+        if data['researcher_category'] in [0, 1] and (
+            data['reference_category'] != 0
+            or not data['reference_name']
+            or not data['reference_email']
+            or not data['reference_title']):
             raise forms.ValidationError("""If you are a student or postdoc,
                 you must provide your supervisor as a reference.""")
 

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -417,6 +417,10 @@ class CredentialApplicationForm(forms.ModelForm):
             raise forms.ValidationError("""If you are a student or postdoc,
                 you must provide your supervisor as a reference.""")
 
+        # If applicant is from USA or Canada, the state must be provided
+        if data['country'] in ['US', 'CA'] and not data['state_province']:
+            raise forms.ValidationError("Please add your state or province.")
+
         if not self.instance and CredentialApplication.objects.filter(user=self.user, status=0):
             raise forms.ValidationError('Outstanding application exists.')
 

--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -62,7 +62,7 @@
         <strong>{{ error|escape }}</strong>
       </div>
     {% endfor %}
-    <p>By submitting this form, you agree to the terms and conditions described on this page.</p>
+    <p>By submitting this form, you agree to the terms and conditions above.</p>
     <hr>
     <button class="btn btn-primary btn-rsp" type="submit">Submit Application</button>
   </form>

--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -51,7 +51,7 @@
     <br>
     <h2>Reference</h2>
     <br>
-    <p>If you are a student or a postdoc, please provide your supervisor's name and contact information. If you are not listed in a directory or other easy-to-find page of your organization’s website, please provide the name and contact information of a reference such as a supervisor or colleague. Do not list yourself as reference.</p>
+    <p>If you are a student or a postdoc, please provide your supervisor's name and contact information. If you are not listed in a directory or other easy-to-find page of your organization’s website, please provide the name and contact information of a reference such as a supervisor or colleague. <em>Do not list yourself as reference</em>.</p>
     {% include "descriptive_inline_form_snippet.html" with form=reference_form %}
     <br>
     <h2>Research Area</h2>


### PR DESCRIPTION
This is a collection of minor changes to the credentialing application form that were requested by KP.

> If Canada or USA is listed as the applicant's country, state should be required.

Added to the form validation.

> Students and postdocs must provide their supervisor name and contact details as a reference.

Added to the form validation.

> "tooltip for first name still says "First and middle names", which isn't right.  Should be just ""First name(s)"

Fixed

> "it would be nice to adjust the width of the tooltip box so that, for example, the suffix tooltip isn't so tall.  Or at least set as ragged-right, rather than centered."

Style updated.

> "second instance of "Do not list yourself as reference." should be wrapped with `<em>`...`</em>` please."

Done

> "tooltip for Research topic says "Brief description on your research...".  Should be "...of your research..."."

Fixed.

>  "you agree to the terms and conditions described on this page." doesn't seem quite right.  The terms and conditions aren't described; they're enumerated.  How about ... "you agree to the terms and conditions above"?

Updated

