### PR TITLE
Changed location for nginx and uwsgi logs

### DIFF
--- a/deploy/common/etc/logrotate.d/nginx
+++ b/deploy/common/etc/logrotate.d/nginx
@@ -1,0 +1,18 @@
+/data/log/nginx/*.log {
+	daily
+	missingok
+	rotate 14
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
+}

--- a/deploy/common/etc/logrotate.d/uwsgi
+++ b/deploy/common/etc/logrotate.d/uwsgi
@@ -1,4 +1,4 @@
-/var/log/uwsgi/*.log 
+/data/log/uwsgi/*.log
 {
         rotate 7
         daily
@@ -6,9 +6,9 @@
         notifempty
         delaycompress
         compress
-        create 0640 pn pn
+        create 0640 www-data www-data
         sharedscripts
         postrotate
-                systemctl restart uwsgi
+                systemctl reload emperor.uwsgi
         endscript
 }

--- a/deploy/common/etc/logrotate.d/uwsgi
+++ b/deploy/common/etc/logrotate.d/uwsgi
@@ -4,7 +4,6 @@
         daily
         missingok
         notifempty
-        copytruncate
         delaycompress
         compress
         create 0640 www-data www-data

--- a/deploy/common/etc/logrotate.d/uwsgi
+++ b/deploy/common/etc/logrotate.d/uwsgi
@@ -4,6 +4,7 @@
         daily
         missingok
         notifempty
+        copytruncate
         delaycompress
         compress
         create 0640 www-data www-data

--- a/deploy/common/etc/logrotate.d/uwsgi
+++ b/deploy/common/etc/logrotate.d/uwsgi
@@ -6,6 +6,7 @@
         notifempty
         delaycompress
         compress
+        su www-data www-data
         create 0640 www-data www-data
         sharedscripts
         postrotate

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -64,8 +64,8 @@ server {
 
     #### End of public data ####
 
-    error_log /var/log/nginx/physionet_error.log warn;
-    access_log /var/log/nginx/physionet_access.log;
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
     log_not_found off;
 
     # Finally, send all non-media requests to the Django server.
@@ -165,8 +165,8 @@ server {
 
     #### End of public data ####
 
-    error_log /var/log/nginx/physionet_error.log warn;
-    access_log /var/log/nginx/physionet_access.log;
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
     log_not_found off;
 
     location / {

--- a/deploy/production/etc/uwsgi/vassals/physionet_uwsgi.ini
+++ b/deploy/production/etc/uwsgi/vassals/physionet_uwsgi.ini
@@ -25,8 +25,8 @@ gid = www-data
 
 # Configure uwsgi logger
 #logto = /var/log/uwsgi/%n.log
-req-logger = file:/var/log/uwsgi/%n-req.log
-logger = file:/var/log/uwsgi/%n.log
+req-logger = file:/data/log/uwsgi/%n-req.log
+logger = file:/data/log/uwsgi/%n.log
 
 # If the app is not found kill the proccess
 need-app = true

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -64,8 +64,8 @@ server {
 
     #### End of public data ####
 
-    error_log /var/log/nginx/physionet_error.log warn;
-    access_log /var/log/nginx/physionet_access.log;
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
     log_not_found off;
 
     # Finally, send all non-media requests to the Django server.
@@ -165,8 +165,8 @@ server {
 
     #### End of public data ####
 
-    error_log /var/log/nginx/physionet_error.log warn;
-    access_log /var/log/nginx/physionet_access.log;
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
     log_not_found off;
 
     location / {

--- a/deploy/staging/etc/uwsgi/vassals/physionet_uwsgi.ini
+++ b/deploy/staging/etc/uwsgi/vassals/physionet_uwsgi.ini
@@ -25,8 +25,8 @@ gid = www-data
 
 # Configure uwsgi logger
 #logto = /var/log/uwsgi/%n.log
-req-logger = file:/var/log/uwsgi/%n-req.log
-logger = file:/var/log/uwsgi/%n.log
+req-logger = file:/data/log/uwsgi/%n-req.log
+logger = file:/data/log/uwsgi/%n.log
 
 # If the app is not found kill the proccess
 need-app = true


### PR DESCRIPTION
The logs for both Nginx and uWSGI keep getting bigger and bigger.
Since there is limited space on the "/var/" partition I would feel safer of they are in a place with lots of space.