### PR TITLE
Fix funny cred app order

### DIFF
--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -22,7 +22,7 @@
 	{{ application.reference_email }} 
 	{% if application.reference_contact_datetime %}
 		[The {{ application.reference_category|yesno:"reference,supervisor" }} was contacted on {{ application.reference_contact_datetime }}]
-	{% elif application.known_ref %}
+	{% elif application.ref_known_flag %}
         	[Reference is known]
 	{% endif %}
       </p>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -964,8 +964,9 @@ def complete_credential_applications(request):
          request.POST['contact_reference'].isdigit():
             application_id = request.POST.get('contact_reference', '')
             application = CredentialApplication.objects.get(id=application_id)
-            application.reference_contact_datetime = timezone.now()
-            application.save()
+            if not application.reference_contact_datetime:
+                application.reference_contact_datetime = timezone.now()
+                application.save()
             # notification.contact_reference(request, application)
             if application.reference_category == 0:
                 mailto = notification.mailto_supervisor(request, application)

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1016,23 +1016,24 @@ def complete_credential_applications(request):
     # 3. reference contacted
     contacted_apps = []
 
-    for application in applications:
-        application.mailto = notification.mailto_process_credential_complete(
-            request, application, comments=False)
-        if application.ref_known_flag() and application.reference_contact_datetime is None:
-            known_ref_apps_not_contacted.append(
-                [application.application_datetime, application])
-        elif not application.ref_known_flag() and application.reference_contact_datetime is None:
-            unknown_ref_apps_not_contacted.append(
-                [application.application_datetime, application])
+    for a in applications:
+        a.mailto = notification.mailto_process_credential_complete(
+            request, a, comments=False)
+
+        if a.ref_known_flag() and a.reference_contact_datetime is None:
+            known_ref_apps_not_contacted.append([a.application_datetime, a])
+        elif not a.ref_known_flag() and a.reference_contact_datetime is None:
+            unknown_ref_apps_not_contacted.append([a.application_datetime, a])
         else:
-            contacted_apps.append(
-                [application.application_datetime, application])
+            contacted_apps.append([a.application_datetime, a])
 
     # Sorting by application date
-    t0 = [item[1] for item in sorted(known_ref_apps_not_contacted, key=lambda x: x[0])]
-    t1 = [item[1] for item in sorted(unknown_ref_apps_not_contacted, key=lambda x: x[0])]
-    t2 = [item[1] for item in sorted(contacted_apps, key=lambda x: x[0])]
+    t0 = [item[1] for item in sorted(known_ref_apps_not_contacted,
+                                     key=lambda x: x[0])]
+    t1 = [item[1] for item in sorted(unknown_ref_apps_not_contacted,
+                                     key=lambda x: x[0])]
+    t2 = [item[1] for item in sorted(contacted_apps,
+                                     key=lambda x: x[0])]
     applications = t0 + t1 + t2
 
     return render(request, 'console/complete_credential_applications.html',

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -771,6 +771,22 @@ class CredentialApplication(models.Model):
         """
         self._apply_decision(3, responder)
 
+    def ref_known_flag(self):
+        """
+        Returns True if the reference is known, else False.
+        """
+        if CredentialApplication.objects.filter(
+            reference_email__iexact=self.reference_email,
+            reference_contact_datetime__isnull=False).exclude(
+            reference_email=''):
+            return True
+        elif LegacyCredential.objects.filter(
+            reference_email__iexact=self.reference_email).exclude(
+            reference_email=''):
+            return True
+        else:
+            return False
+
 
 class CloudInformation(models.Model):
     """


### PR DESCRIPTION
At the moment there is a funny credential application order where the order us by contacted reference and not by application date, an example is as follows:

Person 1
...Date of this agreement: May 1, 2020, 1:37 a.m.

Person 2
...Date of this agreement: May 5, 2020, 9:20 p.m.

Person 3
...Date of this agreement: May 3, 2020, 12:20 a.m.

In this PR after some conversation with KP we agreed on the following order:
- messages with reference not contacted, but with reference known, sorted by application date.
- messages with reference not contacted and reference unknown, sorted by application date.
- messages with reference contacted, sorted by application date.

The way i choosed to sort this is nor an unorthodox way because is a bit more complicated than what it looks.
In order to get all reference not contacted first, I have to sort by null in that way which can be done at the filter level, but the rest I believe it cant be done at that leve. hence the 3 way sort.

Apart from that KP wanted that all credential applications that have the reference as contacted, to not be able to alter that field. Here I check/alter if the reference contacted field is NONE (not contacted) and then and only then update the field.