### PR TITLE
Avoid displaying 'reference is known' if reference email is empty

### DIFF
--- a/physionet-django/console/templates/console/complete_application_display.html
+++ b/physionet-django/console/templates/console/complete_application_display.html
@@ -24,7 +24,7 @@
 	{{ application.reference_email }} 
 	{% if application.reference_contact_datetime %}
 		[The {{ application.reference_category|yesno:"reference,supervisor" }} was contacted on {{ application.reference_contact_datetime }}]
-	{% elif application.reference_email|lower in known_refs %}
+	{% elif application.reference_email and application.reference_email|lower in known_refs %}
         	[Reference is known]
 	{% endif %}
       </p>


### PR DESCRIPTION
This is a minor update to follow up on https://github.com/MIT-LCP/physionet-build/pull/1163. Currently "Reference is known" is displayed next to references where the reference email is None/empty. The change in this pull request should prevent this happening. 