### PR TITLE
Add HTTP/2, and tidy up nginx configuration

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -7,6 +7,7 @@ upstream django {
 ## configuration of the server
 server {
     server_name physionet.org physionet-production.ecg.mit.edu;
+
     charset     utf-8;
 
     # max upload size

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -112,7 +112,7 @@ server {
         }
     }
 
-    listen 443 ssl; # managed by Certbot
+    listen 443 ssl default_server;
     ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
@@ -129,7 +129,7 @@ server {
 }
 
 server {
-    listen      80;
+    listen      80 default_server;
     server_name physionet.org physionet-production.ecg.mit.edu;
 
     # ACME authentication for certificates

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -204,29 +204,3 @@ server {
         return 301 https://$host$request_uri;
     }
 }
-
-server {
-    listen      80;
-    server_name physionet.mit.edu alpha.physionet.org;
-    return      301 https://physionet.org$request_uri;
-}
-
-server {
-    listen      443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
-    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-
-    # SSL stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem;
-
-    # Security headers
-    add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
-    add_header Accept-Ranges bytes;
-
-    server_name physionet.mit.edu alpha.physionet.org;
-    return      301 https://physionet.org$request_uri;
-}

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -16,6 +16,10 @@ server {
     # location for temporary storage of uploaded data
     client_body_temp_path /data/www-tmp;
 
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
+    log_not_found off;
+
     #### Public data ####
 
     include /etc/nginx/custom-mime.types;
@@ -82,10 +86,6 @@ server {
 
     #### End of public data ####
 
-    error_log /data/log/nginx/physionet_error.log warn;
-    access_log /data/log/nginx/physionet_access.log;
-    log_not_found off;
-
     # Finally, send all non-media requests to the Django server.
     location / {
         uwsgi_pass  django;
@@ -130,6 +130,10 @@ server {
 server {
     listen      80 default_server;
     server_name physionet.org physionet-production.ecg.mit.edu;
+
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
+    log_not_found off;
 
     # ACME authentication for certificates
     location /.well-known {
@@ -191,10 +195,6 @@ server {
     }
 
     #### End of public data ####
-
-    error_log /data/log/nginx/physionet_error.log warn;
-    access_log /data/log/nginx/physionet_access.log;
-    log_not_found off;
 
     location / {
         return 301 https://$host$request_uri;

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -125,7 +125,6 @@ server {
 
     # Security headers
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
-    add_header Accept-Ranges bytes;
 }
 
 server {

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -112,7 +112,7 @@ server {
         }
     }
 
-    listen 443 ssl default_server;
+    listen 443 ssl default_server http2;
     ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot

--- a/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen      80;
+    server_name physionet.mit.edu alpha.physionet.org;
+    return      301 https://physionet.org$request_uri;
+}
+
+server {
+    listen      443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    # SSL stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
+    add_header Accept-Ranges bytes;
+
+    server_name physionet.mit.edu alpha.physionet.org;
+    return      301 https://physionet.org$request_uri;
+}

--- a/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
@@ -1,7 +1,16 @@
 server {
     listen      80;
     server_name physionet.mit.edu alpha.physionet.org;
-    return      301 https://physionet.org$request_uri;
+
+    # ACME authentication for certificates
+    location /.well-known/ {
+        root /physionet/;
+        allow all;
+    }
+
+    location / {
+        return 301 https://physionet.org$request_uri;
+    }
 }
 
 server {

--- a/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
@@ -14,7 +14,7 @@ server {
 }
 
 server {
-    listen      443 ssl; # managed by Certbot
+    listen      443 ssl http2;
     ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -112,7 +112,7 @@ server {
         }
     }
 
-    listen 443 ssl; # managed by Certbot
+    listen 443 ssl default_server;
     ssl_certificate /etc/letsencrypt/live/staging.physionet.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/staging.physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
@@ -129,7 +129,7 @@ server {
 }
 
 server {
-    listen      80;
+    listen      80 default_server;
     server_name staging.physionet.org physionet-staging.ecg.mit.edu;
 
     # ACME authentication for certificates

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -112,7 +112,7 @@ server {
         }
     }
 
-    listen 443 ssl default_server;
+    listen 443 ssl default_server http2;
     ssl_certificate /etc/letsencrypt/live/staging.physionet.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/staging.physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -125,7 +125,6 @@ server {
 
     # Security headers
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";
-    add_header Accept-Ranges bytes;
 }
 
 server {

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -16,6 +16,10 @@ server {
     # location for temporary storage of uploaded data
     client_body_temp_path /data/www-tmp;
 
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
+    log_not_found off;
+
     #### Public data ####
 
     include /etc/nginx/custom-mime.types;
@@ -82,10 +86,6 @@ server {
 
     #### End of public data ####
 
-    error_log /data/log/nginx/physionet_error.log warn;
-    access_log /data/log/nginx/physionet_access.log;
-    log_not_found off;
-
     # Finally, send all non-media requests to the Django server.
     location / {
         uwsgi_pass  django;
@@ -130,6 +130,10 @@ server {
 server {
     listen      80 default_server;
     server_name staging.physionet.org physionet-staging.ecg.mit.edu;
+
+    error_log /data/log/nginx/physionet_error.log warn;
+    access_log /data/log/nginx/physionet_access.log;
+    log_not_found off;
 
     # ACME authentication for certificates
     location /.well-known {
@@ -191,10 +195,6 @@ server {
     }
 
     #### End of public data ####
-
-    error_log /data/log/nginx/physionet_error.log warn;
-    access_log /data/log/nginx/physionet_access.log;
-    log_not_found off;
 
     location / {
         return 301 https://$host$request_uri;


### PR DESCRIPTION
This is an assortment of small fixes to the nginx configuration.  In particular, this enables the use of HTTP/2 over TLS, which should give better performance for browsers.

Note that the redirect server configuration is moved to a separate file, /etc/nginx/sites-available/physionet-redirect.conf.  In addition to installing this file, a symlink must be created: /etc/nginx/sites-enabled/physionet-redirect.conf -> ../sites-available/physionet-redirect.conf.
