### PR TITLE
Display submission history in correct order

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -551,10 +551,10 @@ class Metadata(models.Model):
         """
         authors, author_emails = self.get_author_info(include_emails=include_emails)
         storage_info = self.get_storage_info(force_calculate=force_calculate)
-        edit_logs = self.edit_logs.all()
+        edit_logs = self.edit_log_history()
         for e in edit_logs:
             e.set_quality_assurance_results()
-        copyedit_logs = self.copyedit_logs.all()
+        copyedit_logs = self.copyedit_log_history()
         # The last published version. May be None.
         latest_version = self.core_project.publishedprojects.all().last()
         return authors, author_emails, storage_info, edit_logs, copyedit_logs, latest_version

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -522,6 +522,28 @@ class Metadata(models.Model):
             else:
                 return authors
 
+    def edit_log_history(self):
+        """
+        Get a list of EditLog objects in submission order.
+
+        Every object corresponds to a single submission from the
+        author (and objects are listed in that order), but also
+        includes the details of the editor's response (if any) to that
+        particular submission.
+        """
+        return self.edit_logs.order_by('submission_datetime').all()
+
+    def copyedit_log_history(self):
+        """
+        Get a list of CopyeditLog objects in creation order.
+
+        Every object represents a point in time when the project was
+        "opened for copyediting" (which happens once when the project
+        is "accepted", and may happen again if the authors
+        subsequently request further changes.)
+        """
+        return self.copyedit_logs.order_by('start_datetime').all()
+
     def info_card(self, include_emails=True, force_calculate=False):
         """
         Get all the information needed for the project info card

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1169,8 +1169,8 @@ def project_submission(request, project_slug, **kwargs):
     # Whether the submission is currently waiting for the user to approve
     awaiting_user_approval = False
     if project.under_submission():
-        edit_logs = project.edit_logs.all()
-        copyedit_logs = project.copyedit_logs.all()
+        edit_logs = project.edit_log_history()
+        copyedit_logs = project.copyedit_log_history()
         for e in edit_logs:
             e.set_quality_assurance_results()
         # Awaiting authors
@@ -1201,10 +1201,10 @@ def rejected_submission_history(request, project_slug):
     else:
         raise Http404()
     if user.is_admin or project.authors.filter(user=user):
-        edit_logs = project.edit_logs.all()
+        edit_logs = project.edit_log_history()
         for e in edit_logs:
             e.set_quality_assurance_results()
-        copyedit_logs = project.copyedit_logs.all()
+        copyedit_logs = project.copyedit_log_history()
 
         return render(request, 'project/rejected_submission_history.html',
             {'project':project, 'edit_logs':edit_logs,
@@ -1243,10 +1243,10 @@ def published_submission_history(request, project_slug, version):
     else:
         raise Http404()
     if user.is_admin or project.authors.filter(user=user):
-        edit_logs = project.edit_logs.all()
+        edit_logs = project.edit_log_history()
         for e in edit_logs:
             e.set_quality_assurance_results()
-        copyedit_logs = project.copyedit_logs.all()
+        copyedit_logs = project.copyedit_log_history()
 
         return render(request, 'project/published_submission_history.html',
             {'project':project, 'edit_logs':edit_logs,


### PR DESCRIPTION
This should fix the order that submission histories are displayed, in:

- `/projects/*/submission/`
- `/console/submitted-projects/*/edit/`
- `/projects/rejected/*/submission-history/`
- `/projects/published/*/*/submission-history/`

This should fix issue #611.

This is quite a mess - look at how many special cases there are in active_submission_timeline.html, not to mention static_submission_timeline.html.  So, no guarantees that the order won't get screwed up again. :/
