### PR TITLE
Don't allow physionet.org as email address in contact form

### DIFF
--- a/physionet-django/physionet/settings/development/base.py
+++ b/physionet-django/physionet/settings/development/base.py
@@ -16,6 +16,7 @@ MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@dev.physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@dev.physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@dev.physionet.org>'

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -28,6 +28,7 @@ EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
 
+EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@physionet.org>'

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -28,6 +28,7 @@ EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
 
+EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@staging.physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@staging.physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@staging.physionet.org>'

--- a/physionet-django/templates/about/contact.html
+++ b/physionet-django/templates/about/contact.html
@@ -8,7 +8,11 @@
         <div class="col-md-12">
           <div class="form-group">
             {{ field }}
-            <p class="help-block text-danger"></p>
+            {% for error in field.errors %}
+            <div class="alert alert-danger">
+              <strong>{{ error|escape }}</strong>
+            </div>
+            {% endfor %}
           </div>
         </div>
       </div>

--- a/physionet-django/templates/about/contact.html
+++ b/physionet-django/templates/about/contact.html
@@ -3,43 +3,16 @@
     <form method="post" action="#contact">
       {% csrf_token %}
 
+      {% for field in contact_form.visible_fields %}
       <div class="row">
         <div class="col-md-12">
           <div class="form-group">
-            {{ contact_form.name }}
+            {{ field }}
             <p class="help-block text-danger"></p>
           </div>
         </div>
       </div>
-
-
-      <div class="row">
-        <div class="col-md-12">    
-          <div class="form-group">
-            {{ contact_form.email }}
-            <p class="help-block text-danger"></p>
-          </div>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-md-12">    
-          <div class="form-group">
-            {{ contact_form.subject }}
-            <p class="help-block text-danger"></p>
-          </div>
-        </div>
-      </div>
-
-
-      <div class="row">
-        <div class="col-md-12"> 
-          <div class="form-group">
-            {{ contact_form.message }}
-            <p class="help-block text-danger"></p>
-          </div>
-        </div>
-      </div>
+      {% endfor %}
 
       <div class="row">
         <div class="col-md-12 no-pd">

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -2,6 +2,7 @@ import os
 import pdb
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import forms as auth_forms
 from django.contrib.auth import password_validation
 from django.core.files.uploadedfile import UploadedFile
@@ -568,6 +569,14 @@ class ContactForm(forms.Form):
         attrs={'class': 'form-control', 'placeholder': 'Subject *'}))
     message = forms.CharField(max_length=2000, widget=forms.Textarea(
         attrs={'class': 'form-control', 'placeholder': 'Message *'}))
+
+    def clean_email(self):
+        # Disallow addresses that look like they come from this machine.
+        addr = self.cleaned_data['email'].lower()
+        for domain in settings.EMAIL_FROM_DOMAINS:
+            if addr.endswith('@' + domain) or addr.endswith('.' + domain):
+                raise forms.ValidationError('Please enter your email address.')
+        return self.cleaned_data['email']
 
 class CloudForm(forms.ModelForm):
     """


### PR DESCRIPTION
In the contact form (/about/#contact), require the submitter to supply an email address that is *not* on a subdomain of physionet.org, so that the message cannot appear to be a legitimate message "from" physionet.org even though it passes through the same mail servers.
