### PR TITLE
Fix indent in DirectoryInfo class

### DIFF
--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -35,7 +35,7 @@ class FileInfo():
 
 
 class DirectoryInfo():
-     def __init__(self, name):
+    def __init__(self, name):
         self.name = name
 
 


### PR DESCRIPTION
The indent was five spaces instead of four before the `def __init__` function. This removes that extra space to follow PEP8 guidelines.