### PR TITLE
Add a way to add new authors to legacy projects

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -7,11 +7,12 @@ from django.core.validators import validate_integer, validate_email, URLValidato
 from google.cloud import storage
 from django.db import transaction
 from django.conf import settings
+from dal import autocomplete
 
 from notification.models import News
 from project.models import (ActiveProject, EditLog, CopyeditLog, Contact,
-    PublishedProject, exists_project_slug, DataAccess)
-
+                            PublishedProject, exists_project_slug, DataAccess,
+                            PublishedAffiliation, PublishedAuthor)
 from project.validators import validate_slug, MAX_PROJECT_SLUG_LENGTH, validate_doi
 from user.models import User, CredentialApplication
 from console.utility import generate_doi_payload, register_doi
@@ -445,3 +446,49 @@ class PublishedProjectContactForm(forms.ModelForm):
         contact.project = self.project
         contact.save()
         return contact
+
+
+class CreateLegacyAuthorForm(forms.ModelForm):
+    """
+    Merge two user accounts
+    """
+    author = forms.ModelChoiceField(
+        queryset=User.objects.filter(is_active=True).order_by('username'),
+        widget=autocomplete.ModelSelect2(url='user-autocomplete'),
+        required=True,
+        label="Author's username")
+
+    class Meta:
+        model = PublishedAffiliation
+        fields = ('name',)
+        labels = {'name': 'Afiliation', }
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+    def clean_author(self):
+        author = self.cleaned_data['author']
+
+        if self.project.authors.filter(user=author):
+            raise forms.ValidationError('The person is already an author.')
+        return author
+
+    def save(self):
+        if self.errors:
+            return
+
+        author = self.cleaned_data['author']
+        afiliation = super().save(commit=False)
+        display_order = self.project.authors.count() + 1
+        submitting = False
+        if display_order == 1:
+            submitting = True
+
+        afiliation.author = PublishedAuthor.objects.create(
+            first_names=author.profile.first_names, project=self.project,
+            last_name=author.profile.last_name, user=author,
+            display_order=display_order, is_submitting=submitting)
+
+        afiliation.save()
+        return afiliation

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -461,7 +461,7 @@ class CreateLegacyAuthorForm(forms.ModelForm):
     class Meta:
         model = PublishedAffiliation
         fields = ('name',)
-        labels = {'name': 'Afiliation', }
+        labels = {'name': 'Affiliation', }
 
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -479,16 +479,16 @@ class CreateLegacyAuthorForm(forms.ModelForm):
             return
 
         author = self.cleaned_data['author']
-        afiliation = super().save(commit=False)
+        affiliation = super().save(commit=False)
         display_order = self.project.authors.count() + 1
         submitting = False
         if display_order == 1:
             submitting = True
 
-        afiliation.author = PublishedAuthor.objects.create(
+        affiliation.author = PublishedAuthor.objects.create(
             first_names=author.profile.first_names, project=self.project,
             last_name=author.profile.last_name, user=author,
             display_order=display_order, is_submitting=submitting)
 
-        afiliation.save()
-        return afiliation
+        affiliation.save()
+        return affiliation

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -50,7 +50,7 @@
   </div>
 </div>
 <!-- legacy project management -->
-
+{% if project.is_legacy %}
 <div class="card mb-3">
     <div class="card-header">
       Legacy project management
@@ -65,7 +65,7 @@
 
     </div>
 </div>
-
+{% endif %}
 
 <div class="card mb-3">
     <div class="card-header">

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -50,10 +50,10 @@
   </div>
 </div>
 <!-- legacy project management -->
-{% if project.is_legacy %}
+
 <div class="card mb-3">
     <div class="card-header">
-      Legacy project author management
+      Legacy project management
     </div>
     <div class="card-body">
       <h3>Add an author</h3>
@@ -65,7 +65,7 @@
 
     </div>
 </div>
-{% endif %}
+
 
 <div class="card mb-3">
     <div class="card-header">

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -49,6 +49,23 @@
     </div>
   </div>
 </div>
+<!-- legacy project management -->
+{% if project.is_legacy %}
+<div class="card mb-3">
+    <div class="card-header">
+      Legacy project author management
+    </div>
+    <div class="card-body">
+      <h3>Add an author</h3>
+
+      <form method="POST" id="legacy_author_form">
+        {% include "inline_form_snippet.html" with form=legacy_author_form %}
+        <button class="btn btn-primary btn-fixed" name="set_legacy_author" type="submit">Set author</button>
+      </form>
+
+    </div>
+</div>
+{% endif %}
 
 <div class="card mb-3">
     <div class="card-header">

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -78,4 +78,7 @@ urlpatterns = [
 
     # guidelines
     path('guidelines/review/', views.guidelines_review, name='guidelines_review'),
+
+    path('user-autocomplete/', views.UserAutocomplete.as_view(),
+    name='user-autocomplete'),
 ]

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1493,9 +1493,8 @@ def project_access_manage(request, pid):
 class UserAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         """
-        Get all occurrances where a user is active and the username contains
-        the request string.
-        The person doing the search cannot be part of the search results.
+        Get all active users with usernames that match the request string,
+        excluding the user who is doing the search.
         """
         qs = User.objects.filter(is_active=True)
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -19,6 +19,7 @@ from django.db import DatabaseError, transaction
 from django.db.models import Q, CharField, Value, IntegerField, F, functions
 from background_task import background
 from django.contrib.sites.models import Site
+from dal import autocomplete
 
 from notification.models import News
 import notification.utility as notification
@@ -712,6 +713,7 @@ def manage_published_project(request, project_slug, version):
     data_access_form = forms.DataAccessForm(project=project)
     contact_form = forms.PublishedProjectContactForm(project=project,
                                                      instance=project.contact)
+    legacy_author_form = forms.CreateLegacyAuthorForm(project=project)
 
     if request.method == 'POST':
         if any(x in request.POST for x in ['create_doi_core',
@@ -786,6 +788,12 @@ def manage_published_project(request, project_slug, version):
             if contact_form.is_valid():
                 contact_form.save()
                 messages.success(request, 'The contact information has been updated')
+        elif 'set_legacy_author' in request.POST:
+            legacy_author_form = forms.CreateLegacyAuthorForm(project=project,
+                                                              data=request.POST)
+            if legacy_author_form.is_valid():
+                legacy_author_form.save()
+                legacy_author_form = forms.CreateLegacyAuthorForm(project=project)
 
     data_access = DataAccess.objects.filter(project=project)
     authors, author_emails, storage_info, edit_logs, copyedit_logs, latest_version = project.info_card()
@@ -806,7 +814,8 @@ def manage_published_project(request, project_slug, version):
          'rw_tasks': rw_tasks, 'ro_tasks': ro_tasks,
          'anonymous_url': anonymous_url, 'passphrase': passphrase,
          'published_projects_nav': True, 'url_prefix': url_prefix,
-         'contact_form': contact_form})
+         'contact_form': contact_form,
+         'legacy_author_form': legacy_author_form})
 
 
 def gcp_bucket_management(request, project, user):
@@ -1480,3 +1489,17 @@ def project_access_manage(request, pid):
             'c_project': c_project, 'project_members': project_members,
             'project_access_nav': True})
 
+
+class UserAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        """
+        Get all occurrances where a user is active and the username contains
+        the request string.
+        The person doing the search cannot be part of the search results.
+        """
+        qs = User.objects.filter(is_active=True)
+
+        if self.q:
+            qs = qs.filter(username__icontains=self.q)
+
+        return qs

--- a/physionet-django/templates/inline_form_snippet.html
+++ b/physionet-django/templates/inline_form_snippet.html
@@ -1,3 +1,4 @@
+{% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
     <label class="col-md-2" for="{{ field.id_for_label }}" title="{{ field.help_text }}">{{ field.label }}
@@ -20,3 +21,4 @@
 {% for field in form.hidden_fields %}
   {{ field }}
 {% endfor %}
+{{ form.media }}


### PR DESCRIPTION
IF a published project is legacy, then another section will appear to add and only add new authors.

The order of the authors will be sequential as added.
The first author added will be the submitting author.

At the moment I left the corresponding to False as default.

To add the user object, I took a similar approach to the parent project.
closes #1057