### PR TITLE
Add citation details to "project published" notification email

### DIFF
--- a/physionet-django/notification/templates/notification/email/publish_notify.html
+++ b/physionet-django/notification/templates/notification/email/publish_notify.html
@@ -1,11 +1,14 @@
-{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+{% load i18n %}{% load project_templatetags %}{% autoescape off %}{% filter wordwrap:70 %}
 {{ project_info }}
 
 Dear {{ name }},
 
-We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at {{ url_prefix }}{% url 'published_project' published_project.slug published_project.version %}.
+We are delighted to inform you that your project entitled "{{ published_project.title }}" (version {{ published_project.version }}) has been published on PhysioNet. The project is available at: {% if published_project.doi %}https://doi.org/{{ published_project.doi }}{% else %}{{ url_prefix }}{% url 'published_project' published_project.slug published_project.version %}{% endif %}
 
-We encourage you to share this link to increase your work's visibility within the research community. Thanks again for choosing to publish with PhysioNet, and we look forward to working with you again in the future.
+The formal citation is:
+{{ published_project.citation_text_all.APA|html_to_text }}
+
+We encourage you to share these details to increase your work's visibility in the research community.
 
 {{ signature }}
 

--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -2,12 +2,24 @@ from django import template
 from django.shortcuts import reverse
 from django.utils.html import format_html, escape
 from django.utils.http import urlencode
+import html2text
 
 from notification.utility import mailto_url
 
 
 register = template.Library()
 
+
+@register.filter(name='html_to_text')
+def html_to_text(html):
+    """
+    Convert HTML to plain text.
+    """
+    parser = html2text.HTML2Text()
+    parser.ignore_links = True
+    parser.ignore_emphasis = True
+
+    return parser.handle(html).replace('\n','')
 
 @register.filter(name='nbsp')
 def nbsp(text):

--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -19,7 +19,7 @@ def html_to_text(html):
     parser.ignore_links = True
     parser.ignore_emphasis = True
 
-    return parser.handle(html).replace('\n','')
+    return parser.handle(html).replace('\n', '')
 
 @register.filter(name='nbsp')
 def nbsp(text):


### PR DESCRIPTION
Minor change in response to #1068 to add citation details to the email that is sent to authors upon publication. The email now reads:

```
We are delighted to inform you that your project entitled "Test
database" (version 1.0) has been published on PhysioNet. The project
is available at: https://doi.org/10.7966/ymcx-6e03

The formal citation is:
Bot A. Test database (version 1.0). PhysioNet. 2020. Available from:
https://doi.org/10.7966/ymcx-6e03.

We encourage you to share these details to increase your work's
visibility in the research community. Thanks for choosing to
publish with PhysioNet.
```

 

