### PR TITLE
Display DOIs on the copyedit page of the console

### DIFF
--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -11,6 +11,11 @@
       <li class="nav-item">
         <a class="nav-link {% if passphrase %} active {% endif %}" id="anonymous-tab" data-toggle="tab" href="#anonymous" role="tab" aria-controls="anonymous" aria-selected="false">Anonymous Access</a>
       </li>
+      {% if project.submission_status >= 40 %}
+      <li class="nav-item">
+        <a class="nav-link" id="doi-tab" data-toggle="tab" href="#doi" role="tab" aria-controls="timeline" aria-selected="false">DOIs</a>
+      </li>
+      {% endif %}
     </ul>
   </div>
   <div class="card-body">
@@ -79,8 +84,19 @@
             Revoke access
           </button>
           {% endif %}
-
         </form>
+      </div>
+      {# Draft DOI #}
+      <div class="tab-pane fade" id="doi" role="tabpanel" aria-labelledby="doi-tab">
+        <p>The following DOIs have been registered for the project. These may be useful 
+          if a formal citation is required in advance of publication (for example, if the 
+          project is being announced in a press release or cited in paper). DOIs will 
+          become active when the project is published.</p>
+        <div class="alert alert-success">
+          <strong>Core project (Latest version)</strong>: https://doi.org/{{ project.core_project.doi }}<br />
+          <strong>This version (version {{ project.version }})</strong>: https://doi.org/{{ project.doi }}
+        </div>
+      </form>
       </div>
     </div>
   </div>

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -93,8 +93,19 @@
           project is being announced in a press release or cited in paper). DOIs will 
           become active when the project is published.</p>
         <div class="alert alert-success">
-          <strong>Core project (Latest version)</strong>: https://doi.org/{{ project.core_project.doi }}<br />
-          <strong>This version (version {{ project.version }})</strong>: https://doi.org/{{ project.doi }}
+          <strong>Core project (Latest version)</strong>: 
+          {% if project.core_project.doi %}
+          https://doi.org/{{ project.core_project.doi }}
+          {% else %}
+          The core project does not have a DOI.
+          {% endif %}
+          <br />
+          <strong>This version (version {{ project.version }})</strong>:
+          {% if project.doi %}
+          https://doi.org/{{ project.doi }}
+          {% else %}
+          The project version does not have a DOI.
+          {% endif %}
         </div>
       </form>
       </div>


### PR DESCRIPTION
This adds a tab to the copyedit page in the console that displays DOIs that have been registered:

![Screen Shot 2020-03-04 at 16 59 25](https://user-images.githubusercontent.com/822601/76021014-8124f180-5ef2-11ea-8f16-7b0357a6ab7c.png)
