### PR TITLE
Increased the proxy_buffers

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -119,6 +119,10 @@ server {
     # Security headers
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
     add_header Accept-Ranges bytes;
+
+    # Proxy buffers
+    proxy_buffers 24 4k;
+    proxy_buffer_size 1k;
 }
 
 server {
@@ -193,4 +197,8 @@ server {
     location @dynamic {
         return 301 https://$host$request_uri;
     }
+
+    # Proxy buffers
+    proxy_buffers 24 4k;
+    proxy_buffer_size 1k;
 }

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -119,6 +119,10 @@ server {
     # Security headers
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
     add_header Accept-Ranges bytes;
+
+    # Proxy buffers
+    proxy_buffers 24 4k;
+    proxy_buffer_size 1k;
 }
 
 server {
@@ -193,4 +197,8 @@ server {
     location @dynamic {
         return 301 https://$host$request_uri;
     }
+
+    # Proxy buffers
+    proxy_buffers 24 4k;
+    proxy_buffer_size 1k;
 }


### PR DESCRIPTION
Increasing the number of proxy_buffers can allow you to buffer more information.
I am swapping 8 buffers of 4k to 24 buffers of 4k.

Since the proxy_buffer_size holds the header, I am making it smaller.

Second part of #814