### PR TITLE
Replacing the static content of the Challenge page

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+from os import path
+from re import fullmatch
 
 from django.contrib import messages
 from django.http import Http404
@@ -134,7 +136,18 @@ def challenge_overview(request):
     """
     Temporary content overview
     """
-    return render(request, 'about/challenge_index.html')
+    all_challenges = PublishedProject.objects.filter(resource_type=2)
+
+    for challenge in all_challenges:
+        if fullmatch(r'challenge-[0-9]{4}$', challenge.slug):
+            challenge.year = challenge.slug.split('-')[1]
+        if path.exists(path.join(challenge.file_root() , 'sources')):
+            challenge.sources = True
+        if path.exists(path.join(challenge.file_root() , 'papers/index.html')):
+            challenge.papers = True
+
+    return render(request, 'about/challenge_index.html',
+        {'all_challenges': all_challenges})
 
 
 def tutorial_overview(request):

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -136,13 +136,16 @@ def challenge_overview(request):
     """
     Temporary content overview
     """
-    all_challenges = PublishedProject.objects.filter(resource_type=2)
+    all_challenges = PublishedProject.objects.filter(resource_type=2,
+        is_latest_version=True)
 
     for challenge in all_challenges:
         if fullmatch(r'challenge-[0-9]{4}$', challenge.slug):
             challenge.year = challenge.slug.split('-')[1]
         if path.exists(path.join(challenge.file_root() , 'sources')):
             challenge.sources = True
+            if path.exists(path.join(challenge.file_root() , 'sources/index.html')):
+                challenge.sources_index = True
         if path.exists(path.join(challenge.file_root() , 'papers/index.html')):
             challenge.papers = True
 

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -137,7 +137,7 @@ def challenge_overview(request):
     Temporary content overview
     """
     all_challenges = PublishedProject.objects.filter(resource_type=2,
-        is_latest_version=True)
+        is_latest_version=True).order_by('-publish_datetime')
 
     for challenge in all_challenges:
         if fullmatch(r'challenge-[0-9]{4}$', challenge.slug):

--- a/physionet-django/static/custom/css/about.css
+++ b/physionet-django/static/custom/css/about.css
@@ -19,7 +19,6 @@
 
 table, th, td {
   border: 1px solid lightgrey;
-  width: 100%;
 }
 
 tr:nth-child(even) {

--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -45,7 +45,7 @@
         <td>{{ challenge.publish_datetime|date }}</td>
         <td>
           {% if challenge.year %}
-          CinC/PhysioNet {{ challenge.year }}
+          PhysioNet/CinC {{ challenge.year }}
           {% else %}
           PhysioNet
           {% endif %}

--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -51,13 +51,15 @@
           {% endif %}
         </td>
         <td>
-          {% if challenge.sources %}
-          <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'sources' %}">View software</a>
+          {% if challenge.papers %}
+            <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'papers/index.html' %}">View papers</a>
           {% endif %}
         </td>
         <td>
-          {% if challenge.papers %}
-            <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'papers/index.html' %}">View papers</a>
+          {% if challenge.sources and challenge.sources_index %}
+          <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'sources/index.html' %}">View software</a>
+          {% elif challenge.sources %}
+          <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'sources' %}">View software</a>
           {% endif %}
         </td>
       </tr>

--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -22,32 +22,49 @@
 
 <section id="challenge">
   <h1>Challenges</h1>
-    <p> In cooperation with the annual <a href="http://www.cinc.org/"
-    target="_blank">Computing in Cardiology</a> conference, PhysioNet hosts a series
-    of challenges, inviting participants to tackle clinically interesting
-    problems that are either unsolved or not well-solved.</p>
-  <ul>
-    <li><a href="{% url 'published_project_latest' 'challenge-2019' %}">2019</a>: Early Prediction of Sepsis from Clinical Data.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2018' %}">2018</a>: You Snooze, You Win.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2017' %}">2017</a>: AF Classification from a Short Single Lead ECG Recording.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2016' %}">2016</a>: Classification of Normal/Abnormal Heart Sound Recordings.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2015' %}">2015</a>: Reducing false arrhythmia alarms in the icu.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2014' %}">2014</a>: Robust detection of heart beats in multimodal data.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2013' %}">2013</a>: Non-invaside fetal ECG.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2012' %}">2012</a>: Predicting mortality of ICU patients.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2011' %}">2011</a>: Improving the quality of ECGs collected using mobile phones.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2010' %}">2010</a>: Mind the Gap.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2009' %}">2009</a>: Predicting Acute Hypotensive Episodes.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2008' %}">2008</a>: Detecting and Quantifying T-Wave Alternans.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2007' %}">2007</a>: Electrocardiographic Imaging of Myocardial Infarction.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2006' %}">2006</a>: QT Interval Measurement.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2005' %}">2005</a>: The First Five Challenges Revisited.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2004' %}">2004</a>: Spontaneous Termination of Atrial Fibrillation.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2003' %}">2003</a>: Distinguishing Ischemic from Non-Ischemic ST Changes.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2002' %}">2002</a>: RR Interval Time Series Modeling.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2001' %}">2001</a>: Predicting Paroxysmal Atrial Fibrillation.</li>
-    <li><a href="{% url 'published_project_latest' 'challenge-2000' %}">2000</a>: Detecting Sleep Apnea from the ECG.</li>
-  </ul>
+    <p>PhysioNet supports challenges, which invite participants to tackle clinically
+    interesting questions that are either unsolved or not well-solved. In cooperation
+    with the <a href="http://www.cinc.org/" target="_blank">Computing in Cardiology</a>
+     conference, PhysioNet has been co-hosting a challenge annually.</p>
+
+  {% if all_challenges %}
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Date</th>
+        <th>Host</th>
+        <th>Papers</th>
+        <th>Contributed Software</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for challenge in all_challenges %}
+      <tr>
+        <td><a href="{% url 'published_project_latest' challenge.slug %}">{{ challenge.title }}</a></td>
+        <td>{{ challenge.publish_datetime|date }}</td>
+        <td>
+          {% if challenge.year %}
+          CinC/PhysioNet {{ challenge.year }}
+          {% else %}
+          PhysioNet
+          {% endif %}
+        </td>
+        <td>
+          {% if challenge.sources %}
+          <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'sources' %}">View software</a>
+          {% endif %}
+        </td>
+        <td>
+          {% if challenge.papers %}
+            <a href="{% url 'serve_published_project_file' challenge.slug challenge.version 'papers/index.html' %}">View papers</a>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
 
 <p>To find more challenges on PhysioNet, <a href="{% url 'content_index' %}">search our resources</a>.</p>
 </section>


### PR DESCRIPTION
Here I replace the static content of the static page, and also add the
published papers and contributed software section.

For this to work, there has to be some manual labor done.

For the software section, the folder 'sources' has to exists under the project.
If the folder exists, it will create a URL under the challenge index page to a
Nginx http index page, just like in the old website.

For the papers, is somewhat similar.
- Create a papers folder and put all of the papers into the folder (e.g. like the papers folder for https://physionet.org/content/challenge-2018/)
- Save https://archive.physionet.org/challenge/2018/papers/ as an HTML file and upload the file to the challenge files named 'index.html' and place it in the same folder.

Here I fix #819