### PR TITLE
Move temporary files to /data/www-tmp

### DIFF
--- a/deploy/common/etc/tmpfiles.d/physionet.conf
+++ b/deploy/common/etc/tmpfiles.d/physionet.conf
@@ -1,0 +1,6 @@
+# type  path  mode  user  group  age  argument
+
+# /data/www-tmp should be readable/writable only by the web server.
+# Any files there will be removed at boot time or if they have not
+# been accessed for two days.
+D  /data/www-tmp  0700  www-data  root  2d

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -13,6 +13,9 @@ server {
     # max upload size
     client_max_body_size 10G;
 
+    # location for temporary storage of uploaded data
+    client_body_temp_path /data/www-tmp;
+
     #### Public data ####
 
     include /etc/nginx/custom-mime.types;

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -13,6 +13,9 @@ server {
     # max upload size
     client_max_body_size 10G;
 
+    # location for temporary storage of uploaded data
+    client_body_temp_path /data/www-tmp;
+
     #### Public data ####
 
     include /etc/nginx/custom-mime.types;


### PR DESCRIPTION
Avoid filling up the root filesystem when people (try to) upload very large files.  Fixes issue #919.
