### PR TITLE
Appends applicant's email if udacity #927

### DIFF
--- a/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
+++ b/physionet-django/notification/templates/notification/email/mailto_contact_supervisor.html
@@ -8,4 +8,9 @@ Are you {{ applicant_name }}'s supervisor for this project, and is the summary a
 
 Thanks,
 Ken
+
+{% if 'udacity' in application.reference_email %}
+    Applicant's e-mail address: {{ application.user.email }}
+{% endif %}
+
 {% endautoescape %}


### PR DESCRIPTION
This appends the email address of the applicant to the end of the contact reference email if the supervisor being contacted has an email address ending in "@udacity.com". Otherwise, the email is left alone.