### PR TITLE
Adds physionet.mit.edu to ALLOWED_HOSTS

### DIFF
--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -6,7 +6,7 @@ from physionet.settings.base import *
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
+ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org', 'physionet.mit.edu']
 SITE_ID = 3
 
 DATABASES = {


### PR DESCRIPTION
Adds `physionet.mit.edu` to list of `ALLOWED_HOSTS` for the completion of the redirect to `physionet.org`.