### PR TITLE
Synchronous reloading of uwsgi

### DIFF
--- a/deploy/common/etc/systemd/system/emperor.uwsgi.service
+++ b/deploy/common/etc/systemd/system/emperor.uwsgi.service
@@ -3,8 +3,13 @@ Description=uWSGI Emperor
 After=syslog.target
 
 [Service]
+Environment=PHYSIONET_LOCK_FILE=/run/uwsgi/pn.lock
 ExecStart=/physionet/python-env/physionet/bin/uwsgi --emperor /etc/uwsgi/vassals
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/sh -c                                           \
+    "mv -fT /run/uwsgi/pn.lock /run/uwsgi/pn.lock.old &&        \
+     kill -HUP $MAINPID &&                                      \
+     flock -x /run/uwsgi/pn.lock.old /bin/true"
+
 # Requires systemd version 211 or newer
 User=www-data
 Group=www-data


### PR DESCRIPTION
This is the first part of several changes to improve robustness of the
server update process.

When making changes, we want to be able to reload the uwsgi server and
then *wait* until all old threads have finished before doing something
else (like running a migration.)

To do this, we acquire a shared lock on /run/uwsgi/pn.lock when the
settings module is loaded.  This lock is inherited by each worker
process.  Then, when we want to reload:

- rename /run/uwsgi/pn.lock to /run/uwsgi/pn.lock.old
- send SIGHUP to the emperor process
- acquire an exclusive lock on /run/uwsgi/pn.lock.old

which can only finish once all the old workers have exited.

Fun facts:

- uwsgi has an "flock" option, but it uses fcntl(2), not flock(2).
  Uh... yeah.  It might be possible to use that option instead of
  doing the locking ourselves, but I'm not entirely sure it would
  work, and it'd be more complicated and more fragile.

- 'lsof' and 'lslocks' are somewhat misleading in how they report
  flock locks - they indicate that only one process is holding the
  lock, when in fact there may be multiple processes.  This appears to
  be a limitation of Linux.

- Although something similar could probably be done for
  django-background-tasks.service, I think it's not worth it.  If we
  need to reload that service, best just to do a hard restart and let
  interrupted tasks be retried.
