### PR TITLE
Added missing quotation character in copyediting complete email

### DIFF
--- a/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
+++ b/physionet-django/notification/templates/notification/email/copyedit_complete_notify.html
@@ -3,7 +3,7 @@
 
 Dear {{ name }},
 
-We are pleased to say that copyediting of your project entitled {{ project.title }}" is now complete. To proceed with publication, you must now approve the project using the following link:
+We are pleased to say that copyediting of your project entitled "{{ project.title }}" is now complete. To proceed with publication, you must now approve the project using the following link:
 
 {{ url_prefix }}{% url 'project_submission' project.slug %}
 


### PR DESCRIPTION
Hi, just made a small change to add a starting quotation character before the project title in the copyediting complete email, which fixes #923 .