### PR TITLE
Fixing issue in mailto function when the name contains a comma and special char

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -485,7 +485,7 @@ def mailto_reference(request, application):
             'footer': email_footer()
         })
 
-    to = formataddr((application.reference_name,
+    to = formataddr((application.reference_name.replace(',', ''),
                      application.reference_email))
     bcc = 'credential-reference+{0}@{1}'.format(
         application.id, get_current_site(request))
@@ -509,7 +509,7 @@ def mailto_supervisor(request, application):
             'footer': email_footer()
         })
 
-    to = formataddr((application.reference_name,
+    to = formataddr((application.reference_name.replace(',', ''),
                      application.reference_email))
     bcc = 'credential-reference+{0}@{1}'.format(
         application.id, get_current_site(request))
@@ -535,7 +535,7 @@ def mailto_process_credential_complete(request, application, comments=True):
     else:
         body = 'Dear {0},\n\n{1}'.format(application.first_names, body)
 
-    to = formataddr((application.get_full_name(),
+    to = formataddr((application.get_full_name().replace(',', ''),
                      application.user.email))
     bcc = 'credential-reference+{0}@{1}'.format(
         application.id, get_current_site(request))

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -485,6 +485,8 @@ def mailto_reference(request, application):
             'footer': email_footer()
         })
 
+    # rm comma to handle mailto issue with comma and special char.
+    # ref https://github.com/MIT-LCP/physionet-build/issues/1028
     to = formataddr((application.reference_name.replace(',', ''),
                      application.reference_email))
     bcc = 'credential-reference+{0}@{1}'.format(
@@ -509,6 +511,8 @@ def mailto_supervisor(request, application):
             'footer': email_footer()
         })
 
+    # rm comma to handle mailto issue with comma and special char.
+    # ref https://github.com/MIT-LCP/physionet-build/issues/1028
     to = formataddr((application.reference_name.replace(',', ''),
                      application.reference_email))
     bcc = 'credential-reference+{0}@{1}'.format(
@@ -535,6 +539,8 @@ def mailto_process_credential_complete(request, application, comments=True):
     else:
         body = 'Dear {0},\n\n{1}'.format(application.first_names, body)
 
+    # rm comma to handle mailto issue with comma and special char.
+    # Ref https://github.com/MIT-LCP/physionet-build/issues/1028
     to = formataddr((application.get_full_name().replace(',', ''),
                      application.user.email))
     bcc = 'credential-reference+{0}@{1}'.format(


### PR DESCRIPTION
When a credentialed application adds the reference with a special character
ans a comma,  the mailto function breaks the 'TO' at the comma and adds
an empty email in the mailto.

Here I just remove all commas if any on the mailto 'TO' section.

closing #1028