### PR TITLE
More efficient authentication for wget

### DIFF
--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -395,6 +395,7 @@ class TestAccessPublished(TestMixin, TestCase):
             secure=True,
             HTTP_USER_AGENT='Wget/1.18')
         self.assertEqual(response.status_code, 401)
+        self.client.logout()
         response = self.client.get(
             reverse('serve_published_project_file',
                     args=(project.slug, project.version, 'SHA256SUMS.txt')),
@@ -402,6 +403,7 @@ class TestAccessPublished(TestMixin, TestCase):
             HTTP_USER_AGENT='Wget/1.18',
             HTTP_AUTHORIZATION=_basic_auth('aewj@mit.edu', 'Tester11!'))
         self.assertEqual(response.status_code, 403)
+        self.client.logout()
         response = self.client.get(
             reverse('serve_published_project_file',
                     args=(project.slug, project.version, 'SHA256SUMS.txt')),
@@ -409,6 +411,7 @@ class TestAccessPublished(TestMixin, TestCase):
             HTTP_USER_AGENT='libwfdb/10.6.0',
             HTTP_AUTHORIZATION=_basic_auth('rgmark@mit.edu', 'badpassword'))
         self.assertEqual(response.status_code, 401)
+        self.client.logout()
         response = self.client.get(
             reverse('serve_published_project_file',
                     args=(project.slug, project.version, 'SHA256SUMS.txt')),
@@ -418,12 +421,14 @@ class TestAccessPublished(TestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Download archive using wget
+        self.client.logout()
         response = self.client.get(
             reverse('serve_published_project_zip',
                     args=(project.slug, project.version)),
             secure=True,
             HTTP_USER_AGENT='Wget/1.18')
         self.assertEqual(response.status_code, 401)
+        self.client.logout()
         response = self.client.get(
             reverse('serve_published_project_zip',
                     args=(project.slug, project.version)),
@@ -435,29 +440,34 @@ class TestAccessPublished(TestMixin, TestCase):
         # Download file using wget on active projects
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
 
+        self.client.logout()
         response = self.client.get(reverse('serve_active_project_file_editor',
             args=(project.slug, 'RECORDS')), secure=True,
              HTTP_USER_AGENT='Wget/1.18')
         self.assertEqual(response.status_code, 401)
 
+        self.client.logout()
         response = self.client.get(reverse('serve_active_project_file_editor',
             args=(project.slug, 'RECORDS')), secure=True,
             HTTP_USER_AGENT='Wget/1.18',
             HTTP_AUTHORIZATION=_basic_auth('aewj@mit.edu', 'Tester11!'))
         self.assertEqual(response.status_code, 403)
 
+        self.client.logout()
         response = self.client.get(reverse('serve_active_project_file_editor',
             args=(project.slug, 'RECORDS')), secure=True,
             HTTP_USER_AGENT='Wget/1.18',
             HTTP_AUTHORIZATION=_basic_auth('rgmark@mit.edu', 'badpassword'))
         self.assertEqual(response.status_code, 401)
 
+        self.client.logout()
         response = self.client.get(reverse('serve_active_project_file_editor',
             args=(project.slug, 'RECORDS')), secure=True,
             HTTP_USER_AGENT='Wget/1.18',
             HTTP_AUTHORIZATION=_basic_auth('rgmark@mit.edu', 'Tester11!'))
         self.assertEqual(response.status_code, 200)
 
+        self.client.logout()
         response = self.client.get(reverse('serve_active_project_file_editor',
             args=(project.slug, '')), secure=True,
             HTTP_USER_AGENT='Wget/1.18',

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -402,7 +402,7 @@ def check_http_auth(request):
             # Existing session is valid only if the password has not
             # changed.
             if constant_time_compare(user.get_session_auth_hash(),
-                                     authhash):
+                                     authhash) and user.is_active:
                 request.user = user
                 return
 
@@ -417,7 +417,7 @@ def check_http_auth(request):
             user = auth.authenticate(request=request,
                                      username=username,
                                      password=password)
-            if user:
+            if user and user.is_active:
                 request.user = user
 
                 # Save the state in session variables, so that we

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -15,9 +15,11 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.conf import settings
 from django.core.exceptions import (PermissionDenied, ValidationError)
 from django.http import HttpResponse, Http404
+from django.utils.crypto import constant_time_compare
 from googleapiclient.errors import HttpError
 
 from console.utility import create_directory_service
+from user.models import User
 
 LOGGER = logging.getLogger(__name__)
 
@@ -390,6 +392,20 @@ def check_http_auth(request):
         if request.user.is_authenticated:
             return
 
+        try:
+            uid = request.session['pn_httpauth_uid']
+            authhash = request.session['pn_httpauth_hash']
+            user = User.objects.get(id=uid)
+        except (KeyError, User.DoesNotExist):
+            pass
+        else:
+            # Existing session is valid only if the password has not
+            # changed.
+            if constant_time_compare(user.get_session_auth_hash(),
+                                     authhash):
+                request.user = user
+                return
+
         tokens = request.META['HTTP_AUTHORIZATION'].split()
         if len(tokens) == 2 and tokens[0].lower() == 'basic':
             try:
@@ -403,6 +419,16 @@ def check_http_auth(request):
                                      password=password)
             if user:
                 request.user = user
+
+                # Save the state in session variables, so that we
+                # don't have to verify the password on subsequent
+                # requests.  We don't invoke auth.login() here,
+                # specifically so that this session ID cannot be
+                # reused to access URLs that don't permit HTTP
+                # authentication.
+                request.session['pn_httpauth_uid'] = user.id
+                request.session['pn_httpauth_hash'] \
+                    = user.get_session_auth_hash()
 
 
 def require_http_auth(request):


### PR DESCRIPTION
This wound up being more complicated than I expected.

These changes are an attempt to fix the performance problems we've been seeing due to bulk downloads from wget: instead of verifying the password every time (which is slow), use a cookie that can be verified quickly.

This relies on existing Django mechanisms to guarantee integrity of the session data; in fact, this works almost the same way as the standard Django login mechanism.

(The user ID is stored in a session variable, and a hash of the hash of the password is stored in a second session variable.  Thus, if the person changes their password, existing wget jobs should be interrupted.  On the other hand, if they change their username or their primary email address, existing wget jobs should now continue running.)

I considered just using the standard login mechanism (i.e., once you've supplied a valid password, just call auth.login()), but I think it is still useful to restrict HTTP-auth clients to a subset of views, so that for functions such as creating projects or requesting access, you are required to go through the standard login page.

One problem with all this is that the client might not support cookies - this is a problem because the session data is stored server-side, so we may not want to create hundreds of thousands of sessions for a single user.

To deal with that issue, I recommend that we first deploy these changes to production, then wait a day, then deploy a second change that will set the session-ID only for clients that are known to support cookies.  The reason for the delay is so that any clients *currently in the process* of downloading mimic-cxr will be assigned session-IDs.
