### PR TITLE
Fixing typo on function call

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -587,7 +587,7 @@ class Metadata(models.Model):
         if separate_submitting:
             submitting_author = authors.get(is_submitting=True)
             coauthors = authors.filter(is_submitting=False)
-            submitting_author.set_display_infprevious_versiono()
+            submitting_author.set_display_info()
             for a in coauthors:
                 a.set_display_info()
             if include_emails:


### PR DESCRIPTION
Up to now, there is no case where separate_submitting is true. 

I removed the "previous_version" because there is no mention of version in that statement and kept "set_display_info" just as the else statement. 

closes #1034