### PR TITLE
Removes required references for researchers

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -488,7 +488,7 @@ class CredentialApplicationForm(forms.ModelForm):
                        data['reference_email'],
                        data['reference_title']]
 
-        ref_required = data['researcher_category'] in [0, 1, 2, 3, 6]
+        ref_required = data['researcher_category'] in [0, 1, 6]
         supervisor_required = data['researcher_category'] in [0, 1]
         state_required = data['country'] in ['US', 'CA']
 


### PR DESCRIPTION
Removes the reference requirement for Academic (id 2) and Hospital (id 3) researchers in their request for credentialed access. This pulls back the original changes done in #865.

Requested as per @kpierceHST's comment:
```
Yes, please keep reference as a requirement for independent researcher applicants. 

But -- no reference required for academic, industry, government, or hospital researchers.
```