### PR TITLE
Update nginx configuration for new certificate

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -113,15 +113,15 @@ server {
     }
 
     listen 443 ssl default_server http2;
-    ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/physionet.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
     # SSL stapling
     ssl_stapling on;
     ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/physionet.org/fullchain.pem;
 
     # Security headers
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";

--- a/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_redirect_nginx.conf
@@ -15,15 +15,15 @@ server {
 
 server {
     listen      443 ssl http2;
-    ssl_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/alpha.physionet.org/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/physionet.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/physionet.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
     # SSL stapling
     ssl_stapling on;
     ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/alpha.physionet.org/fullchain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/physionet.org/fullchain.pem;
 
     # Security headers
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains; preload";


### PR DESCRIPTION
I've generated the new certificate, but since I specified "physionet.org" as the first hostname in the list, certbot installed the files in /etc/letsencrypt/physionet.org instead of /etc/letsencrypt/alpha.physionet.org where it was before.  So this updates the nginx configuration to match.
