### PR TITLE
Fix check on protected projects

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1517,6 +1517,8 @@ class PublishedProject(Metadata, SubmissionInfo):
         if self.access_policy == 2 and (
             not user.is_authenticated or not user.is_credentialed):
             return False
+        elif self.access_policy == 1 and not user.is_authenticated:
+            return False
 
         if self.is_self_managed_access:
             return DataAccessRequest.objects.filter(


### PR DESCRIPTION
Protected projects dont check if the user is authenticated before
displaying the page.

There is a check done to see if the person has access to the files.
At the moment this check is only to credentialed projects and not
protected. I am adding the check to protected.