### PR TITLE
More efficient authentication part 2

### DIFF
--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -579,12 +579,11 @@ class DualAuthModelBackend():
             logger.error('Unsuccessful authentication {0}'.format(username.lower()))
             return None
 
-    def get_user(self, username):
+    def get_user(self, user_id):
         try:
-            return get_user_model().objects.get(pk=username)
+            return get_user_model().objects.get(pk=user_id)
         except get_user_model().DoesNotExist:
             return None
-
 
 class CredentialApplication(models.Model):
     """


### PR DESCRIPTION
Part 2 of pull #790.

In order to avoid creating lots of useless session IDs, avoid
setting any session ID if the client doesn't appear to support
cookies.  To test whether the client supports cookies, set a
dummy cookie as part of the 401 Unauthorized response.
