### PR TITLE
Add message to reset password page. Closes #1132.

### DIFF
--- a/physionet-django/user/templates/user/reset_password_request.html
+++ b/physionet-django/user/templates/user/reset_password_request.html
@@ -21,7 +21,18 @@ Reset Password
       {% include "form_snippet.html" %}
       <button class="btn btn-lg btn-primary btn-block" type="submit">Get Reset Link</button>
   </form>
+
+  <div class="alert alert-warning alert-dismissible fade show" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <p>If you do not receive an email and you have checked your junk mail folder, it is likely that you do not have an account. Please <a id="register" href="{% url 'register' %}">create one</a>.</p> 
+
+    <p>Accounts created prior to 2019 were <em>not</em> migrated to the new platform. Your credentials will be transferred if you register using the same email address as before.</p>
+  </div>
+
 </div>
+
 {% endblock %}
 
 {% block local_js_bottom %}


### PR DESCRIPTION
This pull request addresses #1132 ("Reset password page should explain that no action is taken if the account does not exist").

We regularly receive messages from people who believe the 'reset password' form is broken because it does not send them an email. In almost all cases, the issue is that the person does not have an account.

After this change, the following message is displayed at http://localhost:8000/reset-password/ 

> If you do not receive an email and you have checked your junk mail folder, it is likely that you do not have an account. Please create one.

> Accounts created prior to 2019 were not migrated to the new platform. Your credentials will be transferred if you register using the same email address as before.