### PR TITLE
Add "PLATFORM_NAME" variable to settings

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -21,6 +21,8 @@ import logging.config
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Customisable platform settings
+PLATFORM_NAME = 'PhysioNet'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/


### PR DESCRIPTION
This is a very minor change that adds a `PLATFORM_NAME` variable to the base settings and sets it to "PhysioNet". The platform name can then be displayed with 

```
from django.conf import settings
settings.PLATFORM_NAME
```

I'm surprised that it didn't exist already, but I don't see it anywhere. The benefits are:

- makes the platform generablisable, by helping to reduce hardcoded "PhysioNet"s.
- helps to avoid misspellings (physionet, Physionet, etc).

Should we take this further and display different values for the different servers (e.g. PhysioNet-Dev; PhysioNet-Staging; PhysioNet)? 