### PR TITLE
Add 7 days notice in outgoing emails

### DIFF
--- a/physionet-django/user/templates/user/email/register_email.html
+++ b/physionet-django/user/templates/user/email/register_email.html
@@ -5,6 +5,8 @@ Thanks for registering for an account on {{ domain }}. Please activate your acco
 
 {{ url_prefix }}{% url 'activate_user' uidb64=uidb64 token=token %}
 
+This link will expire in 7 days or after the account has been activated.
+
 Regards
 The PhysioNet Team
 {% endfilter %}{% endautoescape %}

--- a/physionet-django/user/templates/user/email/reset_password_email.html
+++ b/physionet-django/user/templates/user/email/reset_password_email.html
@@ -6,6 +6,8 @@
 https://{{ domain }}{% url 'reset_password_confirm' uidb64=uid token=token %}
 {% endblock %}
 
+This link will expire in 7 days or after the password has been changed.
+
 Regards
 The PhysioNet Team
 {% endfilter %}{% endautoescape %}

--- a/physionet-django/user/templates/user/email/unverified_email_removal.html
+++ b/physionet-django/user/templates/user/email/unverified_email_removal.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ name }},
 
-The email "{{ email }}" you attempted to add to your account has been un-verified for 15 days and thus removed.
+The email "{{ email }}" you attempted to add to your account has been un-verified for 7 days and thus removed.
 
 Regards
 The PhysioNet Team

--- a/physionet-django/user/templates/user/email/verify_email_email.html
+++ b/physionet-django/user/templates/user/email/verify_email_email.html
@@ -5,6 +5,8 @@ You have requested this email to be added to your account on {{ domain }}. Pleas
 
 {{ url_prefix }}{% url 'verify_email' uidb64=uidb64 token=token %}
 
+This link will expire in 7 days or after the email has been verified.
+
 Regards
 The PhysioNet Team
 {% endfilter %}{% endautoescape %}


### PR DESCRIPTION
Added a 7 days notice on the links that we send out to:
 - Register for new accounts
 - Reset passwords
 - Add new emails

I also updated a html template of a unused function.
The unverified_email_removal.html was part of a 'cron' app that
was removed X time ago. I am guessing this could/should be removed
but just in case I will leave that for another PR.