### PR TITLE
Add an email notification for failed tasks

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -18,8 +18,6 @@ from django.utils import timezone
 from django.db import DatabaseError, transaction
 from django.db.models import Q, CharField, Value, IntegerField, F, functions
 from background_task import background
-from background_task.models import Task, task_failed, task_rescheduled
-from django.dispatch import receiver
 from django.contrib.sites.models import Site
 
 from notification.models import News
@@ -40,37 +38,6 @@ from console.tasks import associated_task, get_associated_tasks
 from django.conf import settings
 
 LOGGER = logging.getLogger(__name__)
-
-
-@receiver(task_rescheduled, sender=Task)
-def task_rescheduled_handler(sender, **kwargs):
-    """
-    Notify the admins when a task has failed and rescheduled
-    """
-    pdb.set_trace()
-    name = kwargs['task'].verbose_name
-    attempts = kwargs['task'].attempts
-    last_error = kwargs['task'].last_error
-    date_time = kwargs['task'].run_at
-    task_name = kwargs['task'].task_name
-    task_params = kwargs['task'].task_params
-    notification.task_rescheduled_notify(name, attempts, last_error,
-                                         date_time, task_name, task_params)
-
-
-@receiver(task_failed, sender=Task)
-def task_failed_handler(sender, **kwargs):
-    """
-    Notify the admins when a task has failed and removed from queue
-    """
-    name = kwargs['completed_task'].verbose_name
-    attempts = kwargs['completed_task'].attempts
-    last_error = kwargs['completed_task'].last_error
-    date_time = kwargs['completed_task'].failed_at
-    task_name = kwargs['completed_task'].task_name
-    task_params = kwargs['completed_task'].task_params
-    notification.task_failed_notify(name, attempts, last_error, date_time,
-                                    task_name, task_params)
 
 
 @associated_task(PublishedProject, 'pid')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -18,6 +18,8 @@ from django.utils import timezone
 from django.db import DatabaseError, transaction
 from django.db.models import Q, CharField, Value, IntegerField, F, functions
 from background_task import background
+from background_task.models import Task, task_failed, task_rescheduled
+from django.dispatch import receiver
 from django.contrib.sites.models import Site
 
 from notification.models import News
@@ -38,6 +40,37 @@ from console.tasks import associated_task, get_associated_tasks
 from django.conf import settings
 
 LOGGER = logging.getLogger(__name__)
+
+
+@receiver(task_rescheduled, sender=Task)
+def task_rescheduled_handler(sender, **kwargs):
+    """
+    Notify the admins when a task has failed and rescheduled
+    """
+    pdb.set_trace()
+    name = kwargs['task'].verbose_name
+    attempts = kwargs['task'].attempts
+    last_error = kwargs['task'].last_error
+    date_time = kwargs['task'].run_at
+    task_name = kwargs['task'].task_name
+    task_params = kwargs['task'].task_params
+    notification.task_rescheduled_notify(name, attempts, last_error,
+                                         date_time, task_name, task_params)
+
+
+@receiver(task_failed, sender=Task)
+def task_failed_handler(sender, **kwargs):
+    """
+    Notify the admins when a task has failed and removed from queue
+    """
+    name = kwargs['completed_task'].verbose_name
+    attempts = kwargs['completed_task'].attempts
+    last_error = kwargs['completed_task'].last_error
+    date_time = kwargs['completed_task'].failed_at
+    task_name = kwargs['completed_task'].task_name
+    task_params = kwargs['completed_task'].task_params
+    notification.task_failed_notify(name, attempts, last_error, date_time,
+                                    task_name, task_params)
 
 
 @associated_task(PublishedProject, 'pid')

--- a/physionet-django/notification/templates/notification/email/notify_failed_task.html
+++ b/physionet-django/notification/templates/notification/email/notify_failed_task.html
@@ -1,0 +1,15 @@
+Dear admins,
+
+The task "{{ name }}" has made {{ attempts }} attempts and failed.
+
+The task has he been marked as complete and it will not be rescheduled.
+
+The final attempt started at {{ date_time }}.
+
+The task name is: {{ task_name }} and was called with the following parameters: {{ task_params | safe}}.
+
+The last error for this task is:
+
+{{ last_error | safe }}
+
+{{ signature }}

--- a/physionet-django/notification/templates/notification/email/notify_failed_task.html
+++ b/physionet-django/notification/templates/notification/email/notify_failed_task.html
@@ -2,7 +2,7 @@ Dear admins,
 
 The task "{{ name }}" has made {{ attempts }} attempts and failed.
 
-The task has he been marked as complete and it will not be rescheduled.
+The task has been marked as completed and it will not be rescheduled.
 
 The final attempt started at {{ date_time }}.
 

--- a/physionet-django/notification/templates/notification/email/notify_rescheduled_task.html
+++ b/physionet-django/notification/templates/notification/email/notify_rescheduled_task.html
@@ -1,0 +1,15 @@
+Dear admins,
+
+The task "{{ name }}" has failed attempt #{{ attempts }}.
+
+The task is being rescheduled.
+
+The last attempt started at {{ date_time }}.
+
+The task name is: {{ task_name }} and it was called with the following parameters: {{ task_params | safe}}.
+
+The last error for this task is:
+
+{{ last_error | safe}}
+
+{{ signature }}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -609,3 +609,41 @@ def notify_aws_access_request(user, project, data_access):
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [user.email], fail_silently=False)
+
+
+def task_failed_notify(name, attempts, last_error, date_time, task_name, task_params):
+    """
+    Notify when a task has failed and not rescheduled
+    """
+    body = loader.render_to_string(
+        'notification/email/notify_failed_task.html', {
+            'name': name,
+            'attempts': attempts,
+            'last_error': last_error,
+            'date_time': date_time.strftime("%Y-%m-%d %H:%M:%S"),
+            'task_name': task_name,
+            'task_params': task_params,
+            'signature': email_signature()
+        })
+    subject = name + " has failed"
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+              [settings.CONTACT_EMAIL], fail_silently=False)
+
+
+def task_rescheduled_notify(name, attempts, last_error, date_time, task_name, task_params):
+    """
+    Notify when a task has been rescheduled
+    """
+    body = loader.render_to_string(
+        'notification/email/notify_rescheduled_task.html', {
+            'name': name,
+            'attempts': attempts,
+            'last_error': last_error,
+            'date_time': date_time.strftime("%Y-%m-%d %H:%M:%S"),
+            'task_name': task_name,
+            'task_params': task_params,
+            'signature': email_signature()
+        })
+    subject = name + " has been rescheduled"
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+              [settings.CONTACT_EMAIL], fail_silently=False)

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -6,7 +6,7 @@ from email.utils import formataddr
 
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.mail import EmailMessage, send_mail
+from django.core.mail import EmailMessage, send_mail, mail_admins
 from django.template import loader
 
 from project.models import License
@@ -626,8 +626,7 @@ def task_failed_notify(name, attempts, last_error, date_time, task_name, task_pa
             'signature': email_signature()
         })
     subject = name + " has failed"
-    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-              [settings.CONTACT_EMAIL], fail_silently=False)
+    mail_admins(subject, body, settings.DEFAULT_FROM_EMAIL)
 
 
 def task_rescheduled_notify(name, attempts, last_error, date_time, task_name, task_params):
@@ -645,5 +644,4 @@ def task_rescheduled_notify(name, attempts, last_error, date_time, task_name, ta
             'signature': email_signature()
         })
     subject = name + " has been rescheduled"
-    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-              [settings.CONTACT_EMAIL], fail_silently=False)
+    mail_admins(subject, body, settings.DEFAULT_FROM_EMAIL)

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -125,6 +125,9 @@ USE_L10N = True
 
 USE_TZ = True
 
+# Django background tasks max attempts
+MAX_ATTEMPTS = 5
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 


### PR DESCRIPTION
When a task fails it sends a signal.
There are two signals, rescheduled and failed.

Here I capture both signals and send emails on each one.

Also, the default MAX_ATTEMPTS for this is by default 25.
I am reducing this to 5. In theory, if it fails once it will fail
all 5 times because the code should not change that fast.

Closes #937
