### PR TITLE
Revert "landing page buttons redirect to search"

### DIFF
--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -26,7 +26,7 @@ PhysioNet
       </p>
       <br>
       <div>
-        <a href="{% url 'database_index' %}">Data</a>
+        <a href="{% url 'database_overview' %}">Data</a>
         <a href="{% url 'software_overview' %}">Software</a>
         <a href="{% url 'challenge_overview' %}">Challenges</a>
         <a href="{% url 'tutorial_overview' %}">Tutorials</a>


### PR DESCRIPTION
This reverts commit 33e0f95456d22febb8988b584fbd15a5801bf930 at the request of Roger.

The "Data" link now goes back to the hardcoded list of projects.