### PR TITLE
Add a timeout to the search tool in the console (thanks @lbulgarelli)

### DIFF
--- a/physionet-django/console/static/console/js/search-console.js
+++ b/physionet-django/console/static/console/js/search-console.js
@@ -1,8 +1,20 @@
 // Script to search lists in the console
 // e.g. search users, news items, etc.
 
+// Init a timeout variable to be used below
+var loadresults = null;
+
 function search(url, value){
-  var csrftoken = getCookie('csrftoken');
-  var data = {'csrfmiddlewaretoken':csrftoken, 'search': value};
-  $('#searchitems').load(url, data);
+    var csrftoken = getCookie('csrftoken');
+
+    // Clear the timeout if it has already been set.
+    // This will prevent the previous task from executing
+    // if it has been less than <MILLISECONDS>
+    clearTimeout(loadresults);
+
+    // Make a new timeout set to go off in <N>ms
+    loadresults = setTimeout(function(){
+        var data = {'csrfmiddlewaretoken':csrftoken, 'search': value};
+        $('#searchitems').load(url, data);
+    }, 500);
 }


### PR DESCRIPTION
In the dynamic search tool in the console (e.g. https://physionet.org/console/users/all/), search results are often returned out of sequence (e.g. when I've just finished typing "hello world" I'll receive the results for "hel"). 

The bug is mentioned at: https://github.com/MIT-LCP/physionet-build/pull/799. In this change, we add a 500ms pause before sending the search request, which helps to address the issue. Thanks @lbulgarelli for working this out.