### PR TITLE
Normalize ZIP file permissions

### DIFF
--- a/physionet-django/physionet/test_utility.py
+++ b/physionet-django/physionet/test_utility.py
@@ -1,0 +1,79 @@
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+
+from django.test import TestCase
+
+from physionet import utility
+
+
+class TestZipFile(TestCase):
+    """
+    Test ZIP file creation.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+
+        self.files_dir = os.path.join(self.tmp_dir.name, 'files')
+        self.subdir = os.path.join(self.files_dir, 'three')
+        self.file1 = os.path.join(self.files_dir, 'one')
+        self.file2 = os.path.join(self.files_dir, 'two')
+        self.file3 = os.path.join(self.files_dir, 'three', 'abc')
+        self.file4 = os.path.join(self.files_dir, 'three', 'def')
+
+        os.mkdir(self.files_dir)
+        os.mkdir(self.subdir)
+        for path in [self.file1, self.file2, self.file3, self.file4]:
+            with open(path, 'w') as f:
+                pass
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_zip(self):
+        """
+        Test that we can create a valid ZIP file.
+
+        This runs physionet.utility.zip_dir and checks that it writes
+        files to the archive in alphabetical order.
+        """
+        zip_path = os.path.join(self.tmp_dir.name, "files.zip")
+        utility.zip_dir(zip_path, self.files_dir)
+
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            self.assertEqual(zf.namelist(),
+                             ['one', 'three/abc', 'three/def', 'two'])
+
+    @unittest.skipIf(shutil.which('zipdetails') is None,
+                     "zipdetails is not installed")
+    def test_zip_permissions(self):
+        """
+        Test that ZIP files not retain file permissions.
+
+        This runs physionet.utility.zip_dir twice, with different
+        permissions for the data files, and checks that the results
+        are identical.  (All files in the archive should be normalized
+        to mode 644 or 755.)
+        """
+        os.chmod(self.file1, 0o644)
+        os.chmod(self.file2, 0o664)
+        os.chmod(self.file3, 0o550)
+        os.chmod(self.file4, 0o750)
+        zip_path1 = os.path.join(self.tmp_dir.name, "files1.zip")
+        utility.zip_dir(zip_path1, self.files_dir)
+
+        os.chmod(self.file1, 0o444)
+        os.chmod(self.file2, 0o444)
+        os.chmod(self.file3, 0o555)
+        os.chmod(self.file4, 0o555)
+        zip_path2 = os.path.join(self.tmp_dir.name, "files2.zip")
+        utility.zip_dir(zip_path2, self.files_dir)
+
+        with open(zip_path1, 'rb') as zf1:
+            contents1 = zf1.read()
+        with open(zip_path2, 'rb') as zf2:
+            contents2 = zf2.read()
+        self.assertEqual(contents1, contents2)

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -220,6 +220,9 @@ def zip_dir(zip_name, target_dir, enclosing_folder=''):
             if proc.wait() != 0:
                 raise subprocess.CalledProcessError(proc.returncode, command)
 
+        # Fix up permission bits inside the zip file
+        normalize_zip_permissions(tmp_zip_name)
+
         # Rename the temporary file to the target filename
         os.rename(tmp_zip_name, zip_name)
 

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -1,5 +1,8 @@
+import logging
 import os
+import re
 import shutil
+import struct
 import subprocess
 import tempfile
 
@@ -7,6 +10,8 @@ from django.conf import settings
 from django.http import HttpResponse, Http404
 from django.utils.html import format_html
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+
+LOGGER = logging.getLogger(__name__)
 
 CONTENT_TYPE = {
     '.html': 'text/html',
@@ -226,6 +231,78 @@ def zip_dir(zip_name, target_dir, enclosing_folder=''):
             os.remove(tmp_zip_name)
         except FileNotFoundError:
             pass
+
+
+def normalize_zip_permissions(zip_name):
+    """
+    Normalize file permissions in a ZIP archive.
+
+    If the archive was created by a program that stores the original
+    Unix file permissions, then for each file in the archive, the
+    permissions are changed to a default value:
+
+    - If the file is executable, it is set to mode 0755 (readable and
+      executable by everyone, writable by the owner).
+
+    - Otherwise, it it set to mode 0644 (readable by everyone,
+      writable by the owner).
+
+    The "DOS read-only bit" is also cleared.
+
+    This can be used to clean a ZIP file, if the original files that
+    were copied into the archive had inconsistent permissions.
+    (Published project files are stored read-only to avoid accidental
+    modification, but when creating an archive for distribution, the
+    permissions should be read/write, as this is more convenient for
+    the user.)
+
+    This relies on the zipdetails program, which is part of the perl
+    package in Debian.
+    """
+
+    command = ('zipdetails', zip_name)
+    try:
+        proc = subprocess.Popen(command, stdin=subprocess.DEVNULL,
+                                stdout=subprocess.PIPE)
+    except FileNotFoundError as exc:
+        LOGGER.warning('cannot execute zipdetails: {}'.format(exc))
+        return
+
+    # Use the output of zipdetails to identify the start of each entry
+    # in the central directory.  Once we've found an entry, patch the
+    # "external file attributes" field.
+
+    # This is a kludge, but the Python zipfile library does not
+    # provide an API to manipulate these bits, nor do the Info-Zip
+    # command line tools.
+
+    with proc, open(zip_name, 'r+b') as zip_file:
+        pattern = re.compile(b'([0-9A-Fa-f]+) CENTRAL HEADER')
+        for line in proc.stdout:
+            m = pattern.match(line)
+            if m:
+                offset = int(m.group(1), 16)
+                zip_file.seek(offset)
+                header = zip_file.read(42)
+                # [0:4] = signature
+                # [5] = original OS (3 = Unix)
+                # [38] = DOS attributes
+                # [40:41] = Unix file mode
+                if len(header) == 42 and header[0:4] == b'\x50\x4B\x01\x02':
+                    if header[5] == 3:
+                        (attrs,) = struct.unpack('<I', header[38:42])
+                        if attrs & (0o111 << 16):
+                            attrs = (attrs & 0xf000fffe) | (0o755 << 16)
+                        else:
+                            attrs = (attrs & 0xf000fffe) | (0o644 << 16)
+                        header = header[0:38] + struct.pack('<I', attrs)
+                        zip_file.seek(offset)
+                        zip_file.write(header)
+                else:
+                    raise Exception('cannot find central directory entry'
+                                    ' at {}'.format(offset))
+        if proc.wait() != 0:
+            raise subprocess.CalledProcessError(proc.returncode, command)
 
 
 def paginate(request, to_paginate, maximum):

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -49,7 +49,8 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     """
 
     published_project = PublishedProject.objects.get(id=pid)
-    published_project.make_special_files(make_zip=make_zip)
+    published_project.make_license_file()
+    published_project.make_checksum_file()
 
     published_project.set_storage_info()
 
@@ -65,6 +66,9 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
 
         for d in dirs:
             os.chmod(os.path.join(root, d), 0o555)
+
+    if make_zip:
+        published_project.make_zip()
 
 
 class SafeHTMLField(ckeditor.fields.RichTextField):


### PR DESCRIPTION
This should fix issue #946: permissions inside ZIP files should be consistent (executable files should always be mode 755, other files should always be mode 644.)

The implementation is ugly but is about the least ugly I could come up with.  Some alternatives I considered:
- Parsing the structure by hand.  Not trivial, given the possibility of having to parse both the traditional zip trailer and the zip64 extensions.
- Using strip-nondeterminism.  Likely inefficient as it makes a second copy of the archive and sorts the entries (which we're already doing), and also normalizes timestamps (which may in fact be a good idea, but for large databases I want to retain rsyncability.)  And strip-nondeterminism has dependencies of its own, and (my impression is) its developers see it as more of a temporary kludge than a stable tool that other programs should be relying on.
- Normalizing permissions on disk before invoking /usr/bin/zip (or, just not making things read-only at all.)  I don't like this because having the files read-only is both a useful safeguard for admins, and a prerequisite for that "sandboxed SFTP" feature I keep talking about. ;)
- Spoofing the file permissions by invoking /usr/bin/zip in an LD_PRELOAD environment.  Well, it's an option.

If anyone knows of any command-line tools or any Python libraries that would provide a way to manipulate the attributes inside a zip file, I'd love to hear of them.


Example:

as rgmark:
- create new version of "Demo 2018 BHI and BSN Data Challenge"
- go to Files and upload "manage.py"
- go to Discovery and enter a short description
- go to Submission and submit
as admin:
- assign self as editor, accept the project, complete copyedit
as rgmark:
- approve the project
as admin:
- publish the project and say "yes, make a zip file"
- wait for it to finish (run manage.py process_tasks, if necessary)
- download the new zip file (A)
- go to the console and click the "make zip" button
- wait for it to finish (run manage.py process_tasks, if necessary)
- download the new zip file (B)

With these changes, the resulting zip files A and B should be identical.


With the current dev branch (plus b13e5322ed93efb7c1d2a55a582392abb8314ca1), zip file A looks like this:
```
$ zipinfo /tmp/demobsn-old-publish.zip 
Archive:  /tmp/demobsn-old-publish.zip
Zip file size: 2570020 bytes, number of entries: 15
-r--r--r--  3.0 unx     7516 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/231.atr
-r--r--r--  3.0 unx  1950000 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/231.dat
-r--r--r--  3.0 unx      333 t- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/231.hea
-r--r--r--  3.0 unx     3914 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/232.atr
-r--r--r--  3.0 unx  1950000 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/232.dat
-r--r--r--  3.0 unx      389 t- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/232.hea
-r--r--r--  3.0 unx       59 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/ANNOTATORS
-rw-r--r--  3.0 unx     1097 t- defX 20-Apr-02 13:31 demo-2018-bhi-and-bsn-data-challenge-2.0/LICENSE.txt
-r--r--r--  3.0 unx        8 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/RECORDS
-rw-r--r--  3.0 unx     1053 t- defX 20-Apr-02 13:31 demo-2018-bhi-and-bsn-data-challenge-2.0/SHA256SUMS.txt
-r--r--r--  3.0 unx        6 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/data1.txt
-r--r--r--  3.0 unx        7 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/data2.txt
-rw-r--r--  3.0 unx      827 t- defX 20-Apr-02 13:29 demo-2018-bhi-and-bsn-data-challenge-2.0/manage.py
-r--r--r--  3.0 unx       12 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/scripts/lib.py
-r--r--r--  3.0 unx        7 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/scripts/starter.py
15 files, 3915228 bytes uncompressed, 2567342 bytes compressed:  34.4%
```
(the new files are writable, the old files are not; manage.py is not executable)

and zip file B looks like this:
```
$ zipinfo /tmp/demobsn-old-console.zip 
Archive:  /tmp/demobsn-old-console.zip
Zip file size: 2570020 bytes, number of entries: 15
-r--r--r--  3.0 unx     7516 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/231.atr
-r--r--r--  3.0 unx  1950000 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/231.dat
-r--r--r--  3.0 unx      333 t- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/231.hea
-r--r--r--  3.0 unx     3914 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/232.atr
-r--r--r--  3.0 unx  1950000 b- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/232.dat
-r--r--r--  3.0 unx      389 t- defX 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/232.hea
-r--r--r--  3.0 unx       59 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/ANNOTATORS
-r--r--r--  3.0 unx     1097 t- defX 20-Apr-02 13:31 demo-2018-bhi-and-bsn-data-challenge-2.0/LICENSE.txt
-r--r--r--  3.0 unx        8 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/RECORDS
-r--r--r--  3.0 unx     1053 t- defX 20-Apr-02 13:31 demo-2018-bhi-and-bsn-data-challenge-2.0/SHA256SUMS.txt
-r--r--r--  3.0 unx        6 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/data1.txt
-r--r--r--  3.0 unx        7 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/data2.txt
-r-xr-xr-x  3.0 unx      827 t- defX 20-Apr-02 13:29 demo-2018-bhi-and-bsn-data-challenge-2.0/manage.py
-r--r--r--  3.0 unx       12 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/scripts/lib.py
-r--r--r--  3.0 unx        7 t- stor 20-Apr-02 13:27 demo-2018-bhi-and-bsn-data-challenge-2.0/scripts/starter.py
15 files, 3915228 bytes uncompressed, 2567342 bytes compressed:  34.4%
```
(none of the files are writable; manage.py is executable)

After making this change, the two files should look like this:
```
$ zipinfo /tmp/demobsn-new-publish.zip 
Archive:  /tmp/demobsn-new-publish.zip
Zip file size: 2570020 bytes, number of entries: 15
-rw-r--r--  3.0 unx     7516 b- defX 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/231.atr
-rw-r--r--  3.0 unx  1950000 b- defX 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/231.dat
-rw-r--r--  3.0 unx      333 t- defX 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/231.hea
-rw-r--r--  3.0 unx     3914 b- defX 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/232.atr
-rw-r--r--  3.0 unx  1950000 b- defX 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/232.dat
-rw-r--r--  3.0 unx      389 t- defX 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/232.hea
-rw-r--r--  3.0 unx       59 t- stor 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/ANNOTATORS
-rw-r--r--  3.0 unx     1097 t- defX 20-Apr-02 13:57 demo-2018-bhi-and-bsn-data-challenge-2.0/LICENSE.txt
-rw-r--r--  3.0 unx        8 t- stor 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/RECORDS
-rw-r--r--  3.0 unx     1053 t- defX 20-Apr-02 13:57 demo-2018-bhi-and-bsn-data-challenge-2.0/SHA256SUMS.txt
-rw-r--r--  3.0 unx        6 t- stor 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/data1.txt
-rw-r--r--  3.0 unx        7 t- stor 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/data2.txt
-rwxr-xr-x  3.0 unx      827 t- defX 20-Apr-02 13:55 demo-2018-bhi-and-bsn-data-challenge-2.0/manage.py
-rw-r--r--  3.0 unx       12 t- stor 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/scripts/lib.py
-rw-r--r--  3.0 unx        7 t- stor 20-Apr-02 13:41 demo-2018-bhi-and-bsn-data-challenge-2.0/scripts/starter.py
15 files, 3915228 bytes uncompressed, 2567342 bytes compressed:  34.4%
```
(all of the files are writable; manage.py is executable).
