### PR TITLE
minor changes to wording of emails for self-managed projects

### DIFF
--- a/physionet-django/notification/templates/notification/email/confirm_user_data_access_request.html
+++ b/physionet-django/notification/templates/notification/email/confirm_user_data_access_request.html
@@ -1,9 +1,9 @@
 Dear {{ data_access_request.requester.get_full_name }},
 
-You have requested access for the project {{ data_access_request.project.title }} {{ data_access_request.project.version }}.
-You will receive a decision by {{ due_date | date }}.
+Thank you for requesting access to the project "{{ data_access_request.project.title }} {{ data_access_request.project.version }}".
+You will receive a decision from the project owners by {{ due_date | date }}.
 
-You can check the status of your request at
+You can check the status of your request at:
 {{ request_protocol}}://{{ request_host}}{% url 'data_access_request_status' data_access_request.project.slug data_access_request.project.version %}
 
 {{ signature }}

--- a/physionet-django/notification/templates/notification/email/notify_user_data_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_user_data_access_request.html
@@ -1,10 +1,10 @@
 Dear {{ data_access_request.requester.get_full_name }},
 
-You have requested access to the data of {{ data_access_request.project }}
+We are writing in response to your request for access to the project "{{ data_access_request.project }}". 
 
-The authors decided to {% if data_access_request.is_accepted %}accept{%else%}not grant{% endif %} this request.
+{% if data_access_request.is_accepted %}We are pleased to say that the project owners have approved{%else%}We are sorry to say that the project owners did not approve{% endif %} the request.
 
-More details following this link:
+For more details, please follow the link below:
 {{ request_protocol}}://{{ request_host}}{% url 'data_access_request_status' data_access_request.project.slug data_access_request.project.version %}
 
 {{ signature }}


### PR DESCRIPTION
This is a couple of minor changes to the wording of emails that are sent to people who request access to self-managed projects. 

The changes are intended to clean up the wording in a couple of places ("e.g. The authors decided to not grant..." is slightly unusual wording, as is "More details following this link:").

## Email 1, sent after requesting access (before this PR):

```
You have requested access for the project selfy 1.0.
You will receive a decision by June 12, 2020.

You can check the status of your request at
http://127.0.0.1:8000/request-access-status/done/1.0/
```

## Email 1, sent after requesting access (after this PR):

```
Thank you for requesting access to the project "selfy 1.0".
You will receive a decision from the project owners by June 12, 2020.

You can check the status of your request at:
http://localhost:8000/request-access-status/done/1.0/
```

## Email 2, sent after a decision is made (before this PR):

```
You have requested access to the data of selfy v1.0

The authors decided to not grant this request.

More details following this link:
http://127.0.0.1:8000/request-access-status/done/1.0/
```

## Email 2, sent after a decision is made (after this PR):

```
We are writing in response to your request for access to the project "selfy v1.0". 

We are sorry to say that the project owners did not approve the request.

For more details, please follow the link below:
http://localhost:8000/request-access-status/done/1.0/
```