### PR TITLE
Add "Full name" column to the list of credentialed users

### DIFF
--- a/physionet-django/console/templates/console/complete_list_credentialed_people.html
+++ b/physionet-django/console/templates/console/complete_list_credentialed_people.html
@@ -36,10 +36,10 @@
           <tbody>
             <tr><th></th><th align="center" colspan="8">MIMIC Data Use Agreements Issued as of  {% now "jS F Y H:i" %}</th></tr>
             <tr>
-            <th></th><th align="left">First name</th><th align="left">Last name</th><th align="left">E-mail</th><th align="left">Country</th><th align="left">MIMIC approval date</th><th align="left">eICU approval date</th><th>General research area for which the data will be used</th>
+            <th></th><th align="left">First name</th><th align="left">Last name</th><th align="left">Full name</th><th align="left">E-mail</th><th align="left">Country</th><th align="left">MIMIC approval date</th><th align="left">eICU approval date</th><th>General research area for which the data will be used</th>
             </tr>
             {% for person in credentialed_people %}
-            <tr><td>{{ forloop.counter   }}</td><td align="left">{{ person.0 }}</td><td align="left">{{ person.1 }}</td><td align="left">{{ person.2 }}</td><td align="left">{{ person.3 }}</td><td align="left">{{ person.4|date }}</td><td align="left">{{ person.5|date }}</td><td>{{ person.6 }}</td></tr>
+            <tr><td>{{ forloop.counter   }}</td><td align="left">{{ person.0 }}</td><td align="left">{{ person.1 }}</td><td align="left">{{ person.0}} {{ person.1 }}</td><td align="left">{{ person.2 }}</td><td align="left">{{ person.3 }}</td><td align="left">{{ person.4|date }}</td><td align="left">{{ person.5|date }}</td><td>{{ person.6 }}</td></tr>
             {% endfor %}
           </tbody>
         </table>


### PR DESCRIPTION
This pull request adds a new column to the table displayed at: http://127.0.0.1:8000/console/complete-list-credentialed-people/. The change was requested by KP, the primary user of the table.

Before the pull request:


<img width="877" alt="Screen Shot 2020-07-01 at 19 20 53" src="https://user-images.githubusercontent.com/822601/86300158-0df56880-bbd0-11ea-8d37-94631f175e65.png">


After the pull request:

<img width="943" alt="Screen Shot 2020-07-01 at 19 20 18" src="https://user-images.githubusercontent.com/822601/86300112-eb634f80-bbcf-11ea-90b3-9fba98eef9dc.png">
