### PR TITLE
Add management page for users to the console

### DIFF
--- a/physionet-django/console/templates/console/rejected_submissions.html
+++ b/physionet-django/console/templates/console/rejected_submissions.html
@@ -33,7 +33,11 @@
             <td>{{ project.title }}</td>
             <td><a href="{% url 'rejected_submission_history' project.slug %}">View History</a></td>
             <td>{{ project.version }}</td>
-            <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</td>
+            <td>{% if project.submitting_author %}
+              <a href="{% url 'user_management' project.submitting_author.user.username %}">{{ project.submitting_author }}</a>
+                {% else %}
+                  {{ project.submitting_author }}
+                {% endif %}</td>
             <td>{{ project.editor }}</td>
             <td>{{ project.creation_datetime|date }}</td>
             <td>{{ project.archive_datetime|date }}</td>

--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -1,0 +1,95 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}User management{% endblock %}
+
+{% block content %}
+
+<div class="col-md-9 no-pd">
+  <h1>{{ subject.username }}</h1>
+  <hr>
+  <h3>Profile</h3>
+  <div class="row mb-1">
+    <div class="col-md-3">
+      Name:
+    </div>
+    <div class="col-md-9">
+      {{ subject.get_full_name }}
+    </div>
+  </div>
+
+  {% if profile.affiliation %}
+    <div class="row mb-1">
+      <div class="col-md-3">
+        Affiliation:
+      </div>
+      <div class="col-md-9">
+        {{ profile.affiliation }}
+      </div>
+    </div>
+  {% endif %}
+
+  {% if profile.location %}
+    <div class="row mb-1">
+      <div class="col-md-3">
+        Location:
+      </div>
+      <div class="col-md-9">
+        {{ profile.location }}
+      </div>
+    </div>
+  {% endif %}
+
+  {% for status, group in emails.items %}
+    <div class="row mb-1">
+        <div class="col-md-3">
+          Email ({{ status }}):
+        </div>
+        <div class="col-md-9">
+          {% for email in group %}
+            {{ email|join:", " }}
+          {% empty %}
+            N/A
+          {% endfor %}
+        </div>
+    </div>
+  {% endfor %}
+
+  {% if profile.website %}
+    <div class="row mb-1">
+      <div class="col-md-3">
+        Website:
+      </div>
+      <div class="col-md-9">
+        <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a>
+      </div>
+    </div>
+  {% endif %}
+
+  <br />
+  {% for status, group in projects.items %}
+  <h3>{{ status }} projects</h3>
+    <ul>
+      {% for project in group %}
+        {% if status == "Unsubmitted" %}
+          <li><a href="{% url 'submission_info' project.slug %}">{{ project.title }}
+            </a> ({% if project.version %}v{{ project.version }}{% else %}version TBC{% endif %})</li>
+        {% elif status == "Submitted" %}
+          <li><a href="{% url 'submission_info' project.slug %}">{{ project.title }}
+            </a> (v{{ project.version }})</li>
+        {% elif status == "Archived" %}
+          <li><a href="{% url 'rejected_submission_history' project.slug %}">{{ project.title }}
+            </a> (v{{ project.version }})</li>
+        {% elif status == "Published" %}
+          <li><a href="{% url 'manage_published_project' project.slug project.version %}">{{ project.title }}
+            </a> (v{{ project.version }})</li>
+        {% endif %}
+      {% empty %}
+        <li>None.</li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+
+</div>
+{% endblock %}

--- a/physionet-django/console/templates/console/users_admin.html
+++ b/physionet-django/console/templates/console/users_admin.html
@@ -24,7 +24,7 @@
         <tbody>
         {% for user in admin_users %}
           <tr>
-            <td><a href="{% url 'public_profile' user.username %}">{{ user.username }}</td>
+            <td><a href="{% url 'user_management' user.username %}">{{ user.username }}</a></td>
             <td>{{ user.get_full_name }}</td>
             <td>{{ user.email }}</td>
             <td>{{ user.join_date }}</td>

--- a/physionet-django/console/templates/console/users_list.html
+++ b/physionet-django/console/templates/console/users_list.html
@@ -16,7 +16,7 @@
       {% for user in users %}
       <tr>
         {% if group == 'all' %}<td>{% if user.is_active %}<span class="fa fa-check"><span class="visually-hidden">&#10004;</span></span>{% endif %}</td>{% endif %}
-        <td><a href="{% url 'public_profile' user.username %}">{{ user.username }}</td>
+        <td><a href="{% url 'user_management' user.username %}">{{ user.username }}</td>
         <td>{{ user.get_full_name }}</td>
         <td>{{ user.email }}</td>
         <td>{{ user.join_date }}</td>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -71,6 +71,8 @@ urlpatterns = [
 
     path('users/search/<group>/', views.users_search, name='users_list_search'),
     path('users/<group>/', views.users, name='users'),
+    path('user/manage/<username>/', views.user_management,
+        name='user_management'),
 
     path('news/', views.news_console, name='news_console'),
     path('news/add/', views.news_add, name='news_add'),


### PR DESCRIPTION
We often have to use the shell to answer questions about individual users (for example, "which projects are associated with user x"?). This change adds an individual profile page for each user to the console (similar to the public profile page).

The page is intended to be a starting point for a user management tool that might be used for tasks such as:
- deactivating/deleting accounts
- checking which projects are associated with a user
- updating or merging accounts
- etc.

The page is accessed by finding the relevant user in the search tool (http://127.0.0.1:8000/console/users/all/) and then clicking the username.

Example profile:

![Screen Shot 2020-11-07 at 04 24 15](https://user-images.githubusercontent.com/822601/98437638-c0bf6100-20b1-11eb-98bf-013c4e158ab1.png)
