### PR TITLE
Daily backup of postgres databases

### DIFF
--- a/deploy/common/etc/cron.d/postgres-daily-backup
+++ b/deploy/common/etc/cron.d/postgres-daily-backup
@@ -1,0 +1,9 @@
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+0 0 * * *  postgres  /usr/local/bin/postgres-daily-backup

--- a/deploy/common/usr/local/bin/postgres-daily-backup
+++ b/deploy/common/usr/local/bin/postgres-daily-backup
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+pg_dumpall > /data/db_dumps/Postgres-full-backup-$(date +\%Y\%m\%d).dump
+pg_dumpall --data-only --column-inserts \
+           > /data/db_dumps/Postgres-data-backup-$(date +\%Y\%m\%d).dump
+pg_dumpall --schema-only \
+           > /data/db_dumps/Postgres-schema-backup-$(date +\%Y\%m\%d).dump
+
+zip -q -Zb -9 /data/db_dumps/PG-Backup-$(date +\%Y\%m\%d).zip \
+    /data/db_dumps/Postgres-*-backup-$(date +\%Y\%m\%d).dump
+
+rm -f /data/db_dumps/Postgres-*-backup-$(date +\%Y\%m\%d).dump


### PR DESCRIPTION
This adds a script to perform a full backup of the postgres databases, once per day.  This is already done on the production server, but I don't see any reason not to include it in the repository.

(The backup is stored in three different formats, which may not be necessary, but the size of these files isn't really significant and having multiple redundant formats might be convenient.)

The script itself was written by @elfeto; I've just made some slight formatting tweaks.
