### PR TITLE
Reduce the width of tables in the credentialing forms

### DIFF
--- a/physionet-django/console/templates/console/past_credential_successful_user_list.html
+++ b/physionet-django/console/templates/console/past_credential_successful_user_list.html
@@ -6,8 +6,8 @@
           <th>Email</th>
           <th>Application Date</th>
           <th>Approval Date</th>
-          <th>Credentialed By</th>
-          <th>View Application</th>
+          <th>Approved By</th>
+          <th>View Details</th>
           <th>Manage</th>
         </tr>
       </thead>

--- a/physionet-django/console/templates/console/past_credential_unsuccessful_user_list.html
+++ b/physionet-django/console/templates/console/past_credential_unsuccessful_user_list.html
@@ -5,11 +5,11 @@
           <th>User</th>
           <th>Email</th>
           <th>Application Date</th>
-          <th>Reference Contact Date</th>
+          <th>Ref. Contact Date</th>
           <th>Decision Date</th>
           <th>Decision</th>
           <th>Comment</th>
-          <th>View Application</th>
+          <th>View Details</th>
           <th>Manage</th>
         </tr>
       </thead>
@@ -19,9 +19,9 @@
           {% with user=application.user %}
             <td><a href="{% url 'public_profile' user.username %}">{{ user.get_full_name }}</td>
             <td>{{ user.email }}</td>
-            <td>{{ application.application_datetime }}</td>
+            <td>{{ application.application_datetime|date }}</td>
             <td>{{ application.reference_contact_datetime|date }}</td>
-            <td>{{ application.decision_datetime }}</td>
+            <td>{{ application.decision_datetime|date }}</td>
             <td>{{ application.get_status_display }}</td>
             <td>{{ application.responder_comments }}</td>
             <td><a href="{% url 'view_credential_application' application.slug %}">View</a></td>


### PR DESCRIPTION
@kpierceHST has asked if we can make it easier to view the credentialing forms, which are currently a little too wide for his screen (specifically http://127.0.0.1:8000//console/past-credential-applications/unsuccessful). 

This is a couple of minor changes to column header text that I think help to address the issue:

- "Reference Contact Date" is now "Ref. Contact Date"
- datetimes are now dates
- "View Application" is now "View Details" 