### PR TITLE
All published projects should have a DOI

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -77,6 +77,8 @@ class EditSubmissionForm(forms.ModelForm):
 
         labels = EditLog.COMMON_LABELS
 
+        auto_doi = forms.BooleanField(required=False, initial=True)
+
         widgets = {
             'soundly_produced': forms.Select(choices=YES_NO_UNDETERMINED),
             'well_described': forms.Select(choices=YES_NO_UNDETERMINED),
@@ -86,7 +88,8 @@ class EditSubmissionForm(forms.ModelForm):
             'no_phi': forms.Select(choices=YES_NO_UNDETERMINED),
             'pn_suitable': forms.Select(choices=YES_NO_UNDETERMINED),
             'editor_comments': forms.Textarea(),
-            'decision': forms.Select(choices=SUBMISSION_RESPONSE_CHOICES)
+            'decision': forms.Select(choices=SUBMISSION_RESPONSE_CHOICES),
+            'auto_doi': forms.HiddenInput()
         }
 
     def __init__(self, resource_type, *args, **kwargs):
@@ -97,8 +100,9 @@ class EditSubmissionForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.resource_type = resource_type
 
+        self.fields['auto_doi'].disabled = True
+
         if not settings.DATACITE_PREFIX:
-            self.fields['auto_doi'].disabled = True
             self.initial['auto_doi'] = False
 
         # This will be used in clean

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1810,8 +1810,7 @@ class EditLog(models.Model):
         'pn_suitable': 'Is the content suitable for PhysioNet?',
         'editor_comments': 'Comments to authors',
         'no_phi': 'Is the project free of protected health information?',
-        'data_machine_readable': 'Are all files machine-readable?',
-        'auto_doi': 'Automatically assign a new DOI once it has been publish?',
+        'data_machine_readable': 'Are all files machine-readable?'
     }
 
     LABELS = (


### PR DESCRIPTION
All published projects should have a DOI, so this change: 

- Removes the "Auto DOI" flag from the editorial decision form.
- Sets the `auto_doi` flag to True unless `DATACITE_PREFIX` is not configured in the settings.

As far as I can see, it isn't currently possible to select the auto DOI field using the form anyway, so this pull request shouldn't change anything functionally.

I'm unclear about the purpose of the `auto_doi` flag, so we may want to clarify this with a comment in the model. I don't see any issues with keeping it for now.

As @elfeto mentioned, there may be situations where we want to manually assign a DOI (e.g. if a project with an existing DOI is migrated). The field might be helpful in those cases (it can be set to False using the shell for now).

