### PR TITLE
notify team when storage request received. closes #1082

### DIFF
--- a/physionet-django/notification/templates/notification/email/storage_request_notify_team.html
+++ b/physionet-django/notification/templates/notification/email/storage_request_notify_team.html
@@ -1,0 +1,11 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+{{ project_info }}
+
+Dear {{ name }},
+
+The authors of a project entitled "{{ project.title }}" have requested more storage. Please grant or deny this request at: {{ url_prefix }}{% url 'storage_requests' %}
+
+{{ signature }}
+
+{{ footer }}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -404,6 +404,28 @@ def publish_notify(request, published_project):
           [settings.CONTACT_EMAIL], fail_silently=False)
 
 
+def storage_request_notify(request, project):
+    """
+    Notify administrators when a storage request is received
+    """
+    subject = 'Storage request received: {0}'.format(
+        project.title)
+
+    content = {'project': project,
+               'domain': get_current_site(request),
+               'url_prefix': get_url_prefix(request),
+               'signature': email_signature(),
+               'project_info': email_project_info(project),
+               'footer': email_footer()}
+
+    content['name'] = "Colleague"
+    body = loader.render_to_string(
+        'notification/email/storage_request_notify_team.html', content)
+
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+              [settings.CONTACT_EMAIL], fail_silently=False)
+
+
 def storage_response_notify(storage_request):
     """
     Notify submitting author when storage request is processed
@@ -427,6 +449,7 @@ def storage_response_notify(storage_request):
 
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [email], fail_silently=False)
+
 
 def contact_reference(request, application):
     """

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -978,6 +978,7 @@ def project_files(request, project_slug, subdir='', **kwargs):
             if storage_request_form.is_valid():
                 storage_request_form.instance.project = project
                 storage_request_form.save()
+                notification.storage_request_notify(request, project)
                 messages.success(request, 'Your storage request has been received.')
             else:
                 messages.error(request, utility.get_form_errors(storage_request_form))


### PR DESCRIPTION
Adds a new email template that is sent when a project contributor requests more storage space. Currently we rely on the PhysioNet team periodically checking https://physionet.org/console/storage-requests/ to identify outstanding storage requests. Closes #1082

The email text is:

```
Project title: My new database
Submission ID: 7vS4pUSYtmk4qwVZHDED
Submitting author: admin --- admin@mit.edu

Dear Colleague,

The authors of a project entitled "My new database" have requested more storage. Please 
grant or deny this request at: http://localhost:8000/console/storage-requests/

Regards,

The PhysioNet Team,
MIT Laboratory for Computational Physiology,
Institute for Medical Engineering and Science,
MIT, E25-505 77 Massachusetts Ave. Cambridge, MA 02139
```