### PR TITLE
Fixes newline in serve_published_project_file URL

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1417,6 +1417,8 @@ def serve_published_project_file(request, project_slug, version,
             else:
                 sandbox = True
 
+            file_path = file_path.replace('%0D','')
+
             return serve_file(file_path, attach=attach, allow_directory=True,
                               sandbox=sandbox)
         except IsADirectoryError:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1417,7 +1417,10 @@ def serve_published_project_file(request, project_slug, version,
             else:
                 sandbox = True
 
-            file_path = file_path.replace('%0D','')
+            if '%0D' in file_path:
+                raise Exception("Newline character in URL",
+                                "Either remove from file_path directly or "
+                                "use.. | tr -d '\r' in bash")
 
             return serve_file(file_path, attach=attach, allow_directory=True,
                               sandbox=sandbox)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1417,11 +1417,6 @@ def serve_published_project_file(request, project_slug, version,
             else:
                 sandbox = True
 
-            if '%0D' in file_path:
-                raise Exception("Newline character in URL",
-                                "Either remove from file_path directly or "
-                                "use.. | tr -d '\r' in bash")
-
             return serve_file(file_path, attach=attach, allow_directory=True,
                               sandbox=sandbox)
         except IsADirectoryError:


### PR DESCRIPTION
Removes the Hex representation of a newline (%0D) from the request URL generated in the `serve_published_project_file` function. Fixes #1050.