### PR TITLE
More heading tags

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -305,7 +305,14 @@ CKEDITOR_CONFIGS = {
         'removeDialogTabs': 'link:advanced',
         'disableNativeSpellChecker': False,
         'width': '100%',
-        'format_tags': 'p;h3',
+
+        # Show options "Heading 2" to "Heading 4" in the format menu,
+        # but map these to <h3>, <h4>, <h5> tags
+        'format_tags': 'p;h2;h3;h4',
+        'format_h2': {'element': 'h3'},
+        'format_h3': {'element': 'h4'},
+        'format_h4': {'element': 'h5'},
+
         'extraPlugins': 'codesnippet,pnmathml',
         'allowedContent': {
             **_inline_tags,


### PR DESCRIPTION

This adds more heading tags to the ckeditor format menu.  It also renumbers them, so "Heading 2" is actually h3, "Heading 3" is actually h4, and "Heading 4" is actually h5.  See issue #975.

I'm not convinced that this is actually less confusing, but that's okay. :)

One concern I do have is that adding these options might result in authors choosing to use h4 rather than h3 because "it looks prettier", producing an inconsistent document structure.
