### PR TITLE
specify that state/province is required for US/Canada residents

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -284,7 +284,7 @@ class PersonalCAF(forms.ModelForm):
             'job_title': """Your job title or position (e.g., student) within 
                 your institution or organization.""",
             'city': "The city where you live.",
-            'state_province': "The state or province where you live.",
+            'state_province': "The state or province where you live. (Required for residents of Canada or the US.)",
             'zip_code': "The zip code of the city where you live.",
             'country': "The country where you live.",
             'webpage': """Your organization's webpage. If possible, please 


### PR DESCRIPTION
this may save time for alert applicants.