### PR TITLE
Pillow requirements for OSX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ google-cloud-storage==1.14.0 \
 html2text==2018.1.9 \
  --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662
 Pillow==7.0.0 \
- --hash=sha256:c5ed816632204a2fc9486d784d8e0d0ae754347aba99c811458d69fcdfd2a2f9
+ --hash=sha256:c5ed816632204a2fc9486d784d8e0d0ae754347aba99c811458d69fcdfd2a2f9 \
+ --hash=sha256:5bfef0b1cdde9f33881c913af14e43db69815c7e8df429ceda4c70a5e529210f
 python-decouple==3.1 \
  --hash=sha256:1317df14b43efee4337a4aa02914bf004f010cd56d6c4bd894e6474ec8c4fe2d
 pytz==2017.2 \


### PR DESCRIPTION
There is a missing hash for Pillow using OSX.