### PR TITLE
Prevents credential change of names

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -247,8 +247,10 @@ class PersonalCAF(forms.ModelForm):
             'organization_name', 'job_title', 'city', 'state_province',
             'zip_code', 'country', 'webpage')
         help_texts = {
-            'first_names': "First name(s).",
-            'last_name': "Last (family) name.",
+            'first_names': """First name(s). Your Physionet first name by default. This 
+                can be edited in your profile settings.""",
+            'last_name': """Last (family) name. Your Physionet last name by default. This 
+                can be edited in your profile settings.""",
             'suffix': """Please leave the suffix blank if your name does not 
                 include a suffix like "Jr." or "III". Do not list degrees. 
                 Do not put a prefix like "Mr" or "Ms". Do not put "not 
@@ -272,6 +274,8 @@ class PersonalCAF(forms.ModelForm):
         widgets = {
            'research_summary': forms.Textarea(attrs={'rows': 3}),
            'suffix': forms.TextInput(attrs={'autocomplete': 'off'}),
+           'first_names': forms.TextInput(attrs={'readonly':'readonly'}),
+           'last_name': forms.TextInput(attrs={'readonly':'readonly'}),
         }
         labels = {
             'state_province': 'State/Province',

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -247,10 +247,10 @@ class PersonalCAF(forms.ModelForm):
             'organization_name', 'job_title', 'city', 'state_province',
             'zip_code', 'country', 'webpage')
         help_texts = {
-            'first_names': """First name(s). Your profile first name by default. This 
-                can be edited in your profile settings.""",
-            'last_name': """Last (family) name. Your profile last name by default. This 
-                can be edited in your profile settings.""",
+            'first_names': """You first name(s). This can be edited in your 
+                profile settings.""",
+            'last_name': """Your last (family) name. This can be edited in 
+                your profile settings.""",
             'suffix': """Please leave the suffix blank if your name does not 
                 include a suffix like "Jr." or "III". Do not list degrees. 
                 Do not put a prefix like "Mr" or "Ms". Do not put "not 

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -274,8 +274,6 @@ class PersonalCAF(forms.ModelForm):
         widgets = {
            'research_summary': forms.Textarea(attrs={'rows': 3}),
            'suffix': forms.TextInput(attrs={'autocomplete': 'off'}),
-           'first_names': forms.TextInput(attrs={'readonly':'readonly'}),
-           'last_name': forms.TextInput(attrs={'readonly':'readonly'}),
         }
         labels = {
             'state_province': 'State/Province',
@@ -290,6 +288,8 @@ class PersonalCAF(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.user = user
         self.profile = user.profile
+        self.fields['first_names'].disabled = True
+        self.fields['last_name'].disabled = True
 
         self.initial = {'first_names':self.profile.first_names,
             'last_name':self.profile.last_name,

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -247,9 +247,9 @@ class PersonalCAF(forms.ModelForm):
             'organization_name', 'job_title', 'city', 'state_province',
             'zip_code', 'country', 'webpage')
         help_texts = {
-            'first_names': """First name(s). Your Physionet first name by default. This 
+            'first_names': """First name(s). Your profile first name by default. This 
                 can be edited in your profile settings.""",
-            'last_name': """Last (family) name. Your Physionet last name by default. This 
+            'last_name': """Last (family) name. Your profile last name by default. This 
                 can be edited in your profile settings.""",
             'suffix': """Please leave the suffix blank if your name does not 
                 include a suffix like "Jr." or "III". Do not list degrees. 


### PR DESCRIPTION
Prevents users from changing their name on new credential applications to prevent future confusion. This was a requested change of @kpierceHST. 