### PR TITLE
Remove hyperlink on associated publication text if URL is not available

### DIFF
--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -115,7 +115,11 @@
 
     {% if publication %}
       <strong>In addition, please cite the original publication:</strong>
-      <p><a href="{{ publication.url }}">{{ publication.citation }}</a></p>
+      {% if publication.url %}
+        <p><a href="{{ publication.url }}">{{ publication.citation }}</a></p>
+      {% else %}
+        <p>{{ publication.citation }}</p>
+      {% endif %}
     {% endif %}
 
     <p>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -102,7 +102,11 @@
 
         {% if publication %}
           <strong>{% if project.is_legacy %}When using this resource{% else %}Additionally{% endif %}, please cite the original publication:</strong>
-          <p><a href="{{ publication.url }}">{{ publication.citation }}</a></p>
+          {% if publication.url %}
+            <p><a href="{{ publication.url }}">{{ publication.citation }}</a></p>
+          {% else %}
+            <p>{{ publication.citation }}</p>
+          {% endif %}
         {% endif %}
 
         <p>


### PR DESCRIPTION
Authors can provide an associated paper for their projects. This paper is listed at the top of the project landing page. e.g. for http://localhost:8000/content/demoeicu/, the following text is displayed (slightly confusing that the demo uses the PhysioNet citation but ignore that!):

![Screen Shot 2020-11-04 at 14 34 42](https://user-images.githubusercontent.com/822601/98159982-82585500-1eab-11eb-9e07-235f89524c6f.png)

The citation is wrapped with a hyperlink whether or not a URL is provided. This change removes the href if a URL is not provided. After the change, if there is no URL you will instead see:

![Screen Shot 2020-11-04 at 14 34 23](https://user-images.githubusercontent.com/822601/98160184-d3684900-1eab-11eb-8f17-f910ab50b0ce.png)