### PR TITLE
Adds a way to alter the contact information.

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -9,8 +9,9 @@ from django.db import transaction
 from django.conf import settings
 
 from notification.models import News
-from project.models import (ActiveProject, EditLog, CopyeditLog,
+from project.models import (ActiveProject, EditLog, CopyeditLog, Contact,
     PublishedProject, exists_project_slug, DataAccess)
+
 from project.validators import validate_slug, MAX_PROJECT_SLUG_LENGTH, validate_doi
 from user.models import User, CredentialApplication
 from console.utility import generate_doi_payload, register_doi
@@ -428,3 +429,19 @@ class DataAccessForm(forms.ModelForm):
         data_access.project = self.project
         data_access.save()
         return data_access
+
+
+class PublishedProjectContactForm(forms.ModelForm):
+    class Meta:
+        model = Contact
+        fields = ('name', 'affiliations', 'email')
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+    def save(self):
+        contact = super().save(commit=False)
+        contact.project = self.project
+        contact.save()
+        return contact

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -52,6 +52,20 @@
 
 <div class="card mb-3">
     <div class="card-header">
+      Contact information
+    </div>
+    <div class="card-body">
+      <h3>Project contact information</h3>
+      <form method="POST" id="contact_form">
+        {% csrf_token %}
+        {% include "inline_form_snippet.html" with form=contact_form %}
+        <button class="btn btn-primary btn-fixed" name="set_contact" type="submit">Set contact</button>
+      </form>
+    </div>
+</div>
+
+<div class="card mb-3">
+    <div class="card-header">
       Contact authors
     </div>
     <div class="card-body">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -710,6 +710,8 @@ def manage_published_project(request, project_slug, version):
     deprecate_form = None if project.deprecated_files else forms.DeprecateFilesForm()
     has_credentials = os.path.exists(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
     data_access_form = forms.DataAccessForm(project=project)
+    contact_form = forms.PublishedProjectContactForm(project=project,
+                                                     instance=project.contact)
 
     if request.method == 'POST':
         if any(x in request.POST for x in ['create_doi_core',
@@ -778,6 +780,12 @@ def manage_published_project(request, project_slug, version):
         elif 'remove_passphrase' in request.POST:
             project.anonymous.all().delete()
             anonymous_url = ''
+        elif 'set_contact' in request.POST:
+            contact_form = forms.PublishedProjectContactForm(
+                instance=project.contact, project=project, data=request.POST)
+            if contact_form.is_valid():
+                contact_form.save()
+                messages.success(request, 'The contact information has been updated')
 
     data_access = DataAccess.objects.filter(project=project)
     authors, author_emails, storage_info, edit_logs, copyedit_logs, latest_version = project.info_card()
@@ -797,7 +805,9 @@ def manage_published_project(request, project_slug, version):
          'data_access_form': data_access_form, 'data_access': data_access,
          'rw_tasks': rw_tasks, 'ro_tasks': ro_tasks,
          'anonymous_url': anonymous_url, 'passphrase': passphrase,
-         'published_projects_nav': True, 'url_prefix': url_prefix})
+         'published_projects_nav': True, 'url_prefix': url_prefix,
+         'contact_form': contact_form})
+
 
 def gcp_bucket_management(request, project, user):
     """


### PR DESCRIPTION
Here I add a tab in the manage published project page to alter the contact information of the published project.

This is useful for challenges and legacy projects. 
closes #1054