### PR TITLE
Add project hyperlink to the access page in the console

### DIFF
--- a/physionet-django/console/templates/console/project_access.html
+++ b/physionet-django/console/templates/console/project_access.html
@@ -24,7 +24,7 @@
         <tbody>
         	{% for project in c_projects %}
         	<tr>
-        		<td>{{ project }}</td>
+        		<td><a href="{% url 'published_project' project.slug project.version %}">{{ project }}</a></a></td>
         		<td>{{ project.publish_datetime }}</td>
         		<td>{{ project.member_count }}</td>
         		<td><a href="{% url 'project_access_manage' project.id %}" class="btn btn-sm btn-primary" role="button">View</a></td>


### PR DESCRIPTION
The `Access` page in the console has a list of projects that require credentialing. However, there's no link to view the project in that page, which might be useful, so I'm adding it.