### PR TITLE
fix typo (Reubmit -> Resubmit)

### DIFF
--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -86,7 +86,7 @@
                     {{ author_comments_form }}
                   </div>
                   <div class="modal-footer">
-                    <button id="resubmit-project-button" class="btn btn-primary" type="submit" name="resubmit_project" disabled>Reubmit Project</button>
+                    <button id="resubmit-project-button" class="btn btn-primary" type="submit" name="resubmit_project" disabled>Resubmit Project</button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                   </div>
                 </form>


### PR DESCRIPTION
> FWIW the Resubmit confirmation button is misspelled (without an "s")

Thanks Meredith Lee for picking this up!