### PR TITLE
Fix style of checkbox and other non-text <input>

### DIFF
--- a/physionet-django/static/custom/css/form-control-input.css
+++ b/physionet-django/static/custom/css/form-control-input.css
@@ -1,6 +1,13 @@
 /* Styling of inputs to have the same bootstrap look as form-control elements */
 
-input, select, django-ckeditor-widget, textarea {
+input[type=email],
+input[type=file],
+input[type=password],
+input[type=text],
+input[type=url],
+select,
+django-ckeditor-widget,
+textarea {
   display: block;
   width: 100%;
   padding: 0.5rem 0.75rem;

--- a/physionet-django/static/custom/css/form-control-input.css
+++ b/physionet-django/static/custom/css/form-control-input.css
@@ -3,6 +3,7 @@
 input[type=email],
 input[type=file],
 input[type=password],
+input[type=search],
 input[type=text],
 input[type=url],
 select,

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -249,12 +249,12 @@ a{
   color: white;
 }
 
-.search-input::-webkit-input-placeholder {
+.navbar .search-input::-webkit-input-placeholder {
   color: grey;
   opacity: unset;
 }
 
-.search-input{
+.navbar .search-input{
   border: unset;
   padding: 5px;
   border-radius: 0;


### PR DESCRIPTION
CSS for input elements is badly broken - elements such as checkboxes are made into "display:block;width:100%" - and rather than fixing the broken rule, I see folks trying to work around it (see pull #897) or avoiding using checkboxes entirely (see pull #855).

Our CSS is awful but let's try to make it better!
