### PR TITLE
Remove right border from indented-box class

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -540,6 +540,7 @@ a, code{
   margin-left: 0.75em;
   padding-left: 25px;
   margin-top: 25px;
+  border-width: 0;
   border-left: 1px solid;
   border-image: linear-gradient(to bottom, silver 0%, silver 60%, transparent 100%) 1% 100%;
           


### PR DESCRIPTION
For some reason a border appeared in the right of the boxes in the `About` and `Share` pages, making it rather ugly. This should simply remove it.