### PR TITLE
Bump django to 2.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,8 @@ bleach==3.1.0 \
  --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16
 chardet==3.0.4 \
  --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-Django==2.2.8 \
- --hash=sha256:fa98ec9cc9bf5d72a08ebf3654a9452e761fbb8566e3f80de199cbc15477e891 \
- --hash=sha256:a4ad4f6f9c6a4b7af7e2deec8d0cbff28501852e5010d6c2dc695d3d1fae7ca0
+Django==2.2.9 \
+ --hash=sha256:687c37153486cf26c3fdcbdd177ef16de38dc3463f094b5f9c9955d91f277b14
 django-autocomplete-light==3.3.4 \
  --hash=sha256:cff0b1cad0e233e49c8cce08dff22868951123cbb79a7c1768eda78845044568
 django-background-tasks==1.2.0 \


### PR DESCRIPTION
This fixes a severe security issue (CVE-2019-19844).  See
https://www.djangoproject.com/weblog/2019/dec/18/security-releases/
