### PR TITLE
account activation with password

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -506,10 +506,10 @@ class ActivationForm(forms.Form):
     """A form for creating new users. Includes all the required
     fields, plus a repeated password.
     """
-    username = forms.CharField(widget=forms.TextInput(attrs={
-        'class': 'form-control', 'disabled': True}))
-    email = forms.EmailField(widget=forms.TextInput(attrs={
-        'class': 'form-control', 'disabled': True}))
+    username = forms.CharField(disabled=True, widget=forms.TextInput(attrs={
+        'class': 'form-control'}))
+    email = forms.EmailField(disabled=True, widget=forms.TextInput(attrs={
+        'class': 'form-control'}))
     password1 = forms.CharField(label='Password',
                     widget=forms.PasswordInput(attrs={'class': 'form-control'}))
     password2 = forms.CharField(label='Password Confirmation',

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -507,9 +507,9 @@ class ActivationForm(forms.Form):
     fields, plus a repeated password.
     """
     username = forms.CharField(widget=forms.TextInput(attrs={
-        'class': 'form-control', 'readonly': True}))
+        'class': 'form-control', 'disabled': True}))
     email = forms.EmailField(widget=forms.TextInput(attrs={
-        'class': 'form-control', 'readonly': True}))
+        'class': 'form-control', 'disabled': True}))
     password1 = forms.CharField(label='Password',
                     widget=forms.PasswordInput(attrs={'class': 'form-control'}))
     password2 = forms.CharField(label='Password Confirmation',

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -522,6 +522,7 @@ class ActivationForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields['username'].initial = user.username
         self.fields['email'].initial = user.email
+        self.user = user
 
     def clean_password2(self):
         # Check that the two password entries match
@@ -530,7 +531,7 @@ class ActivationForm(forms.Form):
         if password1 and password2 and password1 != password2:
             raise forms.ValidationError("The passwords don't match")
 
-        user = User.objects.get(username=self.data['username'])
-        password_validation.validate_password(self.cleaned_data.get('password1'), user=user)
+        password_validation.validate_password(
+            self.cleaned_data.get('password1'), user=self.user)
 
         return password1

--- a/physionet-django/user/templates/user/activate_user.html
+++ b/physionet-django/user/templates/user/activate_user.html
@@ -16,8 +16,17 @@
       <hr>
       {% csrf_token %}
       {% include "inline_form_snippet.html" %}
+      <div class="progress">
+        <div id="StrengthProgressBar" class="progress-bar"></div>
+      </div>
       <button class="btn btn-primary btn-custom btn-rsp" type="submit">Activate</button>
     </form>
 
 </div>
+{% endblock %}
+
+{% block local_js_bottom %}
+<script src="{% static 'zxcvbn/zxcvbn.js' %}"></script>
+<script src="{% static 'zxcvbn/zxcvbn-bootstrap-strength-meter.js' %}"></script>
+<script src="{% static 'zxcvbn/zxcvbn_ProgressBar_Register.js' %}"></script>
 {% endblock %}

--- a/physionet-django/user/templates/user/activate_user.html
+++ b/physionet-django/user/templates/user/activate_user.html
@@ -10,11 +10,14 @@
 
 {% block content %}
 <div class="container">
-    <h2>{{ title }}</h2>
-    {% if isvalid %}
-        <p>Your account has been successfully activated. You may now <a href="{% url 'login' %}">log in</a>.
-    {% else %}
-        <p>There was an error with your link. Please try again or contact the site administrator.</a>.
-    {% endif %}
+  {% include "message_snippet.html" %}
+    <form method="post">
+      <h1 class="form-signin-heading">{{ title }}</h1>
+      <hr>
+      {% csrf_token %}
+      {% include "inline_form_snippet.html" %}
+      <button class="btn btn-primary btn-custom btn-rsp" type="submit">Activate</button>
+    </form>
+
 </div>
 {% endblock %}

--- a/physionet-django/user/templates/user/activate_user_complete.html
+++ b/physionet-django/user/templates/user/activate_user_complete.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block local_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'custom/css/login-register.css' %}"/>
+{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h2>{{ title }}</h2>
+    {% if isvalid %}
+        <p>Your account has been successfully activated. You may now <a href="{% url 'login' %}">log in</a>.
+    {% else %}
+        <p>There was an error with your link. Please try again or contact the site administrator.</a>.
+    {% endif %}
+</div>
+{% endblock %}

--- a/physionet-django/user/templates/user/register.html
+++ b/physionet-django/user/templates/user/register.html
@@ -18,19 +18,10 @@ Register
     <h2 class="form-signin-heading">Create Account</h2>
     {% csrf_token %}
     {% include "form_snippet.html" %}
-  	<div class="progress">
-      <div id="StrengthProgressBar" class="progress-bar"></div>
-    </div>
     <button class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
   </form>
   <div class="form-signin">
     <p>Already have an account? <a href="{% url 'login' %}">Log In</a></p>
   </div>
 </div>
-{% endblock %}
-
-{% block local_js_bottom %}
-<script src="{% static 'zxcvbn/zxcvbn.js' %}"></script>
-<script src="{% static 'zxcvbn/zxcvbn-bootstrap-strength-meter.js' %}"></script>
-<script src="{% static 'zxcvbn/zxcvbn_ProgressBar_Register.js' %}"></script>
 {% endblock %}

--- a/physionet-django/user/test_forms.py
+++ b/physionet-django/user/test_forms.py
@@ -61,11 +61,8 @@ class TestForms(TestCase):
         self.run_test_forms({'last_name': ['This field is required.']})
 
     def test_user_creation_form(self):
-        self.create_test_forms(RegistrationForm, {'email':'tester0@mit.edu',
-            'username':'The-Tester', 'first_names':'Tester Mid',
-            'last_name':'Bot','password1':'Very5trongt0t@11y',
-            'password2':'Very5trongt0t@11y'},{'email':'tester0@mit.edu',
-            'username':'bot-net', 'first_names':'',
-            'last_name':'Bot', 'password1':'weakweak', 'password2':'weakweak'})
-        self.run_test_forms({'first_names':['This field is required.'],
-            'password2':['This password is too weak.']})
+        self.create_test_forms(RegistrationForm, {'email': 'tester0@mit.edu',
+            'username': 'The-Tester', 'first_names': 'Tester Mid',
+            'last_name': 'Bot'}, {'email': 'tester0@mit.edu',
+            'username': 'bot-net', 'first_names': '', 'last_name': 'Bot'})
+        self.run_test_forms({'first_names': ['This field is required.']})

--- a/physionet-django/user/test_integration.py
+++ b/physionet-django/user/test_integration.py
@@ -119,12 +119,18 @@ class TestCredentialing(TestCase):
         # Register and activate a user with old credentialed account
         response = self.client.post(reverse('register'),
             data={'email':'admin@upr.edu', 'username':'adminupr',
-            'first_names': 'admin', 'last_name': 'upr',
-            'password1':'Very5trongt0t@11y', 'password2':'Very5trongt0t@11y'})
+            'first_names': 'admin', 'last_name': 'upr'})
         uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
             mail.outbox[-1].body)[0]
-        response = self.client.get(reverse('activate_user',
-            kwargs={'uidb64':uidb64,'token':token}))
+
+        response = self.client.get(reverse('activate_user', args=(uidb64, token)))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.client.session['_activation_reset_token'], token)
+
+        response = self.client.post(reverse('activate_user',
+            args=(uidb64, 'user-activation')),
+            data={'email':'admin@upr.edu', 'username': 'adminupr',
+            'password1': 'Very5trongt0t@11y', 'password2': 'Very5trongt0t@11y'})
 
         # Check if the user is active and credentialed
         self.assertTrue(User.objects.get(email='admin@upr.edu').is_active)
@@ -152,8 +158,15 @@ class TestCredentialing(TestCase):
             'password1':'Very5trongt0t@11y', 'password2':'Very5trongt0t@11y'})
         uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
             mail.outbox[-1].body)[0]
-        response = self.client.get(reverse('activate_user',
-            kwargs={'uidb64':uidb64,'token':token}))
+
+        response = self.client.get(reverse('activate_user', args=(uidb64, token)))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.client.session['_activation_reset_token'], token)
+
+        response = self.client.post(reverse('activate_user',
+            args=(uidb64, 'user-activation')),
+            data={'email': 'admin@upr.edu', 'username': 'adminupr',
+            'password1': 'Very5trongt0t@11y', 'password2': 'Very5trongt0t@11y'})
 
         # The user is not automatically credentialed because the email's
         # credentialing status was already migrated to the other account

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -35,6 +35,7 @@ from notification.utility import (process_credential_complete,
 logger = logging.getLogger(__name__)
 
 
+@sensitive_post_parameters('password1', 'password2')
 def activate_user(request, uidb64, token):
     """
     Page to active the account of a newly registered user.
@@ -295,7 +296,7 @@ def profile_photo(request, username):
     user = User.objects.get(username__iexact=username)
     return utility.serve_file(user.profile.photo.path)
 
-@sensitive_post_parameters('password1', 'password2')
+
 def register(request):
     """
     User registration page

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -6,13 +6,14 @@ import pytz
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.forms import inlineformset_factory, HiddenInput, CheckboxInput
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.template import loader
 from django.urls import reverse
@@ -20,6 +21,7 @@ from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views.decorators.debug import sensitive_post_parameters
+from django.db import transaction
 
 from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
@@ -32,34 +34,65 @@ from notification.utility import (process_credential_complete,
 
 logger = logging.getLogger(__name__)
 
+
 def activate_user(request, uidb64, token):
     """
     Page to active the account of a newly registered user.
+
+    The user will create the password at this stage and then logged in.
     """
+    activation_session_token = '_activation_reset_token'
+    activation_url_token = 'user-activation'
+    title = "Account activation"
+    context = {'title': 'Invalid Activation Link', 'isvalid': False}
+
     try:
         uid = force_text(urlsafe_base64_decode(uidb64))
         user = User.objects.get(pk=uid)
     except (TypeError, ValueError, OverflowError, User.DoesNotExist):
         user = None
 
-    if user is not None and not user.is_active and default_token_generator.check_token(user, token):
-        user.is_active = True
-        # Check legacy credentials
-        check_legacy_credentials(user, user.email)
-        user.save()
-        email = user.associated_emails.first()
-        email.verification_date = timezone.now()
-        email.is_verified = True
-        email.save()
-        logger.info('User activated - {0}'.format(user.email))
-        context = {'title':'Activation Successful', 'isvalid':True}
-    elif user is not None and user.is_active:
-        context = {'title':'Activation Successful', 'isvalid':True}
+    if request.method == 'GET':
+        if token == activation_url_token:
+            session_token = request.session.get(activation_session_token)
+            if default_token_generator.check_token(user, session_token):
+                # If the token is valid, display the password reset form.
+                form = forms.ActivationForm(user=user)
+                return render(request, 'user/activate_user.html', {
+                    'form': form, 'title': title})
+        else:
+            if default_token_generator.check_token(user, token):
+                # Store the token in the session and redirect to the
+                # password reset form at a URL without the token. That
+                # avoids the possibility of leaking the token in the
+                # HTTP Referer header.
+                request.session[activation_session_token] = token
+                redirect_url = request.path.replace(token, activation_url_token)
+                return HttpResponseRedirect(redirect_url)
     else:
-        logger.warning('Invalid Activation Link')
-        context = {'title':'Invalid Activation Link', 'isvalid':False}
+        if token == activation_url_token:
+            session_token = request.session.get(activation_session_token)
+            form = forms.ActivationForm(user=user, data=request.POST)
+            if form.is_valid() and default_token_generator.check_token(user, session_token):
+                with transaction.atomic():
+                    user.set_password(form.cleaned_data['password1'])
+                    user.is_active = True
+                    # Check legacy credentials
+                    check_legacy_credentials(user, user.email)
+                    user.save()
+                    email = user.associated_emails.first()
+                    email.verification_date = timezone.now()
+                    email.is_verified = True
+                    email.save()
+                    request.session.pop(activation_session_token)
+                    logger.info('User activated - {0}'.format(user.email))
+                    messages.success(request, 'The account has been activated.')
+                    login(request, user)
+                    return redirect('project_home')
+            return render(request, 'user/activate_user.html', {'form': form,
+                'title': title})
 
-    return render(request, 'user/activate_user.html', context)
+    return render(request, 'user/activate_user_complete.html', context)
 
 
 def check_legacy_credentials(user, email):

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -52,6 +52,10 @@ def activate_user(request, uidb64, token):
     except (TypeError, ValueError, OverflowError, User.DoesNotExist):
         user = None
 
+    if user.is_active:
+        messages.success(request, 'The account is active.')
+        return redirect('login')
+
     if request.method == 'GET':
         if token == activation_url_token:
             session_token = request.session.get(activation_session_token)


### PR DESCRIPTION
I am using the same method Django uses to reset the password but with the account validation.
Apparently the user token should be kept secret. 

Django uses active accounts by default, so they don't have a mechanism to hide the password on account activation.
I am using a similar or same code as in "django/contrib/auth/views.py".

This would hopefully open leeway to use the same or similar functions on adding an email and activating it.

