### PR TITLE
Delete LICENSE.txt before writing it

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1440,7 +1440,10 @@ class PublishedProject(Metadata, SubmissionInfo):
         """
         Make the license text file
         """
-        with open(os.path.join(self.file_root(), 'LICENSE.txt'), 'w') as outfile:
+        fname = os.path.join(self.file_root(), 'LICENSE.txt')
+        if os.path.isfile(fname):
+            os.remove(fname)
+        with open(fname, 'w') as outfile:
             outfile.write(self.license_content(fmt='text'))
 
         self.set_storage_info()


### PR DESCRIPTION
LICENSE.txt and SHA256SUMS.txt are generated at the time the
project is published.

(I think these are both bad ideas, as I've written before, but
anyway...)

If the project already contains a file called SHA256SUMS.txt, it
is deleted before writing the new one.  However, this was *not*
done for LICENSE.txt.

Compounding the problem, when the project is created, both
SHA256SUMS.txt and LICENSE.txt (along with all other project
files) are automatically linked from the previous published
version.

This meant:

- if the previous version was not correctly read-only-ified,
  then move_files_as_readonly would modify the existing
  LICENSE.txt with the new text.

- if the previous version *was* correctly read-only-ified, then
  move_files_as_readonly would immediately crash because it was
  not able to write to the existing LICENSE.txt.  Thus, it would
  never go on to generate SHA256SUMS.txt, the zip file, the
  storage info, or mark the new files read-only.  And probably
  nobody here ever noticed because we don't get notifications
  about failed background tasks. :/
