### PR TITLE
Support maintenance mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 SECRET_KEY=secret
 ALLOWED_HOSTS=[]
 
+# System maintenance mode
+#SYSTEM_MAINTENANCE_NO_CHANGES=1
+#SYSTEM_MAINTENANCE_NO_UPLOAD=1
+#SYSTEM_MAINTENANCE_MESSAGE=PhysioNet is undergoing maintenance, and projects cannot be edited. The site will be back online at 16:00 GMT.
+
 # GCP
 # USED to store ALL the published projects to GCP Buckets and BigQuery
 # The delegation email, might be possible to change in the:

--- a/physionet-django/physionet/middleware/maintenance.py
+++ b/physionet-django/physionet/middleware/maintenance.py
@@ -1,0 +1,150 @@
+import functools
+import logging
+
+from django.conf import settings
+from django.core.exceptions import MiddlewareNotUsed
+from django.shortcuts import render
+from django.utils.log import log_response
+
+
+LOGGER = logging.getLogger(__name__)
+
+SAFE_HTTP_METHODS = ('GET', 'HEAD', 'OPTIONS', 'TRACE')
+
+ERROR_TEMPLATE = 'site_maintenance.html'
+
+
+class SystemMaintenanceMiddleware:
+    """
+    Middleware that disables editing during system maintenance.
+
+    This middleware class can be used when the system is undergoing
+    maintenance; it attempts to prevent actions that could make
+    changes on the server side, making the site "read-only" from a
+    visitor's perspective.  This may either be enabled permanently (to
+    operate as an "emergency fallback" server), or temporarily (to
+    freeze the site so that it can be migrated to a replica without
+    loss of data.)
+
+    If settings.SYSTEM_MAINTENANCE_NO_CHANGES is true, all HTTP
+    requests other than GET, HEAD, OPTIONS, and TRACE are disallowed,
+    except for views decorated with 'allow_post_during_maintenance'.
+
+    Disallowed requests will result in an error page with a status of
+    '503 Service Unavailable'.  If the SYSTEM_MAINTENANCE_MESSAGE
+    setting is nonempty, that defines an HTML message that will be
+    displayed on the error page.
+    """
+    def __init__(self, get_response):
+        # Initialize middleware.  get_response is the next middleware
+        # in the chain, which should be called by __call__.  If this
+        # raises MiddlewareNotUsed, the middleware is removed from the
+        # chain and has no effect.
+        self.get_response = get_response
+
+        if settings.SYSTEM_MAINTENANCE_NO_CHANGES:
+            LOGGER.warning(
+                'SYSTEM_MAINTENANCE_NO_CHANGES enabled.  Message: {}'.format(
+                    settings.SYSTEM_MAINTENANCE_MESSAGE))
+        elif settings.SYSTEM_MAINTENANCE_NO_UPLOAD:
+            LOGGER.warning(
+                'SYSTEM_MAINTENANCE_NO_UPLOAD enabled.  Message: {}'.format(
+                    settings.SYSTEM_MAINTENANCE_MESSAGE))
+        else:
+            raise MiddlewareNotUsed()
+
+    def __call__(self, request):
+        # Process a request and invoke the next middleware in the chain.
+        return self.get_response(request)
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        # Prepare to invoke a view function with the given request and
+        # arguments.  If this returns None, the view will be invoked
+        # as usual; if it returns a response, the view is bypassed and
+        # the given response is returned instead.
+        if not settings.SYSTEM_MAINTENANCE_NO_CHANGES:
+            return None
+        elif request.method in SAFE_HTTP_METHODS:
+            return None
+        elif hasattr(view_func, 'view_allow_post_during_maintenance'):
+            return None
+        else:
+            return self._reject(request)
+
+    def process_exception(self, request, exception):
+        # Handle an exception raised by a view.  If this returns None,
+        # the default exception handling is used; if it returns a
+        # response, that response is used instead.
+        if isinstance(exception, ServiceUnavailable):
+            return self._reject(request)
+        else:
+            return None
+
+    def _reject(self, request):
+        return service_unavailable(request)
+
+
+class ServiceUnavailable(Exception):
+    """
+    Exception indicating an action is impossible due to maintenance.
+
+    This exception should be raised by a view if the requested action
+    is disallowed because of settings.SYSTEM_MAINTENANCE_NO_CHANGES or
+    settings.SYSTEM_MAINTENANCE_NO_UPLOAD.
+    """
+    pass
+
+
+def service_unavailable(request):
+    """
+    Generate a '503 Service Unavailable' error page.
+    """
+    response = render(request, ERROR_TEMPLATE, {
+        'maintenance_message': settings.SYSTEM_MAINTENANCE_MESSAGE,
+    }, status=503)
+
+    # Invoke log_response manually (causing the default logging to be
+    # skipped), since otherwise Django will treat a 503 status as an
+    # error requiring a verbose log message and email to admins
+    log_response(
+        'Service Unavailable: %s', request.path,
+        request=request,
+        response=response,
+        level='warning',
+    )
+    return response
+
+
+def allow_post_during_maintenance(view_func):
+    """
+    Decorator for views that may accept POSTs during maintenance.
+
+    This means that when SYSTEM_MAINTENANCE_NO_CHANGES is set, the
+    view may receive POST and other "stateful" HTTP requests, which
+    would normally be disallowed.
+
+    It should be understood that if maintenance mode is active,
+    changes made to the database and/or filesystem might not be
+    persistent, so this decorator should seldom be used.
+    """
+    @functools.wraps(view_func)
+    def wrapped_view(*args, **kwargs):
+        return view_func(*args, **kwargs)
+    wrapped_view.view_allow_post_during_maintenance = True
+    return wrapped_view
+
+
+def disallow_during_maintenance(view_func):
+    """
+    Decorator for views that are disabled during maintenance.
+
+    This means that when SYSTEM_MAINTENANCE_NO_CHANGES is set, the
+    view always returns an error page with a status of "503 Service
+    Unavailable".
+    """
+    @functools.wraps(view_func)
+    def wrapped_view(*args, **kwargs):
+        if settings.SYSTEM_MAINTENANCE_NO_CHANGES:
+            raise ServiceUnavailable()
+        return view_func(*args, **kwargs)
+    return wrapped_view

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'physionet.middleware.maintenance.SystemMaintenanceMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -135,6 +136,19 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR,'static')]
 # Google Storge service account credentials
 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.path.join(BASE_DIR, 'PhysioNet-Data-credentials.json')
+
+# Maintenance mode
+
+# If true, disable all POSTs and other requests to make changes
+SYSTEM_MAINTENANCE_NO_CHANGES = config('SYSTEM_MAINTENANCE_NO_CHANGES',
+                                       cast=bool, default=False)
+# If true, disable upload functions
+SYSTEM_MAINTENANCE_NO_UPLOAD = config('SYSTEM_MAINTENANCE_NO_UPLOAD',
+                                      cast=bool, default=False)
+# HTML error message displayed during maintenance
+SYSTEM_MAINTENANCE_MESSAGE = config('SYSTEM_MAINTENANCE_MESSAGE',
+                                    default=None)
+
 
 # Google G suite Groups service account and Private Key file
 SERVICE_ACCOUNT_EMAIL = 'gcp-physionet-groups@physionet-data.iam.gserviceaccount.com'

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from notification.models import News
 import notification.utility as notification
+from physionet.middleware.maintenance import allow_post_during_maintenance
 from project.models import (License, PublishedProject, Author, ActiveProject,
                             Metadata, ProjectType)
 from user.forms import ContactForm
@@ -57,6 +58,7 @@ def license_content(request, license_slug):
     return render(request, 'about/license_content.html', {'license': license})
 
 
+@allow_post_during_maintenance
 def about(request):
     """
     About the site content.

--- a/physionet-django/project/templates/project/project_files.html
+++ b/physionet-django/project/templates/project/project_files.html
@@ -24,6 +24,10 @@
   <div class="alert alert-form alert-warning alert-dismissible">
     <strong>Only the submitting author may upload or edit files.</strong>
   </div>
+{% elif maintenance_message %}
+  <div class="alert alert-form alert-warning alert-dismissible">
+    {{ maintenance_message }}
+  </div>
 {% endif %}
 
 <div class="card">

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -231,6 +231,9 @@ def project_home(request):
 
 @login_required
 def create_project(request):
+    if settings.SYSTEM_MAINTENANCE_NO_UPLOAD:
+        raise ServiceUnavailable()
+
     user = request.user
 
     n_submitting = Author.objects.filter(user=user, is_submitting=True,
@@ -255,6 +258,9 @@ def new_project_version(request, project_slug):
     Publish a new version of a project
 
     """
+    if settings.SYSTEM_MAINTENANCE_NO_UPLOAD:
+        raise ServiceUnavailable()
+
     user = request.user
 
     n_submitting = Author.objects.filter(user=user, is_submitting=True,

--- a/physionet-django/templates/site_maintenance.html
+++ b/physionet-django/templates/site_maintenance.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}
+Temporarily Unavailable
+{% endblock %}
+
+{% block content %}
+<div class="container" align='center'>
+  <h1>Temporarily Unavailable</h1>
+  <div class="alert alert-warning">
+  {% if maintenance_message %}
+  {{ maintenance_message|safe }}
+  {% else %}
+  The site is currently undergoing maintenance.  Please try again later.
+  {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -303,6 +303,12 @@ def edit_profile(request):
     form = forms.ProfileForm(instance=profile)
 
     if request.method == 'POST':
+        if settings.SYSTEM_MAINTENANCE_NO_UPLOAD:
+            # Allow submitting the form, but do not allow the photo to
+            # be modified.
+            if 'delete_photo' in request.POST or request.FILES:
+                raise ServiceUnavailable()
+
         if 'edit_profile' in request.POST:
             # Update the profile and return to the same page. Place a message
             # at the top of the page: 'your profile has been updated'

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -31,7 +31,8 @@ from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
 from physionet import utility
 from physionet.middleware.maintenance import (allow_post_during_maintenance,
-                                              disallow_during_maintenance)
+                                              disallow_during_maintenance,
+                                              ServiceUnavailable)
 from project.models import Author, License, PublishedProject
 from notification.utility import (process_credential_complete,
                                   credential_application_request,
@@ -492,6 +493,9 @@ def credential_application(request):
     if user.is_credentialed or CredentialApplication.objects.filter(
             user=user, status=0):
         return redirect('edit_credentialing')
+
+    if settings.SYSTEM_MAINTENANCE_NO_UPLOAD:
+        raise ServiceUnavailable()
 
     if request.method == 'POST':
         # We use the individual forms to render the errors in the template

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -23,12 +23,14 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
 from django.db import transaction
 
 from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
 from physionet import utility
+from physionet.middleware.maintenance import allow_post_during_maintenance
 from project.models import Author, License, PublishedProject
 from notification.utility import (process_credential_complete,
                                   credential_application_request,
@@ -38,6 +40,7 @@ from notification.utility import (process_credential_complete,
 logger = logging.getLogger(__name__)
 
 
+@method_decorator(allow_post_during_maintenance, 'dispatch')
 class LoginView(auth_views.LoginView):
     template_name = 'user/login.html'
     authentication_form = forms.LoginForm

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -30,7 +30,8 @@ from django.db import transaction
 from user import forms
 from user.models import AssociatedEmail, Profile, User, CredentialApplication, LegacyCredential, CloudInformation
 from physionet import utility
-from physionet.middleware.maintenance import allow_post_during_maintenance
+from physionet.middleware.maintenance import (allow_post_during_maintenance,
+                                              disallow_during_maintenance)
 from project.models import Author, License, PublishedProject
 from notification.utility import (process_credential_complete,
                                   credential_application_request,
@@ -65,6 +66,7 @@ class PasswordResetDoneView(auth_views.PasswordResetDoneView):
 
 # Prompt user to enter new password and carry out password reset (if
 # url is valid)
+@method_decorator(disallow_during_maintenance, 'dispatch')
 class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
     template_name = 'user/reset_password_confirm.html'
     success_url = reverse_lazy('reset_password_complete')
@@ -90,6 +92,7 @@ edit_password = PasswordChangeView.as_view()
 
 
 @sensitive_post_parameters('password1', 'password2')
+@disallow_during_maintenance
 def activate_user(request, uidb64, token):
     """
     Page to active the account of a newly registered user.
@@ -396,6 +399,7 @@ def user_settings(request):
 
 
 @login_required
+@disallow_during_maintenance
 def verify_email(request, uidb64, token):
     """
     Page to verify an associated email


### PR DESCRIPTION
This adds several new options that can be set in .env.

SYSTEM_MAINTENANCE_NO_CHANGES means that generally, nothing is allowed to make persistent changes.  For example, no one is allowed to register an account, change their password, edit project descriptions, or upload files.  However, this doesn't prevent people from logging in to view protected/unpublished projects.

SYSTEM_MAINTENANCE_NO_UPLOAD means that project files cannot be manipulated.  For example, new projects can't be created, files can't be uploaded, and active projects can't be published.  However, project descriptions can be edited and most other site functions work normally.

SYSTEM_MAINTENANCE_MESSAGE optionally defines the error message that is displayed.

For further background and discussion, see issue #674.


The "no-changes" mode is enforced by middleware.  GET requests should not modify server-side state, so are generally allowed.  POST requests can modify server-side state, so are generally disallowed.  There are some exceptions:

- /login/ uses POST, and it saves session information on the server side, but keeping login functional is more important than retaining the information, so this is allowed in "no-changes" mode.

- /reset/X/Y/ and /activate/X/Y/ rely on proper operation of sessions (and of course submitting the form makes changes to the user tables), so these are disallowed in "no-changes" mode.

- /verify/X/Y/ makes changes even on a GET request, so this is disallowed in "no-changes" mode.

- /about/ (yeah, that's the contact form) uses POST, but doesn't save information to the database.  It merely sends a message to the mail server, which doesn't care about any of this.


"No-upload" mode is enforced by individual views:

- /projects/X/files/: in no-upload mode, controls should be disabled and uploads should be refused.

- /projects/create/: all access denied.

- /projects/new-version/X/: all access denied.

- /console/submitted-projects/X/copyedit/: should allow editing description but not files.

- /console/submitted-projects/X/publish/: all access denied.

- /console/published-projects/X/Y/: should allow managing DOIs, uploading to GCP, but not changing files.


As you can see, there are a number of corner cases to consider, but I think this is better than a blanket approach that would make protected projects inaccessible for hours or days.  Please try to look for any other corner cases I've missed.
