### PR TITLE
Allow monitoring active uwsgi requests

### DIFF
--- a/physionet-django/physionet/wsgi.py
+++ b/physionet-django/physionet/wsgi.py
@@ -9,8 +9,26 @@ https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 
 import os
 
+from django.core.signals import request_started, request_finished
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "physionet.settings.development")
 
 application = get_wsgi_application()
+
+# If we are running under uWSGI, then store the current request path
+# in the process name (which can be seen with 'ps ax'.)
+try:
+    from uwsgi import setprocname
+except ImportError:
+    pass
+else:
+    def set_process_name_for_request(sender, environ, **kwargs):
+        path = environ.get('PATH_INFO', '<unknown>')
+        setprocname('uwsgi ' + path)
+
+    def unset_process_name(sender, **kwargs):
+        setprocname('uwsgi (idle)')
+
+    request_started.connect(set_process_name_for_request)
+    request_finished.connect(unset_process_name)


### PR DESCRIPTION
A few times, I've logged in and noticed that some uwsgi process seemed to be running for an unusually long time (> 5 minutes.)  Generally a single request shouldn't ever take that long, and if it were multiple requests you would expect them to be distributed between multiple uwsgi workers.

But even if you see this happening, it's difficult to see what exactly is going on, because the request won't be *logged* (either by uwsgi or nginx) until after it finishes.

So here, we store the request path in the process command line, using the (undocumented?) uwsgi.setprocname function.  The path will then appear in the output of 'ps ax' or 'top -c'.
