### PR TITLE
Use restricted DUA for anonymous access to projects. Closes #1133

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -27,7 +27,7 @@ from django.utils.html import format_html, format_html_join
 
 from project.fileviews import display_project_file
 from project import forms
-from project.models import (Affiliation, Author, AuthorInvitation,
+from project.models import (Affiliation, Author, AuthorInvitation, License,
                             ActiveProject, PublishedProject, StorageRequest, Reference, DataAccess,
                             ArchivedProject, ProgrammingLanguage, Topic, Contact, Publication,
                             PublishedAuthor, EditLog, CopyeditLog, DUASignature, CoreProject, GCP,
@@ -1999,5 +1999,9 @@ def anonymous_login(request, anonymous_url):
             # Invalid form error
             messages.error(request, 'Submission unsuccessful. See form for errors.')
 
+    # For anonymous access, use the "restricted" license/DUA
+    license_slug = 'physionet-restricted-health-data-license-150'
+    license = License.objects.get(slug=license_slug)
+
     return render(request, 'project/anonymous_login.html', {'anonymous_url': anonymous_url,
-                  'form': form, 'license':project.license})
+                  'form': form, 'license': license})


### PR DESCRIPTION
Currently, when an anonymous URL/passphrase is created, the login page displays the DUA associated with the project. For example, if a "credentialed" project is submitted, then the anonymous login page will display the credentialed DUA. See #1133 for a screenshot.

The anonymous link is typically used to grant access to external reviewers. In these cases, we do not expect the reviewers to go through the full credentialing process to see the data, so it is inappropriate to display the credentialed DUA.

This pull request changes the anonymous access login page to always display the "restricted license", which I think is appropriate for all datasets. After the update, the login page looks like this:

<img width="1030" alt="Screen Shot 2020-09-26 at 13 59 26" src="https://user-images.githubusercontent.com/822601/94347366-71413c00-0001-11eb-932b-b57bd3bc9b32.png">
