### PR TITLE
Only display public profile for active accounts.

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -340,7 +340,7 @@ def public_profile(request, username):
     """
     A user's public profile
     """
-    if User.objects.filter(username__iexact=username).exists():
+    if User.objects.filter(username__iexact=username, is_active=True).exists():
         public_user = User.objects.get(username__iexact=username)
         public_email = public_user.associated_emails.filter(is_public=True).first()
     else:


### PR DESCRIPTION
Currently we create a profile page for all user accounts, even those that are not yet active. This changes adds a requirement for the account to be active, because the majority of inactive accounts are spam. 