### PR TITLE
Purge unactivated accounts

### DIFF
--- a/deploy/production/etc/cron.d/physionet
+++ b/deploy/production/etc/cron.d/physionet
@@ -12,3 +12,4 @@
 
 # Remove expired Django sessions
 31 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.production /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py clearsessions
+35 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.production /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py purgeaccounts

--- a/deploy/staging/etc/cron.d/physionet
+++ b/deploy/staging/etc/cron.d/physionet
@@ -12,3 +12,4 @@
 
 # Remove expired Django sessions
 31 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.staging /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py clearsessions
+35 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.staging /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py purgeaccounts

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -1,0 +1,31 @@
+import logging
+from datetime import date
+
+from django.core.management.base import BaseCommand
+
+from user.models import User
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        """
+        For each app, write the fixture data
+        """
+        user_list = User.objects.filter(is_active=False)
+        today = date.today()
+        deleted = []
+        for user in user_list:
+            dates = today - user.join_date
+            if dates.days >= 7:
+                deleted.append(" - Username: {0}\n   Email: {1}\n   "
+                               "Full Name: {2}".format(user.username,
+                                                       user.email,
+                                                       user.get_full_name()))
+                user.delete()
+        LOGGER.info("The following accounts were removed:")
+        for line in deleted:
+            print(line)
+        LOGGER.info("Total accounts removed {}".format(len(deleted)))

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import date, timedelta
 
 from django.core.management.base import BaseCommand
 
@@ -12,10 +12,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """
-        For each app, write the fixture data
+        Delete all user accounts after 7 days of creation if they were not
+        activated.
         """
-        user_list = User.objects.filter(is_active=False)
         today = date.today()
+        limit = today - timedelta(days=7)
+        user_list = User.objects.filter(is_active=False, join_date__lt=limit)
         deleted = []
         for user in user_list:
             dates = today - user.join_date

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         deleted = []
         for user in user_list:
             dates = today - user.join_date
-            deleted.append(" - Username: {0}\n   Email: {1}\n   Full Name: "
+            deleted.append("\n - Username: {0}\n   Email: {1}\n   Full Name: "
                            "{2}".format(user.username, user.email,
                                         user.get_full_name()))
             user.delete()

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -21,12 +21,11 @@ class Command(BaseCommand):
         deleted = []
         for user in user_list:
             dates = today - user.join_date
-            if dates.days >= 7:
-                deleted.append(" - Username: {0}\n   Email: {1}\n   "
-                               "Full Name: {2}".format(user.username,
-                                                       user.email,
-                                                       user.get_full_name()))
-                user.delete()
+            deleted.append(" - Username: {0}\n   Email: {1}\n   Full Name: "
+                           "{2}".format(user.username, user.email,
+                                        user.get_full_name()))
+            user.delete()
+
         LOGGER.info("The following accounts were removed:")
         for line in deleted:
             LOGGER.info(line)

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -29,5 +29,5 @@ class Command(BaseCommand):
                 user.delete()
         LOGGER.info("The following accounts were removed:")
         for line in deleted:
-            print(line)
+            LOGGER.info(line)
         LOGGER.info("Total accounts removed {}".format(len(deleted)))


### PR DESCRIPTION
A cronjob is created to run the command to purge the accounts.

I added a command to the Django management in which once runned
it will remove all unactivated accounts after 7 days of creation.

No notice to the user is given at this time.

Closing issue #795