### PR TITLE
Improvements to recommended citation

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -22,7 +22,7 @@ from django.db import models, DatabaseError, transaction
 from django.forms.utils import ErrorList
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import strip_tags
+from django.utils.html import format_html, strip_tags
 from django.utils.text import slugify
 from background_task import background
 from django.utils.crypto import get_random_string
@@ -736,9 +736,13 @@ class UnpublishedProject(models.Model):
         authors = self.authors.all().order_by('display_order')
         year = timezone.now().year
         doi = '10.13026/*****'
-        return '{} ({}). {}. PhysioNet. https://doi.org/{}'.format(
-            ', '.join(a.initialed_name() for a in authors),
-            year, self.title, doi)
+        return format_html(
+            '{authors} ({year}). {title}. '
+            '<i>PhysioNet</i>. https://doi.org/{doi}',
+            authors=', '.join(a.initialed_name() for a in authors),
+            year=year,
+            title=self.title,
+            doi=doi)
 
     def get_previous_slug(self):
         """
@@ -1504,12 +1508,20 @@ class PublishedProject(Metadata, SubmissionInfo):
 
         authors = self.authors.all().order_by('display_order')
         if self.doi:
-            return '{} ({}). {}. PhysioNet. https://doi.org/{}'.format(
-                ', '.join(a.initialed_name() for a in authors),
-                self.publish_datetime.year, self.title, self.doi)
-        return '{} ({}). {}. PhysioNet.'.format(
-            ', '.join(a.initialed_name() for a in authors),
-            self.publish_datetime.year, self.title)
+            return format_html(
+                '{authors} ({year}). {title}. '
+                '<i>PhysioNet</i>. https://doi.org/{doi}',
+                authors=', '.join(a.initialed_name() for a in authors),
+                year=self.publish_datetime.year,
+                title=self.title,
+                doi=self.doi)
+        else:
+            return format_html(
+                '{authors} ({year}). {title}. '
+                '<i>PhysioNet</i>.',
+                authors=', '.join(a.initialed_name() for a in authors),
+                year=self.publish_datetime.year,
+                title=self.title)
 
     def remove(self, force=False):
         """

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1511,7 +1511,8 @@ class PublishedProject(Metadata, SubmissionInfo):
         if self.doi:
             return format_html(
                 '{authors} ({year}). {title} (version {version}). '
-                '<i>PhysioNet</i>. https://doi.org/{doi}',
+                '<i>PhysioNet</i>. '
+                '<a href="https://doi.org/{doi}">https://doi.org/{doi}</a>',
                 authors=', '.join(a.initialed_name() for a in authors),
                 year=self.publish_datetime.year,
                 title=self.title,

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -737,11 +737,12 @@ class UnpublishedProject(models.Model):
         year = timezone.now().year
         doi = '10.13026/*****'
         return format_html(
-            '{authors} ({year}). {title}. '
+            '{authors} ({year}). {title} (version {version}). '
             '<i>PhysioNet</i>. https://doi.org/{doi}',
             authors=', '.join(a.initialed_name() for a in authors),
             year=year,
             title=self.title,
+            version=self.version,
             doi=doi)
 
     def get_previous_slug(self):
@@ -1509,19 +1510,21 @@ class PublishedProject(Metadata, SubmissionInfo):
         authors = self.authors.all().order_by('display_order')
         if self.doi:
             return format_html(
-                '{authors} ({year}). {title}. '
+                '{authors} ({year}). {title} (version {version}). '
                 '<i>PhysioNet</i>. https://doi.org/{doi}',
                 authors=', '.join(a.initialed_name() for a in authors),
                 year=self.publish_datetime.year,
                 title=self.title,
+                version=self.version,
                 doi=self.doi)
         else:
             return format_html(
-                '{authors} ({year}). {title}. '
+                '{authors} ({year}). {title} (version {version}). '
                 '<i>PhysioNet</i>.',
                 authors=', '.join(a.initialed_name() for a in authors),
                 year=self.publish_datetime.year,
-                title=self.title)
+                title=self.title,
+                version=self.version)
 
     def remove(self, force=False):
         """


### PR DESCRIPTION
This makes a few changes to the style of the recommended citation
at the top of each project page.  In particular, the version
number is included, which I think is essential.

Further typographical nitpicking is welcome.

Before:

<blockquote>Mark, R. G. (2020). Demo Limited Clinical Dataset. PhysioNet. https://doi.org/10.13026/*****</blockquote>

<blockquote>Mark, R. (2019). Demo 2018 BHI and BSN Data Challenge. PhysioNet.</blockquote>

<blockquote>Mark, R. G. (2018). Demo eICU Collaborative Research Database. PhysioNet. https://doi.org/10.13026/G2F309</blockquote>

After:

<blockquote>Mark, R. G. (2020). Demo Limited Clinical Dataset (version 1.0.0). <i>PhysioNet</i>. https://doi.org/10.13026/*****</blockquote>

<blockquote>Mark, R. (2019). Demo 2018 BHI and BSN Data Challenge (version 1.0). <i>PhysioNet</i>.</blockquote>

<blockquote>Mark, R. G. (2018). Demo eICU Collaborative Research Database (version 2.0.0). <i>PhysioNet</i>. <a href="https://doi.org/10.13026/G2F309">https://doi.org/10.13026/G2F309</a></blockquote>
