### PR TITLE
Fixes format and content in about/database_test #1080

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -135,11 +135,14 @@ def database_overview_test(request):
     Temporary content overview
     """
     open_projects = PublishedProject.objects.filter(
-        resource_type=0, access_policy=0).order_by(Lower('title'))
+        resource_type=0, access_policy=0,
+        is_latest_version=True).order_by(Lower('title'))
     restricted_projects = PublishedProject.objects.filter(
-        resource_type=0, access_policy=1).order_by(Lower('title'))
+        resource_type=0, access_policy=1,
+        is_latest_version=True).order_by(Lower('title'))
     credentialed_projects = PublishedProject.objects.filter(
-        resource_type=0, access_policy=2).order_by(Lower('title'))
+        resource_type=0, access_policy=2,
+        is_latest_version=True).order_by(Lower('title'))
     return render(request, 'about/database_index_test.html',
                   {'open_projects': open_projects,
                    'restricted_projects': restricted_projects,

--- a/physionet-django/templates/about/database_content_test.html
+++ b/physionet-django/templates/about/database_content_test.html
@@ -50,6 +50,9 @@ This page displays an alphabetical list of databases in the PhysioNet archives g
 {% endfor %}
 </ul>
 
+<br>
+<hr>
+
 <h2 id="credentialed">Credentialed Access</h2>
 <ul>
   {% for project in credentialed_projects %}


### PR DESCRIPTION
Adds a missing line break and prevents previous versions of projects to be displayed. Currently all versions of a project are displayed on the test database page though we would only like the most recent version. Fixes both #1078 and #1080.