### PR TITLE
Display only latest version on Latest Resources

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -20,7 +20,7 @@ def home(request):
     Homepage
     """
     featured = PublishedProject.objects.filter(featured__isnull=False).order_by('featured')[:6]
-    latest = PublishedProject.objects.all().order_by('-publish_datetime')[:6]
+    latest = PublishedProject.objects.filter(is_latest_version=True).order_by('-publish_datetime')[:6]
     news_pieces = News.objects.all().order_by('-publish_datetime')[:5]
 
     return render(request, 'home.html', {'featured': featured,


### PR DESCRIPTION
Right now if there are two versions of the same project published at a similar time, then they might end up in the "Latest Resources" section of the index page. 

Here I only allow the latest versions for each publications.