### PR TITLE
Added missing gs prefix to gcp download command

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
@@ -9,7 +9,7 @@ The URL for the storage bucket in GCP is:
 https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}
 
 You can use the following command to copy the content of the bucket to your computer:
-gsutil -m cp -r {{ project.gcp.bucket_name }} DESTINATION
+gsutil -m cp -r gs://{{ project.gcp.bucket_name }} DESTINATION
 
 {% else %}
 You have requested access to use {{ project }} in GCP BigQuery.


### PR DESCRIPTION
This will give the proper command syntax to download files from GCP. It was missing the "gs://"