### PR TITLE
Require profile photos to be a valid PNG or JPEG image

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -239,7 +239,7 @@ class ProfileForm(forms.ModelForm):
     """
     For editing the profile
     """
-    photo = forms.ImageField(required=False, widget=ProfilePhotoInput(
+    photo = SaferImageField(required=False, widget=ProfilePhotoInput(
         attrs={'template_name': 'user/profile_photo_input.html'}))
 
     class Meta:


### PR DESCRIPTION
We allow people to upload a picture that is displayed on their profile page.

This is handled by a Django ImageField, which parses the image using Pillow (PIL).  It is, after all, useful to know that the file is actually a valid image.

Currently, we also require the uploaded filename to have a ".jpg" or ".png" suffix.  However, this is meaningless; there's nothing stopping somebody from uploading a JPEG image with a ".png" suffix, or an EPS file with a ".jpg" suffix, or whatever.

Parsing EPS files (for example) on the server is a hornet's nest of potential security bugs, and there's no reason to do that here unless we actually wanted to convert the image into some other format.  Pillow supports *dozens* of formats that we don't care about and don't want to support.

This is IMHO poor design on the part of Pillow, and poor design on the part of Django.  But I suspect it may be difficult to get this fixed.

So:

1. Avoid parsing formats we don't care about, by checking the bytes at the start of the file before it is ever passed to Pillow.  This means that if there's a bug in Ghostscript, it doesn't matter here, because there's no way that a file that starts with '\xff\xd8' or '\x89PNG\x0d\x0a\x1a\x0a' could possibly be treated as PostScript.

2. Ignore the uploaded filename. Set the filename (and the Content-Type) according to the actual type of data it contains.
