### PR TITLE
Remove sandbox for training report PDF

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -486,7 +486,9 @@ def training_report(request, application_slug):
 
     if request.user == application.user or request.user.is_admin:
         try:
-            return utility.serve_file(application.training_completion_report.path, False)
+            return utility.serve_file(
+                application.training_completion_report.path, attach=False,
+                sandbox=False)
         except FileNotFoundError:
             raise Http404()
 


### PR DESCRIPTION
Due to the sandbox issue and chrome, the PDFs from the user training reports cant be rendered while I use google chrome.

https://bugs.chromium.org/p/chromium/issues/detail?id=413851

Since this is only for the PDF, I don't see a harm setting the sandbox and attach flags to False to render the PDF.