### PR TITLE
Modifies search link to forward directly to desired content

### DIFF
--- a/physionet-django/templates/about/database_content.html
+++ b/physionet-django/templates/about/database_content.html
@@ -1,7 +1,7 @@
 <section id="overview">
   <h2>Overview</h2>
 <p>
-This page displays an alphabetical list of all the databases on PhysioNet. To search content on PhysioNet, <a href="{% url 'content_index' %}">visit the search page</a>. Enter the search terms, add a filter for resource type if needed, and select how you would like the results to be ordered (for example, by relevance, by date, or by title).</p>
+This page displays an alphabetical list of all the databases on PhysioNet. To search content on PhysioNet, <a href="{% url 'content_index' %}?types=0">visit the search page</a>. Enter the search terms, add a filter for resource type if needed, and select how you would like the results to be ordered (for example, by relevance, by date, or by title).</p>
 <p>Each project is made available under one of the following access policies:</p>
 <ul>
   <li>Open Access: Accessible by all users, with minimal restrictions on reuse.</li>

--- a/physionet-django/templates/about/software_content.html
+++ b/physionet-django/templates/about/software_content.html
@@ -1,6 +1,6 @@
 <section id="overview">
     <h2>Overview</h2>
-  <p>This page displays an alphabetical list of all software projects on PhysioNet. To search content on PhysioNet, <a href="{% url 'content_index' %}">visit the search page</a>. Enter the search terms, add a filter for resource type if needed, and select how you would like the results to be ordered (for example, by relevance, by date, or by title).</p>
+  <p>This page displays an alphabetical list of all software projects on PhysioNet. To search content on PhysioNet, <a href="{% url 'content_index' %}?types=1">visit the search page</a>. Enter the search terms, add a filter for resource type if needed, and select how you would like the results to be ordered (for example, by relevance, by date, or by title).</p>
   <p>Many of the time series datasets on PhysioNet (for example, ECGs) are shared in waveform-database (WFDB) compatible file formats.  For more information on these formats, see the <a href="/physiotools/wag" />WFDB Applications Guide</a>. WFDB-formatted datasets can also be viewed online with <a href="{% url 'lightwave_home' %}">LightWAVE</a>.</p>
 </section>
 


### PR DESCRIPTION
Modifies both the database and software search links to forward directly to the search page again except now only the desired resource type is selected. For example, the redirect from the software page would take the user to the search page with only the software resource type selected.