### PR TITLE
Reduces max table width #608

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -41,6 +41,7 @@ table {
   border-top: 1px solid #dfdfdf;
   border-bottom: 1px solid #dfdfdf;
   margin: 1em auto;
+  max-width: 90%;
 }
 table > caption {
   caption-side: top;


### PR DESCRIPTION
Changed the `max-width` attribute of the `physionet.css` file to reduce the maximum displayed table width for published projects.