### PR TITLE
User active check on AnonymousUser

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -54,7 +54,7 @@ def activate_user(request, uidb64, token):
     except (TypeError, ValueError, OverflowError, User.DoesNotExist):
         user = None
 
-    if user.is_active:
+    if user and user.is_active:
         messages.success(request, 'The account is active.')
         return redirect('login')
 


### PR DESCRIPTION
If the user activation link is invalid the error is raised is an `AttributeError` because user is currently an `AnonymousUser` without `is_active` which will always raise the error.

Here I check if the user is None, or a user object to then check the `is_active`.