### PR TITLE
Show DOI in project preview as 'https://doi.org/10.13026/*****'

### DIFF
--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -173,7 +173,7 @@
         <h5 class="card-header">Discovery</h5>
         <div class="card-body">
           <p><strong>DOI:</strong><br>
-            10.13026/[XXXXXX]
+            https://doi.org/10.13026/*****
           </p>
 
           {% if languages %}


### PR DESCRIPTION
For consistency, show the DOI in the project preview in the same format used in the published project.
