### PR TITLE
More robust server upgrades

### DIFF
--- a/deploy/common/etc/sudoers.d/physionet
+++ b/deploy/common/etc/sudoers.d/physionet
@@ -1,0 +1,18 @@
+#### PhysioNet privileged operations ####
+
+# This file defines specific commands that may be invoked by automated
+# scripts using 'sudo'.  Each command listed in this file must have a
+# single, clearly-defined function.  The program must be carefully
+# written to check all of its inputs to avoid privilege escalation.
+# Do not add commands to this list without carefully considering the
+# consequences.
+
+Defaults:pn env_reset, !env_keep, !env_check
+
+# Reload emperor.uwsgi.service (if it is running)
+pn ALL=(root:root) NOPASSWD: \
+    /bin/systemctl reload emperor.uwsgi.service
+
+# Restart django-background-tasks.service (if it is running)
+pn ALL=(root:root) NOPASSWD: \
+    /bin/systemctl try-restart django-background-tasks.service

--- a/deploy/post-receive
+++ b/deploy/post-receive
@@ -2,36 +2,113 @@
 
 set -e
 
-destination=/physionet/physionet-build/
+install_dir=/physionet/physionet-build
+working_dir=/physionet/physionet-build.new
+venv_dir=/physionet/python-env/physionet
+log_file=/physionet/update.log
 branch=$(cat /physionet/deploy-branch) # production or staging
 
-echo "Deploying $branch into $destination"
-GIT_WORK_TREE=$destination git checkout --force $branch
+while read -r old new refname; do
+    if [ "$refname" = "refs/heads/$branch" ]; then
+        oldrev=$old
+        newrev=$new
+    fi
+done
+if [ -z "$oldrev" ] || [ -z "$newrev" ]; then
+    exit
+fi
 
-echo "Updating content"
-export DJANGO_SETTINGS_MODULE=physionet.settings.$branch
-cd $destination
-source /physionet/python-env/physionet/bin/activate
-pip install -r requirements.txt
-cd physionet-django
-python manage.py collectstatic --noinput
+################################################################
 
-echo "Checking system configuration files"
+# If the following commands fail, it is too late to abort the push.
+# Try to avoid doing things that might fail!
+
+echo "$(date '+%F %T %z'): $branch: post-receive started" >> $log_file
 exec 3>&1
+exec &> >(tee -a $log_file)
+
+export DJANGO_SETTINGS_MODULE=physionet.settings.$branch
+
+. $venv_dir/bin/activate
+
+# Unpack files into $working_dir
+rm -rf $working_dir
+mkdir -p $working_dir
+git archive "$newrev" | tar -x -C $working_dir
+ln -s $install_dir/.env $working_dir/.env
+
+# Check what migrations should be applied
+(
+    cd $working_dir/physionet-django
+    ./manage.py getmigrationtargets --current > OLD-TARGETS
+    ./manage.py getmigrationtargets --early -v2 > EARLY-TARGETS 2>> $log_file
+    ./manage.py getmigrationtargets > LATE-TARGETS
+)
+
+# Run early migrations
+(
+    cd $working_dir/physionet-django
+    if cmp -s OLD-TARGETS EARLY-TARGETS; then
+        echo "- No early migrations to apply."
+    else
+        echo "* Applying early migrations..."
+        ./manage.py migratetargets EARLY-TARGETS --no-input |
+            tee -a $log_file | grep 'Applying' >&3
+        echo >> $log_file
+    fi
+)
+
+echo "* Installing new static files..."
+(
+    cd $working_dir/physionet-django
+    ./manage.py collectstatic --no-input >> $log_file
+)
+
+echo "* Installing new server code..."
+GIT_WORK_TREE=$install_dir git checkout --force "$branch" 2>> $log_file
+
+echo "* Reloading uwsgi server..."
+sudo systemctl reload emperor.uwsgi.service
+(
+    cd $working_dir/physionet-django
+    if cmp -s OLD-TARGETS LATE-TARGETS; then
+        # assume that if there are no migrations, no need to restart
+        # background tasks (and don't even bother showing a message)
+        :
+    else
+        echo "* Restarting django-background-tasks..."
+        sudo systemctl try-restart django-background-tasks.service
+    fi
+)
+
+# Run late migrations
+(
+    cd $working_dir/physionet-django
+    if cmp -s EARLY-TARGETS LATE-TARGETS; then
+        echo "- No late migrations to apply."
+    else
+        echo "* Applying late migrations..."
+        ./manage.py migrate --no-input |
+            tee -a $log_file | grep 'Applying' >&3
+    fi
+)
+
+# Check for updated configuration files
 confupdate=$(
-    cd $destination/deploy
+    cd $install_dir/deploy
     for subdir in common $branch; do
         ( cd $subdir; find * -type f ) | while read file; do
             if ! diff -Nu /$file $subdir/$file >&3; then
-                echo " * $subdir/$file"
+                echo "   $subdir/$file"
             fi
         done
     done
 )
 
-echo "Done. If there are any database changes, please make the migrations now."
 if [ -n "$confupdate" ]; then
-    echo "Install updated configuration files if needed (see above):"
+    echo "Note: configuration files are out of date (see above):"
     echo "$confupdate"
 fi
-echo "Then, run 'touch /etc/uwsgi/vassals/physionet_uwsgi.ini'."
+
+echo "$(date '+%F %T %z'): $branch: post-receive finished" >> $log_file
+echo >> $log_file

--- a/deploy/post-receive
+++ b/deploy/post-receive
@@ -5,7 +5,7 @@ set -e
 install_dir=/physionet/physionet-build
 working_dir=/physionet/physionet-build.new
 venv_dir=/physionet/python-env/physionet
-log_file=/physionet/update.log
+log_file=/data/log/pn/update.log
 branch=$(cat /physionet/deploy-branch) # production or staging
 
 while read -r old new refname; do

--- a/deploy/post-receive
+++ b/deploy/post-receive
@@ -112,7 +112,7 @@ fi
 # Restart the django-background-tasks server
 (
     cd $working_dir/physionet-django
-    if ! cmp -s OLD-TARGETS LATE-TARGETS; then
+    if cmp -s OLD-TARGETS LATE-TARGETS; then
         # assume that if there are no migrations, no need to restart
         # background tasks (and don't even bother showing a message)
         :

--- a/deploy/post-receive
+++ b/deploy/post-receive
@@ -20,6 +20,23 @@ fi
 
 ################################################################
 
+for opt in $(env | grep '^GIT_PUSH_OPTION_[0-9]*=' |
+                 cut -d= -f2- | tr ',' ' '); do
+    case $opt in
+        no-pip)            no_pip=1 ;;
+        no-static)         no_static=1 ;;
+        no-install)        no_install=1 ;;
+        no-uwsgi)          no_uwsgi=1 ;;
+        no-bgtasks)        no_bgtasks=1 ;;
+        no-migrate)        no_migrate=1 ;;
+        no-early-migrate)  no_early_migrate=1 ;;
+        no-late-migrate)   no_late_migrate=1 ;;
+        *) ;;
+    esac
+done
+
+################################################################
+
 # If the following commands fail, it is too late to abort the push.
 # Try to avoid doing things that might fail!
 
@@ -50,6 +67,11 @@ ln -s $install_dir/.env $working_dir/.env
     cd $working_dir/physionet-django
     if cmp -s OLD-TARGETS EARLY-TARGETS; then
         echo "- No early migrations to apply."
+    elif [ -n "$no_migrate" ]; then
+        echo "- SKIPPING early migrations due to --push-option=no-migrate"
+    elif [ -n "$no_early_migrate" ]; then
+        echo "- SKIPPING early migrations due to" \
+             "--push-option=no-early-migrate"
     else
         echo "* Applying early migrations..."
         ./manage.py migratetargets EARLY-TARGETS --no-input |
@@ -58,34 +80,68 @@ ln -s $install_dir/.env $working_dir/.env
     fi
 )
 
-echo "* Installing new static files..."
+# Copy new static files into /data/pn-static
+if [ -n "$no_static" ]; then
+    echo '- SKIPPING new static files due to --push-option=no-static'
+else
+    echo "* Installing new static files..."
+    (
+        cd $working_dir/physionet-django
+        ./manage.py collectstatic --no-input >> $log_file
+    )
+fi
+
+# Install into /physionet/physionet-build
+if [ -n "$no_install" ]; then
+    echo "- SKIPPING installation due to --push-option=no-install"
+else
+    echo "* Installing new server code..."
+    GIT_WORK_TREE=$install_dir git checkout --force "$branch" 2>> $log_file
+fi
+
+# Restart the uwsgi server
+if [ -n "$no_uwsgi" ]; then
+    echo "- SKIPPING reloading uwsgi server due to --push-option=no-uwsgi"
+elif [ -n "$no_install" ]; then
+    echo "- SKIPPING reloading uwsgi server due to --push-option=no-install"
+else
+    echo "* Reloading uwsgi server..."
+    sudo systemctl reload emperor.uwsgi.service
+fi
+
+# Restart the django-background-tasks server
 (
     cd $working_dir/physionet-django
-    ./manage.py collectstatic --no-input >> $log_file
-)
-
-echo "* Installing new server code..."
-GIT_WORK_TREE=$install_dir git checkout --force "$branch" 2>> $log_file
-
-echo "* Reloading uwsgi server..."
-sudo systemctl reload emperor.uwsgi.service
-(
-    cd $working_dir/physionet-django
-    if cmp -s OLD-TARGETS LATE-TARGETS; then
+    if ! cmp -s OLD-TARGETS LATE-TARGETS; then
         # assume that if there are no migrations, no need to restart
         # background tasks (and don't even bother showing a message)
         :
+    elif [ -n "$no_bgtasks" ]; then
+        echo "- SKIPPING restarting django-background-tasks due to"
+        echo "  --push-option=no-bgtasks"
+    elif [ -n "$no_install" ]; then
+        echo "- SKIPPING restarting django-background-tasks due to"
+        echo "  --push-option=no-install"
     else
         echo "* Restarting django-background-tasks..."
         sudo systemctl try-restart django-background-tasks.service
     fi
 )
 
-# Run late migrations
+# Run late migrations (as well as early migrations, if they were
+# skipped before)
 (
     cd $working_dir/physionet-django
     if cmp -s EARLY-TARGETS LATE-TARGETS; then
         echo "- No late migrations to apply."
+    elif [ -n "$no_migrate" ]; then
+        echo "- SKIPPING late migrations due to --push-option=no-migrate"
+    elif [ -n "$no_late_migrate" ]; then
+        echo "- SKIPPING late migrations due to --push-option=no-late-migrate"
+    elif [ -n "$no_uwsgi" ]; then
+        echo "- SKIPPING late migrations due to --push-option=no-uwsgi"
+    elif [ -n "$no_install" ]; then
+        echo "- SKIPPING late migrations due to --push-option=no-install"
     else
         echo "* Applying late migrations..."
         ./manage.py migrate --no-input |

--- a/deploy/update
+++ b/deploy/update
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+install_dir=/physionet/physionet-build
+working_dir=/physionet/physionet-build.new
+venv_dir=/physionet/python-env/physionet
+log_file=/physionet/update.log
+branch=$(cat /physionet/deploy-branch) # production or staging
+
+refname=$1
+oldrev=$2
+newrev=$3
+
+if [ $# != 3 ]; then
+    echo "usage: $0 <ref> <oldrev> <newrev>" >&2
+    exit 1
+fi
+if [ "$refname" != "refs/heads/$branch" ]; then
+    exit
+fi
+
+################################################################
+
+# If the following commands fail, the push is aborted.  Try to check
+# for things that might cause problems!
+
+echo ============================================================ >> $log_file
+echo "$(date '+%F %T %z'): $branch: update started" >> $log_file
+echo "Updating $branch (see $log_file for details):"
+exec 3>&1
+exec &> >(tee -a $log_file)
+
+export DJANGO_SETTINGS_MODULE=physionet.settings.$branch
+
+# Display summary of commits added/removed
+echo "old: $oldrev" >> $log_file
+git log "$oldrev...$newrev" --reverse --topo-order \
+    --pretty=format:' %m %h %an: %s'; echo
+echo "new: $newrev" >> $log_file
+echo
+
+# Unpack files into $working_dir
+rm -rf $working_dir
+mkdir -p $working_dir
+git archive "$newrev" | tar -x -C $working_dir
+ln -s $install_dir/.env $working_dir/.env
+
+echo "* Installing new requirements..."
+. $venv_dir/bin/activate
+pip3 install -r $working_dir/requirements.txt \
+     --quiet --require-hashes --log $log_file
+echo >> $log_file
+
+# Run 'getmigrationtargets' to check whether migrations make sense
+# (e.g. broken dependencies, ghost migrations)
+echo "* Checking migrations..."
+(
+    cd $working_dir/physionet-django
+    ./manage.py getmigrationtargets --current > /dev/null
+    ./manage.py getmigrationtargets --early > /dev/null
+    ./manage.py getmigrationtargets > /dev/null
+)
+
+echo "$(date '+%F %T %z'): $branch: update finished" >> $log_file

--- a/deploy/update
+++ b/deploy/update
@@ -5,7 +5,7 @@ set -e
 install_dir=/physionet/physionet-build
 working_dir=/physionet/physionet-build.new
 venv_dir=/physionet/python-env/physionet
-log_file=/physionet/update.log
+log_file=/data/log/pn/update.log
 branch=$(cat /physionet/deploy-branch) # production or staging
 
 refname=$1

--- a/deploy/update
+++ b/deploy/update
@@ -22,6 +22,36 @@ fi
 
 ################################################################
 
+for opt in $(env | grep '^GIT_PUSH_OPTION_[0-9]*=' |
+                 cut -d= -f2- | tr ',' ' '); do
+    case $opt in
+        no-pip)            no_pip=1 ;;
+        no-static)         no_static=1 ;;
+        no-install)        no_install=1 ;;
+        no-uwsgi)          no_uwsgi=1 ;;
+        no-bgtasks)        no_bgtasks=1 ;;
+        no-migrate)        no_migrate=1 ;;
+        no-early-migrate)  no_early_migrate=1 ;;
+        no-late-migrate)   no_late_migrate=1 ;;
+        *)
+            echo "unknown option --push-option=$opt"
+            echo
+            echo "supported push options:"
+            echo "  no-pip"
+            echo "  no-static"
+            echo "  no-install"
+            echo "  no-uwsgi"
+            echo "  no-bgtasks"
+            echo "  no-migrate"
+            echo "  no-early-migrate"
+            echo "  no-late-migrate"
+            exit 1
+            ;;
+    esac
+done
+
+################################################################
+
 # If the following commands fail, the push is aborted.  Try to check
 # for things that might cause problems!
 
@@ -46,11 +76,17 @@ mkdir -p $working_dir
 git archive "$newrev" | tar -x -C $working_dir
 ln -s $install_dir/.env $working_dir/.env
 
-echo "* Installing new requirements..."
 . $venv_dir/bin/activate
-pip3 install -r $working_dir/requirements.txt \
-     --quiet --require-hashes --log $log_file
-echo >> $log_file
+
+# Install new dependencies from 'requirements.txt' into $venv_dir
+if [ -n "$no_pip" ]; then
+    echo "- SKIPPING requirements due to --push-option=no-pip"
+else
+    echo "* Installing new requirements..."
+    pip3 install -r $working_dir/requirements.txt \
+         --quiet --require-hashes --log $log_file
+    echo >> $log_file
+fi
 
 # Run 'getmigrationtargets' to check whether migrations make sense
 # (e.g. broken dependencies, ghost migrations)

--- a/physionet-django/user/management/commands/getmigrationtargets.py
+++ b/physionet-django/user/management/commands/getmigrationtargets.py
@@ -1,0 +1,220 @@
+import collections
+import sys
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DEFAULT_DB_ALIAS, connections, migrations
+
+from django.db.migrations.executor import MigrationExecutor
+
+
+def is_late_migration(migration):
+    """
+    Check whether a Migration is marked as a "late" migration.
+
+    This means that the migration should not be applied until after
+    all database clients have been upgraded to support the new schema.
+    The default expectation is that the migration should be applied
+    before upgrading clients.
+
+    A "late" migration is one that has the MIGRATE_AFTER_INSTALL
+    attribute set to True.  An "early" migration has
+    MIGRATE_AFTER_INSTALL absent, or set to False.
+
+    For example, a migration that creates a new table or column should
+    typically be an early migration (since old clients will ignore the
+    column but new clients expect it to be present):
+
+        class Migration(migrations.Migration):
+            dependencies = [
+                ('foo', '0100_asdfghjk'),
+            ]
+            operations = [
+                migrations.AddField(
+                    model_name='mywidget',
+                    name='myproperty',
+                    field=models.DateTimeField(blank=True, null=True),
+                )
+            ]
+
+    but one that removes an existing column should typically be a late
+    migration (since old clients will expect it to be present but new
+    clients will ignore it):
+
+        class Migration(migrations.Migration):
+            dependencies = [
+                ('foo', '0100_asdfghjk'),
+            ]
+            operations = [
+                migrations.RemoveField(
+                    model_name='mywidget',
+                    name='myproperty',
+                )
+            ]
+            MIGRATE_AFTER_INSTALL = True
+    """
+    if not isinstance(migration, migrations.Migration):
+        raise TypeError('expected a Migration, not {!r}'.format(migration))
+    return getattr(migration, 'MIGRATE_AFTER_INSTALL', False)
+
+
+class Command(BaseCommand):
+    """
+    Management command to display current migration targets.
+
+    This command outputs a sequence of lines, each line containing an
+    app name followed by a migration name (suitable for passing to the
+    'migrate' command.)  The lines are in "forward" order, i.e. each
+    line may have dependencies on the lines before it, but not the
+    lines after it.
+
+    Running this command with no arguments displays the latest
+    migration for each app.
+
+    Running this command with the --early option displays the latest
+    migration that is *not* marked as MIGRATE_AFTER_INSTALL.
+
+    Running this command with the --current option displays the latest
+    migrations that are currently applied.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--database', default=DEFAULT_DB_ALIAS,
+            help='Name of database')
+        parser.add_argument(
+            '--current', action='store_true',
+            help='List currently-applied migrations')
+        parser.add_argument(
+            '--early', action='store_true',
+            help='Only consider "early" (pre-install) migrations')
+
+    def handle(self, *args, **options):
+        db = options['database']
+        connection = connections[db]
+
+        executor = MigrationExecutor(connection)
+
+        # Get a list of all migrations that would be applied, in
+        # order, starting from zero.
+        default_targets = executor.loader.graph.leaf_nodes()
+        default_plan = executor.migration_plan(default_targets,
+                                               clean_start=True)
+
+        applied = executor.loader.applied_migrations
+        desired = []
+
+        if options['verbosity'] >= 2:
+            sys.stderr.write('Default migration plan:\n')
+            self._print_migration_plan(default_plan, applied)
+            sys.stderr.write('\n')
+
+        for migration, _ in default_plan:
+            app = migration.app_label
+            name = migration.name
+            if options['current']:
+                # If --current is set, only list migrations that have
+                # already been applied.
+                if (app, name) in applied:
+                    desired.append((app, name))
+            elif options['early']:
+                # If --early is set, only list migrations that have
+                # already been applied OR that are considered "early"
+                # migrations.
+                if ((app, name) in applied
+                        or not is_late_migration(migration)):
+                    desired.append((app, name))
+            else:
+                # If neither --current nor --early is set, list all
+                # migrations.
+                desired.append((app, name))
+
+        # Check if there are any migrations applied that we don't know
+        # about.
+        ghosts = applied - set(desired)
+        if ghosts:
+            mlist = ', '.join('{}.{}'.format(app, name)
+                              for app, name in sorted(ghosts))
+            raise CommandError("Some migrations that have already been "
+                               "applied ({}) are not present in the "
+                               "source tree.".format(mlist))
+
+        # Determine the last desired migration for each individual
+        # app, in the order that they would have been applied by
+        # default.  (This should ensure that the migrations *can* be
+        # applied by calling 'manage.py migrate APP NAME' separately
+        # for each app, in the given order, without going backwards.)
+        targets = collections.OrderedDict()
+        for (app, name) in desired:
+            targets[app] = name
+            targets.move_to_end(app)
+
+        # Now make a plan for applying only the target migrations,
+        # starting from the current state.
+        current_plan = executor.migration_plan(list(targets.items()))
+
+        if options['verbosity'] >= 2:
+            sys.stderr.write('Chosen migration plan:\n')
+            self._print_migration_plan(current_plan, applied)
+            sys.stderr.write('\n')
+
+        # Check that the new plan contains only "desired" migrations.
+        selected = set(applied)
+        for migration, _ in current_plan:
+            app = migration.app_label
+            name = migration.name
+            selected.add((app, name))
+            if options['early'] and is_late_migration(migration):
+                # This can happen if the current migration is 0100,
+                # 0101 is a late migration that depends on 0100, and
+                # 0102 is an early migration that depends on 0101.
+                #
+                # That's not allowed - it means that 0101 depends on
+                # application changes being installed first, but the
+                # application changes depend on 0102 being applied
+                # first.
+                #
+                # Instead, such a change must be deployed in stages:
+                # the application code that 0101 depends on must be
+                # installed first; then 0101 and 0102 can be applied;
+                # and then the new application code that depends on
+                # 0102 can be installed.
+                raise CommandError("Applying early migrations would "
+                                   "require first applying {}.{}, which "
+                                   "is a late migration".format(app, name))
+            elif (app, name) not in desired:
+                # This shouldn't be possible.
+                raise CommandError("Wait a minute, what is {}.{}?  That "
+                                   "wasn't in the list!".format(app, name))
+
+        # Check that all of the "desired" migrations have already been
+        # applied or will be applied by the new plan.
+        missing = set(desired) - selected
+        if missing:
+            # This can happen if there are multiple independent early
+            # migrations for the same app, and the merge migration is
+            # a late migration.  That's not allowed since there isn't
+            # a unique target to specify.
+            mlist = ', '.join('{}.{}'.format(app, name)
+                              for app, name in sorted(missing))
+            raise CommandError("Applying chosen migrations would "
+                               "skip some desired migrations ({}). "
+                               "Missing merge?".format(mlist))
+
+        # Print target migrations in the order that they should be
+        # applied.
+        for (app, name) in targets.items():
+            sys.stdout.write('{} {}\n'.format(app, name))
+
+    def _print_migration_plan(self, plan, applied_migrations):
+        for migration, _ in plan:
+            app = migration.app_label
+            name = migration.name
+            if (app, name) in applied_migrations:
+                sys.stderr.write('[X]')
+            else:
+                sys.stderr.write('[ ]')
+            if is_late_migration(migration):
+                sys.stderr.write(' @')
+            else:
+                sys.stderr.write(' -')
+            sys.stderr.write(' {}.{}\n'.format(app, name))

--- a/physionet-django/user/management/commands/migratetargets.py
+++ b/physionet-django/user/management/commands/migratetargets.py
@@ -1,0 +1,41 @@
+from django.db import DEFAULT_DB_ALIAS
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--database', default=DEFAULT_DB_ALIAS,
+            help='Name of database')
+        parser.add_argument(
+            '--plan', action='store_true',
+            help='Show a list of actions to perform')
+        parser.add_argument(
+            '--noinput', '--no-input', action='store_false',
+            dest='interactive',
+            help='Never prompt for input')
+        parser.add_argument(
+            '--reverse', action='store_true',
+            help='Apply migrations in reverse order')
+        parser.add_argument(
+            'filename',
+            help='name of file listing migrations to apply')
+
+    def handle(self, *args, **options):
+        migrations = []
+        with open(options['filename'], 'r') as f:
+            for l in f:
+                (app, name) = l.split()
+                migrations.append((app, name))
+
+        if options['reverse']:
+            migrations.reverse()
+
+        for (app, name) in migrations:
+            call_command('migrate', app_label=app,
+                         migration_name=name,
+                         database=options['database'],
+                         plan=options['plan'],
+                         interactive=options['interactive'],
+                         verbosity=options['verbosity'])

--- a/test-upgrade.sh
+++ b/test-upgrade.sh
@@ -1,0 +1,393 @@
+#!/bin/bash
+#
+# Test live upgradability of the PhysioNet Django server.
+#
+# This script attempts to test that, if the production server is
+# running the specified git revision (e.g. 'origin/production'), and
+# we perform a live upgrade to the version currently in the working
+# tree, the server should remain functional at all times.
+#
+# Note that these tests will run resetdb/loaddemo (multiple times) and
+# thus will destroy the contents of your local development database.
+# These tests only work because we use a "mirror" database for testing
+# (in physionet.settings.development.sqlite and
+# physionet.settings.development.pgsql), which is not the usual Django
+# configuration.
+#
+# We assume that upgrade steps will be performed in the following
+# order.  Some steps might not actually change anything, and the
+# corresponding tests may be skipped.
+#
+# STEP 1: Upgrade dependencies according to requirements.txt.
+#
+#   At this point, the database has not been modified, and the old
+#   server code is still running, but new Python libraries may have
+#   been installed.  (Some of those might include database migrations
+#   of their own, which will not have been applied.)  We simulate this
+#   condition by loading the demo database (manage.py
+#   resetdb/loaddemo) from OLD-REVISION, then using pip to upgrade the
+#   dependencies.  The old server tests should still pass under these
+#   circumstances.
+#
+# STEP 2: Apply "early" migrations from the new version.
+#
+#   Now, the old server code is still running, but the database has
+#   been upgraded by applying some migrations.  We simulate this by
+#   using the old demo database (kept from the previous test) and
+#   using the new server code (manage.py migratetargets) to apply
+#   early migrations to that database.  The old server tests should
+#   still pass under these circumstances.
+#
+# STEP 3: Restart server processes using the new server code.
+#
+#   Now, the new server code is running, but the database has not yet
+#   had "late" migrations applied.  We simulate this by loading the
+#   new demo database (manage.py resetdb/loaddemo) and then
+#   un-applying late migrations (manage.py migratetargets).  The new
+#   server tests should pass under these circumstances.
+#
+# STEP 4: Apply "late" migrations from the new version.
+#
+#   Now, the new server code is running and the database has been
+#   fully upgraded.  This should be equivalent to a clean installation
+#   of the new server code, and the new server tests should pass under
+#   these circumstances.
+#
+# There are a lot of caveats here - this doesn't test whether the
+# server keeps working while migrations are happening, doesn't test
+# whether the old server works with new static files installed, and of
+# course doesn't test whether anything could go wrong due to
+# desynchronization between server and client.  "In-place" upgrades
+# are risky, too: there could be traps due to libraries, server code,
+# or template files being partially installed.
+
+set -e
+set -o pipefail
+
+################################################################
+# Initialization
+
+# Parse command line
+verbose=
+if [ "$1" = "-v" ]; then
+    verbose=1
+    shift
+fi
+if [ $# = 0 ]; then
+    echo "Usage: $0 [-v] old-revision [test-args]" >&2
+    exit 1
+fi
+oldrevname=$1
+shift
+test_args=("$@")
+test_args+=("--keepdb")
+if [ -n "$verbose" ]; then
+    test_args+=("--verbosity=3")
+fi
+
+case ${DJANGO_SETTINGS_MODULE-none} in
+    physionet.settings.development.*|none)
+        ;;
+    *)
+        echo "Unsupported DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE" >&2
+        exit 1
+        ;;
+esac
+
+# Go to top level directory of the git repository
+scriptname=$(which "$0")
+topdir=$(dirname "$scriptname")
+topdir=$(realpath "$topdir")
+cd "$topdir"
+
+# Identify the "old" revision to be upgraded from
+oldrev=$(git rev-parse --verify "$oldrevname^{commit}")
+
+# Generate a pretty name for the "current" revision
+currevname=$(git describe --all --always --dirty)
+
+################################################################
+# Functions for reporting test results
+
+# Show message that a test was skipped
+msg_skip()
+{
+    echo "$*" >&3
+}
+
+# Show message that a test is running
+msg_testing()
+{
+    current_test="$*"
+    echo "$*" >&2
+    echo "================================================================" >&2
+    printf "%s" "$*..." >&3
+}
+
+# Show message that a test succeeded
+msg_success()
+{
+    current_test=
+    echo " OK" >&3
+    echo "================================================================" >&2
+}
+
+# Show message that a test failed
+msg_failure()
+{
+    echo " FAILED" >&3
+    echo " *** FAILED: $current_test" >&2
+    echo "================================================================" >&2
+}
+
+# Show message that a test failed, and exit immediately
+msg_critical()
+{
+    msg_failure
+    fgrep ' *** FAILED: ' "$topdir/$logfile" >&3
+    exit 1
+}
+
+# Run a command and report success or failure
+check_cmd()
+{
+    echo "$(pwd) \$ $*" | sed "s|$olddir|<OLD>|g" | sed "s|$topdir|<NEW>|g" >&2
+    if env "$@"; then
+        msg_success
+    else
+        echo " *** '$*' failed ($?)" >&2
+        msg_failure
+    fi
+}
+
+# Run a command and exit if it fails
+prereq_cmd()
+{
+    echo "$(pwd) \$ $*" | sed "s|$olddir|<OLD>|g" | sed "s|$topdir|<NEW>|g" >&2
+    if ! env "$@"; then
+        echo " *** '$*' failed ($?)" >&2
+        msg_critical
+    fi
+}
+
+################################################################
+# Set up logging
+
+logfile=$(echo "test-upgrade_$(date +%Y%m%d%H%M)_${currevname}.log" | tr / ,)
+if [ -n "$verbose" ]; then
+    exec 3>/dev/null &> >(tee -a "$logfile")
+else
+    exec 3>&1 &>"$logfile"
+    echo "Testing upgrade from $oldrevname to $currevname" >&3
+    echo "  Log file: $logfile" >&3
+fi
+
+echo "================================================================"
+echo "Testing upgrade:"
+echo " * Old: $oldrevname ($oldrev)"
+echo " * New: $currevname (HEAD=$(git rev-parse HEAD))"
+echo " * DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE-unset}"
+echo
+
+# Show commits added/removed between old revision and HEAD
+git log "$oldrev...HEAD" --reverse --topo-order \
+    --pretty=format:' %m %h %an: %s'
+echo
+echo
+
+# Show a summary of uncommitted changes
+git status --short
+
+echo "================================================================"
+
+################################################################
+# Set up working directory and useful variables
+
+workdir=$topdir/test-upgrade.tmp
+rm -rf "$workdir"
+
+olddir=$workdir/old
+mkdir -p "$olddir"
+git archive "$oldrev" | tar -x -C "$olddir"
+
+venvdir=$workdir/VE
+venvcachedir=$topdir/test-upgrade.cache
+mkdir -p "$venvcachedir"
+
+old_reqs_hash=$(md5sum "$olddir/requirements.txt" | cut -d' ' -f1)
+new_reqs_hash=$(md5sum "$topdir/requirements.txt" | cut -d' ' -f1)
+
+current_targets=$workdir/CURRENT-TARGETS
+old_targets=$workdir/OLD-TARGETS
+early_targets=$workdir/EARLY-TARGETS
+late_targets=$workdir/LATE-TARGETS
+
+ln -s "$topdir/.env" "$olddir/.env"
+
+export PATH=$venvdir/bin:$PATH
+
+################################################################
+# Set up old virtualenv directory and demo database
+(
+    cd "$olddir/physionet-django"
+
+    msg_testing "Installing old requirements"
+    cachefile=$venvcachedir/$old_reqs_hash.tar.gz
+    if [ -f "$cachefile" ]; then
+        prereq_cmd mkdir "$venvdir"
+        prereq_cmd tar -xzf "$cachefile" -C "$venvdir"
+    else
+        prereq_cmd virtualenv --quiet --quiet \
+                   --no-download -ppython3 "$venvdir"
+        prereq_cmd pip3 install --require-hashes \
+                   -r "$olddir/requirements.txt"
+        prereq_cmd tar -czf "$cachefile" -C "$venvdir" .
+    fi
+    msg_success
+
+    msg_testing "Loading old demo database"
+    prereq_cmd ./manage.py resetdb
+    prereq_cmd ./manage.py loaddemo
+    msg_success
+)
+################################################################
+# Upgrade virtualenv directory
+(
+    cd "$topdir/physionet-django"
+
+    msg_testing "Installing new requirements"
+    if ! cmp -s "$olddir/requirements.txt" "$topdir/requirements.txt"; then
+        cachefile=$venvcachedir/$old_reqs_hash-$new_reqs_hash.tar.gz
+        if [ -f "$cachefile" ]; then
+            prereq_cmd rm -rf "$venvdir"
+            prereq_cmd mkdir "$venvdir"
+            prereq_cmd tar -xzf "$cachefile" -C "$venvdir"
+        else
+            prereq_cmd pip3 install --require-hashes \
+                       -r "$topdir/requirements.txt"
+            prereq_cmd tar -czf "$cachefile" -C "$venvdir" .
+        fi
+    fi
+    msg_success
+)
+################################################################
+# Check migrations
+(
+    cd "$topdir/physionet-django"
+
+    msg_testing "Checking migrations"
+    prereq_cmd rm -f db.sqlite3
+    prereq_cmd ln -s "$olddir/physionet-django/db.sqlite3" db.sqlite3
+    prereq_cmd ./manage.py makemigrations --dry-run --no-input --check
+    prereq_cmd ./manage.py getmigrationtargets --current > "$old_targets"
+    prereq_cmd ./manage.py getmigrationtargets --early > "$early_targets"
+    prereq_cmd ./manage.py getmigrationtargets > "$late_targets"
+    msg_success
+)
+################################################################
+# Run old tests, on old database, with new virtualenv
+# (between upgrade steps 1 and 2)
+(
+    cd "$olddir/physionet-django"
+    if cmp -s "$olddir/requirements.txt" "$topdir/requirements.txt"; then
+        msg_skip "Skipping tests - requirements haven't changed."
+    else
+        msg_testing "Testing old server (with new libraries)"
+        check_cmd ./manage.py test "${test_args[@]}"
+    fi
+)
+################################################################
+# Run old tests, on old database, after early migrations
+# (between upgrade steps 2 and 3)
+(
+    cd "$topdir/physionet-django"
+    msg_testing "Performing early migrations"
+    prereq_cmd ./manage.py migratetargets --no-input "$early_targets"
+    prereq_cmd ./manage.py getmigrationtargets --current > "$current_targets"
+    check_cmd diff "$early_targets" "$current_targets"
+)
+(
+    cd "$olddir/physionet-django"
+    if cmp -s "$old_targets" "$early_targets"; then
+        msg_skip "Skipping tests - no early migrations."
+    else
+        msg_testing "Testing old server (after early migrations)"
+        check_cmd PHYSIONET_HYBRID_TEST=new-db \
+                  ./manage.py test "${test_args[@]}"
+    fi
+)
+################################################################
+# Check that migrations can be applied to old database, forward and
+# backward
+(
+    cd "$topdir/physionet-django"
+
+    msg_testing "Performing late migrations"
+    check_cmd ./manage.py migrate --no-input
+
+    msg_testing "Undoing all migrations"
+    check_cmd ./manage.py migratetargets --no-input \
+              --reverse "$old_targets"
+
+    msg_testing "Checking migrations were undone"
+    prereq_cmd ./manage.py getmigrationtargets --current > "$current_targets"
+    check_cmd diff "$old_targets" "$current_targets"
+)
+################################################################
+# Run new tests, on new database
+# (after upgrade step 4)
+(
+    cd "$topdir/physionet-django"
+
+    msg_testing "Loading new demo database"
+    prereq_cmd rm -f db.sqlite3
+    prereq_cmd ./manage.py resetdb
+    prereq_cmd ./manage.py loaddemo
+    msg_success
+
+    msg_testing "Testing new server"
+    check_cmd ./manage.py test "${test_args[@]}"
+)
+################################################################
+# Run new tests, on new database, before late migrations
+# (between upgrade steps 3 and 4)
+(
+    cd "$topdir/physionet-django"
+
+    msg_testing "Undoing late migrations"
+    prereq_cmd ./manage.py migratetargets --no-input --reverse "$early_targets"
+    prereq_cmd ./manage.py getmigrationtargets --current > "$current_targets"
+    check_cmd diff "$early_targets" "$current_targets"
+
+    if cmp -s "$early_targets" "$late_targets"; then
+        msg_skip "Skipping tests - no late migrations."
+    else
+        msg_testing "Testing new server (before late migrations)"
+        check_cmd PHYSIONET_HYBRID_TEST=old-db \
+                  ./manage.py test "${test_args[@]}"
+    fi
+)
+################################################################
+# Check that migrations can be applied to new database, backward and
+# forward
+(
+    cd "$topdir/physionet-django"
+
+    msg_testing "Undoing early migrations"
+    check_cmd ./manage.py migratetargets --no-input \
+              --reverse "$old_targets"
+
+    msg_testing "Checking migrations were undone"
+    prereq_cmd ./manage.py getmigrationtargets --current > "$current_targets"
+    check_cmd diff "$old_targets" "$current_targets"
+
+    msg_testing "Redoing all migrations"
+    check_cmd ./manage.py migrate --no-input
+)
+
+if fgrep ' *** FAILED: ' "$topdir/$logfile" >&3; then
+    exit 1
+else
+    echo "Success" >&3
+    exit 0
+fi


### PR DESCRIPTION
These are some changes to hopefully improve the workflow for
deploying upgrades to the server.

(I wrote most of this a few weeks ago but haven't touched it since.
Further testing is needed, and there may be some corner cases that
need to be addressed, which I don't have time to work on right now -
but I thought it would be useful to put this up as-is, as a preview of
possible things to come!)

Key changes here:

- Migrations will be applied automatically.

- "Late" migrations (those that should be applied after upgrading,
  rather than before) will need to be indicated using a custom
  attribute of the Migration class.

- Servers will be restarted/reloaded automatically.

- Much less verbose output from 'git push'; details will be logged in
  /physionet/update.log.
