### PR TITLE
Fixing typo and known ref search

### DIFF
--- a/physionet-django/console/templates/console/known_references_list.html
+++ b/physionet-django/console/templates/console/known_references_list.html
@@ -30,5 +30,5 @@
       {% endfor %}
     </tbody>
   </table>
-  {% include "console/pagination.html" with pagination=application %}
+  {% include "console/pagination.html" with pagination=all_known_ref %}
 </div>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -949,8 +949,8 @@ def known_references_search(request):
             reference_contact_datetime__isnull=True).order_by(
             '-reference_contact_datetime')
 
-        if len(applications) == 0:
-            all_known_ref = paginate(request, applications, 50)
+        if len(search_field) == 0:
+            all_known_ref = paginate(request, all_known_ref, 50)
 
         return render(request, 'console/known_references_list.html', {
             'all_known_ref': all_known_ref})


### PR DESCRIPTION
Pagination for known ref is "broken" because of a variable typo, here I set the correct one.

The same happened in the search function.