### PR TITLE
Add reminder word to reminder emails

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -135,7 +135,7 @@ def submitted_projects(request):
                 pid = request.POST.get('send_approval_reminder', '')
                 project = ActiveProject.objects.get(id=pid)
                 notification.copyedit_complete_notify(request, project,
-                    project.copyedit_logs.last())
+                    project.copyedit_logs.last(), reminder=True)
                 project.latest_reminder = timezone.now()
                 project.save()
                 messages.success(request, 'The reminder email has been sent.')
@@ -143,7 +143,7 @@ def submitted_projects(request):
                 pid = request.POST.get('send_revision_reminder', '')
                 project = ActiveProject.objects.get(id=pid)
                 notification.edit_decision_notify(request, project,
-                    project.edit_logs.last())
+                    project.edit_logs.last(), reminder=True)
                 project.latest_reminder = timezone.now()
                 project.save()
                 messages.success(request, 'The reminder email has been sent.')
@@ -188,7 +188,7 @@ def editor_home(request):
             pid = request.POST.get('send_reminder', '')
             project = ActiveProject.objects.get(id=pid)
             notification.edit_decision_notify(request, project,
-                project.edit_logs.last())
+                project.edit_logs.last(), reminder=True)
             project.latest_reminder = timezone.now()
             project.save()
             messages.success(request, 'The reminder email has been sent.')
@@ -431,7 +431,7 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
                 {'project':project})
         elif 'send_reminder' in request.POST:
             notification.copyedit_complete_notify(request, project,
-                project.copyedit_logs.last())
+                project.copyedit_logs.last(), reminder=True)
             messages.success(request, 'The reminder email has been sent.')
             project.latest_reminder = timezone.now()
             project.save()

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -253,7 +253,7 @@ def editor_notify_new_project(project, assigner):
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [project.editor.email], fail_silently=False)
 
-def edit_decision_notify(request, project, edit_log):
+def edit_decision_notify(request, project, edit_log, reminder=False):
     """
     Notify authors when an editor makes a decision
     """
@@ -269,6 +269,9 @@ def edit_decision_notify(request, project, edit_log):
     else:
         subject = 'Submission accepted for project: {}'.format(project.title)
         template = 'notification/email/accept_submission_notify.html'
+    # Prepend reminder to the subject if needed
+    if reminder:
+        subject = "Reminder - {}".format(subject)
 
     for email, name in project.author_contact_info():
         body = loader.render_to_string(template, {
@@ -286,11 +289,14 @@ def edit_decision_notify(request, project, edit_log):
                   [email], fail_silently=False)
 
 
-def copyedit_complete_notify(request, project, copyedit_log):
+def copyedit_complete_notify(request, project, copyedit_log, reminder=False):
     """
     Notify authors when the editor has finished copyediting
     """
     subject = 'Your approval needed to publish: {0}'.format(project.title)
+    # Prepend reminder to the subject if needed
+    if reminder:
+        subject = "Reminder - {}".format(subject)
 
     for person in project.author_list():
         if not person.approval_datetime:


### PR DESCRIPTION
As a continuation to #786, here I add the word reminder to the emails to inform that the emails are a reminder.