### PR TITLE
Track project modification time

### DIFF
--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -172,9 +172,22 @@ class TestState(TestMixin):
         Author approves publication
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+
+        def get_project():
+            return ActiveProject.objects.get(id=project.id)
+
+        # The following steps should not alter the project timestamp,
+        # since project "Metadata" fields are not being changed (only
+        # "SubmissionInfo").
+        timestamp = project.modified_datetime
+
         project.submit(author_comments='')
+        self.assertEqual(get_project().modified_datetime, timestamp)
+
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
+        self.assertEqual(get_project().modified_datetime, timestamp)
+
         self.client.login(username='admin', password='Tester11!')
         # Accept submission
         response = self.client.post(reverse(
@@ -184,16 +197,22 @@ class TestState(TestMixin):
                 'pn_suitable': 1, 'editor_comments': 'Good.', 'decision': 2,
                 'auto_doi': 1
             })
+        self.assertEqual(get_project().modified_datetime, timestamp)
+
         # Complete copyedit
         response = self.client.post(reverse(
             'copyedit_submission', args=(project.slug,)),
             data={'complete_copyedit':'', 'made_changes':0})
+        self.assertEqual(get_project().modified_datetime, timestamp)
+
         # Approve publication
         self.assertFalse(ActiveProject.objects.get(id=project.id).is_publishable())
         self.client.login(username='rgmark', password='Tester11!')
         response = self.client.post(reverse(
             'project_submission', args=(project.slug,)),
             data={'approve_publication':''})
+        self.assertEqual(get_project().modified_datetime, timestamp)
+
         self.assertTrue(ActiveProject.objects.get(id=project.id).is_publishable())
 
     def test_publish(self):

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -576,6 +576,11 @@ class DiscoveryForm(forms.ModelForm):
         data = self.cleaned_data['short_description']
         return ' '.join(data.split())
 
+    def save(self, *args, **kwargs):
+        result = super().save(*args, **kwargs)
+        self.instance.content_modified()
+        return result
+
 
 class AffiliationFormSet(forms.BaseInlineFormSet):
     """

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -307,6 +307,14 @@ class Topic(models.Model):
     def __str__(self):
         return self.description
 
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.project.content_modified()
+
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        self.project.content_modified()
+
 
 class PublishedTopic(models.Model):
     """
@@ -336,6 +344,14 @@ class Reference(models.Model):
 
     def __str__(self):
         return self.description
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.project.content_modified()
+
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        self.project.content_modified()
 
 
 class PublishedReference(models.Model):
@@ -378,6 +394,14 @@ class Publication(BasePublication):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     project = GenericForeignKey('content_type', 'object_id')
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.project.content_modified()
+
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        self.project.content_modified()
 
 
 class PublishedPublication(BasePublication):

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -828,6 +828,24 @@ class UnpublishedProject(models.Model):
         """
         return os.path.isfile(os.path.join(self.file_root(), 'RECORDS'))
 
+    def content_modified(self):
+        """
+        Update the project's modification timestamp.
+
+        The modification timestamp (modified_datetime) is
+        automatically updated when the object is saved, if any of the
+        project's Metadata fields have been modified (see
+        UnpublishedProject.save).
+
+        This function should be called when saving or deleting
+        objects, other than the UnpublishedProject itself, that are
+        part of the project's visible content.
+        """
+
+        # Note: modified_datetime is an auto_now field, so it is
+        # automatically set to the current time whenever it is saved.
+        self.save(update_fields=['modified_datetime'])
+
     @classmethod
     def from_db(cls, *args, **kwargs):
         """

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -425,11 +425,17 @@ class ProjectType(models.Model):
 
 class Metadata(models.Model):
     """
-    Metadata for all projects
+    Visible content of a published or unpublished project.
 
-    https://schema.datacite.org/
-    https://schema.datacite.org/meta/kernel-4.0/doc/DataCite-MetadataKernel_v4.1.pdf
-    https://www.nature.com/sdata/publish/for-authors#format
+    Every project (ActiveProject, PublishedProject, and
+    ArchivedProject) inherits from this class as well as
+    SubmissionInfo.  The difference is that the fields of this class
+    contain public information that will be shown on the published
+    project pages; SubmissionInfo contains internal information about
+    the publication process.
+
+    New fields should be added to this class only if they affect the
+    content of the project as it will be shown when published.
     """
 
     ACCESS_POLICIES = (
@@ -478,18 +484,6 @@ class Metadata(models.Model):
     core_project = models.ForeignKey('project.CoreProject',
                                      related_name='%(class)ss',
                                      on_delete=models.CASCADE)
-
-    # When the submitting project was created
-    creation_datetime = models.DateTimeField(auto_now_add=True)
-
-    edit_logs = GenericRelation('project.EditLog')
-    copyedit_logs = GenericRelation('project.CopyeditLog')
-
-    # For ordering projects with multiple versions
-    version_order = models.PositiveSmallIntegerField(default=0)
-
-    # Anonymous access
-    anonymous = GenericRelation('project.AnonymousAccess')
 
     class Meta:
         abstract = True
@@ -683,7 +677,19 @@ class Metadata(models.Model):
 class SubmissionInfo(models.Model):
     """
     Submission information, inherited by all projects.
+
+    Every project (ActiveProject, PublishedProject, and
+    ArchivedProject) inherits from this class as well as Metadata.
+    The difference is that the fields of this class contain internal
+    information about the publication process; Metadata contains the
+    public information that will be shown on the published project
+    pages.
+
+    New fields should be added to this class only if they do not
+    affect the content of the project as it will be shown when
+    published.
     """
+
     editor = models.ForeignKey('user.User',
         related_name='editing_%(class)ss', null=True,
         on_delete=models.SET_NULL, blank=True)
@@ -699,6 +705,18 @@ class SubmissionInfo(models.Model):
     # The last copyedit (if any)
     copyedit_completion_datetime = models.DateTimeField(null=True, blank=True)
     author_approval_datetime = models.DateTimeField(null=True, blank=True)
+
+    # When the submitting project was created
+    creation_datetime = models.DateTimeField(auto_now_add=True)
+
+    edit_logs = GenericRelation('project.EditLog')
+    copyedit_logs = GenericRelation('project.CopyeditLog')
+
+    # For ordering projects with multiple versions
+    version_order = models.PositiveSmallIntegerField(default=0)
+
+    # Anonymous access
+    anonymous = GenericRelation('project.AnonymousAccess')
 
     class Meta:
         abstract = True

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -434,6 +434,11 @@ class Metadata(models.Model):
     project pages; SubmissionInfo contains internal information about
     the publication process.
 
+    In particular, the UnpublishedProject modified_datetime will be
+    updated when any field of Metadata is altered (see
+    UnpublishedProject.save), but not when a field of SubmissionInfo
+    is modified.
+
     New fields should be added to this class only if they affect the
     content of the project as it will be shown when published.
     """
@@ -685,6 +690,11 @@ class SubmissionInfo(models.Model):
     public information that will be shown on the published project
     pages.
 
+    In particular, UnpublishedProject.modified_datetime will be
+    updated when any field of Metadata is altered (see
+    UnpublishedProject.save), but not when a field of SubmissionInfo
+    is modified.
+
     New fields should be added to this class only if they do not
     affect the content of the project as it will be shown when
     published.
@@ -726,7 +736,11 @@ class UnpublishedProject(models.Model):
     """
     Abstract model inherited by ArchivedProject/ActiveProject
     """
+
+    # Date and time that the project's content was modified.
+    # See content_modified() and save().
     modified_datetime = models.DateTimeField(auto_now=True)
+
     # Whether this project is being worked on as a new version
     is_new_version = models.BooleanField(default=False)
     # Access url slug, also used as a submitting project id.
@@ -813,6 +827,88 @@ class UnpublishedProject(models.Model):
         Whether the project has wfdb files.
         """
         return os.path.isfile(os.path.join(self.file_root(), 'RECORDS'))
+
+    @classmethod
+    def from_db(cls, *args, **kwargs):
+        """
+        Instantiate an object from the database.
+        """
+        instance = super(UnpublishedProject, cls).from_db(*args, **kwargs)
+
+        # Save the original field values so that we can later check if
+        # they have been modified.  Note that by using __dict__, this
+        # will omit any deferred fields.
+        instance.orig_fields = instance.__dict__.copy()
+        return instance
+
+    def save(self, *, content_modified=None,
+             force_insert=False, update_fields=None, **kwargs):
+        """
+        Save this object to the database.
+
+        In addition to the standard keyword arguments, this accepts an
+        optional content_modified argument: if true, modified_datetime
+        will be set to the current time; if false, neither
+        modified_datetime nor the Metadata fields will be saved.
+
+        If this object was loaded from the database, and none of the
+        Metadata fields have been changed from their original values,
+        then content_modified defaults to False.  Otherwise,
+        content_modified defaults to True.
+        """
+
+        # Note: modified_datetime is an auto_now field, so it is
+        # automatically set to the current time (unless we exclude it
+        # using update_fields.)
+
+        if force_insert or update_fields:
+            # If force_insert is specified, then we want to insert a
+            # new object, which means setting the timestamp.  If
+            # update_fields is specified, then we want to update
+            # precisely those fields.  In either case, use the default
+            # save method.
+            return super().save(force_insert=force_insert,
+                                update_fields=update_fields,
+                                **kwargs)
+
+        # If content_modified is not specified, then detect
+        # automatically.
+        if content_modified is None:
+            if hasattr(self, 'orig_fields'):
+                # Check whether any of the Metadata fields have been
+                # modified since the object was loaded from the database.
+                for f in Metadata._meta.fields:
+                    fname = f.attname
+                    if fname not in self.orig_fields:
+                        # If the field was initially deferred (and
+                        # thus its original value is unknown), assume
+                        # that it has been modified.  This is not
+                        # ideal, but in general, it should be possible
+                        # to avoid this by explicitly setting
+                        # update_fields or content_modified whenever
+                        # deferred fields are used.
+                        LOGGER.warning(
+                            'saving project with initially deferred fields')
+                        content_modified = True
+                        break
+                    if self.orig_fields[fname] != getattr(self, fname):
+                        content_modified = True
+                        break
+            else:
+                # If the object was not initially created by from_db,
+                # assume content has been modified.
+                content_modified = True
+
+        if content_modified:
+            # If content has been modified, then save normally.
+            return super().save(**kwargs)
+        else:
+            # If content has not been modified, then exclude all of the
+            # Metadata fields as well as modified_datetime.
+            fields = ({f.name for f in self._meta.fields}
+                      - {f.name for f in Metadata._meta.fields}
+                      - {'id', 'modified_datetime'})
+            return super().save(update_fields=fields, **kwargs)
 
 
 class ArchivedProject(Metadata, UnpublishedProject, SubmissionInfo):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -274,6 +274,8 @@ class TestAccessPresubmission(TestMixin):
         self.assertFalse(os.path.isfile(os.path.join(project.file_root(), 'notes', 'PATIENTS.csv.gz')))
 
         # Upload file. Use same file content already existing.
+        project.refresh_from_db()
+        timestamp = project.modified_datetime
         with open(os.path.join(project.file_root(), 'D_ITEMS.csv.gz'), 'rb') as f:
             response = self.client.post(reverse(
                 'project_files', args=(project.slug,)),
@@ -283,6 +285,9 @@ class TestAccessPresubmission(TestMixin):
         self.assertEqual(
             open(os.path.join(project.file_root(), 'D_ITEMS.csv.gz'), 'rb').read(),
             open(os.path.join(project.file_root(), 'notes/D_ITEMS.csv.gz'), 'rb').read())
+        project.refresh_from_db()
+        self.assertGreater(project.modified_datetime, timestamp)
+
         # Invalid subdir
         response = self.client.post(
             reverse('project_files', args=(project.slug,)),

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -418,6 +418,9 @@ class TestProjectEditing(TestCase):
         response = self.client.post(content_url, data=data)
         self.assertEqual(response.status_code, 200)
 
+        project.refresh_from_db()
+        timestamp = project.modified_datetime
+
         # Post some HTML, and verify that forbidden tags/attributes
         # are removed
         input_html = """
@@ -449,6 +452,7 @@ class TestProjectEditing(TestCase):
         self.assertEqual(response.status_code, 200)
         project.refresh_from_db()
         self.assertHTMLEqual(project.background, expected_html)
+        self.assertGreater(project.modified_datetime, timestamp)
 
         # Post some blank text in a required field and verify that the
         # project cannot be submitted

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -908,6 +908,7 @@ def process_items(request, form):
     """
     if form.is_valid():
         success_msg, errors = form.perform_action()
+        form.project.content_modified()
         if errors:
             messages.error(request, errors)
         else:
@@ -973,7 +974,6 @@ def project_files(request, project_slug, subdir='', **kwargs):
         else:
             # process the file manipulation post
             subdir = process_files_post(request, project)
-            project.modified_datetime = timezone.now()
 
     if is_submitting and project.author_editable():
         files_editable = True

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -752,8 +752,6 @@ def project_discovery(request, project_slug, **kwargs):
             discovery_form.save()
             publication_formset.save()
             topic_formset.save()
-            project.modified_datetime = timezone.now()
-            project.save()
             messages.success(request, 'Your discovery information has been updated.')
             topic_formset = TopicFormSet(instance=project)
             publication_formset = PublicationFormSet(instance=project)


### PR DESCRIPTION
Summary: Attempt to track the date and time when an active project was most recently modified (issue #894).  Update it when it should be updated, don't update it when it shouldn't be.

In particular:

1. A project should be considered "modified" when any files/directories are added, removed, or renamed.

2. A project should be considered "modified" when its description fields are changed.

3. A project should be considered "modified" when the publication or the list of references is changed.

4. A project should *not* be considered "modified" when the author submits it, the editor accepts or rejects it, authors approve it, etc.

5. A project should *not* be considered "modified" when the editor completes copyediting and doesn't change anything.  (This may be unreliable due to ckeditor and bleach making changes to the markup without changing the semantics.)

It's difficult to do this in any clean, consistent way.  (2), (4), and (5) all involve changing one or more fields of the ActiveProject object; (3) involves changing objects *other* than the ActiveProject; (1) doesn't involve changing the database at all.

The project model has always been divided into two abstract parent classes (Metadata and SubmissionInfo), although this distinction didn't really mean anything in the past.  However, for the most part, the Metadata fields are the ones that contain public project content (like "resource_type" and "abstract") and the SubmissionInfo fields are the ones that relate to the publication state (like "editor" and "submission_datetime".)  So to begin with, I've tried to formalize this, moving a few of the internal fields from Metadata to SubmissionInfo.

UnpublishedProject has the field "modified_datetime" which is updated automatically whenever the object is saved.  Here, I've changed this behavior: if the object was initially loaded from the database, and none of its Metadata fields were changed (!=) from their initial values, save() will skip saving those fields as well as modified_datetime.  In other cases, modified_datetime is updated as usual.

This is a kludge, but I'm not sure how to make it less kludgy, other than by splitting Metadata and SubmissionInfo into completely separate objects.  That may be what we want to do eventually, but that's a big disruptive change.

I've changed the save() and delete() of Topic, Reference, and Publication to force an update of the project's modified_datetime.  There may be a better way to do this!  Indirection through a GenericForeignKey is particularly unsettling.


As a result of these changes:

- project_content will change the modification timestamp if any changes were made to either the flat fields or the references.

- project_access will change the modification timestamp if any changes were made to the license or policy.

- project_discovery will always change the modification timestamp.  (This one deals with many-to-many fields, so it's not trivial to hook into save() in the same way.)

- project_files will change the modification timestamp when a "valid" file manipulation form is submitted (although it might not have had any effect.)

- Editing the relevant fields through /admin/ should also change the timestamp when appropriate.  (I haven't tested this very much.)


One thing this *doesn't* do is to change the modified_datetime when the list of authors changes.  There are some practical reasons:

- Any author can change their affiliation at any time before the project is submitted.  It feels slightly wrong for the "modification time" to be affected by non-submitting authors.

- Any author can change their displayed name at any time (even if the project is not editable!)  So if we really wanted to be sure that 'modified_datetime' reflects any change to the byline, that would require touching every active project you're coauthoring, whenever you change the spelling of your name.  Making that work would require breaking several layers of abstraction.

- When an author approves publication, that also touches the Author object, so it would be *another* class that needs to handle two distinct "save" conditions, and I just didn't want to go there.
