### PR TITLE
Fix error when user searches for a string containing a special regex character

### DIFF
--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -63,7 +63,7 @@ def get_content(resource_type, orderby, direction, search_term):
     if len(search_term) == 0:
         query = Q(resource_type__in=resource_type)
     else:
-        search_term = re.split(r'\s*[\;\,\s]\s*', search_term)
+        search_term = re.split(r'\s*[\;\,\s]\s*', re.escape(search_term))
         query = reduce(operator.or_, (Q(topics__description__iregex=r'{0}{1}{0}'.format(wb,
             item)) for item in search_term))
         query = query | reduce(operator.or_, (Q(abstract__iregex=r'{0}{1}{0}'.format(wb,


### PR DESCRIPTION
Currently https://physionet.org/content/ raises an error if someone searches for a string  containing a special regex character (e.g. `(`). See: #778.

This is a minor change to fix that:
- fixes the error, by wrapping the search string in [`re.escape` ](https://docs.python.org/2/library/re.html#re.escape)
- renames `topic` to `search_term` in `get_content()` for clarity (here topic had dual meaning - the name of the keywords associated with a project, as well as the name of the search string)

