### PR TITLE
Fix typo in editors tools tab (assignment -> assigment)

### DIFF
--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -9,7 +9,7 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
-        <a class="nav-link active" id="assignment-tab" data-toggle="tab" href="#assignment" role="tab" aria-controls="assignment" aria-selected="true">Awaiting Editor Assigment {{ assignment_projects|task_count_badge|safe }}</a>
+        <a class="nav-link active" id="assignment-tab" data-toggle="tab" href="#assignment" role="tab" aria-controls="assignment" aria-selected="true">Awaiting Editor Assignment {{ assignment_projects|task_count_badge|safe }}</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" id="decision-tab" data-toggle="tab" href="#decision" role="tab" aria-controls="decision" aria-selected="false">Awaiting Decision {{ decision_projects|task_count_badge|safe }}</a>


### PR DESCRIPTION
This fixes a typo that has been bothering me for a while!

`Awaiting Editor Assigment` should be `Awaiting Editor Assignment`.