### PR TITLE
Fixed Unicode in schema metadata #863

### DIFF
--- a/physionet-django/project/templates/project/schema_metadata.json
+++ b/physionet-django/project/templates/project/schema_metadata.json
@@ -1,23 +1,23 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",
-  "@type": "{{ project.schema_org_resource_type|escapejs }}",
-  "name": "{{ project.title|escapejs }}",
-  "description": "{{ project.abstract|truncatechars_html:5000|striptags|escapejs }}",
-  "version": "{{ project.version|escapejs }}",
-  "license": "{{ project.license.home_page|escapejs }}",
-  "datePublished" : "{{ project.publish_datetime|date|escapejs }}",
-  "url": "https://{{ current_site }}{% url 'published_project' project.slug|escapejs project.version|escapejs %}",
+  "@type": "{{ project.schema_org_resource_type }}",
+  "name": "{{ project.title }}",
+  "description": "{{ project.abstract|truncatechars_html:5000|striptags }}",
+  "version": "{{ project.version }}",
+  "license": "{{ project.license.home_page }}",
+  "datePublished" : "{{ project.publish_datetime|date }}",
+  "url": "https://{{ current_site }}{% url 'published_project' project.slug project.version %}",
   {% if project.doi %}
-  "identifier": "https://doi.org/{{ project.doi|escapejs }}",
+  "identifier": "https://doi.org/{{ project.doi }}",
   {% endif %}
   "creator": [
   {% for author in authors %}
     {
       "@type": "Person",
-      "givenName": "{{ author.first_names|escapejs }}",
-      "familyName": "{{ author.last_name|escapejs }}",
-      "name": "{{ author.first_names|escapejs }} {{ author.last_name|escapejs }}"
+      "givenName": "{{ author.first_names }}",
+      "familyName": "{{ author.last_name }}",
+      "name": "{{ author.first_names }} {{ author.last_name }}"
     }{% if forloop.counter < authors|length %},{% endif %}
   {% endfor %}
     ],
@@ -28,7 +28,7 @@
   "distribution": [
     {
       "@type": "DataDownload",
-      "contentUrl": "https://{{ current_site }}{% url 'published_project' project.slug|escapejs project.version|escapejs %}#files"
+      "contentUrl": "https://{{ current_site }}{% url 'published_project' project.slug project.version %}#files"
     }
   ]
 }


### PR DESCRIPTION
Removed Unicode that was appearing in the schema metadata as noticed in issue #863. The `escapejs` filter was causing the conversion of Unicode characters directly to their respective encodings instead of the ASCII equivalent. To solve this issue, the `escapejs` filter was removed for each of the values it appeared in.