### PR TITLE
Trying to fix server 502 error

### DIFF
--- a/deploy/production/etc/uwsgi/vassals/physionet_uwsgi.ini
+++ b/deploy/production/etc/uwsgi/vassals/physionet_uwsgi.ini
@@ -3,20 +3,25 @@
 # Django-related settings
 # the base directory
 chdir           = /physionet/physionet-build/physionet-django
+
 # Django's wsgi file
 module          = physionet.wsgi
+
 # the virtualenv
 home            = /physionet/python-env/physionet
 
 # process-related settings
 # master
 master          = true
+
 # maximum number of worker processes
 processes       = 10
+
 # the socket
 socket          = /physionet/deploy/physionet.sock
 # ... with appropriate permissions - may be needed
 chmod-socket    = 664
+
 # clear environment on exit
 vacuum          = true
 
@@ -28,10 +33,40 @@ gid = www-data
 req-logger = file:/data/log/uwsgi/%n-req.log
 logger = file:/data/log/uwsgi/%n.log
 
+# Log all 5++ erros
+log-5xx = true
+
+# Only valid uWSGI options are tolerated.
+strict = true
+
 # If the app is not found kill the proccess
 need-app = true
+
 # Kill all processes on termination
 die-on-term = true
+
+# Enable thunder lock to prevent the thundering herd problem.
+thunder-lock = true
+
+# Shut down worker processes when we exit.
+no-orphans = true
+
+# This will give memory usage of each process in log file at location
+memory-report = true
+
+# Worker recycling can prevent issues that become apparent over time such
+# as memory leaks or unintentional states. In some circumstances, however,
+# it can improve performance because newer processes have fresh memory space.
+max-requests = 1000                  ; Restart workers after this many requests
+max-worker-lifetime = 3600           ; Restart workers after this many seconds
+reload-on-rss = 2048                 ; Restart workers after this much resident memory
+worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
+py-call-osafterfork = true			 ; Allow them to receive signals to attempt to gracefully time out requests
+
+# This configuration will restart a worker process after any of the following events:
+# - 1000 requests have been handled
+# - The worker has allocated 2 GB of memory
+# - 1 hour has passed
 
 # declaring the correct settings file
 env             = DJANGO_SETTINGS_MODULE=physionet.settings.production

--- a/deploy/staging/etc/uwsgi/vassals/physionet_uwsgi.ini
+++ b/deploy/staging/etc/uwsgi/vassals/physionet_uwsgi.ini
@@ -3,20 +3,24 @@
 # Django-related settings
 # the base directory
 chdir           = /physionet/physionet-build/physionet-django
+
 # Django's wsgi file
 module          = physionet.wsgi
+
 # the virtualenv
 home            = /physionet/python-env/physionet
 
 # process-related settings
 # master
 master          = true
+
 # maximum number of worker processes
 processes       = 10
 # the socket
 socket          = /physionet/deploy/physionet.sock
 # ... with appropriate permissions - may be needed
 chmod-socket    = 664
+
 # clear environment on exit
 vacuum          = true
 
@@ -28,10 +32,39 @@ gid = www-data
 req-logger = file:/data/log/uwsgi/%n-req.log
 logger = file:/data/log/uwsgi/%n.log
 
+# Log all 5++ erros
+log-5xx = true
+
+# Only valid uWSGI options are tolerated.
+strict = true
+
 # If the app is not found kill the proccess
 need-app = true
 # Kill all processes on termination
 die-on-term = true
+
+# Enable thunder lock to prevent the thundering herd problem.
+thunder-lock = true
+
+# Shut down worker processes when we exit.
+no-orphans = true
+
+# This will give memory usage of each process in log file at location
+memory-report = true
+
+# Worker recycling can prevent issues that become apparent over time such
+# as memory leaks or unintentional states. In some circumstances, however,
+# it can improve performance because newer processes have fresh memory space.
+max-requests = 1000                  ; Restart workers after this many requests
+max-worker-lifetime = 3600           ; Restart workers after this many seconds
+reload-on-rss = 2048                 ; Restart workers after this much resident memory
+worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
+py-call-osafterfork = true			 ; Allow them to receive signals to attempt to gracefully time out requests
+
+# This configuration will restart a worker process after any of the following events:
+# - 1000 requests have been handled
+# - The worker has allocated 2 GB of memory
+# - 1 hour has passed
 
 # declaring the correct settings file
 env             = DJANGO_SETTINGS_MODULE=physionet.settings.staging


### PR DESCRIPTION
There was an error in which uWSGI stopped working with no errors in the log and
just stopped responding. To make it work again it was restarted, but it happened
several times after that.

This is an attempt to fix that error, adding a bit more logging, and enabling
"thunder-lock" to see if that was the cause of the problem or part of it.
Enabling thunder-lock should put a stop to the thundering herd problem if we have it.

Also, here I introduce the concept of worker recycling.
Worker recycling can prevent issues that become apparent over time such as memory
leaks or unintentional states. In some circumstances, however, it can improve
performance because newer processes have “fresh memory space”.

uWSGI provides multiple methods for recycling workers. Assuming the app is relatively
quick to reload, all three of the methods below should be effectively harmless and
provide protection against different failure scenarios.