### PR TITLE
Fix newline removal from credentialed serve_file

### DIFF
--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -101,6 +101,7 @@ def serve_file(file_path, attach=True, allow_directory=False, sandbox=True):
     If allow_directory is true and file_path ends with a slash, serve
     a simple HTML directory listing.
     """
+    file_path = file_path.strip()
     accel_path = _file_x_accel_path(file_path)
     if accel_path:
         response = HttpResponse()


### PR DESCRIPTION
I just added a strip on the filename before its evaluated to serve a file. This will remove unwanted spaces and newline characters.

```
Internal Server Error: /files/eicu-crd/2.0/test.txt

BadHeaderError at /files/eicu-crd/2.0/test.txt
Header values can't contain newlines (got '/protected/published-projects/eicu-crd/2.0/test.txt\r')
...
```