### PR TITLE
Group database index by access policy. Relates to #1078.

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -127,10 +127,16 @@ def database_overview(request):
     """
     Temporary content overview
     """
-    all_projects = PublishedProject.objects.filter(
-        resource_type=0, is_latest_version=True).order_by(Lower('title'))
+    projects = {}
+    for i, policy in Metadata.ACCESS_POLICIES:
+        projects[i] = {}
+        projects[i]['policy'] = policy
+        projects[i]['projects'] = PublishedProject.objects.filter(
+            access_policy=i, resource_type=0, is_latest_version=True
+            ).order_by(Lower('title'))
+
     return render(request, 'about/database_index.html',
-                  {'all_projects': all_projects})
+                  {'projects': projects})
 
 
 def software_overview(request):

--- a/physionet-django/templates/about/database_content.html
+++ b/physionet-django/templates/about/database_content.html
@@ -13,9 +13,19 @@ This page displays an alphabetical list of all the databases on PhysioNet. To se
 <br>
 <hr>
 
-<h2 id="databases">All Databases</h2>
-<ul>
-  {% for project in all_projects %}
-  <li><a href="{% url 'published_project_latest' project.slug %}">{{ project.title }}</a>: {% if project.short_description %}{{ project.short_description }}{% else %}{{ project.abstract_text_content|truncatechars_html:200 }}{% endif %}</li>
+{% for i, group in projects.items %}
+  <h2 id="{{ group.policy|lower }}">{{ group.policy }} databases</h2>
+    <ul>
+      {% for p in group.projects %}
+        <li><a href="{% url 'published_project_latest' p.slug %}">{{ p.title }}</a>:
+          {% if p.short_description %}
+            {{ p.short_description }}
+        {% else %}
+          {{ p.abstract_text_content|truncatechars_html:200 }}
+          {% endif %}
+        </li>
+      {% empty %}
+        <li>No databases available.</li>
+      {% endfor %}
+    </ul>
 {% endfor %}
-</ul>

--- a/physionet-django/templates/about/database_index.html
+++ b/physionet-django/templates/about/database_index.html
@@ -25,9 +25,11 @@ PhysioNet Databases
             <!-- Databases -->
             <ul>
               <li><a href="#overview">Overview</a></li>
-              <li><a href="#databases">All databases</a></li>
-            </li>
+              {% for i, group in projects.items %}
+                <li><a href="#{{ group.policy|lower }}">{{ group.policy }} access</a></li>
+              {% endfor %}
           </ul>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
KP would like a link that displays all projects requiring a Data Use Agreement. The database index (https://physionet.org/about/database/) seems like a good place to support this request. Relates to #1078.

After this change, http://physionet.org/about/database/#open would take users to a list of projects that require credentialed access.  

Groups are split by access type in the view and then rendered in the appropriate template. If the list of databases is empty for an access type, "No databases available." is displayed. e.g.

![Screen Shot 2020-10-29 at 13 03 14](https://user-images.githubusercontent.com/822601/97607237-1d05ef00-19e7-11eb-8b33-9d7287e42b0a.png)
