### PR TITLE
Clean up temporary files in test-upgrade.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ media/credential-applications/*
 physionet-django/static/published-projects/*
 physionet-django/static/wfdbcal
 physionet-django/test.log
+test-upgrade.tmp
+test-upgrade.cache
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/test-upgrade.sh
+++ b/test-upgrade.sh
@@ -204,6 +204,9 @@ echo "================================================================"
 # Set up working directory and useful variables
 
 workdir=$topdir/test-upgrade.tmp
+if [ -d "$workdir" ]; then
+    find "$workdir" -type d -exec chmod u+w '{}' ';'
+fi
 rm -rf "$workdir"
 
 olddir=$workdir/old
@@ -388,6 +391,9 @@ export PATH=$venvdir/bin:$PATH
 if fgrep ' *** FAILED: ' "$topdir/$logfile" >&3; then
     exit 1
 else
+    find "$workdir" -type d -exec chmod u+w '{}' ';'
+    rm -rf "$workdir"
+
     echo "Success" >&3
     exit 0
 fi


### PR DESCRIPTION
test-upgrade.sh will fail if you try to run it twice, because some directories are changed to be read-only so the files can't be deleted.

(This may be due to recent changes in loaddemo and the testing scripts.  It might be better for us *not* to mark directories read-only since it makes little real difference and it's an annoyance for testing, but either way, this is the current behavior so the test script has to deal with it. :P)

