### PR TITLE
Check if the legacy reference has been contacted

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -975,7 +975,8 @@ def complete_credential_applications(request):
             temp.append([0, application])
         elif LegacyCredential.objects.filter(
             reference_email__iexact=application.reference_email).exclude(
-                reference_email=''):
+                reference_email='') and \
+                application.reference_contact_datetime is None:
             application.known_ref = True
             temp.append([0, application])
         else:


### PR DESCRIPTION
If the application has a reference from a legacy application and
that reference has been contacted in the current application, then
mark the reference as contacted not as known.