### PR TITLE
Adds ability to cache static files  #510

### DIFF
--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -56,3 +56,5 @@ STATIC_ROOT = '/data/pn-static'
 if RUNNING_TEST_SUITE:
     MEDIA_ROOT = os.path.join(MEDIA_ROOT, 'test')
     STATIC_ROOT = os.path.join(STATIC_ROOT, 'test')
+
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'


### PR DESCRIPTION
Utilizes the `ManifestStaticFilesStorage` Django subclass to enable caching of static files. This works by appending a MD5 hash to the static file name in order to properly version each instance of the file.