### PR TITLE
Minor change to combine the get_full_name methods

### DIFF
--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -405,7 +405,7 @@ def generate_doi_info(project, core_project=False, publish=False):
     for author in author_list:
         authors.append({"givenName": author.first_names,
                         "familyName": author.last_name,
-                        "name": author.get_full_name_srs()})
+                        "name": author.get_full_name(reverse=True)})
 
     description = project.abstract_text_content()
     payload = {

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -265,14 +265,17 @@ class PublishedAuthor(BaseAuthor):
         unique_together = (('user', 'project'),
                            ('display_order', 'project'))
 
-    def get_full_name(self):
-        return ' '.join([self.first_names, self.last_name])
-
-    def get_full_name_srs(self):
+    def get_full_name(self, reverse=False):
         """
-        Return the full name in SRS format
+        Return the full name.
+        Args:
+            reverse: Format of the return string. If False (default) then
+                'firstnames lastname'. If True then 'lastname, firstnames'.
         """
-        return ', '.join([self.last_name, self.first_names])
+        if reverse:
+            return ', '.join([self.last_name, self.first_names])
+        else:
+            return ' '.join([self.first_names, self.last_name])
 
     def set_display_info(self):
         """


### PR DESCRIPTION
Currently the PublishedAuthor object has two methods to get the full name:

- `get_full_name_srs()` which returns a name in the form "Mark, Roger"
- `get_full_name()` method which returns a name in the form "Roger Mark".

This combines the two methods.