### PR TITLE
Keep the wsgi and nginx logs for a longer time

### DIFF
--- a/deploy/common/etc/logrotate.d/nginx
+++ b/deploy/common/etc/logrotate.d/nginx
@@ -1,7 +1,7 @@
 /data/log/nginx/*.log {
 	daily
 	missingok
-	rotate 3650
+	rotate 90
 	compress
 	delaycompress
 	notifempty

--- a/deploy/common/etc/logrotate.d/nginx
+++ b/deploy/common/etc/logrotate.d/nginx
@@ -1,7 +1,7 @@
 /data/log/nginx/*.log {
 	daily
 	missingok
-	rotate 14
+	rotate 3650
 	compress
 	delaycompress
 	notifempty

--- a/deploy/common/etc/logrotate.d/uwsgi
+++ b/deploy/common/etc/logrotate.d/uwsgi
@@ -1,6 +1,6 @@
 /data/log/uwsgi/*.log
 {
-        rotate 3650
+        rotate 90
         daily
         missingok
         notifempty

--- a/deploy/common/etc/logrotate.d/uwsgi
+++ b/deploy/common/etc/logrotate.d/uwsgi
@@ -1,6 +1,6 @@
 /data/log/uwsgi/*.log
 {
-        rotate 7
+        rotate 3650
         daily
         missingok
         notifempty


### PR DESCRIPTION
Set the log rotation to remove files after 10 years of logs.
This is a temporary measure to not loose the logs until they are analyzed.