### PR TITLE
Convert AuthorInvitation email addresses to lowercase. Ref #1149.

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -817,7 +817,8 @@ class InviteAuthorForm(forms.ModelForm):
 
     def clean_email(self):
         "Ensure it is a fresh invite to a non-author"
-        data = self.cleaned_data['email']
+
+        data = self.cleaned_data['email'].lower()
 
         for author in self.project.authors.all():
             if data in author.user.get_emails():


### PR DESCRIPTION
Submitting authors are able to invite co-authors by adding email addresses to the form at: https://physionet.org/projects/SLUG/authors/. If upper characters are used, the invitation will not match to a user because user addresses are always stored in lowercase (see #1149). 

This patch fixes the issue by converting AuthorInvitation addresses to lowercase, using an approach that appears elsewhere in our forms. e.g.: https://github.com/MIT-LCP/physionet-build/blob/956ab21e6a7b8e9d60fee42c0fd645b7b68207f3/physionet-django/user/forms.py#L61-L68


