### PR TITLE
Follow IDF recommendation for displaying DOIs

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -736,7 +736,7 @@ class UnpublishedProject(models.Model):
         authors = self.authors.all().order_by('display_order')
         year = timezone.now().year
         doi = '10.13026/*****'
-        return '{} ({}). {}. PhysioNet. doi:{}'.format(
+        return '{} ({}). {}. PhysioNet. https://doi.org/{}'.format(
             ', '.join(a.initialed_name() for a in authors),
             year, self.title, doi)
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1504,7 +1504,7 @@ class PublishedProject(Metadata, SubmissionInfo):
 
         authors = self.authors.all().order_by('display_order')
         if self.doi:
-            return '{} ({}). {}. PhysioNet. doi:{}'.format(
+            return '{} ({}). {}. PhysioNet. https://doi.org/{}'.format(
                 ', '.join(a.initialed_name() for a in authors),
                 self.publish_datetime.year, self.title, self.doi)
         return '{} ({}). {}. PhysioNet.'.format(


### PR DESCRIPTION
Follow the current recommendations of the International DOI Foundation to format DOIs in the reference list, which as of this publication is as follows:

```
https://doi.org/xxxxx
```

See for example:
- https://www.crossref.org/display-guidelines/
- https://apastyle.apa.org/style-grammar-guidelines/references/dois-urls
