### PR TITLE
Adds zipcode to credentialing email #926

### DIFF
--- a/physionet-django/notification/templates/notification/email/mailto_contact_applicant.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_applicant.html
@@ -10,6 +10,7 @@ Organization Name: {{ application.organization_name }}
 Job title or position: {{ application.job_title }}
 City: {{ application.city }}
 State/Province: {{ application.state_province }}
+ZIP/postal code: {{ application.zip_code }}
 Country: {{ application.get_country_display }}
 Webpage: {% if application.webpage %}{{ application.webpage }}{% endif %}
 

--- a/physionet-django/project/templates/project/schema_metadata.json
+++ b/physionet-django/project/templates/project/schema_metadata.json
@@ -1,23 +1,23 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",
-  "@type": "{{ project.schema_org_resource_type|escapejs }}",
-  "name": "{{ project.title|escapejs }}",
-  "description": "{{ project.abstract|truncatechars_html:5000|striptags|escapejs }}",
-  "version": "{{ project.version|escapejs }}",
-  "license": "{{ project.license.home_page|escapejs }}",
-  "datePublished" : "{{ project.publish_datetime|date|escapejs }}",
-  "url": "https://{{ current_site }}{% url 'published_project' project.slug|escapejs project.version|escapejs %}",
+  "@type": "{{ project.schema_org_resource_type }}",
+  "name": "{{ project.title }}",
+  "description": "{{ project.abstract|truncatechars_html:5000|striptags }}",
+  "version": "{{ project.version }}",
+  "license": "{{ project.license.home_page }}",
+  "datePublished" : "{{ project.publish_datetime|date }}",
+  "url": "https://{{ current_site }}{% url 'published_project' project.slug project.version %}",
   {% if project.doi %}
-  "identifier": "https://doi.org/{{ project.doi|escapejs }}",
+  "identifier": "https://doi.org/{{ project.doi }}",
   {% endif %}
   "creator": [
   {% for author in authors %}
     {
       "@type": "Person",
-      "givenName": "{{ author.first_names|escapejs }}",
-      "familyName": "{{ author.last_name|escapejs }}",
-      "name": "{{ author.first_names|escapejs }} {{ author.last_name|escapejs }}"
+      "givenName": "{{ author.first_names }}",
+      "familyName": "{{ author.last_name }}",
+      "name": "{{ author.first_names }} {{ author.last_name }}"
     }{% if forloop.counter < authors|length %},{% endif %}
   {% endfor %}
     ],
@@ -28,7 +28,7 @@
   "distribution": [
     {
       "@type": "DataDownload",
-      "contentUrl": "https://{{ current_site }}{% url 'published_project' project.slug|escapejs project.version|escapejs %}#files"
+      "contentUrl": "https://{{ current_site }}{% url 'published_project' project.slug project.version %}#files"
     }
   ]
 }

--- a/physionet-django/project/templates/project/schema_metadata.json
+++ b/physionet-django/project/templates/project/schema_metadata.json
@@ -1,23 +1,23 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",
-  "@type": "{{ project.schema_org_resource_type }}",
-  "name": "{{ project.title }}",
-  "description": "{{ project.abstract|truncatechars_html:5000|striptags }}",
-  "version": "{{ project.version }}",
-  "license": "{{ project.license.home_page }}",
-  "datePublished" : "{{ project.publish_datetime|date }}",
-  "url": "https://{{ current_site }}{% url 'published_project' project.slug project.version %}",
+  "@type": "{{ project.schema_org_resource_type|escapejs }}",
+  "name": "{{ project.title|escapejs }}",
+  "description": "{{ project.abstract|truncatechars_html:5000|striptags|escapejs }}",
+  "version": "{{ project.version|escapejs }}",
+  "license": "{{ project.license.home_page|escapejs }}",
+  "datePublished" : "{{ project.publish_datetime|date|escapejs }}",
+  "url": "https://{{ current_site }}{% url 'published_project' project.slug|escapejs project.version|escapejs %}",
   {% if project.doi %}
-  "identifier": "https://doi.org/{{ project.doi }}",
+  "identifier": "https://doi.org/{{ project.doi|escapejs }}",
   {% endif %}
   "creator": [
   {% for author in authors %}
     {
       "@type": "Person",
-      "givenName": "{{ author.first_names }}",
-      "familyName": "{{ author.last_name }}",
-      "name": "{{ author.first_names }} {{ author.last_name }}"
+      "givenName": "{{ author.first_names|escapejs }}",
+      "familyName": "{{ author.last_name|escapejs }}",
+      "name": "{{ author.first_names|escapejs }} {{ author.last_name|escapejs }}"
     }{% if forloop.counter < authors|length %},{% endif %}
   {% endfor %}
     ],
@@ -28,7 +28,7 @@
   "distribution": [
     {
       "@type": "DataDownload",
-      "contentUrl": "https://{{ current_site }}{% url 'published_project' project.slug project.version %}#files"
+      "contentUrl": "https://{{ current_site }}{% url 'published_project' project.slug|escapejs project.version|escapejs %}#files"
     }
   ]
 }

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -265,6 +265,7 @@
     "job_title": "Professor",
     "city": "Cambridge",
     "state_province": "Massachussetts",
+    "zip_code": "02134",
     "country": "US",
     "webpage": "http://imes.mit.edu/people/faculty/mark-roger/",
     "training_course_name": "CITI Data or Specimens Only Research Course",


### PR DESCRIPTION
This fixes the zipcode not showing up when automatically generating the credentialing email to be sent to applicants. After further investigation, this was due to the zipcode not being included in the `demo-user.json` file as well as the zipcode field not being included in the `mailto_contact_applicant.html` code.