### PR TITLE
CSV parsing infinite loop

### DIFF
--- a/physionet-django/project/templates/project/file_view_csv.html
+++ b/physionet-django/project/templates/project/file_view_csv.html
@@ -31,6 +31,10 @@
   <a href="{{ file.download_url }}">Click here to download the
     complete file.</a>
 </div>
+{% elif missing_newline %}
+<div class="card-footer text-center missing-newline-warning">
+  Warning: missing newline at end of file
+</div>
 {% endif %}
 {% endblock %}
 
@@ -40,6 +44,9 @@
     margin: 0px;
     background-color: #fff;
     border: 1px solid #dfdfdf;
+  }
+  .missing-newline-warning {
+    color: #f00;
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
If a CSV file is missing a line feed at the end, CSVFileView goes into an infinite loop.

I don't want to encourage authors to release such files, since they make life difficult for people trying to process the data... but anyway, the site shouldn't crash or freeze when attempting to display such a file. :)
