### PR TITLE
Fixes 400 server error during physionet.mit.edu redirect

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -209,7 +209,7 @@ server {
 server {
     listen      80;
     server_name physionet.mit.edu;
-    return      301 https://physionet.org$request_uri;
+    rewrite     ^/(.*)$ https://physionet.org/$1 permanent;
 }
 
 server {
@@ -229,5 +229,5 @@ server {
     add_header Accept-Ranges bytes;
 
     server_name physionet.mit.edu;
-    return      301 https://physionet.org$request_uri;
+    rewrite     ^/(.*)$ https://physionet.org/$1 permanent;
 }


### PR DESCRIPTION
When trying to access physionet.mit.edu, a 400 server error is encountered with the current nginx config file. Adding this to `ALLOWED_HOSTS` solves the problem but the top URL reads `physionet.mit.edu` which isn't what we intend. Therefore, it appears like a rewrite is necessary to achieve our desired result. Suggestions are welcome though since this is my first time handling the servers on my own.