### PR TITLE
Fix legacy publish function

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1948,7 +1948,7 @@ class LegacyProject(models.Model):
         """
         p = PublishedProject.objects.create(title=self.title,
             doi=self.doi, slug=self.slug,
-            resource_type=self.resource_type,
+            resource_type=ProjectType.objects.get(id=self.resource_type),
             core_project=CoreProject.objects.create(),
             abstract=self.abstract,
             is_legacy=True, full_description=self.full_description,


### PR DESCRIPTION
At some point in time the resource type was a number and it was
changed to a ForeignKey to ProjectType.

The chages were done in all places but the project legacy model