### PR TITLE
Remove contact form (temporarily?) and add a contact email address. May help to address #1096.

### DIFF
--- a/physionet-django/templates/about/contact.html
+++ b/physionet-django/templates/about/contact.html
@@ -1,31 +1,8 @@
 <section id="form">
   <div>
-    <form method="post" action="#contact">
-      {% csrf_token %}
 
-      {% for field in contact_form.visible_fields %}
-      <div class="row">
-        <div class="col-md-12">
-          <div class="form-group">
-            {{ field }}
-            {% for error in field.errors %}
-            <div class="alert alert-danger">
-              <strong>{{ error|escape }}</strong>
-            </div>
-            {% endfor %}
-          </div>
-        </div>
-      </div>
-      {% endfor %}
+  <p>PhysioNet is maintained by researchers and engineers at the MIT Laboratory for Computational Physiology. 
+     To reach us, email <a href=mailto:contact@physionet.org>contact@physionet.org</a>.</p>
 
-      <div class="row">
-        <div class="col-md-12 no-pd">
-          <div class="col-lg-12 button-wrapper">
-            <div id="success"></div>
-            <button class="btn btn-primary btn-xl" type="submit">Send Message</button>
-          </div>
-        </div>
-      </div>
-    </form>
   </div>
 </section>


### PR DESCRIPTION
We currently display a contact form at: https://physionet.org/about/#contact. 

Displaying the form may contribute to the issue described in #1096 (physionet emails being labelled as spam), because spammers send us messages using the form with our address as the sender.

This pull request removes the form. It is intended to be a temporary fix while we investigate other solutions for managing emails sent by the form. 