### PR TITLE
Notify team when new project is submitted

### DIFF
--- a/physionet-django/notification/templates/notification/email/submit_notify_team.html
+++ b/physionet-django/notification/templates/notification/email/submit_notify_team.html
@@ -1,0 +1,11 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+{{ project_info }}
+
+Dear {{ name }},
+
+The project entitled "{{ project.title }}" has been submitted to PhysioNet.
+
+{{ signature }}
+
+{{ footer }}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -184,6 +184,14 @@ def submit_notify(project):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
+    subject = 'A new project has been submitted: {0}'.format(project.title)
+    email_context['name'] = "Colleague"
+    body = loader.render_to_string(
+        'notification/email/submit_notify_team.html', email_context)
+        
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+          [settings.CONTACT_EMAIL], fail_silently=False)
+
 
 def resubmit_notify(project):
     """


### PR DESCRIPTION
Following from #994, this sends an email to the PhysioNet team when a project is submitted, which will keep the team updated on new datasets being submitted. Fixes #992.