### PR TITLE
Add simple reporting metrics for credentialing applications

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -167,17 +167,25 @@
 
       <!-- usage stats -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
-        <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion">
+      {% if stats_nav %}
+        <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion" aria-expanded="true">
+      {% else %}
+        <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion" aria-expanded="False">
+      {% endif %}
           <i class="fa fa-fw fa-chart-area"></i>
           <span class="nav-link-text">Usage Stats</span>
         </a>
         <!-- submenu -->
+        {% if stats_nav %}
+        <ul class="sidenav-second-level collapse show" id="statsComponents">
+        {% else  %}
         <ul class="sidenav-second-level collapse" id="statsComponents">
+        {% endif %}
           <li>
             <a href="{% url 'editorial_stats' %}">Editorial</a>
           </li>
-          <li>
-            <a href="#">Not Implemented</a>
+          <li class="nav-item {% if submenu == 'credential' %}active{% endif %}">
+            <a href="{% url 'credentialing_stats' %}">Credentialing</a>
           </li>
         </ul>
       </li>

--- a/physionet-django/console/templates/console/credentialing_stats.html
+++ b/physionet-django/console/templates/console/credentialing_stats.html
@@ -1,0 +1,43 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}Credentialing metrics{% endblock %}
+
+{% block content %}
+
+<div class="card mb-3">
+  <div class="card-header">
+    Credentialing metrics
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+
+      <table class="table table-bordered">
+        <tr>
+          <th>Year</th>
+          <th>Total applications</th>
+          <th>Total handled (accepted + rejected)</th>
+          <th>Approved (%)</th>
+          <th>Decision time (days, median)</th>
+          <th>Time to contact reference (days, median)</th>
+          <th>Reference response time (days, median)</th>
+        </tr>
+        {% for year, value in stats.items %}
+          <tr>
+            <td>{{ year }}</td>
+            <td>{{ value.count }}</td>
+            <td>{{ value.processed }}</td>
+            <td>{{ value.approved }}</td>
+            <td>{{ value.time_to_decision }}</td>
+            <td>{{ value.time_to_ref }}</td>
+            <td>{{ value.time_to_reply }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -88,4 +88,6 @@ urlpatterns = [
 
     # editorial stats
     path('usage/editorial/stats/', views.editorial_stats, name='editorial_stats'),
+    path('usage/credentialing/stats/', views.credentialing_stats,
+         name='credentialing_stats'),
 ]

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -13068,10 +13068,10 @@
   "pk": 108,
   "fields": {
     "slug": "eW2e7VDCst44ziWjaota",
-    "application_datetime": "2020-04-08T18:49:03.693Z",
+    "application_datetime": "2019-04-08T18:49:03.693Z",
     "user": 206,
-    "first_names": "Alistair",
-    "last_name": "Johnson",
+    "first_names": "Tom",
+    "last_name": "Pollard",
     "researcher_category": 1,
     "organization_name": "Massachusetts Institute of Technology, Laboratory of Computa",
     "job_title": "Researcher",
@@ -13097,7 +13097,7 @@
     "reference_response_text": "",
     "research_summary": "MIMIC stuff",
     "project_of_interest": null,
-    "decision_datetime": "2020-04-08T18:49:33.506Z",
+    "decision_datetime": "2019-04-08T18:49:33.506Z",
     "responder": 1,
     "responder_comments": "inadequate research summary"
   }


### PR DESCRIPTION
Adds a page to the console at http://localhost:8000/console/usage/credentialing/stats/ that displays basic metrics for credentialing applications. Also makes minor updates the demo data so applications are displayed over 2 years - 2019 and 2020.

<img width="786" alt="Screen Shot 2020-10-14 at 23 05 26" src="https://user-images.githubusercontent.com/822601/96072185-c1c5ef80-0e71-11eb-9510-d3e4bc778f00.png">

- Year: Year that the application was submitted.
- Total applications: Count of the number of applications in the given year.
- Total handled: Count of the applications processed (e.g. in the 2020 demo data, there are 107 applications but only 2 have been accepted or rejected).
- Approved (%): Proportion of applications approved (e.g. Of the two applications in 2020 that were processed, one was accepted and one was rejected).
- Decision time (days, median): Median time in days from application to acceptance/rejection.
- Time to contact reference (days, median): Median time in days from application to contacting the reference.
- Reference response time (days, median): Median time in days between contacting the reference and the response being received.
