### PR TITLE
Fix name and lastname disabled in cred apps

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -394,6 +394,10 @@ class CredentialApplicationForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.user = user
         self.profile = user.profile
+        self.fields['first_names'].disabled = True
+        self.fields['last_name'].disabled = True
+        self.initial = {'first_names': self.profile.first_names,
+                        'last_name': self.profile.last_name}
 
     def clean(self):
         data = self.cleaned_data


### PR DESCRIPTION
In #1041 disabled was introduced to name and last name for the credentialed applications. Since both fields are disabled they are not in the request.POST variables which makes this form to fail
with the following error:
 - {'first_names': ['This field is required.'], 'last_name': ['This field is required.']}

To be able to fix this, one has to disable the field in the form init so that the field isn't "cleaned" with an empty value and then initialize the field with the current name and last name.