### PR TITLE
Adds zipcode to credentialing email (*Updated*) #926

### DIFF
--- a/physionet-django/notification/templates/notification/email/mailto_contact_applicant.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_applicant.html
@@ -10,6 +10,7 @@ Organization Name: {{ application.organization_name }}
 Job title or position: {{ application.job_title }}
 City: {{ application.city }}
 State/Province: {{ application.state_province }}
+ZIP/postal code: {{ application.zip_code }}
 Country: {{ application.get_country_display }}
 Webpage: {% if application.webpage %}{{ application.webpage }}{% endif %}
 

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -265,6 +265,7 @@
     "job_title": "Professor",
     "city": "Cambridge",
     "state_province": "Massachussetts",
+    "zip_code": "02139",
     "country": "US",
     "webpage": "http://imes.mit.edu/people/faculty/mark-roger/",
     "training_course_name": "CITI Data or Specimens Only Research Course",


### PR DESCRIPTION
This fixes the zipcode not showing up when automatically generating the credentialing email to be sent to applicants.