### PR TITLE
Remove duplicated code for authors in UnpublishedProject

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -994,7 +994,6 @@ class UnpublishedProject(models.Model):
     publications = GenericRelation('project.Publication')
     topics = GenericRelation('project.Topic')
 
-    authors = GenericRelation('project.Author')
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Deleted the repeated time "authors" is defined in UnpublishedProject and tested to make sure a migration isn't required, which fixes #984.