### PR TITLE
Define user views in user.views

### DIFF
--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -2,14 +2,10 @@ from django.contrib.auth import views as auth_views
 from django.urls import path, re_path, reverse_lazy
 
 from user import views
-from user.forms import LoginForm
 
 
 urlpatterns = [
-    path('login/', auth_views.LoginView.as_view(
-        template_name='user/login.html',
-        authentication_form=LoginForm,
-        redirect_authenticated_user=True), name='login'),
+    path('login/', views.login, name='login'),
 
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
 

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -1,5 +1,4 @@
-from django.contrib.auth import views as auth_views
-from django.urls import path, re_path, reverse_lazy
+from django.urls import path, re_path
 
 from user import views
 
@@ -29,11 +28,7 @@ urlpatterns = [
     # Settings
     path('settings/', views.user_settings, name='user_settings'),
     path('settings/profile/', views.edit_profile, name='edit_profile'),
-    path('settings/password/', auth_views.PasswordChangeView.as_view(
-        success_url = reverse_lazy('edit_password_complete'),
-        template_name='user/edit_password.html',
-        ),
-        name='edit_password'),
+    path('settings/password/', views.edit_password, name='edit_password'),
     path('settings/password/changed/', views.edit_password_complete, name='edit_password_complete'),
     path('settings/emails/', views.edit_emails, name='edit_emails'),
     path('settings/username/', views.edit_username, name='edit_username'),

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -17,9 +17,8 @@ urlpatterns = [
     path('reset-password/', views.reset_password_request,
          name='reset_password_request'),
     # Page shown after reset email has been sent
-    path('reset-password/sent/', auth_views.PasswordResetDoneView.as_view(
-        template_name='user/reset_password_sent.html'),
-        name='reset_password_sent'),
+    path('reset-password/sent/', views.reset_password_sent,
+         name='reset_password_sent'),
     # Prompt user to enter new password and carry out password reset (if url is valid)
     re_path('^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         auth_views.PasswordResetConfirmView.as_view(

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -21,10 +21,7 @@ urlpatterns = [
          name='reset_password_sent'),
     # Prompt user to enter new password and carry out password reset (if url is valid)
     re_path('^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        auth_views.PasswordResetConfirmView.as_view(
-        template_name='user/reset_password_confirm.html',
-        success_url=reverse_lazy('reset_password_complete')),
-        name='reset_password_confirm'),
+            views.reset_password_confirm, name='reset_password_confirm'),
     # Password reset successfully carried out
     path('reset/complete/',
         auth_views.PasswordResetCompleteView.as_view(

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -7,7 +7,7 @@ from user import views
 urlpatterns = [
     path('login/', views.login, name='login'),
 
-    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('logout/', views.logout, name='logout'),
 
     path('register/', views.register, name='register'),
     re_path('^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -23,10 +23,8 @@ urlpatterns = [
     re_path('^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
             views.reset_password_confirm, name='reset_password_confirm'),
     # Password reset successfully carried out
-    path('reset/complete/',
-        auth_views.PasswordResetCompleteView.as_view(
-        template_name='user/reset_password_complete.html'),
-        name='reset_password_complete'),
+    path('reset/complete/', views.reset_password_complete,
+         name='reset_password_complete'),
 
     # Settings
     path('settings/', views.user_settings, name='user_settings'),

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -14,11 +14,8 @@ urlpatterns = [
         views.activate_user, name='activate_user'),
 
     # Request password reset
-    path('reset-password/', auth_views.PasswordResetView.as_view(
-        template_name='user/reset_password_request.html',
-        success_url=reverse_lazy('reset_password_sent'),
-        email_template_name='user/email/reset_password_email.html'),
-        name='reset_password_request'),
+    path('reset-password/', views.reset_password_request,
+         name='reset_password_request'),
     # Page shown after reset email has been sent
     path('reset-password/sent/', auth_views.PasswordResetDoneView.as_view(
         template_name='user/reset_password_sent.html'),

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.tokens import default_token_generator
+import django.contrib.auth.views as auth_views
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
@@ -35,6 +36,15 @@ from notification.utility import (process_credential_complete,
 
 
 logger = logging.getLogger(__name__)
+
+
+class LoginView(auth_views.LoginView):
+    template_name = 'user/login.html'
+    authentication_form = forms.LoginForm
+    redirect_authenticated_user = True
+
+
+login = LoginView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -72,12 +72,18 @@ class PasswordResetCompleteView(auth_views.PasswordResetCompleteView):
     template_name = 'user/reset_password_complete.html'
 
 
+class PasswordChangeView(auth_views.PasswordChangeView):
+    success_url = reverse_lazy('edit_password_complete')
+    template_name = 'user/edit_password.html'
+
+
 login = LoginView.as_view()
 logout = LogoutView.as_view()
 reset_password_request = PasswordResetView.as_view()
 reset_password_sent = PasswordResetDoneView.as_view()
 reset_password_confirm = PasswordResetConfirmView.as_view()
 reset_password_complete = PasswordResetCompleteView.as_view()
+edit_password = PasswordChangeView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -18,7 +18,7 @@ from django.forms import inlineformset_factory, HiddenInput, CheckboxInput
 from django.http import HttpResponse, Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.template import loader
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.encoding import force_bytes, force_text
@@ -48,8 +48,16 @@ class LogoutView(auth_views.LogoutView):
     pass
 
 
+# Request password reset
+class PasswordResetView(auth_views.PasswordResetView):
+    template_name = 'user/reset_password_request.html'
+    success_url = reverse_lazy('reset_password_sent')
+    email_template_name = 'user/email/reset_password_email.html'
+
+
 login = LoginView.as_view()
 logout = LogoutView.as_view()
+reset_password_request = PasswordResetView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -44,7 +44,12 @@ class LoginView(auth_views.LoginView):
     redirect_authenticated_user = True
 
 
+class LogoutView(auth_views.LogoutView):
+    pass
+
+
 login = LoginView.as_view()
+logout = LogoutView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -60,10 +60,18 @@ class PasswordResetDoneView(auth_views.PasswordResetDoneView):
     template_name = 'user/reset_password_sent.html'
 
 
+# Prompt user to enter new password and carry out password reset (if
+# url is valid)
+class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
+    template_name = 'user/reset_password_confirm.html'
+    success_url = reverse_lazy('reset_password_complete')
+
+
 login = LoginView.as_view()
 logout = LogoutView.as_view()
 reset_password_request = PasswordResetView.as_view()
 reset_password_sent = PasswordResetDoneView.as_view()
+reset_password_confirm = PasswordResetConfirmView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -55,9 +55,15 @@ class PasswordResetView(auth_views.PasswordResetView):
     email_template_name = 'user/email/reset_password_email.html'
 
 
+# Page shown after reset email has been sent
+class PasswordResetDoneView(auth_views.PasswordResetDoneView):
+    template_name = 'user/reset_password_sent.html'
+
+
 login = LoginView.as_view()
 logout = LogoutView.as_view()
 reset_password_request = PasswordResetView.as_view()
+reset_password_sent = PasswordResetDoneView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -67,11 +67,17 @@ class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
     success_url = reverse_lazy('reset_password_complete')
 
 
+# Password reset successfully carried out
+class PasswordResetCompleteView(auth_views.PasswordResetCompleteView):
+    template_name = 'user/reset_password_complete.html'
+
+
 login = LoginView.as_view()
 logout = LogoutView.as_view()
 reset_password_request = PasswordResetView.as_view()
 reset_password_sent = PasswordResetDoneView.as_view()
 reset_password_confirm = PasswordResetConfirmView.as_view()
+reset_password_complete = PasswordResetCompleteView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')


### PR DESCRIPTION
Instead of defining view functions in user.urls (and customizing them using keyword arguments to as_view), define them in user.views (and customize them by subclassing.)

This makes it more clear how to extend them, and separates the URL patterns from the functions that handle them.
