### PR TITLE
Tweak checkbox layout in data access request form

### DIFF
--- a/physionet-django/project/templates/project/request_data_access.html
+++ b/physionet-django/project/templates/project/request_data_access.html
@@ -90,8 +90,8 @@ Request Access to {{ project.title }} {{ project.version }}
                 </div>
 
                 <div >
-                    {{ project_request_form.agree_dua }}
                      <label for="id_proj-agree_dua">
+                         {{ project_request_form.agree_dua }}
                          By submitting this form, I, {{ full_user_name }},
                          agree with the above terms.
                      </label>


### PR DESCRIPTION
In the data access request form (http://localhost:8000/request-access/demoselfmanaged/1.0.0/), if the window is too narrow for the checkbox and its label to be displayed on a single line, the line is broken after the checkbox.

