### PR TITLE
Escape paths correctly in /files/

### DIFF
--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -5,6 +5,7 @@ import shutil
 import struct
 import subprocess
 import tempfile
+import urllib.parse
 
 from django.conf import settings
 from django.http import HttpResponse, Http404
@@ -109,7 +110,7 @@ def serve_file(file_path, attach=True, allow_directory=False, sandbox=True):
     accel_path = _file_x_accel_path(file_path)
     if accel_path:
         response = HttpResponse()
-        response['X-Accel-Redirect'] = accel_path
+        response['X-Accel-Redirect'] = urllib.parse.quote(accel_path)
         response['Content-Type'] = ''
     else:
         if file_path.endswith('/') and allow_directory:

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -90,7 +90,7 @@ def file_content_type(filename):
     return CONTENT_TYPE.get(ext, 'text/plain')
 
 def _file_x_accel_path(file_path):
-    static_root = settings.STATIC_ROOT
+    static_root = settings.STATIC_ROOT or settings.STATICFILES_DIRS[0]
     media_root = settings.MEDIA_ROOT
     media_alias = settings.MEDIA_X_ACCEL_ALIAS
     if media_alias:


### PR DESCRIPTION
Paths used in the X-Accel-Redirect header must be URL-escaped.  In particular, there's some buggy client out there that occasionally tries to download some files with %0D appended to the URL, which results in a 500 error because serve_file tries to set a response header with a control character in it.

In addition to control characters, this should allow correct handling of non-ASCII characters, as well as special ASCII characters like space, percent, and question-mark.  We don't currently allow any of those characters in published project files, but we should try to be robust.
