### PR TITLE
Clarify who is able to request storage. closes #1085

### DIFF
--- a/physionet-django/project/templates/project/project_files.html
+++ b/physionet-django/project/templates/project/project_files.html
@@ -22,7 +22,7 @@
   </div>
 {% elif not is_submitting %}
   <div class="alert alert-form alert-warning alert-dismissible">
-    <strong>Only the submitting author may upload or edit files.</strong>
+    <strong>Only the submitting author may manage files and request more storage.</strong>
   </div>
 {% elif maintenance_message %}
   <div class="alert alert-form alert-warning alert-dismissible">


### PR DESCRIPTION
Minor change to wording, to clarify who can request more storage for project submissions. It is a response to the following comment in issue #1085 

> I'm wondering if it's possible to update the text to "Only the submitting author may request more storage, upload, or otherwise manage files.". I've had a few people contact me about how to increase storage and I think it's because they are not submitting authors.

@alistairewj is this text okay with you? If so, please check and merge!