### PR TITLE
adjust mailto template to show only fields in the credentialing appli…

### DIFF
--- a/physionet-django/notification/templates/notification/email/mailto_contact_applicant.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_applicant.html
@@ -13,20 +13,11 @@ State/Province: {{ application.state_province }}
 Country: {{ application.get_country_display }}
 Webpage: {% if application.webpage %}{{ application.webpage }}{% endif %}
 
-Human studies training course (name of course): {{ application.training_course_name }}
-Date completed: {{ application.training_completion_date }}
-
 Reference Category: {{ application.get_reference_category_display }}
 Reference's Name: {{ application.reference_name }}
 Reference's Email: {{ application.reference_email }}
 Reference's job title or position: {{ application.reference_title }}
 
-{% if application.course_category %}
-Course Category: {{ application.get_course_category_display }}
-Course Info: {{ application.course_info }}
-{% endif %}
-
-Application Date: {{ application.application_datetime|date }}
-Project of interest: {{ application.project_of_interest }}
 General research area for which the data will be used: {{ application.research_summary }}
+Application Date: {{ application.application_datetime|date }}
 {% endautoescape %}


### PR DESCRIPTION
fix the e-mail message generated via "Send e-mail to applicant" link so that it shows only the fields shown in the application form.