### PR TITLE
Adds 'Load More' button for news #777

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -53,13 +53,26 @@
 
   <!-- Latest news and announcements -->
   {% if news %}
-  <div class="alert alert-primary" role="alert">
-    {% for new in news %}
-      <strong>{{ new.title|safe }}</strong>
-      <em>({{ new.publish_datetime }})</em>
-      {{ new.content|safe }}
-    {% endfor %}
-  </div>
+    <div class="alert alert-primary" role="alert">
+      {% for new in news %}
+        {% if news|length > 2 %}
+          {% if forloop.counter == 3 %}
+            <details><summary>More news</summary>
+          {% endif %}
+        {% endif %}
+        <p>  
+          <strong>{{ new.title|safe }}</strong>
+          <em>({{ new.publish_datetime }})</em>
+          {{ new.content|safe }}
+          {% if news|length > 2 %}
+            {% if forloop.counter == news|length %}</span>{% endif %}
+          {% endif %}
+        </p>
+      {% endfor %}
+      {% if news|length > 2 %}
+        </details>
+      {% endif %}
+    </div>
   {% endif %}
 
   <div class="row">


### PR DESCRIPTION
Adds button which gives users the option to view more news or collapse after finishing reading. This prevents the entire news section from being displayed without the user's preference and therefore reduces the starting page length. The button is first a dropdown which says "View all announcements" then converts to a dropup which says "View less" after clicked. If the "View less" dropup is clicked, then the button will convert back the initial dropdown.