### PR TITLE
Fix some <label for='...'> attributes

### DIFF
--- a/physionet-django/project/templates/project/content_inline_form_snippet.html
+++ b/physionet-django/project/templates/project/content_inline_form_snippet.html
@@ -1,7 +1,7 @@
 {% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
-    <label class="col-md-2" for="{{ field.html_name }}">
+    <label class="col-md-2" for="{{ field.id_for_label }}">
       {{ field.label|title }}
       {% if field.help_text|slice:"0:1" == "*" %}
         <a style="color:red"> *</a>

--- a/physionet-django/project/templates/project/project_files_form.html
+++ b/physionet-django/project/templates/project/project_files_form.html
@@ -56,7 +56,7 @@
           </button>
         </div>
           <div class="modal-body">
-            <label>{{ create_folder_form.folder_name.label }}:</label>
+            <label for="{{ create_folder_form.folder_name.id_for_label }}">{{ create_folder_form.folder_name.label }}:</label>
             {{ create_folder_form.folder_name }}
           </div>
           <div class="modal-footer">
@@ -78,7 +78,7 @@
         </div>
           <div class="modal-body">
             <p id="rename-item-message"></p>
-            <label>{{ rename_item_form.new_name.label }}:</label>
+            <label for="{{ rename_item_form.new_name.id_for_label }}">{{ rename_item_form.new_name.label }}:</label>
             {{ rename_item_form.new_name }}
           </div>
           <div class="modal-footer">
@@ -100,7 +100,7 @@
         </div>
           <div class="modal-body">
             <p id="move-items-message"></p>
-            <label>{{ move_items_form.destination_folder.label }}:</label>
+            <label for="{{ move_items_form.destination_folder.id_for_label }}">{{ move_items_form.destination_folder.label }}:</label>
             {{ move_items_form.destination_folder }}
           </div>
           <div class="modal-footer">

--- a/physionet-django/templates/descriptive_inline_form_snippet.html
+++ b/physionet-django/templates/descriptive_inline_form_snippet.html
@@ -1,7 +1,7 @@
 {% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
-    <label class="col-md-3" for="{{ field.html_name }}">
+    <label class="col-md-3" for="{{ field.id_for_label }}">
       {{ field.label|capfirst }}
       {% if field.field.required %}
         <a style="color:red"> *</a>

--- a/physionet-django/templates/form_snippet.html
+++ b/physionet-django/templates/form_snippet.html
@@ -1,6 +1,6 @@
 {% for field in form.visible_fields %}
   <div class="form-group">
-    <label for="{{ field.html_name }}" title="{{ field.help_text }}">{{ field.label|safe }}
+    <label for="{{ field.id_for_label }}" title="{{ field.help_text }}">{{ field.label|safe }}
     </label> {{ field }}
     {% for error in field.errors %}
       <div class="alert alert-danger">

--- a/physionet-django/templates/inline_form_snippet.html
+++ b/physionet-django/templates/inline_form_snippet.html
@@ -1,6 +1,6 @@
 {% for field in form.visible_fields %}
   <div class="form-group row">
-    <label class="col-md-2" for="{{ field.html_name }}" title="{{ field.help_text }}">{{ field.label }}
+    <label class="col-md-2" for="{{ field.id_for_label }}" title="{{ field.help_text }}">{{ field.label }}
     </label>
     <div class='col-md-10'>
       {{ field }}


### PR DESCRIPTION
I could have sworn that we had to try to fix this once before...

The 'for' attribute of a label must correspond to the 'id' of the target element, not its 'name'.  For example, in /register/, the "email" field has an 'id' of 'id_email' and a 'name' of 'email', so the corresponding label must have 'for="id_email"'.
