### PR TITLE
Dynamically generate software content #1092

### DIFF
--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -57,6 +57,8 @@ urlpatterns = [
         name='database_overview'),
     path('about/software/', views.software_overview,
         name='software_overview'),
+    path('about/software_test/', views.software_overview_test,
+        name='software_overview_test'),
     path('about/challenge/', views.challenge_overview,
         name='challenge_overview'),
     path('about/tutorial/', views.tutorial_overview,

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -140,6 +140,16 @@ def software_overview(request):
     return render(request, 'about/software_index.html')
 
 
+def software_overview_test(request):
+    """
+    Temporary content overview
+    """
+    all_projects = PublishedProject.objects.filter(
+        resource_type=1, is_latest_version=True).order_by(Lower('title'))
+    return render(request, 'about/software_index_test.html',
+                  {'all_projects': all_projects})
+
+
 def challenge_overview(request):
     """
     Temporary content overview

--- a/physionet-django/templates/about/software_content_test.html
+++ b/physionet-django/templates/about/software_content_test.html
@@ -1,0 +1,15 @@
+<section id="overview">
+    <h2>Overview</h2>
+  <p>This page displays an alphabetical list of all software projects on PhysioNet. To search content on PhysioNet, <a href="{% url 'content_index' %}">visit the search page</a>. Enter the search terms, add a filter for resource type if needed, and select how you would like the results to be ordered (for example, by relevance, by date, or by title).</p>
+  <p>Many of the time series datasets on PhysioNet (for example, ECGs) are shared in waveform-database (WFDB) compatible file formats.  For more information on these formats, see the <a href="https://www.physionet.org/physiotools/wag" />WFDB Applications Guide</a>. WFDB-formatted datasets can also be viewed online with <a href="{% url 'lightwave_home' %}">LightWAVE</a>.</p>
+</section>
+
+<hr>
+<br>
+
+<h2 id="software">All Software</h2>
+<ul>
+  {% for project in all_projects %}
+  <li><a href="{% url 'published_project_latest' project.slug %}">{{ project.title }}</a>: {% if project.short_description %}{{ project.short_description }}{% else %}{{ project.abstract_text_content|truncatechars_html:200 }}{% endif %}</li>
+{% endfor %}
+</ul>

--- a/physionet-django/templates/about/software_index_test.html
+++ b/physionet-django/templates/about/software_index_test.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block title %}
+PhysioNet Software
+{% endblock %}
+
+
+{% block local_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'custom/css/about.css' %}">
+{% endblock %}
+
+
+{% block content %}
+
+<div class="main">
+  <div class="row">
+    <div class="main-side">
+
+      <div class="card">
+        <h2 class="card-header">Software</h2>
+        <div class="card-body">
+
+            <!-- Software -->
+            <ul>
+              <li><a href="#overview">Overview</a></li>
+              <li><a href="#software">All software</a></li>
+            </ul>
+
+        </div>
+      </div>
+    </div>
+    <div class="main-content">
+      <div>{% include "about/software_content_test.html" %}</div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Fixes the issue of the list of [software](https://physionet.org/about/software/) not being dynamically generated. In the past, this software list was generated manually which was difficult to keep up with so a dynamic solution was requested. I display each software project in alphabetical order by their lowercase title after first introducing the search feature, WFDB format, and LightWAVE. Fixes #1092.