### PR TITLE
Redirects alpha.physionet.org to physionet.org #1079

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -6,8 +6,7 @@ upstream django {
 
 ## configuration of the server
 server {
-    server_name physionet.org alpha.physionet.org physionet-production.ecg.mit.edu;
-
+    server_name physionet.org physionet-production.ecg.mit.edu;
     charset     utf-8;
 
     # max upload size
@@ -130,7 +129,7 @@ server {
 
 server {
     listen      80;
-    server_name physionet.org alpha.physionet.org physionet-production.ecg.mit.edu;
+    server_name physionet.org physionet-production.ecg.mit.edu;
 
     # ACME authentication for certificates
     location /.well-known {
@@ -208,7 +207,7 @@ server {
 
 server {
     listen      80;
-    server_name physionet.mit.edu;
+    server_name physionet.mit.edu alpha.physionet.org;
     return      301 https://physionet.org$request_uri;
 }
 
@@ -228,6 +227,6 @@ server {
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
     add_header Accept-Ranges bytes;
 
-    server_name physionet.mit.edu;
+    server_name physionet.mit.edu alpha.physionet.org;
     return      301 https://physionet.org$request_uri;
 }

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -6,7 +6,7 @@ from physionet.settings.base import *
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['alpha.physionet.org', 'physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
+ALLOWED_HOSTS = ['physionet-production.ecg.mit.edu', 'physionet.org', 'www.physionet.org']
 SITE_ID = 3
 
 DATABASES = {


### PR DESCRIPTION
Redirects `alpha.physionet.org` to `physionet.org` in the same way that the recently added `physionet.mit.edu` redirects to `physionet.org`. The reason for this new redirect is that `alpha.physionet.org` was intended as a temporary domain while the new PhysioNet website was under development. Fixes #1079.