### PR TITLE
Citation text in project preview

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -210,6 +210,15 @@ class Author(BaseAuthor):
         """
         return self.user.profile.get_full_name()
 
+    def initialed_name(self):
+        """
+        Return author's name in citation style.
+        """
+        last = self.user.profile.last_name
+        first = self.user.profile.first_names
+        return '{}, {}'.format(
+            last, ' '.join('{}.'.format(i[0]) for i in first.split()))
+
     def disp_name_email(self):
         """
         """
@@ -689,6 +698,23 @@ class UnpublishedProject(models.Model):
             used = None
         return StorageInfo(allowance=self.core_project.storage_allowance,
                            used=used, include_remaining=True)
+
+    def citation_text(self):
+        """
+        Return template citation text.
+
+        This text resembles the final "citation text" as it will
+        appear once the project is published.  Since the project is
+        not yet published, the current year is used in place of the
+        publication year, and '*****' is used in place of the DOI
+        suffix.
+        """
+        authors = self.authors.all().order_by('display_order')
+        year = timezone.now().year
+        doi = '10.13026/*****'
+        return '{} ({}). {}. PhysioNet. doi:{}'.format(
+            ', '.join(a.initialed_name() for a in authors),
+            year, self.title, doi)
 
     def get_previous_slug(self):
         """

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -99,7 +99,7 @@
     <div class="alert alert-secondary">
 
     <strong>When using this resource, please cite:</strong>
-      <p>[Your citation will appear here]</p>
+      <p>{{ project.citation_text }}</p>
 
     {% if publication %}
       <strong>In addition, please cite the original publication:</strong>


### PR DESCRIPTION
In the project preview, rather than displaying:

    When using this resource, please cite:
    [Your citation will appear here]

which might be confusing to authors, display:

    When using this resource, please cite:
    Mark, R. G. (2019). MIT-BIH Arrhythmia Database. PhysioNet. doi:10.13026/*****

Does this seem clear enough?