### PR TITLE
Fixes URL display for anonymous access #733

### DIFF
--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -66,7 +66,7 @@
           <br>
           {% if anonymous_url %}
             The URL for reviewer access is:
-            <a href="{% url 'anonymous_login' anonymous_url %}" target="_blank">{{ request.get_host }}{% url 'anonymous_login' anonymous_url %}</a>
+            <a href="{% url 'anonymous_login' anonymous_url %}" target="_blank">{{ url_prefix }}{% url 'anonymous_login' anonymous_url %}</a>
           {% endif %}
         </p>
         <div

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -710,6 +710,8 @@ def manage_published_project(request, project_slug, version):
     ro_tasks = [task for (task, read_only) in tasks if read_only]
     rw_tasks = [task for (task, read_only) in tasks if not read_only]
 
+    url_prefix = notification.get_url_prefix(request)
+
     return render(request, 'console/manage_published_project.html',
         {'project': project, 'authors': authors, 'author_emails': author_emails,
          'storage_info': storage_info, 'edit_logs': edit_logs,
@@ -719,7 +721,7 @@ def manage_published_project(request, project_slug, version):
          'data_access_form': data_access_form, 'data_access': data_access,
          'rw_tasks': rw_tasks, 'ro_tasks': ro_tasks,
          'anonymous_url': anonymous_url, 'passphrase': passphrase,
-         'published_projects_nav': True})
+         'published_projects_nav': True, 'url_prefix': url_prefix})
 
 
 @login_required


### PR DESCRIPTION
Replace `request.get_host`  with `url_prefix` as generated from the `notification.utility.url_prefix` function. This adds the correct version of either `http` or `https` to the displayed anonymous URL.