### PR TITLE
Automatically run doctests

### DIFF
--- a/physionet-django/physionet/tests.py
+++ b/physionet-django/physionet/tests.py
@@ -1,6 +1,6 @@
 import doctest
 
-from notification import utility
+from physionet import utility
 
 # Automatically run documentation tests in these modules.
 DOCTEST_MODULES = [


### PR DESCRIPTION
The doctest module provides a convenient way to write simple unit tests that also serve as API documentation (or documentation that also functions as a test case).

These changes add doctests (for the notification.utility and physionet.utility modules) to the Django testing framework so that 'manage.py' runs them automatically.
