### PR TITLE
Show Anonymous access on non-open projects

### DIFF
--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -60,6 +60,7 @@
     </div>
 </div>
 
+{% if project.access_policy %}
 <div class="card mb-3">
     <div class="card-header">
       Anonymous access
@@ -100,6 +101,7 @@
         </form>
     </div>
 </div>
+{% endif %}
 
 <div class="card mb-3">
     <div class="card-header">


### PR DESCRIPTION
At the moment the "Anonymous access" section is shown even on open projects under the manage published projects page.

Here I hide from the console the section of Anonymous access to projects that are open to the world.