### PR TITLE
Check quota and file size using JS before upload

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -86,7 +86,8 @@ class UploadFilesForm(ActiveProjectFilesForm):
     `subdir` is the project subdirectory relative to the file root.
     """
     file_field = forms.FileField(widget=forms.ClearableFileInput(
-        attrs={'multiple': True}), required=False, allow_empty_file=True)
+        attrs={'multiple': True, 'onchange': "check_size('upload');"}), required=False,
+        allow_empty_file=True)
 
     def clean_file_field(self):
         """

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -86,7 +86,7 @@ class UploadFilesForm(ActiveProjectFilesForm):
     `subdir` is the project subdirectory relative to the file root.
     """
     file_field = forms.FileField(widget=forms.ClearableFileInput(
-        attrs={'multiple': True, 'onchange': "check_size('upload');"}), required=False,
+        attrs={'multiple': True, 'onchange': "check_upload_size_limit('upload');"}), required=False,
         allow_empty_file=True)
 
     def clean_file_field(self):

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -1,10 +1,9 @@
 {% load static %}
 
 <div id="forms-and-panel">
-  <form method="post" enctype="multipart/form-data" onsubmit="check_size('submit')">
+  <form method="post" enctype="multipart/form-data" onsubmit="check_upload_size_limit('submit')">
     {% csrf_token %}
     {% include "project/project_files_form.html" %}
-
     <div id="files-panel" class="card">
       <div class="card-header">
         Folder Navigation:
@@ -197,7 +196,7 @@
     document.getElementById("delete-items-message").innerHTML = "Are you sure you wish to delete the "+ n_selected + " selected item(s)?"
   }
 
-  function check_size(stage){
+  function check_upload_size_limit(stage){
     // Check the size of the files to be uploaded and stop the form if the file
     // size exceeds the maximum allowed.
 
@@ -210,19 +209,19 @@
       size = size + files[i].size;
     }
     // Check against the remaining quota
-    if ({{ storage_info.remaining }} - size <= 0){
-      // Set the size in the message to be shown
+    if (size >= {{ storage_info.remaining }}){
+      // Disable the submit button on the form
+      $('#upload-files-button-submit').attr("disabled", true);
+      // Set the size in the message to be shwon
       $('#data_size').text(readableBytes(size))
-      // Minimize the current window
-      $('#upload-files-modal').modal('toggle');
       // Show the message
-      $('#upload_files_quota').modal('toggle');
-      if (stage == 'submit'){
-        // If the form is being submitted prevent the submission
-        $('form').submit(function (evt) {
-          evt.preventDefault();
-        });
-      }
+      $('#error_data_size').show();
+    }
+    else{
+      // Hide the message
+      $('#error_data_size').hide();
+      // Enable the submit button on the form
+      $('#upload-files-button-submit').attr("disabled", false);
     }
   }
 

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <div id="forms-and-panel">
-  <form method="post" enctype="multipart/form-data">
+  <form method="post" enctype="multipart/form-data" onsubmit="check_size('submit')">
     {% csrf_token %}
     {% include "project/project_files_form.html" %}
 
@@ -196,5 +196,41 @@
     setInputRequirements("")
     document.getElementById("delete-items-message").innerHTML = "Are you sure you wish to delete the "+ n_selected + " selected item(s)?"
   }
+
+  function check_size(stage){
+    // Check the size of the files to be uploaded and stop the form if the file
+    // size exceeds the maximum allowed.
+
+    // The size is calculated in bytes
+    files = $('#id_file_field').get(0).files;
+    size = 0;
+    // Add the size of all the files into a single variable
+    for (i = 0; i < files.length; i++)
+    {
+      size = size + files[i].size;
+    }
+    // Check against the remaining quota
+    if ({{ storage_info.remaining }} - size <= 0){
+      // Set the size in the message to be shown
+      $('#data_size').text(readableBytes(size))
+      // Minimize the current window
+      $('#upload-files-modal').modal('toggle');
+      // Show the message
+      $('#upload_files_quota').modal('toggle');
+      if (stage == 'submit'){
+        // If the form is being submitted prevent the submission
+        $('form').submit(function (evt) {
+          evt.preventDefault();
+        });
+      }
+    }
+  }
+
+function readableBytes(bytes) {
+    // Return the size of given bytes in a readable format
+    var i = Math.floor(Math.log(bytes) / Math.log(1024)),
+    sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    return (bytes / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + sizes[i];
+}
 
 </script>

--- a/physionet-django/project/templates/project/project_files.html
+++ b/physionet-django/project/templates/project/project_files.html
@@ -99,6 +99,27 @@
 </div>
 <br>
 
+<div class="modal fade" id="upload_files_quota" tabindex="-1" role="dialog" aria-labelledby="upload_files_quota_label" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="upload_files_quota_label">Project quota exceeded</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>The selected file/s exceed the capacity left in your storage quota.</p>
+        <p>The remaining size is {{ storage_info.readable_remaining }}.</p>
+        <p>The total size of the file/s you are trying to upload is <a id='data_size'></a>.</p>
+        <p>You can request more space by clicking "Request storage".</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 {% if project.has_wfdb %}
   <p><a href="{% url 'lightwave_project_home' project.slug %}?db={{ project.slug }}" target="_blank"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
 {% endif %}

--- a/physionet-django/project/templates/project/project_files.html
+++ b/physionet-django/project/templates/project/project_files.html
@@ -99,27 +99,6 @@
 </div>
 <br>
 
-<div class="modal fade" id="upload_files_quota" tabindex="-1" role="dialog" aria-labelledby="upload_files_quota_label" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="upload_files_quota_label">Project quota exceeded</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <p>The selected file/s exceed the capacity left in your storage quota.</p>
-        <p>The remaining size is {{ storage_info.readable_remaining }}.</p>
-        <p>The total size of the file/s you are trying to upload is <a id='data_size'></a>.</p>
-        <p>You can request more space by clicking "Request storage".</p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
 {% if project.has_wfdb %}
   <p><a href="{% url 'lightwave_project_home' project.slug %}?db={{ project.slug }}" target="_blank"><i class="fas fa-chart-line"></i> Visualize waveforms</a></p>
 {% endif %}

--- a/physionet-django/project/templates/project/project_files_form.html
+++ b/physionet-django/project/templates/project/project_files_form.html
@@ -37,6 +37,13 @@
           <div class="modal-body">
             <p>Individual file size limit: {{ individual_size_limit }}.</p>
             {{ upload_files_form.file_field }}
+
+            <label id='error_data_size' style="display:none">
+              <br>
+              <p>
+              The selected file/s exceed the capacity left in your storage quota. You can request more space by clicking "Request storage".</p>
+              <p>The remaining size is {{ storage_info.readable_remaining }}. The total size of the file/s you are trying to upload is <a id='data_size'></a>.</p>
+            </label>
           </div>
           <div class="modal-footer">
             <button id="upload-files-button-submit" class="btn btn-success" name="upload_files" value="{{ subdir }}" type="submit"><i class="fa fa-arrow-circle-up"></i> Upload Files</button>

--- a/physionet-django/project/templates/project/project_files_form.html
+++ b/physionet-django/project/templates/project/project_files_form.html
@@ -37,13 +37,13 @@
           <div class="modal-body">
             <p>Individual file size limit: {{ individual_size_limit }}.</p>
             {{ upload_files_form.file_field }}
-
-            <label id='error_data_size' style="display:none">
-              <br>
-              <p>
-              The selected file/s exceed the capacity left in your storage quota. You can request more space by clicking "Request storage".</p>
-              <p>The remaining size is {{ storage_info.readable_remaining }}. The total size of the file/s you are trying to upload is <a id='data_size'></a>.</p>
-            </label>
+            <br>
+            <div id='error_data_size' style="display:none" class="alert alert-danger">
+              <p>The selected files are larger than your remaining storage allowance for this project.
+              You can request more space by clicking "Request Storage".</p>
+              <p>The total size of the selected files is <span id="data_size"></span>.<br>
+              Your remaining storage allowance is {{ storage_info.readable_remaining }}.</p>
+            </div>
           </div>
           <div class="modal-footer">
             <button id="upload-files-button-submit" class="btn btn-success" name="upload_files" value="{{ subdir }}" type="submit"><i class="fa fa-arrow-circle-up"></i> Upload Files</button>


### PR DESCRIPTION
Here I am adding the size of all the files being uploaded after
the files were chosen but before the form was submitted.

If the files sizes exceeds the remaining quota a message will be
shown. If the form was submitted and the file sizes exceeds the
remaining quota then the message will be shown and the form will
be prevented from running.

This is an attempt to fix #940