### PR TITLE
Allow handling editor to be reassigned

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -58,6 +58,22 @@ class AssignEditorForm(forms.Form):
         return pid
 
 
+class ReassignEditorForm(forms.Form):
+    """
+    Assign an editor to a project under submission
+    """
+    editor = forms.ModelChoiceField(queryset=User.objects.filter(
+        is_admin=True), widget=forms.Select(attrs={'onchange': 'set_editor_text()'}))
+
+    def __init__(self, user, *args, **kwargs):
+        """
+        Set the appropriate queryset
+        """
+        super().__init__(*args, **kwargs)
+        self.fields['editor'].queryset = self.fields['editor'].queryset.exclude(
+            username=user.username)
+
+
 class EditSubmissionForm(forms.ModelForm):
     """
     For an editor to make a decision regarding a submission.

--- a/physionet-django/console/templates/console/awaiting_authors.html
+++ b/physionet-django/console/templates/console/awaiting_authors.html
@@ -75,4 +75,11 @@
 
 {% block local_js_bottom %}
 <script src="{% static 'custom/js/enable-popover.js' %}"></script>
+{% if project.editor == user %}
+<script>
+  function set_editor_text(){
+    $('#project_author').text($( "#id_editor option:selected" ).text());
+  }
+</script>
+{% endif %}
 {% endblock %}

--- a/physionet-django/console/templates/console/awaiting_authors.html
+++ b/physionet-django/console/templates/console/awaiting_authors.html
@@ -78,7 +78,7 @@
 {% if project.editor == user %}
 <script>
   function set_editor_text(){
-    $('#project_author').text($( "#id_editor option:selected" ).text());
+    $('#project_editor').text($( "#id_editor option:selected" ).text());
   }
 </script>
 {% endif %}

--- a/physionet-django/console/templates/console/copyedit_submission.html
+++ b/physionet-django/console/templates/console/copyedit_submission.html
@@ -97,4 +97,12 @@
 {% if project.has_other_versions or project.version_order %}
   <script src="{% static 'custom/js/disable-title.js' %}"></script>
 {% endif %}
+
+{% if project.editor == user %}
+<script>
+  function set_editor_text(){
+    $('#project_author').text($( "#id_editor option:selected" ).text());
+  }
+</script>
+{% endif %}
 {% endblock %}

--- a/physionet-django/console/templates/console/copyedit_submission.html
+++ b/physionet-django/console/templates/console/copyedit_submission.html
@@ -101,7 +101,7 @@
 {% if project.editor == user %}
 <script>
   function set_editor_text(){
-    $('#project_author').text($( "#id_editor option:selected" ).text());
+    $('#project_editor').text($( "#id_editor option:selected" ).text());
   }
 </script>
 {% endif %}

--- a/physionet-django/console/templates/console/edit_submission.html
+++ b/physionet-django/console/templates/console/edit_submission.html
@@ -32,4 +32,11 @@
 
 {% block local_js_bottom %}
 <script src="{% static 'custom/js/enable-popover.js' %}"></script>
+{% if project.editor == user %}
+<script>
+  function set_editor_text(){
+    $('#project_author').text($( "#id_editor option:selected" ).text());
+  }
+</script>
+{% endif %}
 {% endblock %}

--- a/physionet-django/console/templates/console/edit_submission.html
+++ b/physionet-django/console/templates/console/edit_submission.html
@@ -35,7 +35,7 @@
 {% if project.editor == user %}
 <script>
   function set_editor_text(){
-    $('#project_author').text($( "#id_editor option:selected" ).text());
+    $('#project_editor').text($( "#id_editor option:selected" ).text());
   }
 </script>
 {% endif %}

--- a/physionet-django/console/templates/console/submission_info.html
+++ b/physionet-django/console/templates/console/submission_info.html
@@ -23,4 +23,11 @@
 
 {% block local_js_bottom %}
 <script src="{% static 'custom/js/enable-popover.js' %}"></script>
+{% if project.editor == user %}
+<script>
+  function set_editor_text(){
+    $('#project_author').text($( "#id_editor option:selected" ).text());
+  }
+</script>
+{% endif %}
 {% endblock %}

--- a/physionet-django/console/templates/console/submission_info.html
+++ b/physionet-django/console/templates/console/submission_info.html
@@ -26,7 +26,7 @@
 {% if project.editor == user %}
 <script>
   function set_editor_text(){
-    $('#project_author').text($( "#id_editor option:selected" ).text());
+    $('#project_editor').text($( "#id_editor option:selected" ).text());
   }
 </script>
 {% endif %}

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -110,7 +110,7 @@
                   <h5 class="modal-title" id="exampleModalLongTitle">Editor Reassignment</h5>
                 </div>
                 <div class="modal-body">
-                  <p>Please confirm you want to assign '<span id="project_author"></span>' as the new project editor of {{ project }}</p>
+                  <p>Please confirm you want to assign '<span id="project_editor"></span>' as the new project editor of {{ project }}</p>
                 </div>
                 <div class="modal-footer">
                   <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -11,6 +11,11 @@
       <li class="nav-item">
         <a class="nav-link {% if passphrase %} active {% endif %}" id="anonymous-tab" data-toggle="tab" href="#anonymous" role="tab" aria-controls="anonymous" aria-selected="false">Anonymous Access</a>
       </li>
+      {% if project.editor == user %}
+      <li class="nav-item">
+        <a class="nav-link {% if passphrase %} active {% endif %}" id="reassign-tab" data-toggle="tab" href="#reassign" role="tab" aria-controls="reassign" aria-selected="false">Assign new editor</a>
+      </li>
+      {% endif %}
       {% if project.submission_status >= 40 %}
       <li class="nav-item">
         <a class="nav-link" id="doi-tab" data-toggle="tab" href="#doi" role="tab" aria-controls="timeline" aria-selected="false">DOIs</a>
@@ -86,6 +91,39 @@
           {% endif %}
         </form>
       </div>
+
+      {# Permanent Reassign #}
+      {% if project.editor == user %}
+      <div class="tab-pane fade" id="reassign" role="tabpanel" aria-labelledby="reassign-tab">
+        <p>Permanently reassign the project to another editor.</p>
+        <form action="{% url 'submission_info' project.slug %}" method="POST" id="reassign_editor_form">
+          {% csrf_token %}
+          {% include "form_snippet.html" with form=reassign_editor_form %}
+          <br>
+          <button class="btn btn-primary btn-rsp" type="button" data-toggle="modal" data-target="#reassign_editor_modal">Reassign</button>
+
+          <!-- Start Modal -->
+          <div class="modal fade" id="reassign_editor_modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLongTitle" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="exampleModalLongTitle">Editor Reassignment</h5>
+                </div>
+                <div class="modal-body">
+                  <p>Please confirm you want to assign '<span id="project_author"></span>' as the new project editor of {{ project }}</p>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                  <button type="submit" class="btn btn-primary" name="reassign_editor">Save changes</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        <!-- End Modal -->
+        </form>
+      </div>
+      {% endif %}
+
       {# Draft DOI #}
       <div class="tab-pane fade" id="doi" role="tabpanel" aria-labelledby="doi-tab">
         <p>The following DOIs have been registered for the project. These may be useful 

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -48,6 +48,29 @@ class TestState(TestMixin):
         self.assertTrue(project.editor, editor)
         self.assertEqual(project.submission_status, 20)
 
+    def test_reassign_editor(self):
+        """
+        Assign an editor, then re-asign it
+        """
+        # Submit project
+        project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        project.submit(author_comments='')
+        # Assign editor
+        self.client.login(username='admin', password='Tester11!')
+        editor = User.objects.get(username='tompollard')
+        response = self.client.post(reverse('submitted_projects'), data={
+            'project': project.id, 'editor': editor.id})
+        project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        self.assertTrue(project.editor, editor)
+        self.assertEqual(project.submission_status, 20)
+
+        # Reassign editor
+        editor = User.objects.get(username='admin')
+        response = self.client.post(reverse('submission_info',
+            args=(project.slug,)), data={'editor': editor.id})
+        project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        self.assertTrue(project.editor, editor)
+
     def test_edit_reject(self):
         """
         Edit a project, rejecting it.

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -50,7 +50,7 @@ class TestState(TestMixin):
 
     def test_reassign_editor(self):
         """
-        Assign an editor, then re-asign it
+        Assign an editor, then reassign it
         """
         # Submit project
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -237,8 +237,7 @@ def submission_info(request, project_slug):
         project.anonymous.all().delete()
         anonymous_url, passphrase = '', 'revoked'
     elif 'reassign_editor' in request.POST and reassign_editor_form.is_valid():
-        project.assign_editor(reassign_editor_form.cleaned_data['editor'],
-                              is_reassigned=True)
+        project.reassign_editor(reassign_editor_form.cleaned_data['editor'])
         notification.editor_notify_new_project(project, user, reassigned=True)
         messages.success(request, 'The editor has been reassigned')
         LOGGER.info("The editor for the project {0} has been reassigned from "

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -241,6 +241,9 @@ def submission_info(request, project_slug):
                               is_reassigned=True)
         notification.editor_notify_new_project(project, user, reassigned=True)
         messages.success(request, 'The editor has been reassigned')
+        LOGGER.info("The editor for the project {0} has been reassigned from "
+                    "{1} to {2}".format(project, user,
+                        reassign_editor_form.cleaned_data['editor']))
 
     url_prefix = notification.get_url_prefix(request)
     return render(request, 'console/submission_info.html',

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -237,7 +237,8 @@ def submission_info(request, project_slug):
         project.anonymous.all().delete()
         anonymous_url, passphrase = '', 'revoked'
     elif 'reassign_editor' in request.POST and reassign_editor_form.is_valid():
-        project.reassign_editor(reassign_editor_form.cleaned_data['editor'])
+        project.assign_editor(reassign_editor_form.cleaned_data['editor'],
+                              is_reassigned=True)
         notification.editor_notify_new_project(project, user, reassigned=True)
         messages.success(request, 'The editor has been reassigned')
 

--- a/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
+++ b/physionet-django/notification/templates/notification/email/editor_notify_new_project.html
@@ -4,6 +4,7 @@
 Dear {{ editor }},
 
 {{ user }} has assigned you the role of handling editor for a project entitled "{{ project.title }}".
+
 {{ signature }}
 
 {{ footer }}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -234,7 +234,8 @@ def assign_editor_notify(project):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
-def editor_notify_new_project(project, assigner):
+
+def editor_notify_new_project(project, assigner, reassigned=False):
     """
     Notify authors when an editor is assigned
     """
@@ -244,15 +245,19 @@ def editor_notify_new_project(project, assigner):
     body = loader.render_to_string(
         'notification/email/editor_notify_new_project.html', {
             'project': project,
-            'editor': project.editor,
+            'editor': project.editor.get_full_name(),
             'signature': email_signature(),
             'user': assigner.get_full_name(),
             'project_info': email_project_info(project),
             'footer': email_footer()
         })
+    if reassigned:
+        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+                  [project.editor.email, assigner.email], fail_silently=False)
+    else:
+        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+                  [project.editor.email], fail_silently=False)
 
-    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-              [project.editor.email], fail_silently=False)
 
 def edit_decision_notify(request, project, edit_log, reminder=False):
     """

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1087,14 +1087,21 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         self.submitting_author = self.submitting_author()
 
-    def assign_editor(self, editor, is_reassigned=False):
+    def assign_editor(self, editor):
         """
-        Assign an editor to the project
+        Assign an editor to the project and set the submission status to the
+        edit stage.
         """
         self.editor = editor
-        if not is_reassigned:
-            self.submission_status = 20
-            self.editor_assignment_datetime = timezone.now()
+        self.submission_status = 20
+        self.editor_assignment_datetime = timezone.now()
+        self.save()
+
+    def reassign_editor(self, editor):
+        """
+        Reassign the current project editor with new editor
+        """
+        self.editor = editor
         self.save()
 
     def reject(self):

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1087,20 +1087,13 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         self.submitting_author = self.submitting_author()
 
-    def assign_editor(self, editor):
+    def assign_editor(self, editor, is_reassigned=False):
         """
         Assign an editor to the project
         """
         self.editor = editor
-        self.submission_status = 20
-        self.editor_assignment_datetime = timezone.now()
-        self.save()
-
-    def reassign_editor(self, editor):
-        """
-        Assign another editor to the project
-        """
-        self.editor = editor
+        if not is_reassigned:
+            self.submission_status = 20
         self.editor_assignment_datetime = timezone.now()
         self.save()
 

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1096,6 +1096,14 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         self.editor_assignment_datetime = timezone.now()
         self.save()
 
+    def reassign_editor(self, editor):
+        """
+        Assign another editor to the project
+        """
+        self.editor = editor
+        self.editor_assignment_datetime = timezone.now()
+        self.save()
+
     def reject(self):
         """
         Reject a project under submission

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1094,7 +1094,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         self.editor = editor
         if not is_reassigned:
             self.submission_status = 20
-        self.editor_assignment_datetime = timezone.now()
+            self.editor_assignment_datetime = timezone.now()
         self.save()
 
     def reject(self):

--- a/physionet-django/project/templates/project/static_submission_timeline.html
+++ b/physionet-django/project/templates/project/static_submission_timeline.html
@@ -17,7 +17,7 @@
     <li class="list-group-item">
       <div class="row">
         <div class="col-md-2">{{ project.author_approval_datetime|date }}</div>
-        <div class="col-md-10">All authors approved the final project for publication.
+        <div class="col-md-10">All authors approved the final project for publication.</div>
       </div>
     </li>
 
@@ -64,6 +64,7 @@
               <p>The submitting author included the following comments:</p>
               <a class="editor-comments">{{ e.author_comments|linebreaks }}</a>
             {% endif %}
+          </div>
         </div>
       </li>
     {% endif %}
@@ -97,7 +98,7 @@
   <li class="list-group-item">
     <div class="row">
       <div class="col-md-2">{{ project.editor_assignment_datetime|date }}</div>
-      <div class="col-md-10">The project was assigned the editor: {{ project.editor.disp_name_email }}
+      <div class="col-md-10">The project was assigned an editor.</div>
     </div>
   </li>
 

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -3084,7 +3084,7 @@
     "join_date": "2020-04-07",
     "last_login": "2020-04-07T15:42:48.087Z",
     "is_active": true,
-    "is_admin": false,
+    "is_admin": true,
     "is_credentialed": false,
     "credential_datetime": null
   }

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -7,7 +7,7 @@
     "email": "admin@mit.edu",
     "username": "admin",
     "join_date": "2017-11-11",
-    "last_login": "2020-03-29T21:53:22.380Z",
+    "last_login": "2020-04-07T15:42:43.445Z",
     "is_active": true,
     "is_admin": true,
     "is_credentialed": false,
@@ -3060,6 +3060,36 @@
   }
 },
 {
+  "model": "user.user",
+  "pk": 205,
+  "fields": {
+    "password": "",
+    "email": "felipe1.torres.cs@gmail.com",
+    "username": "felipe1",
+    "join_date": "2020-04-07",
+    "last_login": null,
+    "is_active": false,
+    "is_admin": false,
+    "is_credentialed": false,
+    "credential_datetime": null
+  }
+},
+{
+  "model": "user.user",
+  "pk": 206,
+  "fields": {
+    "password": "pbkdf2_sha256$150000$JZYaK8Hpb5gx$pvZssTnlQ7MPxvbaK1ODb6h7KntEMKCFOBZM/ieBfHg=",
+    "email": "tpollard@mit.edu",
+    "username": "tompollard",
+    "join_date": "2020-04-07",
+    "last_login": "2020-04-07T15:42:48.087Z",
+    "is_active": true,
+    "is_admin": false,
+    "is_credentialed": false,
+    "credential_datetime": null
+  }
+},
+{
   "model": "user.userlogin",
   "pk": 1,
   "fields": {
@@ -3083,6 +3113,24 @@
   "fields": {
     "user": 9,
     "login_date": "2020-03-29T21:53:48.939Z",
+    "ip": "127.0.0.1"
+  }
+},
+{
+  "model": "user.userlogin",
+  "pk": 4,
+  "fields": {
+    "user": 1,
+    "login_date": "2020-04-07T15:42:43.444Z",
+    "ip": "127.0.0.1"
+  }
+},
+{
+  "model": "user.userlogin",
+  "pk": 5,
+  "fields": {
+    "user": 206,
+    "login_date": "2020-04-07T15:42:48.087Z",
     "ip": "127.0.0.1"
   }
 },
@@ -5985,6 +6033,34 @@
   }
 },
 {
+  "model": "user.associatedemail",
+  "pk": 208,
+  "fields": {
+    "user": 205,
+    "email": "felipe1.torres.cs@gmail.com",
+    "is_primary_email": true,
+    "added_date": "2020-04-07T14:44:47.295Z",
+    "verification_date": null,
+    "verification_token": null,
+    "is_verified": false,
+    "is_public": false
+  }
+},
+{
+  "model": "user.associatedemail",
+  "pk": 209,
+  "fields": {
+    "user": 206,
+    "email": "tpollard@mit.edu",
+    "is_primary_email": true,
+    "added_date": "2020-04-07T15:41:51.851Z",
+    "verification_date": "2020-04-07T15:42:48.084Z",
+    "verification_token": null,
+    "is_verified": true,
+    "is_public": false
+  }
+},
+{
   "model": "user.legacycredential",
   "pk": 1,
   "fields": {
@@ -8647,6 +8723,32 @@
     "user": 204,
     "first_names": "Pamela",
     "last_name": "Smith",
+    "affiliation": "",
+    "location": "",
+    "website": "",
+    "photo": ""
+  }
+},
+{
+  "model": "user.profile",
+  "pk": 205,
+  "fields": {
+    "user": 205,
+    "first_names": "Felipe",
+    "last_name": "F\u00e1bregas",
+    "affiliation": "",
+    "location": "",
+    "website": "",
+    "photo": ""
+  }
+},
+{
+  "model": "user.profile",
+  "pk": 206,
+  "fields": {
+    "user": 206,
+    "first_names": "Tom",
+    "last_name": "Pollard",
     "affiliation": "",
     "location": "",
     "website": "",


### PR DESCRIPTION
Allow the current project editor to reassign the project. This will send an email to both the new and old editor.

The form changes are handled in the submission_info function only.

Closing #943
