### PR TITLE
Fixes references order #590

### DIFF
--- a/physionet-django/project/models.py
+++ b/physionet-django/project/models.py
@@ -1701,7 +1701,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                     published_project.set_version_order()
 
                 # Same content, different objects.
-                for reference in self.references.all():
+                for reference in self.references.all().order_by('id'):
                     published_reference = PublishedReference.objects.create(
                         description=reference.description,
                         project=published_project)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1103,7 +1103,7 @@ def project_preview(request, project_slug, subdir='', **kwargs):
     corresponding_author = authors.get(is_corresponding=True)
     corresponding_author.text_affiliations = ', '.join(a.name for a in corresponding_author.affiliations.all())
 
-    references = project.references.all()
+    references = project.references.all().order_by('id')
     publication = project.publications.all().first()
     topics = project.topics.all()
     parent_projects = project.parent_projects.all()
@@ -1530,7 +1530,7 @@ def published_project(request, project_slug, version, subdir=''):
     authors = project.authors.all().order_by('display_order')
     for a in authors:
         a.set_display_info()
-    references = project.references.all()
+    references = project.references.all().order_by('id')
     publication = project.publications.all().first()
     topics = project.topics.all()
     languages = project.programming_languages.all()


### PR DESCRIPTION
Maintains the order of references originally submitted during the creation and editing of a new project. Fixes #590.