### PR TITLE
Fix check for gcp access

### DIFF
--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -304,12 +304,6 @@ def grant_gcp_group_access(user, project, data_access):
 
     try:
         group_members = service.members()
-        # Check is the access was granted and no action is needed
-        members = group_members.list(groupKey=data_access.location).execute()
-        if email in str(members):
-            return '{0} was previously awarded to {1} for project: {2}'.format(
-                access, email, project)
-
         outcome = group_members.insert(groupKey=data_access.location, body={
             "email": email, "delivery_settings": "NONE"}).execute()
         if outcome['role'] == "MEMBER":
@@ -320,6 +314,9 @@ def grant_gcp_group_access(user, project, data_access):
         raise Exception('Wrong access granted to {0} in GCP email {1}'.format(
             email, data_access.location))
     except HttpError as error:
+        if json.loads(error.content)['error']['message'] == 'Member already exists.':
+            return '{0} was previously awarded to {1} for project: {2}'.format(
+                access, email, project)
         raise error
 
 

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -295,9 +295,9 @@ def grant_gcp_group_access(user, project, data_access):
     email = user.cloud_information.gcp_email.email
     service = create_directory_service(settings.GCP_DELEGATION_EMAIL)
     access = ""
-    if data_access == 3:
+    if data_access.platform == 3:
         access = "Access to the GCP bucket"
-    elif data_access == 4:
+    elif data_access.platform == 4:
         access = "Access to the GCP BigQuery"
     else:
         return False

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1619,7 +1619,7 @@ def project_request_access(request, project_slug, version, access_type):
         return redirect('edit_cloud')
 
     for access in data_access:
-        if access_type == 2 and user and access.platform == access_type:
+        if access_type == 2 and access.platform == access_type:
             message = utility.grant_aws_open_data_access(user, project)
             notification.notify_aws_access_request(user, project, access)
             messages.success(request, message)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1619,11 +1619,11 @@ def project_request_access(request, project_slug, version, access_type):
         return redirect('edit_cloud')
 
     for access in data_access:
-        if access_type == 2 and user:
+        if access_type == 2 and user and access.platform == access_type:
             message = utility.grant_aws_open_data_access(user, project)
             notification.notify_aws_access_request(user, project, access)
             messages.success(request, message)
-        elif access_type in [3, 4]:
+        elif access_type in [3, 4] and access.platform == access_type:
             message = utility.grant_gcp_group_access(user, project, access)
             if message:
                 notification.notify_gcp_access_request(access, user, project)


### PR DESCRIPTION
Right now the check will always be a return False because it's doing a comparison of 3 and 4 against an object.

Also, there can be multiple access types like BigQuery and Storage and the person is requesting one. Now I am checking to check if that specific one exists.