### PR TITLE
Disables contact reference button #927

### DIFF
--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -10,9 +10,15 @@
     <form action="" method="post" class="form-signin"> <!-- empty action generates error! -->
       <p>
 	{% csrf_token %}
-	<button name="contact_reference" value="{{ application.id }}" type="submit" style="margin-right: 1em;">
-	  Contact Reference
-	</button> 
+	{% if application.known_ref %}
+		<button name="contact_reference" value="{{ application.id }}" type="submit" style="margin-right: 1em;">
+			Contact Reference
+		</button> 
+	{% else %}
+		<button name="contact_reference" value="{{ application.id }}" type="submit" style="margin-right: 1em;" disabled>
+		Contact Reference
+		</button> 
+	{% endif %}
 	{{ application.reference_email }} 
 	{% if application.reference_contact_datetime %}
 		[The {{ application.reference_category|yesno:"reference,supervisor" }} was contacted on {{ application.reference_contact_datetime }}]

--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -10,7 +10,7 @@
     <form action="" method="post" class="form-signin"> <!-- empty action generates error! -->
       <p>
 	{% csrf_token %}
-	{% if application.known_ref %}
+	{% if application.reference_email %}
 		<button name="contact_reference" value="{{ application.id }}" type="submit" style="margin-right: 1em;">
 			Contact Reference
 		</button> 


### PR DESCRIPTION
This disbales the contact reference button if no reference is known or given at the time. The button will still appear but will be unable to be clicked.