### PR TITLE
add author comments to the submission notification emails

### DIFF
--- a/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
+++ b/physionet-django/notification/templates/notification/email/resubmit_notify_editor.html
@@ -3,9 +3,10 @@
 
 Dear {{ name }},
 
-The project you have requested revisions for, "{{ project.title }}", has been resubmitted for review.
+The project "{{ project.title }}" was resubmitted for review.
 
-We would be grateful if you could review the revised submission within 7 days.
+We would be grateful if you could review the revised submission within 7 days. {% if author_comments %}The author included the following comment with the submission: 
+{{ author_comments }}{% endif %}
 
 {{ signature }}
 

--- a/physionet-django/notification/templates/notification/email/submit_notify_team.html
+++ b/physionet-django/notification/templates/notification/email/submit_notify_team.html
@@ -3,7 +3,9 @@
 
 Dear {{ name }},
 
-The project entitled "{{ project.title }}" has been submitted to PhysioNet.
+The project entitled "{{ project.title }}" has been submitted to PhysioNet. {% if project.author_comments %}The author included the following comment with the submission: 
+
+{{ project.author_comments }}{% endif %}
 
 {{ signature }}
 

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -184,6 +184,7 @@ def submit_notify(project):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                   [email], fail_silently=False)
 
+    # notify editorial team
     subject = 'A new project has been submitted: {0}'.format(project.title)
     email_context['name'] = "Colleague"
     body = loader.render_to_string(
@@ -193,7 +194,7 @@ def submit_notify(project):
           [settings.CONTACT_EMAIL], fail_silently=False)
 
 
-def resubmit_notify(project):
+def resubmit_notify(project, comments):
     """
     Notify authors and the editor when a project is resubmitted
     """
@@ -213,7 +214,9 @@ def resubmit_notify(project):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
                           [email], fail_silently=False)
 
+    # notify editorial team
     email_context['name'] = project.editor.get_full_name()
+    email_context['author_comments'] = comments
     body = loader.render_to_string(
         'notification/email/resubmit_notify_editor.html', email_context)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1198,7 +1198,8 @@ def project_submission(request, project_slug, **kwargs):
         if 'submit_project' in request.POST and is_submitting:
             author_comments_form = forms.AuthorCommentsForm(data=request.POST)
             if project.is_submittable() and author_comments_form.is_valid():
-                project.submit(author_comments=author_comments_form.cleaned_data['author_comments'])
+                comments = author_comments_form.cleaned_data['author_comments']
+                project.submit(author_comments=comments)
                 notification.submit_notify(project)
                 messages.success(request, 'Your project has been submitted. You will be notified when an editor is assigned.')
             elif project.integrity_errors:
@@ -1208,8 +1209,9 @@ def project_submission(request, project_slug, **kwargs):
         elif 'resubmit_project' in request.POST and is_submitting:
             author_comments_form = forms.AuthorCommentsForm(data=request.POST)
             if project.is_resubmittable() and author_comments_form.is_valid():
-                project.resubmit(author_comments=author_comments_form.cleaned_data['author_comments'])
-                notification.resubmit_notify(project)
+                comments = author_comments_form.cleaned_data['author_comments']
+                project.resubmit(author_comments=comments)
+                notification.resubmit_notify(project, comments)
                 messages.success(request, 'Your project has been resubmitted. You will be notified when the editor makes their decision.')
         # Author approves publication
         elif 'approve_publication' in request.POST:
@@ -1225,10 +1227,10 @@ def project_submission(request, project_slug, **kwargs):
             # Register the approval if valid
             if project.approve_author(author):
                 if project.submission_status == 60:
-                    messages.success(request, 'You have approved the publication of your project. The editor will publish it shortly')
+                    messages.success(request, 'You have approved the project for publication. The editor will publish it shortly')
                     notification.authors_approved_notify(request, project)
                 else:
-                    messages.success(request, 'You have approved the publication of your project.')
+                    messages.success(request, 'You have approved the project for publication.')
                 authors = project.authors.all().order_by('display_order')
             else:
                 messages.error(request, 'Invalid')


### PR DESCRIPTION
When an author submits or resubmits a project to PhysioNet, a notification email is automatically sent to the PhysioNet team. 

Authors sometimes add a comment alongside their submission, which is easy to miss (it is displayed on a non-obvious "submission history" page). 

This is a minor change to include author comments in the notification email. Examples of the new emails are below:

## New submission:

```
Project title: This is a test2
Submission ID: UQV8fK9fP7TaD2E541Hn
Submitting author: admin --- admin@mit.edu

Dear Colleague,

The project entitled "This is a test2" has been submitted to
PhysioNet. The author added the following comment with the submission:

Here is the project for review.

Regards,

The PhysioNet Team,
MIT Laboratory for Computational Physiology,
Institute for Medical Engineering and Science,
MIT, E25-505 77 Massachusetts Ave. Cambridge, MA 02139
```

## Resubmission

```
Project title: ert
Submission ID: 2bBi05ylZqcbRK6cOPCz
Submitting author: admin --- admin@mit.edu

Dear Admin Bot,

The project that you requested revisions for, "ert", was resubmitted
for review.

We would be grateful if you could review the revised submission within
7 days. The author included the following comment with the submission: 

Thanks for the thorough review. I have updated the files as
requested.

Regards,

The PhysioNet Team,
MIT Laboratory for Computational Physiology,
Institute for Medical Engineering and Science,
MIT, E25-505 77 Massachusetts Ave. Cambridge, MA 02139
```


