### PR TITLE
Minor changes to make KP's credentialing page less slow to load

### DIFF
--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -1,8 +1,10 @@
+{% load console_templatetags %}
+
 <div class="card mb-4" style="color: {{ color }}">
   <div class="card-header" id="application_{{ application.id }}">
     <h2 style="font-size: 1.2rem;">{{ application.get_full_name }}</h2>
     <p>
-      <a href='{{ application.mailto }}' style="padding-right: 1.5rem;">
+      <a href='{% mail_credential_applicant application %}' style="padding-right: 1.5rem;">
 	Send e-mail to applicant
       </a>  {{ application.user.email }} <br>
       Researcher's Category: {{ application.get_researcher_category_display }}<br>

--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -24,7 +24,7 @@
 	{{ application.reference_email }} 
 	{% if application.reference_contact_datetime %}
 		[The {{ application.reference_category|yesno:"reference,supervisor" }} was contacted on {{ application.reference_contact_datetime }}]
-	{% elif application.ref_known_flag %}
+	{% elif application.reference_email|lower in known_refs %}
         	[Reference is known]
 	{% endif %}
       </p>

--- a/physionet-django/console/templatetags/console_templatetags.py
+++ b/physionet-django/console/templatetags/console_templatetags.py
@@ -1,5 +1,6 @@
 from django import template
 
+import notification.utility as notification
 
 register = template.Library()
 
@@ -17,3 +18,11 @@ def task_count_badge(item):
     return '<span class="badge badge-pill badge-{}">{}</span>'.format(
         context_class, len(item))
 
+
+@register.simple_tag(name='mail_credential_applicant', takes_context=True)
+def mail_credential_applicant(context, a):
+    """
+    Prepare a template email to someone who has applied for credentialing.
+    """
+    return notification.mailto_process_credential_complete(context['request'],
+                                                           a, comments=False)

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1050,9 +1050,7 @@ def complete_credential_applications(request):
     contacted_apps = []
 
     for a in applications:
-        a.mailto = notification.mailto_process_credential_complete(
-            request, a, comments=False)
-
+        
         if a.ref_known_flag() and a.reference_contact_datetime is None:
             known_ref_apps_not_contacted.append([a.application_datetime, a])
         elif not a.ref_known_flag() and a.reference_contact_datetime is None:

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -795,7 +795,8 @@ class CredentialApplication(models.Model):
 
     def ref_known_flag(self):
         """
-        Returns True if the reference is known, else False.
+        Returns True if the reference is known, else False. By "Known" we mean
+        that the reference has been previously contacted.
         """
         if CredentialApplication.objects.filter(
             reference_email__iexact=self.reference_email,


### PR DESCRIPTION
As noted in https://github.com/MIT-LCP/physionet-build/issues/1157, the "Complete Credentialing Page" is incredibly slow to load. This pull request makes a couple of small changes in attempt to begin to address this:

- moves the `mail_credential_applicant` function to a templatetag. Doesn't really make a difference to speed, but it is cleaner.
- avoids using the `ref_known_flag()` method on the CredentialingApplication, which was leading to lots of unnecessary queries.

It's still very slow after the changes, so more work is needed (e.g. not pre-loading the mailto content for every email in complete_application_display).

Load times for the demo data before change: 

Resource | Value
-- | --
User CPU time | 12.029 sec
System CPU time | 8.000 sec
Total CPU time | 20.029 sec
Elapsed time | 23.252 sec

Load times for the demo data after change: 

Resource	| Value
-- | --
User CPU time | 4.023 sec
System CPU time | 2.336 sec
Total CPU time | 7.359 sec
Elapsed time | 7.780 sec

