### PR TITLE
Remove duplicated code from physionet.settings.development

### DIFF
--- a/physionet-django/physionet/settings/development/base.py
+++ b/physionet-django/physionet/settings/development/base.py
@@ -1,0 +1,39 @@
+import os
+from physionet.settings.base import *
+
+DEBUG = True
+SESSION_COOKIE_SECURE = False
+
+ALLOWED_HOSTS = ['*']
+
+INSTALLED_APPS += [
+    'debug_toolbar',
+]
+
+MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@dev.physionet.org>'
+CONTACT_EMAIL = 'PhysioNet Contact <contact@dev.physionet.org>'
+SERVER_EMAIL = 'PhysioNet System <root@dev.physionet.org>'
+
+ADMINS = [('PhysioNet Technical', 'technical@dev.physionet.org')]
+
+DEBUG_TOOLBAR_CONFIG = {
+    'JQUERY_URL': '',
+}
+
+DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'demo-files')
+
+MEDIA_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'media')
+
+# If defined, MEDIA_X_ACCEL_ALIAS is the virtual URL path
+# corresponding to MEDIA_ROOT. If possible, when serving a file
+# located in MEDIA_ROOT, the response will use an X-Accel-Redirect
+# header so that nginx can serve the file directly.
+MEDIA_X_ACCEL_ALIAS = None
+
+if RUNNING_TEST_SUITE:
+    MEDIA_ROOT = os.path.join(MEDIA_ROOT, 'test')
+    STATICFILES_DIRS[0] = os.path.join(STATICFILES_DIRS[0], 'test')

--- a/physionet-django/physionet/settings/development/pgsql.py
+++ b/physionet-django/physionet/settings/development/pgsql.py
@@ -1,28 +1,4 @@
-import os
-from physionet.settings.base import *
-
-DEBUG = True
-SESSION_COOKIE_SECURE = False
-
-ALLOWED_HOSTS = ['*']
-
-INSTALLED_APPS += [
-    'debug_toolbar',
-]
-
-MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]
-
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@dev.physionet.org>'
-CONTACT_EMAIL = 'PhysioNet Contact <contact@dev.physionet.org>'
-SERVER_EMAIL = 'PhysioNet System <root@dev.physionet.org>'
-
-ADMINS = [('PhysioNet Technical', 'technical@dev.physionet.org')]
-
-DEBUG_TOOLBAR_CONFIG = {
-    'JQUERY_URL': '',
-}
+from physionet.settings.development.base import *
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
@@ -39,17 +15,3 @@ DATABASES = {
         }
     }
 }
-
-DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'demo-files')
-
-MEDIA_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'media')
-
-# If defined, MEDIA_X_ACCEL_ALIAS is the virtual URL path
-# corresponding to MEDIA_ROOT. If possible, when serving a file
-# located in MEDIA_ROOT, the response will use an X-Accel-Redirect
-# header so that nginx can serve the file directly.
-MEDIA_X_ACCEL_ALIAS = None
-
-if RUNNING_TEST_SUITE:
-    MEDIA_ROOT = os.path.join(MEDIA_ROOT, 'test')
-    STATICFILES_DIRS[0] = os.path.join(STATICFILES_DIRS[0], 'test')

--- a/physionet-django/physionet/settings/development/sqlite.py
+++ b/physionet-django/physionet/settings/development/sqlite.py
@@ -1,28 +1,4 @@
-import os
-from physionet.settings.base import *
-
-DEBUG = True
-SESSION_COOKIE_SECURE = False
-
-ALLOWED_HOSTS = ['*']
-
-INSTALLED_APPS += [
-    'debug_toolbar',
-]
-
-MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]
-
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@dev.physionet.org>'
-CONTACT_EMAIL = 'PhysioNet Contact <contact@dev.physionet.org>'
-SERVER_EMAIL = 'PhysioNet System <root@dev.physionet.org>'
-
-ADMINS = [('PhysioNet Technical', 'technical@dev.physionet.org')]
-
-DEBUG_TOOLBAR_CONFIG = {
-    'JQUERY_URL': '',
-}
+from physionet.settings.development.base import *
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
@@ -35,17 +11,3 @@ DATABASES = {
         }
     }
 }
-
-DEMO_FILE_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'demo-files')
-
-MEDIA_ROOT = os.path.join(os.path.abspath(os.path.join(BASE_DIR, os.pardir)), 'media')
-
-# If defined, MEDIA_X_ACCEL_ALIAS is the virtual URL path
-# corresponding to MEDIA_ROOT. If possible, when serving a file
-# located in MEDIA_ROOT, the response will use an X-Accel-Redirect
-# header so that nginx can serve the file directly.
-MEDIA_X_ACCEL_ALIAS = None
-
-if RUNNING_TEST_SUITE:
-    MEDIA_ROOT = os.path.join(MEDIA_ROOT, 'test')
-    STATICFILES_DIRS[0] = os.path.join(STATICFILES_DIRS[0], 'test')


### PR DESCRIPTION
Settings modules physionet.settings.development.sqlite and physionet.settings.development.pgsql are identical except for the choice of database storage/engine.  Avoid duplication, by moving everything else into a shared module (physionet.settings.development.base.)

Just to make life a little simpler.
