### PR TITLE
Include the latest reminder date in the console

### DIFF
--- a/physionet-django/console/templates/console/awaiting_authors.html
+++ b/physionet-django/console/templates/console/awaiting_authors.html
@@ -30,6 +30,7 @@
           <button class="btn btn-lg btn-primary" name="send_reminder" type="submit">Send Reminder Email</button>
         {% else %}
           <button class="btn btn-lg btn-primary" name="send_reminder" type="submit" disabled>Send Reminder Email</button>
+          Last sent on: {{ project.latest_reminder }}
         {% endif %}
       </form>
     </div>

--- a/physionet-django/console/templates/console/editor_home.html
+++ b/physionet-django/console/templates/console/editor_home.html
@@ -24,8 +24,8 @@
             <tr>
               <th>Project</th>
               <th>Submitting Author</th>
-              <th>Submission Date</th>
-              <th>Resubmission Date</th>
+              <th>Submitted</th>
+              <th>Resubmitted</th>
               <th>Action</th>
             </tr>
           </thead>
@@ -67,8 +67,9 @@
             <tr>
               <th>Project</th>
               <th>Submitting Author</th>
-              <th>Submission Date</th>
-              <th>Revision Request Date</th>
+              <th>Submitted</th>
+              <th>Revision requested</th>
+              <th>Latest reminder</th>
               <th>Action</th>
             </tr>
           </thead>
@@ -79,6 +80,7 @@
               <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
               <td>{{ project.submission_datetime|date }}</td>
               <td>{{ project.revision_request_datetime|date }}</td>
+              <td>{{ project.latest_reminder|date }}</td>
               <td>
                 <form action="" method="post" class="form-signin">
                   {% csrf_token %}
@@ -113,8 +115,8 @@
             <tr>
               <th>Project</th>
               <th>Submitting Author</th>
-              <th>Submission Date</th>
-              <th>Editor Accept Date</th>
+              <th>Submitted</th>
+              <th>Accepted</th>
               <th>Action</th>
             </tr>
           </thead>
@@ -150,9 +152,10 @@
             <tr>
               <th>Project</th>
               <th>Submitting Author</th>
-              <th>Submission Date</th>
-              <th>Editor Accept Date</th>
-              <th>Copyedit Completion Date</th>
+              <th>Submitted</th>
+              <th>Accepted</th>
+              <th>Copyedit Completed</th>
+              <th>Latest reminder</th>
               <th>Action</th>
             </tr>
           </thead>
@@ -164,6 +167,7 @@
               <td>{{ project.submission_datetime|date }}</td>
               <td>{{ project.editor_accept_datetime|date }}</td>
               <td>{{ project.copyedit_completion_datetime|date }}</td>
+              <td>{{ project.latest_reminder|date }}</td>
               <td><a class="btn btn-primary btn-sm" href="{% url 'awaiting_authors' project.slug %}" role="button">View</a></td>
             </tr>
           {% endfor %}
@@ -189,10 +193,10 @@
             <tr>
               <th>Project</th>
               <th>Submitting Author</th>
-              <th>Submission Date</th>
-              <th>Editor Accept Date</th>
-              <th>Copyedit Completion Date</th>
-              <th>Author Approval Date</th>
+              <th>Submitted</th>
+              <th>Accepted</th>
+              <th>Copyedit Completed</th>
+              <th>Author Approved</th>
               <th>Action</th>
             </tr>
           </thead>

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -25,6 +25,9 @@
           Storage Used: {{ storage_info.readable_used }} / {{ storage_info.readable_allowance }}<br>
           Version: {{ project.version }}
           {% if project.version_order %}<br>Latest Published Version: <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>{% endif %}
+          {% if project.latest_reminder %}
+            <br>Latest reminder email sent on: {{ project.latest_reminder }}
+          {% endif %}
         </p>
         <p class="card-text">
           Description: {{ project.short_description }}

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -157,7 +157,7 @@
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.submission_datetime|date }}</td>
                   <td>{{ project.revision_request_datetime|date }}</td>
-                  <td>{{ project.latest_reminder |date }}</td>
+                  <td>{{ project.latest_reminder|date }}</td>
                   <td>{{ project.editor }}</td>
                   <td>
                     <form action="" method="post" class="form-signin">
@@ -240,7 +240,7 @@
                   <td>{{ project.submission_datetime|date }}</td>
                   <td>{{ project.editor_accept_datetime|date }}</td>
                   <td>{{ project.copyedit_completion_datetime|date }}</td>
-                  <td>{{ project.latest_reminder |date }}</td>
+                  <td>{{ project.latest_reminder|date }}</td>
                   <td>{{ project.editor }}</td>
                   <td>
                     {% if project.latest_reminder < yesterday %}

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -145,6 +145,7 @@
                   <th>Submitted By</th>
                   <th>Submitted</th>
                   <th>Revision Requested</th>
+                  <th>Latest reminder</th>
                   <th>Editor</th>
                   <th>Action</th>
                 </tr>
@@ -156,6 +157,7 @@
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.submission_datetime|date }}</td>
                   <td>{{ project.revision_request_datetime|date }}</td>
+                  <td>{{ project.latest_reminder |date }}</td>
                   <td>{{ project.editor }}</td>
                   <td>
                     <form action="" method="post" class="form-signin">
@@ -186,7 +188,7 @@
                   <th>Project</th>
                   <th>Submitted By</th>
                   <th>Submitted</th>
-                  <th>Editor Accepted</th>
+                  <th>Accepted</th>
                   <th>Editor</th>
                   <th>Manage</th>
                 </tr>
@@ -223,8 +225,9 @@
                   <th>Project</th>
                   <th>Submitted By</th>
                   <th>Submitted</th>
-                  <th>Editor Accepted</th>
+                  <th>Accepted</th>
                   <th>Copyedit Completed</th>
+                  <th>Latest reminder</th>
                   <th>Editor</th>
                   <th>Action</th>
                 </tr>
@@ -237,6 +240,7 @@
                   <td>{{ project.submission_datetime|date }}</td>
                   <td>{{ project.editor_accept_datetime|date }}</td>
                   <td>{{ project.copyedit_completion_datetime|date }}</td>
+                  <td>{{ project.latest_reminder |date }}</td>
                   <td>{{ project.editor }}</td>
                   <td>
                     {% if project.latest_reminder < yesterday %}
@@ -264,7 +268,7 @@
                   <th>Project</th>
                   <th>Submitted By</th>
                   <th>Submitted</th>
-                  <th>Editor Accepted</th>
+                  <th>Accepted</th>
                   <th>Copyedit Completed</th>
                   <th>Author Approved</th>
                   <th>Editor</th>


### PR DESCRIPTION
As mentioned in #786, here I add the latest reminder date on the editor home, submitted projects page and submitted project info card.