### PR TITLE
Error handling when requesting project AWS access

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_aws_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_aws_access_request.html
@@ -1,10 +1,25 @@
 Dear {{ user.get_full_name }},
 
-You have requested access to use {{ project }} in AWS S3 Storage.
+You are receiving this email because you applied for access to {{ project }} on Amazon Web Services.
+
+{% if successful %}
+We are pleased to confirm that you have been granted access to use {{ project }} in AWS S3 Storage.
 
 The name of the bucket is: {{ data_access.location }}
 
 You can use the following command to copy the content of the bucket to your computer:
 aws s3 sync {{ data_access.location }} DESTINATION
+{% else %}
+We are sorry to say that we were unable to grant access to use {{ project }} in AWS S3 Storage at this time.
+
+Reasons might include:
+ - The service is not available in your location.
+ - An incorrect AWS ID was used.
+ - The service requested is no longer available.
+
+Please reapply for access if you are able to address the issue.
+
+If you think this was an error please contact {{ contact_email }}.
+{% endif %}
 
 {{ signature }}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -597,12 +597,14 @@ def notify_gcp_access_request(data_access, user, project):
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [email], fail_silently=False)
 
-def notify_aws_access_request(user, project, data_access):
+def notify_aws_access_request(user, project, data_access, successful):
     subject = 'PhysioNet Amazon Web Service storage access'
     body = loader.render_to_string(
         'notification/email/notify_aws_access_request.html', {
             'user': user,
             'project': project,
+            'successful': successful,
+            'contact_email': settings.CONTACT_EMAIL,
             'signature': email_signature(),
             'footer': email_footer(),
             'data_access': data_access

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -310,14 +310,14 @@
               {% if item.platform == 1 %} {# ID for AWS open data #}
                 <li>Access using AWS <a href="{{item.location}}">Open Data repository</a></li>
               {% elif item.platform == 2 %} {# ID for AWS cloud bucket #}
-                <li><a href="{% url 'project_request_access' project.slug project.version 2 %}">Request access</a> to the data using AWS command line tools: <pre class="shell-command">aws s3 sync {{item.location}} DESTINATION</pre></li>
+                <li><a href="{% url 'published_project_request_access' project.slug project.version 2 %}">Request access</a> to the data using AWS command line tools: <pre class="shell-command">aws s3 sync {{item.location}} DESTINATION</pre></li>
               {% elif item.platform == 3 %} {# ID for Google cloud bucket email #}
                 {% if project.gcp and project.gcp.sent_files %}
-                    <li><a href="{% url 'project_request_access' project.slug project.version 3 %}">Request access</a> to the files using the <a href="https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}/">Google Cloud Storage Browser</a>. Login with a Google account is required.</li>
+                    <li><a href="{% url 'published_project_request_access' project.slug project.version 3 %}">Request access</a> to the files using the <a href="https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}/">Google Cloud Storage Browser</a>. Login with a Google account is required.</li>
                 {% endif %}
 
               {% elif item.platform == 4 %} {# ID for google BigQuery email #}
-                <li><a href="{% url 'project_request_access' project.slug project.version 4 %}">Request access</a> using Google BigQuery.</li>
+                <li><a href="{% url 'published_project_request_access' project.slug project.version 4 %}">Request access</a> using Google BigQuery.</li>
               {% endif %}
             {% endfor %}
           {% endif %}
@@ -356,7 +356,7 @@
             {% elif item.platform == 2 %} {# ID for AWS cloud bucket #}
               <li>Access the data using AWS command line tools: <pre class="shell-command">aws s3 sync {{item.location}} DESTINATION</pre></li>
             {% elif item.platform == 4 %} {# ID for google BigQuery #}
-              <li><a href="{% url 'project_request_access' project.slug project.version 4 %}">Request access</a> using Google BigQuery.</li>
+              <li><a href="{% url 'published_project_request_access' project.slug project.version 4 %}">Request access</a> using Google BigQuery.</li>
             {% endif %}
           {% endfor %}
         {% endif %}

--- a/physionet-django/project/urls.py
+++ b/physionet-django/project/urls.py
@@ -79,7 +79,8 @@ urlpatterns = [
         name='project_submission'),
 
     path('<project_slug>/<version>/request_access/<int:access_type>',
-        views.project_request_access, name='project_request_access'),
+        views.published_project_request_access,
+        name='published_project_request_access'),
 
     re_path('^(?P<project_slug>\w+)/download/(?P<full_file_name>.*)$',
         views.serve_active_project_file_editor,

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -265,6 +265,7 @@ def get_form_errors(form):
         all_errors += form.errors[field]
     return all_errors
 
+
 def grant_aws_open_data_access(user, project):
     """
     Function to grant a AWS ID access to the bukets in the Open Data
@@ -278,11 +279,18 @@ def grant_aws_open_data_access(user, project):
         settings.AWS_HEADER_KEY2: settings.AWS_HEADER_VALUE2}
     # Do a request to AWS and try to add the user ID to the bucket
     response = requests.post(url, data=json.dumps(payload), headers=headers)
-    message = response.json()['message'].split(',')[0]
-    # The message can differ if the ID is already there, or non-existent
-    LOGGER.info("AWS message '{0}' for project {1}".format(
-        response.json()['message'], project))
-    return message
+    try:
+        message = response.json()['message'].split(',')[0]
+        # The message can differ if the ID is already there, or non-existent
+        LOGGER.info("AWS message '{0}' for project {1}".format(
+            response.json()['message'], project))
+        return message
+    except AttributeError:
+        LOGGER.info("Invalid AWS ID: {0} on user: {1} for the current bucket "
+            "policy.\nError: {2}".format(user.cloud_information.aws_id,
+                                         user, response.json()['error']))
+        message = "Access could not be granted."
+
 
 
 def grant_gcp_group_access(user, project, data_access):

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -270,6 +270,16 @@ def grant_aws_open_data_access(user, project):
     """
     Function to grant a AWS ID access to the bukets in the Open Data
     AWS platform.
+
+    Possible responses are:
+
+    b'{"error": "Unexpected error: An error occurred (MalformedPolicy) when
+        calling the PutBucketPolicy operation: Invalid principal in policy",
+        "message": null}'
+    b'{"error": "None", "message": "Accounts [\'XXXYYYZZZ\'] have been added,
+        accounts [] have been skipped since already exist, accounts [] have
+        been deleted since policy is too large"}'
+    b'{"error": "None", "message": "No new accounts to add"}'
     """
     url = settings.AWS_CLOUD_FORMATION
     # The payload has to be a string in an array
@@ -279,17 +289,24 @@ def grant_aws_open_data_access(user, project):
         settings.AWS_HEADER_KEY2: settings.AWS_HEADER_VALUE2}
     # Do a request to AWS and try to add the user ID to the bucket
     response = requests.post(url, data=json.dumps(payload), headers=headers)
-    try:
-        message = response.json()['message'].split(',')[0]
-        # The message can differ if the ID is already there, or non-existent
-        LOGGER.info("AWS message '{0}' for project {1}".format(
-            response.json()['message'], project))
+
+    if response.status_code < 200 or response.status_code >= 300:
+        LOGGER.info("Error sending adding the AWS ID to the Bucket Policy."
+                    "The request payload is {0}\nThe errror is the following: "
+                    "{1}\n".format(payload, response.content))
+        return "Access could not be granted."
+
+    message = response.json()['message']
+    if message == "No new accounts to add":
+        LOGGER.info("AWS response adding {0} to project {1}\n{2}".format(
+            user.cloud_information.aws_id, project, message))
         return message
-    except AttributeError:
-        LOGGER.info("Invalid AWS ID: {0} on user: {1} for the current bucket "
-            "policy.\nError: {2}".format(user.cloud_information.aws_id,
-                                         user, response.json()['error']))
-        message = "Access could not be granted."
+    elif "Accounts ['{}'] have been added".format(user.cloud_information.aws_id) in message:
+        LOGGER.info("AWS response adding {0} to project {1}\n{2}".format(
+            user.cloud_information.aws_id, project, message))
+        return message.split(',')[0]
+    LOGGER.info('Unknown response from AWS - {0}\nThe payload is {1}'.format(
+        payload, response.content))
 
 
 

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -307,7 +307,7 @@ def grant_aws_open_data_access(user, project):
         return message.split(',')[0]
     LOGGER.info('Unknown response from AWS - {0}\nThe payload is {1}'.format(
         payload, response.content))
-
+    return "There was an error granting access."
 
 
 def grant_gcp_group_access(user, project, data_access):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1849,8 +1849,14 @@ def published_project_request_access(request, project_slug, version, access_type
     for access in data_access:
         if access_type == 2 and access.platform == access_type:
             message = utility.grant_aws_open_data_access(user, project)
-            notification.notify_aws_access_request(user, project, access)
-            messages.success(request, message)
+            error_messages = ["Access could not be granted.",
+                              "There was an error granting access."]
+            if message not in error_messages:
+                notification.notify_aws_access_request(user, project, access, True)
+                messages.success(request, message)
+            else:
+                notification.notify_aws_access_request(user, project, access, False)
+                messages.error(request, message)
         elif access_type in [3, 4] and access.platform == access_type:
             message = utility.grant_gcp_group_access(user, project, access)
             if message:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1821,7 +1821,7 @@ def data_access_request_view(request, project_slug, version, user_id):
 
 
 @login_required
-def project_request_access(request, project_slug, version, access_type):
+def published_project_request_access(request, project_slug, version, access_type):
     """
     Page to grant access to AWS storage, Google storage or Big Query
     to a specific user.


### PR DESCRIPTION
There is/were an issue with the function to grant access to MIMIC using AWS cloud formation.

The reason is because of the AWS/China.

The only workaround given to us by AWS was to put a copy of MIMIC in a AWS owned by a Chinese collaborator. This fixes the error by ignoring it until a better solution is found.

Fixes #727 