### PR TITLE
Refactor DOI utility functions. Improve metadata.

### DIFF
--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -276,4 +276,4 @@ class TestState(TestMixin):
             self.assertEqual(project.doi, '10.0000/aaa')
             self.assertEqual(project.core_project.doi, '10.0000/bbb')
 
-        self.assertEqual(mocker.call_count, 6)
+        self.assertEqual(mocker.call_count, 4)

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -261,7 +261,7 @@ class TestState(TestMixin):
                 {'data': {'attributes': {'state': 'draft'}}})},
         ])
 
-        # Updating DOI state (console.utility.send_doi_update)
+        # Updating DOI state (console.utility.update_doi)
         mocker.put('https://api.datacite.example/dois/10.0000/aaa')
         mocker.put('https://api.datacite.example/dois/10.0000/bbb')
 

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -242,7 +242,7 @@ class TestState(TestMixin):
         """
 
         # Initial creation of draft DOIs
-        # (console.utility.create_doi_draft)
+        # (console.utility.register_doi)
         mocker.post('https://api.datacite.example/dois', [
             {'text': json.dumps(
                 {'data': {'attributes': {'doi': '10.0000/aaa'}}})},

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -357,52 +357,93 @@ def update_doi(doi, payload):
                                                                    title, doi))
 
 
-def generate_doi_info(project, core_project=False, publish=False):
+def generate_doi_payload(project, core_project=False, event="draft"):
     """
-    Generate the payload and url to be used to update a DOI information.
+    Generate a payload for registering or updating a DOI.
 
-    Returns the payload that will publish or update the DOI and its URL
+    Args:
+        project (obj): Project object.
+        core_project (bool): If the metadata relates to the core project
+            then core_project=True, else core_project=False.
+        event (str): Either "draft" or "publish".
+
+    Returns:
+        payload (dict): The metadata to be sent to the DataCite API.
     """
     current_site = Site.objects.get_current()
-    #
-    url = '{0}/{1}'.format(settings.DATACITE_API_URL, project.doi)
-    project_url = "https://{0}{1}".format(current_site, reverse(
-        'published_project', args=(project.slug, project.version)))
+
+    if event == "publish" and core_project:
+        project_url = "https://{0}{1}".format(current_site, reverse(
+            'published_project_latest', args=(project.slug,)))
+    elif event == "publish":
+        project_url = "https://{0}{1}".format(current_site, reverse(
+            'published_project', args=(project.slug, project.version)))
+    else:
+        project_url = ""
 
     if core_project:
-        url = '{0}/{1}'.format(settings.DATACITE_API_URL,
-            project.core_project.doi)
-        project_url = "https://{0}/{1}".format(current_site, reverse(
-            'published_project_latest', args=(project.slug,)))
+        version = "latest"
+    else:
+        version = project.version
 
-    author_list = project.author_list().order_by('display_order')
     authors = []
-    for author in author_list:
-        authors.append({"givenName": author.first_names,
-                        "familyName": author.last_name,
-                        "name": author.get_full_name(reverse=True)})
+    if event == "publish":
+        author_list = project.author_list().order_by('display_order')
+        for author in author_list:
+            authors.append({"givenName": author.first_names,
+                            "familyName": author.last_name,
+                            "name": author.get_full_name(reverse=True)})
 
-    description = project.abstract_text_content()
+    # link to parent or child projects
+    if event == "publish" and core_project:
+        # add children if core project
+        versions = project.core_project.get_published_versions()
+        relation = []
+        for v in versions:
+            relation.append({"relationType": "HasVersion",
+                             "relatedIdentifier": v.doi,
+                             "relatedIdentifierType": "DOI"})
+    elif event == "publish":
+        # add parent if not core project
+        relation = [{
+          "relationType": "IsVersionOf",
+          "relatedIdentifier": project.core_project.doi,
+          "relatedIdentifierType": "DOI"
+        }]
+    else:
+        relation = []
+
+    resource_type = 'Dataset'
+    if project.resource_type.name == 'Software':
+        resource_type = 'Software'
+
     payload = {
         "data": {
             "type": "dois",
             "attributes": {
+                "event": event,
+                "prefix": settings.DATACITE_PREFIX,
                 "titles": [{
                     "title": project.title
                 }],
+                "publisher": current_site.name,
                 "publicationYear": timezone.now().year,
+                "types": {
+                    "resourceTypeGeneral": resource_type
+                },
                 "creators": authors,
+                "version": version,
                 "descriptions": [{
-                    "description": description,
+                    "description": project.abstract_text_content(),
                     "descriptionType": "Abstract"
                 }],
-                "url": project_url
+                "url": project_url,
+                "relatedIdentifiers": relation,
             }
         }
     }
-    if publish:
-        payload["data"]["attributes"]["event"] = "publish"
-    return payload, url
+
+    return payload
 
 
 def get_doi_status(project_doi):

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -490,9 +490,24 @@ def publish_submission(request, project_slug, *args, **kwargs):
             published_project = project.publish(slug=slug,
                 make_zip=int(publish_form.cleaned_data['make_zip']))
             notification.publish_notify(request, published_project)
-            utility.publish_doi(published_project)
+
+            # update the core and project DOIs with latest metadata
+            if published_project.core_project.doi:
+                payload_core = utility.generate_doi_payload(published_project,
+                                                            core_project=True,
+                                                            event="publish")
+                utility.update_doi(published_project.core_project.doi,
+                                   payload_core)
+
+            if published_project.doi:
+                payload = utility.generate_doi_payload(published_project,
+                                                       core_project=False,
+                                                       event="publish")
+                utility.update_doi(published_project.doi, payload)
+
             return render(request, 'console/publish_complete.html',
                 {'published_project': published_project, 'editor_home': True})
+
     publishable = project.is_publishable()
     url_prefix = notification.get_url_prefix(request)
     publish_form = forms.PublishForm(project=project)

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -493,7 +493,9 @@ def publish_submission(request, project_slug, *args, **kwargs):
 
             # update the core and project DOIs with latest metadata
             if published_project.core_project.doi:
-                payload_core = utility.generate_doi_payload(published_project,
+                core = published_project.core_project
+                latest = core.publishedprojects.get(is_latest_version=True)
+                payload_core = utility.generate_doi_payload(latest,
                                                             core_project=True,
                                                             event="publish")
                 utility.update_doi(published_project.core_project.doi,

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -406,6 +406,12 @@ class CoreProject(models.Model):
         "Whether there is a new version being worked on"
         return bool(self.activeprojects.filter())
 
+    def get_published_versions(self):
+        """
+        Return a queryset of PublishedProjects, sorted by version.
+        """
+        return self.publishedprojects.filter().order_by('version_order')
+
 
 class ProjectType(models.Model):
     """


### PR DESCRIPTION
This set of changes builds on Felipe's work on integrating PhysioNet with the DataCite API. The changes are briefly outlined below.

1) The DOI utility functions have been refactored so that we now have:
- `generate_doi_payload()` to generate a set of metadata to be uploaded via the DataCite API.
- `register_doi()` to register a DOI.
- `update_doi` to update the status of a registered DOI. 

2) Relationships between the core DOI and the version DOI are now captured in the metadata. The core project will list versions in the `HasVersion` attribute, and the versions will list the core project in the `IsVersionOf` attribute.

These changes help to avoid duplication of the payload metadata, and I think make things simpler.

#### An example of "draft" DOI metadata is below:

```
{
  "id": "https://doi.org/10.7966/fp69-se96",
  "doi": "10.7966/FP69-SE96",
  "url": "",
  "types": {
    "resourceTypeGeneral": "Dataset"
  },
  "creators": [],
  "titles": [
    {
      "title": "TEST1"
    }
  ],
  "publisher": "PhysioNet-dev",
  "publicationYear": 2020,
  "descriptions": [
    {
      "description": "Test\n",
      "descriptionType": "Abstract"
    }
  ],
  "relatedIdentifiers": [],
  "providerId": "physiont",
  "clientId": "physiont.physiont",
  "agency": "DataCite",
  "state": "draft"
}
```

#### An example of findable DOI metadata for a (latest version) core project is:

```
{
  "id": "https://doi.org/10.7966/26sk-ks61",
  "doi": "10.7966/26SK-KS61",
  "url": "https://localhost:8000//content/demoeicu/",
  "types": {
    "resourceTypeGeneral": "Dataset"
  },
  "creators": [
    {
      "name": "Mark, Roger Greenwood",
      "givenName": "Roger Greenwood",
      "familyName": "Mark"
    }
  ],
  "titles": [
    {
      "title": "Demo eICU Collaborative Research Database"
    }
  ],
  "publisher": "PhysioNet-dev",
  "publicationYear": 2020,
  "descriptions": [
    {
      "description": "The eICU Collaborative Research Database is a large multi-center critical care\ndatabase made available by Philips Healthcare in partnership with the MIT\nLaboratory for Computational Physiology.\n\n",
      "descriptionType": "Abstract"
    }
  ],
  "relatedIdentifiers": [
    {
      "relationType": "HasVersion",
      "relatedIdentifier": "10.13026/G2F309",
      "relatedIdentifierType": "DOI"
    }
  ],
  "providerId": "physiont",
  "clientId": "physiont.physiont",
  "agency": "DataCite",
  "state": "findable"
}
```

#### An example of findable DOI metadata for a (versioned) project is:

```
{
  "id": "https://doi.org/10.7966/d31d-z235",
  "doi": "10.7966/D31D-Z235",
  "url": "https://localhost:8000/content/demoeicu/2.1.0/",
  "types": {
    "resourceTypeGeneral": "Dataset"
  },
  "creators": [
    {
      "name": "Mark, Roger Greenwood",
      "givenName": "Roger Greenwood",
      "familyName": "Mark"
    }
  ],
  "titles": [
    {
      "title": "Demo eICU Collaborative Research Database"
    }
  ],
  "publisher": "PhysioNet-dev",
  "publicationYear": 2020,
  "descriptions": [
    {
      "description": "The eICU Collaborative Research Database is a large multi-center critical care\ndatabase made available by Philips Healthcare in partnership with the MIT\nLaboratory for Computational Physiology.\n\n",
      "descriptionType": "Abstract"
    }
  ],
  "relatedIdentifiers": [
    {
      "relationType": "IsVersionOf",
      "relatedIdentifier": "10.7966/26sk-ks61",
      "relatedIdentifierType": "DOI"
    }
  ],
  "providerId": "physiont",
  "clientId": "physiont.physiont",
  "agency": "DataCite",
  "state": "findable"
}
```

This pull request incorporates several of the changes in #892. To address a couple of the points raised in that pull request:

> If you think it's really important to publish the project and assign DOIs in a *single form submission*, I would advise splitting it up similar to how Felipe originally wrote it:
> - create draft DOI(s) and save them to the CoreProject/ActiveProject
> - call project.publish and notification.publish_notify
> - update and publish the DOIs with the final metadata

This is no longer an issue, because the draft will be registered at the acceptance stage as before. If we decide to allow assignment of DOIs in a single form submission in future, I don't think the draft -> findable workflow will work, because there is too much latency in the DataCite system (this is what led to my refactoring in the first place). If you try to update a newly registered DOI, you'll end up with a DOI not found error.

> 3. It looks to me like you're not filling in the HasVersion correctly
> for the newly-published version (your example above has a
> "relatedIdentifier" of null.)  To create two DOIs that are both
> pointing to each other, you *have* to make at least three requests to
> the API :)

Well spotted! This should now be fixed, because the published project object exists when the payload is sent.
