### PR TITLE
Better handling of LICENSE/SHA256SUMS before publication

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -219,6 +219,7 @@ class CopyeditForm(forms.ModelForm):
             project.latest_reminder = now
             copyedit_log.save()
             project.save()
+            project.create_license_file()
             return copyedit_log
 
 

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -425,6 +425,11 @@ class NewProjectVersionForm(forms.ModelForm):
                 except FileExistsError:
                     pass
             for f in files:
+                # Skip linking files that are automatically generated
+                # during publication.
+                if (directory == older_file_root
+                        and f in ('SHA256SUMS.txt', 'LICENSE.txt')):
+                    continue
                 try:
                     os.link(os.path.join(directory, f),
                             os.path.join(destination, f))

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -49,7 +49,13 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     """
 
     published_project = PublishedProject.objects.get(id=pid)
+
+    # The license file should have been generated earlier (by
+    # CopyeditForm).  The following line is kept for the benefit of
+    # older projects that are currently in the pipeline; once all such
+    # projects have been published, this line should be removed.
     published_project.make_license_file()
+
     published_project.make_checksum_file()
 
     published_project.set_storage_info()

--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -611,6 +611,19 @@ class Metadata(models.Model):
 
         return content
 
+    def create_license_file(self):
+        """
+        Create a file containing the text of the project license.
+
+        A file 'LICENSE.txt' is created at the top level of the
+        project directory, replacing any existing file with that name.
+        """
+        fname = os.path.join(self.file_root(), 'LICENSE.txt')
+        if os.path.isfile(fname):
+            os.remove(fname)
+        with open(fname, 'x') as outfile:
+            outfile.write(self.license_content(fmt='text'))
+
     def get_directory_content(self, subdir=''):
         """
         Return information for displaying files and directories from
@@ -1443,13 +1456,13 @@ class PublishedProject(Metadata, SubmissionInfo):
     def make_license_file(self):
         """
         Make the license text file
-        """
-        fname = os.path.join(self.file_root(), 'LICENSE.txt')
-        if os.path.isfile(fname):
-            os.remove(fname)
-        with open(fname, 'w') as outfile:
-            outfile.write(self.license_content(fmt='text'))
 
+        This creates the LICENSE.txt file, and then recalculates and
+        saves the project storage size.
+
+        This function is deprecated; use create_license_file instead.
+        """
+        self.create_license_file()
         self.set_storage_info()
 
     def make_special_files(self, make_zip):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -376,6 +376,12 @@ class TestProjectCreation(TestMixin):
         newpath = os.path.join(newproject.file_root(), 'admissions.csv')
         self.assertTrue(os.path.samefile(oldpath, newpath))
 
+        # SHA256SUMS.txt should not be linked
+        oldpath = os.path.join(oldproject.file_root(), 'SHA256SUMS.txt')
+        newpath = os.path.join(newproject.file_root(), 'SHA256SUMS.txt')
+        self.assertTrue(os.path.exists(oldpath))
+        self.assertFalse(os.path.exists(newpath))
+
 
 class TestProjectEditing(TestCase):
     """


### PR DESCRIPTION
This fixes a couple of small issues related to publishing file content.

- LICENSE.txt should be visible to authors before approval (issue #520)

- Do not link SHA256SUMS.txt and LICENSE.txt from the previous project version (thought there was an issue about that but I can't find one.)

