### PR TITLE
Add Content-Security-Policy for project files

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -24,6 +24,17 @@ server {
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
+
+        location ~ \.pdf$ {
+            # Temporary workaround: Chromium doesn't permit viewing PDF
+            # files in sandboxed mode:
+            # https://bugs.chromium.org/p/chromium/issues/detail?id=271452
+            # Until this is fixed, disable CSP sandbox for published
+            # PDF files.
+        }
+        location ~ . {
+            add_header Content-Security-Policy "sandbox; default-src 'self'";
+        }
     }
 
     location /physiobank/database {
@@ -82,6 +93,9 @@ server {
     location /protected/ {
         internal;
         alias   /data/pn-media/; # note the trailing slash
+
+        # preserve Content-Security-Policy header from X-Accel-Redirect
+        add_header Content-Security-Policy $upstream_http_content_security_policy;
 
         location /protected/published-projects/ {
             autoindex on;

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -24,6 +24,17 @@ server {
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
+
+        location ~ \.pdf$ {
+            # Temporary workaround: Chromium doesn't permit viewing PDF
+            # files in sandboxed mode:
+            # https://bugs.chromium.org/p/chromium/issues/detail?id=271452
+            # Until this is fixed, disable CSP sandbox for published
+            # PDF files.
+        }
+        location ~ . {
+            add_header Content-Security-Policy "sandbox; default-src 'self'";
+        }
     }
 
     location /physiobank/database {
@@ -82,6 +93,9 @@ server {
     location /protected/ {
         internal;
         alias   /data/pn-media/; # note the trailing slash
+
+        # preserve Content-Security-Policy header from X-Accel-Redirect
+        add_header Content-Security-Policy $upstream_http_content_security_policy;
 
         location /protected/published-projects/ {
             autoindex on;

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -93,7 +93,7 @@ def _file_x_accel_path(file_path):
         elif file_path.startswith(media_root + '/'):
             return media_alias + file_path[len(media_root):]
 
-def serve_file(file_path, attach=True, allow_directory=False):
+def serve_file(file_path, attach=True, allow_directory=False, sandbox=True):
     """
     Serve a file to download. file_path is the real path of the file on
     the server.
@@ -118,6 +118,8 @@ def serve_file(file_path, attach=True, allow_directory=False):
                 response = HttpResponse(f.read())
                 response['Content-Type'] = file_content_type(file_path)
     base = os.path.basename(file_path)
+    if sandbox:
+        response['Content-Security-Policy'] = "sandbox; default-src 'self'"
     if attach:
         response['Content-Disposition'] = 'attachment; filename=' + base
     else:


### PR DESCRIPTION
As a general principle:

* Documents that are part of a published project shouldn't be allowed to include resources (e.g. images or stylesheets) that are not under PhysioNet's control - those resources might disappear, or they might be used to surreptitiously track visitors.

* Documents shouldn't be allowed to include JavaScript or other programmatic content, which could be used by a malicious uploader to exfiltrate protected data from PhysioNet, attack the browser itself... or simply refer to external resources, which are problematic for the above reasons.

Most recent browsers support the "Content-Security-Policy" header, which can be used to restrict the capabilities of a web page.  This is by no means a complete solution - the editors still need to check uploaded files for problematic content.  However:

- This should reduce the security risks to *editors* posed by malicious uploaders.

- This should help authors to catch mistakes (e.g. referring to an external image) when proofreading.

Note that this only applies to *project files*.  We should probably also add security policies for dynamic pages, but that's a slightly more complicated issue.

Also note that this *doesn't* apply to published PDF files, because that breaks Chromium's PDF viewer.  (It *seems* to work with Firefox's PDF viewer - at leas, Firefox will display a PDF file that is served with "C-S-P: sandbox".  It may be the case that Firefox doesn't support JavaScript in PDF files at all - I'm not sure.)
