### PR TITLE
Clean up expired sessions

### DIFF
--- a/deploy/production/etc/cron.d/physionet
+++ b/deploy/production/etc/cron.d/physionet
@@ -1,0 +1,14 @@
+#### PhysioNet scheduled tasks ####
+
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+## Daily tasks ##
+
+# Remove expired Django sessions
+31 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.production /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py clearsessions

--- a/deploy/staging/etc/cron.d/physionet
+++ b/deploy/staging/etc/cron.d/physionet
@@ -1,0 +1,14 @@
+#### PhysioNet scheduled tasks ####
+
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+## Daily tasks ##
+
+# Remove expired Django sessions
+31 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.staging /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py clearsessions


### PR DESCRIPTION
Add a cron job to remove expired sessions from the database.  Fixes issue #791.

Testing this is fun.

It's a bit annoying that, yet again, the configuration needs to be duplicated for staging and production... we should have a better way of handling that.
