### PR TITLE
catch filename too long error (fixes #1093)

### DIFF
--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -1,3 +1,4 @@
+from errno import ENAMETOOLONG
 import os
 
 from django.http import Http404
@@ -38,6 +39,9 @@ def display_project_file(request, project, file_path):
         return redirect(request.path + '/')
     except (FileNotFoundError, NotADirectoryError):
         raise Http404()
+    except OSError as err:
+        if err.errno == ENAMETOOLONG:
+            raise Http404()
 
     with infile:
         if file_path.endswith('.csv.gz'):

--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -44,6 +44,11 @@ def display_project_file(request, project, file_path):
             raise Http404()
         else:
             raise err
+    except IOError as err:
+        if err.errno == ENAMETOOLONG:
+            raise Http404()
+        else:
+            raise err
 
     with infile:
         if file_path.endswith('.csv.gz'):

--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -39,12 +39,7 @@ def display_project_file(request, project, file_path):
         return redirect(request.path + '/')
     except (FileNotFoundError, NotADirectoryError):
         raise Http404()
-    except OSError as err:
-        if err.errno == ENAMETOOLONG:
-            raise Http404()
-        else:
-            raise err
-    except IOError as err:
+    except (IOError, OSError) as err:
         if err.errno == ENAMETOOLONG:
             raise Http404()
         else:

--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -42,6 +42,8 @@ def display_project_file(request, project, file_path):
     except OSError as err:
         if err.errno == ENAMETOOLONG:
             raise Http404()
+        else:
+            raise err
 
     with infile:
         if file_path.endswith('.csv.gz'):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -670,6 +670,7 @@ class TestAccessPublished(TestMixin):
         Test access to an open project.
         """
         project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+
         # Public user. Anyone can access files and landing page
         response = self.client.get(reverse('published_project',
             args=(project.slug, project.version,)))
@@ -688,6 +689,12 @@ class TestAccessPublished(TestMixin):
         self.assertEqual(response.status_code, 404)
         response = self.client.get(reverse('display_published_project_file',
             args=(project.slug, project.version, 'Makefile/fnord')))
+        self.assertEqual(response.status_code, 404)
+
+        # Raise a 404 if the requested filename is too long
+        long_fn = 'Makefile/fnord'*1000
+        response = self.client.get(reverse('display_published_project_file',
+            args=(project.slug, project.version, long_fn)))
         self.assertEqual(response.status_code, 404)
 
     @prevent_request_warnings


### PR DESCRIPTION
HTTP requests raise an OSError (`OSError: [Errno 63] File name too long`) if the file name that is requested is too long for the operating system to handle. The length of the filename required to raise an error varies by system. The error can be reproduced in iPython with something like:

```
from errno import ENAMETOOLONG

t = "hello"*1000

try: 
    open(t) 
except OSError as err: 
    if err.errno == ENAMETOOLONG: 
        print("TOO LONG") 
```

This pull request catches the error and displays a 404 message to the user. An alternative would be to truncate the request, but I don't think this gains anything.