### PR TITLE
Register and update DOIs for published projects using the console

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -168,14 +168,12 @@ class EditSubmissionForm(forms.ModelForm):
                 if self.cleaned_data['auto_doi']:
                     # register draft DOIs
                     if not project.doi:
-                        payload = generate_doi_payload(project,
-                                                               event="draft")
+                        payload = generate_doi_payload(project, event="draft")
                         project.doi = register_doi(payload)
                         project.save()
                     if not project.core_project.doi:
-                        payload = generate_doi_payload(project,
-                                                               core_project=True,
-                                                               event="draft")
+                        payload = generate_doi_payload(project, event="draft",
+                                                       core_project=True)
                         project.core_project.doi = register_doi(payload)
                         project.core_project.save()
 

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -254,23 +254,6 @@ class PublishForm(forms.Form):
         return data
 
 
-class DOIForm(forms.ModelForm):
-    """
-    Form to edit the doi of a published project
-    """
-    class Meta:
-        model = PublishedProject
-        fields = ('doi',)
-        labels = {'doi':'DOI'}
-
-    def clean_doi(self):
-        data = self.cleaned_data['doi']
-        validate_doi(data)
-        if PublishedProject.objects.filter(doi=data).exclude(id=self.instance.id):
-            raise forms.ValidationError('Published project with DOI already exists.')
-        return data
-
-
 class TopicForm(forms.Form):
     """
     Form to set tags for a published project

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -165,6 +165,9 @@ class EditSubmissionForm(forms.ModelForm):
                 project.editor_accept_datetime = now
                 project.latest_reminder = now
 
+                CopyeditLog.objects.create(project=project)
+                project.save()
+
                 if self.cleaned_data['auto_doi']:
                     # register draft DOIs
                     if not project.doi:
@@ -174,9 +177,6 @@ class EditSubmissionForm(forms.ModelForm):
                         payload = generate_doi_payload(project, event="draft",
                                                        core_project=True)
                         register_doi(payload, project.core_project)
-
-                CopyeditLog.objects.create(project=project)
-                project.save()
 
             return edit_log
 

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -169,13 +169,11 @@ class EditSubmissionForm(forms.ModelForm):
                     # register draft DOIs
                     if not project.doi:
                         payload = generate_doi_payload(project, event="draft")
-                        project.doi = register_doi(payload)
-                        project.save()
+                        register_doi(payload, project)
                     if not project.core_project.doi:
                         payload = generate_doi_payload(project, event="draft",
                                                        core_project=True)
-                        project.core_project.doi = register_doi(payload)
-                        project.core_project.save()
+                        register_doi(payload, project.core_project)
 
                 CopyeditLog.objects.create(project=project)
                 project.save()

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -62,7 +62,7 @@
 
 <div class="card mb-3">
     <div class="card-header">
-      Anonymous Access
+      Anonymous access
     </div>
     <div class="card-body">
         <p>
@@ -103,13 +103,47 @@
 
 <div class="card mb-3">
     <div class="card-header">
-      Manage DOIs
+      Manage Digital Object Identifiers (DOIs)
     </div>
     <div class="card-body">
-    <form action="" method="post">
+      <p>All published projects should be associated with two DOIs: (1) A version-specific DOI, and (2)
+        A "core project" DOI that resolves to the latest version .</p>
+      <div class="alert alert-success">
+        <strong>Core project (Latest version)</strong>: 
+        {% if project.core_project.doi %}
+        https://doi.org/{{ project.core_project.doi }}
+        {% else %}
+        The core project does not have a DOI.
+        {% endif %}
+        <br />
+        <strong>This version (version {{ project.version }})</strong>:
+        {% if project.doi %}
+        https://doi.org/{{ project.doi }}
+        {% else %}
+        The project version does not have a DOI.
+        {% endif %}
+      </div>
+
+    <form action="{% url 'manage_published_project' project.slug project.version %}" method="POST" id="manage_doi_form">
       {% csrf_token %}
-      {% include "form_snippet.html" with form=doi_form %}
-      <button class="btn btn-primary btn-fixed" name="set_doi" type="submit">Set DOI</button>
+      {% if project.core_project.doi %}
+        <button class="btn btn-primary btn-rsp" type="submit" name="update_doi_core">
+          Update metadata (core)
+        </button>
+      {% else %}
+        <button class="btn btn-primary btn-rsp" type="submit" name="create_doi_core">
+          Create DOI (core)
+        </button>  
+      {% endif %}
+      {% if project.doi %}
+        <button class="btn btn-primary btn-rsp" type="submit" name="update_doi_version">
+          Update metadata (v.{{ project.version }})
+        </button>
+      {% else %}
+        <button class="btn btn-primary btn-rsp" type="submit" name="create_doi_version">
+          Create DOI (v.{{ project.version }})
+        </button>
+      {% endif %}
     </form>
     </div>
 </div>

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -274,9 +274,6 @@ def register_doi(payload, project):
         project (obj): The ActiveProject, PublishedProject, or CoreProject
             that is associated with the payload.
 
-    Returns:
-        doi (str): On success, returns the assigned DOI.
-
     Example of the API return response.
     {
        'data':{
@@ -427,8 +424,6 @@ def register_doi(payload, project):
         # Update the DOI field for the project
         queryset = type(project).objects.filter(id=project.id, doi='PENDING')
         queryset.update(doi=doi)
-
-    return doi
 
 
 def update_doi(doi, payload):

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -26,6 +26,14 @@ ROLES = ['roles/storage.legacyBucketReader',
          'roles/storage.objectViewer']
 
 
+class DOIExistsError(Exception):
+    pass
+
+
+class DOICreationError(Exception):
+    pass
+
+
 def check_bucket_exists(project, version):
     """
     Check if a bucket exists.
@@ -256,12 +264,15 @@ def create_directory_service(user_email, group=False):
     return build('admin', 'directory_v1', credentials=credentials)
 
 
-def register_doi(payload):
+def register_doi(payload, project):
     """
-    Create a draft DOI with basic project information via a POST request.
+    Create a DOI with basic project information via a POST request. Saves
+    the DOI to the project.doi field.
 
     Args:
         payload (dict): The metadata to be sent to the DataCite API.
+        project (obj): The ActiveProject, PublishedProject, or CoreProject
+            that is associated with the payload.
 
     Returns:
         doi (str): On success, returns the assigned DOI.
@@ -384,23 +395,39 @@ def register_doi(payload):
     headers = {'Content-Type': 'application/vnd.api+json'}
     request_url = settings.DATACITE_API_URL
 
-    response = post(request_url, data=json.dumps(payload), headers=headers,
-                    auth=HTTPBasicAuth(settings.DATACITE_USER,
-                    settings.DATACITE_PASS))
+    # Check whether the project already has a DOI assigned.
+    # type(project) returns CoreProject, ActiveProject, or PublishedProject
+    queryset = type(project).objects.filter(id=project.id, doi=None)
 
-    if response.status_code < 200 or response.status_code >= 300:
-        raise Exception("""There was an unknown error submitting the DOI. Here
-            is the response text: {}""".format(response.text))
+    # Hold DOI field to prevent multiple calls from registering multiple DOIs.
+    if queryset.update(doi='PENDING') != 1:
+        raise DOIExistsError('Project already has a DOI')
+    doi = None
 
-    content = json.loads(response.text)
-    doi = content['data']['attributes']['doi']
-    validate_doi(doi)
+    try:
+        response = post(request_url, data=json.dumps(payload), headers=headers,
+                        auth=HTTPBasicAuth(settings.DATACITE_USER,
+                        settings.DATACITE_PASS))
 
-    event = payload['data']['attributes']['event']
-    title = payload['data']['attributes']['titles'][0]['title']
+        if response.status_code < 200 or response.status_code >= 300:
+            # Remove the pending status
+            raise DOICreationError("""There was an unknown error creating the
+                DOI. Here is the response text: {}""".format(response.text))
 
-    LOGGER.info("DOI ({0}) for project '{1}' created: {2}.".format(event,
-                                                                   title, doi))
+        content = json.loads(response.text)
+        doi = content['data']['attributes']['doi']
+        validate_doi(doi)
+
+        event = payload['data']['attributes']['event']
+        title = payload['data']['attributes']['titles'][0]['title']
+        LOGGER.info("DOI ({0}) for project '{1}' created: {2}.".format(event,
+                                                                       title,
+                                                                       doi))
+    finally:
+        # Update the DOI field for the project
+        queryset = type(project).objects.filter(id=project.id, doi='PENDING')
+        queryset.update(doi=doi)
+
     return doi
 
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -498,8 +498,7 @@ def publish_submission(request, project_slug, *args, **kwargs):
                 payload_core = utility.generate_doi_payload(latest,
                                                             core_project=True,
                                                             event="publish")
-                utility.update_doi(published_project.core_project.doi,
-                                   payload_core)
+                utility.update_doi(core.doi, payload_core)
 
             if published_project.doi:
                 payload = utility.generate_doi_payload(published_project,

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -643,8 +643,7 @@ def manage_doi_request(request, project):
     if 'create_doi_core' in request.POST:
         payload = utility.generate_doi_payload(project, core_project=True,
                                                event="publish")
-        project.core_project.doi = utility.register_doi(payload)
-        project.core_project.save()
+        utility.register_doi(payload, project.core_project)
         message = "The DOI was created."
     elif 'update_doi_core' in request.POST:
         payload = utility.generate_doi_payload(project, core_project=True,
@@ -653,8 +652,7 @@ def manage_doi_request(request, project):
         message = "The DOI metadata was updated."
     elif 'create_doi_version' in request.POST:
         payload = utility.generate_doi_payload(project, event="publish")
-        project.doi = utility.register_doi(payload)
-        project.save()
+        utility.register_doi(payload, project)
         message = "The DOI was created."
     elif 'update_doi_version' in request.POST:
         payload = utility.generate_doi_payload(project, event="publish")

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -504,7 +504,7 @@
   "pk": "2e780890-644d-4166-b0ca-e3d31596405b",
   "fields": {
     "creation_datetime": "2017-10-30T14:30:30Z",
-    "doi": "",
+    "doi": null,
     "storage_allowance": 104857600
   }
 },
@@ -513,7 +513,7 @@
   "pk": "66951d55-e473-4a98-a24f-4fad05ed967b",
   "fields": {
     "creation_datetime": "2018-11-14T20:20:39.927Z",
-    "doi": "",
+    "doi": null,
     "storage_allowance": 104857600
   }
 },
@@ -522,7 +522,7 @@
   "pk": "950032c4-2d96-43d6-84d5-e1652f451a79",
   "fields": {
     "creation_datetime": "2017-10-30T14:30:30Z",
-    "doi": "",
+    "doi": null,
     "storage_allowance": 104857600
   }
 },
@@ -531,7 +531,7 @@
   "pk": "ba881793-f671-4215-9487-070c04bdb4e2",
   "fields": {
     "creation_datetime": "2017-10-30T14:30:30Z",
-    "doi": "",
+    "doi": null,
     "storage_allowance": 104857600
   }
 },
@@ -540,7 +540,7 @@
   "pk": "ff038b01-14a2-4af1-9a7d-9f9845c45219",
   "fields": {
     "creation_datetime": "2017-10-30T14:30:30Z",
-    "doi": "",
+    "doi": null,
     "storage_allowance": 104857600
   }
 },
@@ -549,7 +549,7 @@
   "pk": "85c5bad7-5f20-4194-8a20-0ff37ccee9a0",
   "fields": {
     "creation_datetime": "2019-03-01T14:30:30Z",
-    "doi": "",
+    "doi": null,
     "storage_allowance": 104857600
   }
 },
@@ -789,7 +789,7 @@
     "compressed_storage_size": 786,
     "publish_datetime": "2019-03-17T07:53:10.022Z",
     "is_latest_version": true,
-    "doi": "",
+    "doi": null,
     "is_legacy": false,
     "has_wfdb": true,
     "full_description": "",


### PR DESCRIPTION
Add buttons to the management page for published projects to allow DOIs to be registered and updated.

![Screen Shot 2020-03-20 at 10 51 51](https://user-images.githubusercontent.com/822601/77175311-d1768480-6a98-11ea-9372-23618e9c80cc.png)

Before merging, I'd like to work out how best to prevent multiple DOIs being registered when someone quickly clicks the "Create DOI" button several times in succession. Any suggestions? 

Some thoughts are:

- ~~adding a "wait for request response" step to `views.manage_doi_request()` or `utility.register_doi()`~~
- adding a "check whether a DOI already exists for the same title and version" step to `views.manage_doi_request()` or `utility.register_doi()`
- always register a draft first, and then move to findable state with `utility.update_doi()`. Doesn't really solve the underlying issue.