### PR TITLE
Modifies about/database_test page #1078

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -134,19 +134,10 @@ def database_overview_test(request):
     """
     Temporary content overview
     """
-    open_projects = PublishedProject.objects.filter(
-        resource_type=0, access_policy=0,
-        is_latest_version=True).order_by(Lower('title'))
-    restricted_projects = PublishedProject.objects.filter(
-        resource_type=0, access_policy=1,
-        is_latest_version=True).order_by(Lower('title'))
-    credentialed_projects = PublishedProject.objects.filter(
-        resource_type=0, access_policy=2,
+    all_projects = PublishedProject.objects.filter(
         is_latest_version=True).order_by(Lower('title'))
     return render(request, 'about/database_index_test.html',
-                  {'open_projects': open_projects,
-                   'restricted_projects': restricted_projects,
-                   'credentialed_projects': credentialed_projects})
+                  {'all_projects': all_projects})
 
 
 def software_overview(request):

--- a/physionet-django/templates/about/database_content_test.html
+++ b/physionet-django/templates/about/database_content_test.html
@@ -1,23 +1,3 @@
-<section id="citation">
-  <h2>Suggested Citation</h2>
-  <p>If you use resources from PhysioNet in a publication, please credit
-  the author(s) using the citation displayed at the top of the published content. Please also include the standard citation for PhysioNet:</p>
-
-  <p class="alert alert-primary" role="alert">Goldberger AL, Amaral LAN, Glass L,
-    Hausdorff JM, Ivanov PCh, Mark RG,
-  Mietus JE, Moody GB, Peng C-K, Stanley HE.  PhysioBank, PhysioToolkit, and
-  PhysioNet: Components of a New Research Resource for Complex Physiologic
-  Signals.
-  <i>Circulation</i> <b>101</b>(23):e215-e220 [Circulation Electronic Pages;
-  <a href="http://circ.ahajournals.org/content/101/23/e215.full"
-  target="other">http://circ.ahajournals.org/content/101/23/e215.full</a>];
-  2000 (June 13).</p>
-</section>
-
-<br>
-<hr>
-
-
 <section id="overview">
   <h2>Overview</h2>
 <p>

--- a/physionet-django/templates/about/database_content_test.html
+++ b/physionet-django/templates/about/database_content_test.html
@@ -18,44 +18,24 @@
 <hr>
 
 
-<section id="summary">
+<section id="overview">
   <h2>Overview</h2>
 <p>
-This page displays an alphabetical list of databases in the PhysioNet archives grouped by access policy. To find more databases on PhysioNet, <a href="{% url 'content_index' %}">search our resources</a>.</p>
+This page displays an alphabetical list of all the databases on PhysioNet. To search content on PhysioNet, <a href="{% url 'content_index' %}">visit the search page</a>. Enter the search terms, add a filter for resource type if needed, and select how you would like the results to be ordered (for example, by relevance, by date, or by title).</p>
+<p>Each project is made available under one of the following access policies:</p>
 <ul>
-<li> <a href="#open">Open Access</a>: The content is shared under an open access license (e.g. MIT License; Creative Commons licenses).</li>
-<li> <a href="#restricted">Restricted Access</a>: Users must (1) have a PhysioNet account and (2) sign a Data Use Agreement (DUA).</li>
-<li> <a href="#credentialed">Credentialed Access</a>: Users must (1) have a PhysioNet account, (2) sign a DUA, and (3) complete the online Collaborative Institutional Training Initiative (CITI) training.</li>
-</li>
+  <li>Open Access: Accessible by all users, with minimal restrictions on reuse.</li>
+  <li>Restricted Access: Accessible by registered users who sign a Data Use Agreement.</li>
+  <li>Credentialed Access: Accessible by registered users who complete the <a href="{% url 'edit_credentialing' %}">credentialing process</a> and sign a Data Use Agreement.</li>
 </ul>
 </section>
 
 <br>
 <hr>
 
-<h2 id="open">Open Access</h2>
+<h2 id="databases">All Databases</h2>
 <ul>
-  {% for project in open_projects %}
-  <li><a href="{% url 'published_project_latest' project.slug %}">{{ project.title }}</a>: {% if project.short_description %}{{ project.short_description }}{% else %}{{ project.abstract_text_content|truncatechars_html:200 }}{% endif %}</li>
-{% endfor %}
-</ul>
-
-<br>
-<hr>
-
-<h2 id="restricted">Restricted Access</h2>
-<ul>
-{% for project in restricted_projects %}
-  <li><a href="{% url 'published_project_latest' project.slug %}">{{ project.title }}</a>: {% if project.short_description %}{{ project.short_description }}{% else %}{{ project.abstract_text_content|truncatechars_html:200 }}{% endif %}</li>
-{% endfor %}
-</ul>
-
-<br>
-<hr>
-
-<h2 id="credentialed">Credentialed Access</h2>
-<ul>
-  {% for project in credentialed_projects %}
+  {% for project in all_projects %}
   <li><a href="{% url 'published_project_latest' project.slug %}">{{ project.title }}</a>: {% if project.short_description %}{{ project.short_description }}{% else %}{{ project.abstract_text_content|truncatechars_html:200 }}{% endif %}</li>
 {% endfor %}
 </ul>

--- a/physionet-django/templates/about/database_index_test.html
+++ b/physionet-django/templates/about/database_index_test.html
@@ -24,9 +24,8 @@ PhysioNet Databases
 
             <!-- Databases -->
             <ul>
-              <li><a href="#open">Open Access</a></li>
-              <li><a href="#restricted">Restricted Access</a></li>
-              <li><a href="#credentialed">Credentialed Access</a></li>
+              <li><a href="#overview">Overview</a></li>
+              <li><a href="#databases">All databases</a></li>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Modifies the `about/database_test` page to now display just a single list of all the latest versions of the databases sorted in alphabetical order. This replaces the previous layout which was separated by access policy. Additionally, more information is given on how to search for databases as well as the differences between the access policies for each database. Fixes #1078.