### PR TITLE
Adds accessibility link #1123

### DIFF
--- a/physionet-django/templates/footer.html
+++ b/physionet-django/templates/footer.html
@@ -8,6 +8,7 @@
       <div class="col-xs-10 center col-centered">
         <p>PhysioNet is a repository of freely-available medical research data, managed by the <a href="http://lcp.mit.edu/" target="_blank">MIT Laboratory for Computational Physiology</a>.</p>
         <p>Supported by the <a href="http://www.nigms.nih.gov/"  target="_blank">National Institute of General Medical Sciences (NIGMS)</a> and the <a href="https://www.nibib.nih.gov/" target="_blank">National Institute of Biomedical Imaging and Bioengineering (NIBIB)</a> under NIH grant number 2R01GM104987-09.</p>
+        <p>For more accessibility options, see <a href="https://accessibility.mit.edu">MIT's accessibility page</a>.</p>
         <p><a href="#">Back to top</a></p>
       </div>
     </div>


### PR DESCRIPTION
Adds the accessibility link required by new MIT policy to the footer. This approach provides a very short description and adds a hyperlink to MIT's accessibility page. Fixes #1123.