### PR TITLE
Ignore Virtual Studio Code temporary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ TAGS
 
 # Credential file
 physionet-django/*credentials*
+
+# VSCode temp file
+.vscode/


### PR DESCRIPTION
Virtual Studio Code creates a temporary file/folder (".vscode/"). This change will help to prevent people/me accidentally committing the file to the repo!