### PR TITLE
Adds physionet.mit.edu to servers

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -205,3 +205,29 @@ server {
         return 301 https://$host$request_uri;
     }
 }
+
+server {
+    listen      80;
+    server_name physionet.mit.edu;
+    return      301 https://physionet.org$request_uri;
+}
+
+server {
+    listen      443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    # SSL stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
+    add_header Accept-Ranges bytes;
+
+    server_name physionet.mit.edu;
+    return      301 https://physionet.org$request_uri;
+}


### PR DESCRIPTION
Adds `physionet.mit.edu` to list of servers accepted by Django in the `nginx` configuration. This is needed since Tom and I have decided to redirect all traffic requests from `physionet.mit.edu` to `physionet.org`. The redirect has already been set up with the MIT Service Desk, we just need to give permission to it here and later update the certificates.