### PR TITLE
Fix variable name in validate_slug validator

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -100,7 +100,7 @@ def validate_slug(value):
         raise ValidationError(
             'Invalid file name "%(slug)s". '
             'Slug may be at most %(limit)s characters long.',
-            params={'filename': value, 'limit': MAX_PROJECT_SLUG_LENGTH})
+            params={'slug': value, 'limit': MAX_PROJECT_SLUG_LENGTH})
     if (not re.fullmatch(r'[a-z0-9](?:[a-z0-9-]*[a-z0-9])?', value) or '--' in value):
         raise ValidationError("""
             Slug must only contain lowercase alphanumerics and hyphens, and


### PR DESCRIPTION
This is a minor change to fix a variable name in the `validate_slug` function in `project.validators.py`. 

Currently we have:

```
    if len(value) > MAX_PROJECT_SLUG_LENGTH:
        raise ValidationError(
            'Invalid file name "%(slug)s". '
            'Slug may be at most %(limit)s characters long.',
            params={'filename': value, 'limit': MAX_PROJECT_SLUG_LENGTH})
```

The string includes a variable called `slug`, but this incorrectly referred to with `filename` in the params field.