### PR TITLE
Add variation to credentialing application dates in the demo fixtures

### DIFF
--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -8973,7 +8973,7 @@
   "pk": 3,
   "fields": {
     "slug": "qdOWz3Bn0k8FkqtcLpdu",
-    "application_datetime": "2020-03-29T21:51:08.618Z",
+    "application_datetime": "2020-05-20T22:50:08.618Z",
     "user": 8,
     "first_names": "Deborah",
     "last_name": "Bui",
@@ -9090,7 +9090,7 @@
   "pk": 6,
   "fields": {
     "slug": "INNoIkyrtrHCVXbxTHz6",
-    "application_datetime": "2020-03-29T21:51:09.035Z",
+    "application_datetime": "2020-04-19T21:39:09.035Z",
     "user": 13,
     "first_names": "Odis",
     "last_name": "Singer",
@@ -9207,7 +9207,7 @@
   "pk": 9,
   "fields": {
     "slug": "CGEln47LBdyVUkswCBng",
-    "application_datetime": "2020-03-29T21:51:09.611Z",
+    "application_datetime": "2020-03-26T21:51:09.611Z",
     "user": 20,
     "first_names": "Douglas",
     "last_name": "Hughes",
@@ -9285,7 +9285,7 @@
   "pk": 11,
   "fields": {
     "slug": "pYeh1H1mEUeuAiRExfEq",
-    "application_datetime": "2020-03-29T21:51:09.860Z",
+    "application_datetime": "2020-03-29T17:29:01.860Z",
     "user": 23,
     "first_names": "Troy",
     "last_name": "Funk",
@@ -9324,7 +9324,7 @@
   "pk": 12,
   "fields": {
     "slug": "92D60e53t3lE9lwORvsE",
-    "application_datetime": "2020-03-29T21:51:10.022Z",
+    "application_datetime": "2020-03-24T11:50:10.022Z",
     "user": 25,
     "first_names": "Geraldine",
     "last_name": "Pennington",
@@ -9363,7 +9363,7 @@
   "pk": 13,
   "fields": {
     "slug": "YvYeoyUxOjMBvRYdMUru",
-    "application_datetime": "2020-03-29T21:51:10.103Z",
+    "application_datetime": "2020-03-29T18:13:10.103Z",
     "user": 26,
     "first_names": "Debra",
     "last_name": "Douglas",
@@ -9402,7 +9402,7 @@
   "pk": 14,
   "fields": {
     "slug": "kSkH3svkQyCE1RpI5bZa",
-    "application_datetime": "2020-03-29T21:51:10.337Z",
+    "application_datetime": "2020-03-24T20:32:10.337Z",
     "user": 29,
     "first_names": "Leroy",
     "last_name": "Shaffer",
@@ -9441,7 +9441,7 @@
   "pk": 15,
   "fields": {
     "slug": "3niq5ZuHnhhdtSX2qHlU",
-    "application_datetime": "2020-03-29T21:51:10.589Z",
+    "application_datetime": "2020-03-23T21:39:10.589Z",
     "user": 32,
     "first_names": "Monica",
     "last_name": "Davis",
@@ -9480,7 +9480,7 @@
   "pk": 16,
   "fields": {
     "slug": "qgRhw3V6PGBH7m5Qp5on",
-    "application_datetime": "2020-03-29T21:51:10.673Z",
+    "application_datetime": "2020-03-19T13:50:10.673Z",
     "user": 33,
     "first_names": "Ethel",
     "last_name": "Knox",
@@ -9519,7 +9519,7 @@
   "pk": 17,
   "fields": {
     "slug": "E15Myv2ScWRXsw9Cyqsv",
-    "application_datetime": "2020-03-29T21:51:10.867Z",
+    "application_datetime": "2020-03-25T09:31:10.867Z",
     "user": 35,
     "first_names": "Sara",
     "last_name": "Sparks",
@@ -9558,7 +9558,7 @@
   "pk": 18,
   "fields": {
     "slug": "LrfZMZJQOMrmgJr6jkgV",
-    "application_datetime": "2020-03-29T21:51:11.032Z",
+    "application_datetime": "2020-03-29T07:11:11.032Z",
     "user": 37,
     "first_names": "Eileen",
     "last_name": "Jackson",
@@ -9597,7 +9597,7 @@
   "pk": 19,
   "fields": {
     "slug": "mkW92RlgIMMIVyYaC2eX",
-    "application_datetime": "2020-03-29T21:51:11.132Z",
+    "application_datetime": "2020-03-28T11:57:11.132Z",
     "user": 38,
     "first_names": "Henrietta",
     "last_name": "Deoliveira",
@@ -9636,7 +9636,7 @@
   "pk": 20,
   "fields": {
     "slug": "PIyJnDmF1KvoO1GO8aOs",
-    "application_datetime": "2020-03-29T21:51:11.403Z",
+    "application_datetime": "2020-03-28T21:31:11.403Z",
     "user": 41,
     "first_names": "Ralph",
     "last_name": "Dunaway",
@@ -9675,7 +9675,7 @@
   "pk": 21,
   "fields": {
     "slug": "WqSIR1ol9FfbMC0h0IFt",
-    "application_datetime": "2020-03-29T21:51:11.649Z",
+    "application_datetime": "2020-03-27T12:21:11.649Z",
     "user": 44,
     "first_names": "Patrick",
     "last_name": "Michael",
@@ -9714,7 +9714,7 @@
   "pk": 22,
   "fields": {
     "slug": "3Pr7MQTftV4j9yhjbYUH",
-    "application_datetime": "2020-03-29T21:51:11.728Z",
+    "application_datetime": "2020-03-29T14:11:11.728Z",
     "user": 45,
     "first_names": "Diane",
     "last_name": "Dumas",
@@ -9753,7 +9753,7 @@
   "pk": 23,
   "fields": {
     "slug": "fQ9wSvLXQFvXAPzTVqDL",
-    "application_datetime": "2020-03-29T21:51:11.898Z",
+    "application_datetime": "2020-03-28T18:23:11.898Z",
     "user": 47,
     "first_names": "Hoa",
     "last_name": "Vance",
@@ -9792,7 +9792,7 @@
   "pk": 24,
   "fields": {
     "slug": "3SEjpDcdwryxt3Li5QWS",
-    "application_datetime": "2020-03-29T21:51:12.061Z",
+    "application_datetime": "2020-03-28T12:12:12.061Z",
     "user": 49,
     "first_names": "Tori",
     "last_name": "White",
@@ -9831,7 +9831,7 @@
   "pk": 25,
   "fields": {
     "slug": "XFcMZ6KytaAEOfC0VGFt",
-    "application_datetime": "2020-03-29T21:51:12.152Z",
+    "application_datetime": "2020-03-29T13:11:12.152Z",
     "user": 50,
     "first_names": "Victoria",
     "last_name": "Dawkins",
@@ -9870,7 +9870,7 @@
   "pk": 26,
   "fields": {
     "slug": "E52ROdo3hYnPEldQewI6",
-    "application_datetime": "2020-03-29T21:51:12.390Z",
+    "application_datetime": "2020-03-27T23:14:12.390Z",
     "user": 53,
     "first_names": "Jenna",
     "last_name": "Mcdermott",
@@ -9909,7 +9909,7 @@
   "pk": 27,
   "fields": {
     "slug": "F2rZzkhKOBMnZ2UTWMk4",
-    "application_datetime": "2020-03-29T21:51:12.646Z",
+    "application_datetime": "2020-03-27T06:17:12.646Z",
     "user": 56,
     "first_names": "Devin",
     "last_name": "Linney",
@@ -9948,7 +9948,7 @@
   "pk": 28,
   "fields": {
     "slug": "EQnspRxBm6QlPpd86Sm9",
-    "application_datetime": "2020-03-29T21:51:12.740Z",
+    "application_datetime": "2020-03-27T04:13:12.740Z",
     "user": 57,
     "first_names": "Miguel",
     "last_name": "Bryon",
@@ -9987,7 +9987,7 @@
   "pk": 29,
   "fields": {
     "slug": "vYxll4yYIwQTm1fOPSXI",
-    "application_datetime": "2020-03-29T21:51:12.895Z",
+    "application_datetime": "2020-03-28T19:44:12.895Z",
     "user": 59,
     "first_names": "Michael",
     "last_name": "Pugh",
@@ -10026,7 +10026,7 @@
   "pk": 30,
   "fields": {
     "slug": "yyHJkwUuEH2MBlhVMmaZ",
-    "application_datetime": "2020-03-29T21:51:13.063Z",
+    "application_datetime": "2020-03-28T17:33:13.063Z",
     "user": 61,
     "first_names": "Virginia",
     "last_name": "Kaplan",
@@ -10065,7 +10065,7 @@
   "pk": 31,
   "fields": {
     "slug": "4OxnRrQpnqSeFJync4g6",
-    "application_datetime": "2020-03-29T21:51:13.177Z",
+    "application_datetime": "2020-03-27T22:20:13.177Z",
     "user": 62,
     "first_names": "Patricia",
     "last_name": "Bane",
@@ -10104,7 +10104,7 @@
   "pk": 32,
   "fields": {
     "slug": "fLSfjR5ZL8InHEwikPMk",
-    "application_datetime": "2020-03-29T21:51:13.434Z",
+    "application_datetime": "2020-03-28T08:50:13.434Z",
     "user": 65,
     "first_names": "Becky",
     "last_name": "Perry",
@@ -10143,7 +10143,7 @@
   "pk": 33,
   "fields": {
     "slug": "mhnQcQdOlRpkERtmKQjm",
-    "application_datetime": "2020-03-29T21:51:13.674Z",
+    "application_datetime": "2020-03-26T20:11:13.674Z",
     "user": 68,
     "first_names": "Lettie",
     "last_name": "Allen",
@@ -10182,7 +10182,7 @@
   "pk": 34,
   "fields": {
     "slug": "9B8JbnKvpoT42guHqOCx",
-    "application_datetime": "2020-03-29T21:51:13.776Z",
+    "application_datetime": "2020-03-28T07:01:13.776Z",
     "user": 69,
     "first_names": "Tommie",
     "last_name": "Aleo",
@@ -10221,7 +10221,7 @@
   "pk": 35,
   "fields": {
     "slug": "5gcPm8e4OmQwlX9UwXGm",
-    "application_datetime": "2020-03-29T21:51:13.942Z",
+    "application_datetime": "2020-03-28T10:11:13.942Z",
     "user": 71,
     "first_names": "Virginia",
     "last_name": "Whittingham",
@@ -10260,7 +10260,7 @@
   "pk": 36,
   "fields": {
     "slug": "9Rqt6gvxaJq3Z6ej9eTs",
-    "application_datetime": "2020-03-29T21:51:14.107Z",
+    "application_datetime": "2020-03-19T22:01:14.107Z",
     "user": 73,
     "first_names": "Peter",
     "last_name": "Neri",
@@ -10299,7 +10299,7 @@
   "pk": 37,
   "fields": {
     "slug": "YaV1iPlZjNN0fRG3lIaz",
-    "application_datetime": "2020-03-29T21:51:14.191Z",
+    "application_datetime": "2020-03-28T10:06:14.191Z",
     "user": 74,
     "first_names": "Joseph",
     "last_name": "Garden",
@@ -10338,7 +10338,7 @@
   "pk": 38,
   "fields": {
     "slug": "X9rLCOxcVd1VNzU8dxiy",
-    "application_datetime": "2020-03-29T21:51:14.450Z",
+    "application_datetime": "2020-03-28T09:07:14.450Z",
     "user": 77,
     "first_names": "Luther",
     "last_name": "Tolle",
@@ -10377,7 +10377,7 @@
   "pk": 39,
   "fields": {
     "slug": "3oMF0BTmJnV8HnvIWTox",
-    "application_datetime": "2020-03-29T21:51:14.749Z",
+    "application_datetime": "2020-03-28T08:55:14.749Z",
     "user": 80,
     "first_names": "Rob",
     "last_name": "Provine",
@@ -10416,7 +10416,7 @@
   "pk": 40,
   "fields": {
     "slug": "xra730Gfcd7VsMeySREs",
-    "application_datetime": "2020-03-29T21:51:14.832Z",
+    "application_datetime": "2020-03-29T07:48:14.832Z",
     "user": 81,
     "first_names": "Bethann",
     "last_name": "Eliason",
@@ -10455,7 +10455,7 @@
   "pk": 41,
   "fields": {
     "slug": "wJLogxwj4JvoGh90BzXU",
-    "application_datetime": "2020-03-29T21:51:15.026Z",
+    "application_datetime": "2020-03-29T21:23:09.026Z",
     "user": 83,
     "first_names": "Dwight",
     "last_name": "Fox",
@@ -10494,7 +10494,7 @@
   "pk": 42,
   "fields": {
     "slug": "1wQDIy2bEJREh7JvHTHk",
-    "application_datetime": "2020-03-29T21:51:15.183Z",
+    "application_datetime": "2020-03-29T12:31:15.183Z",
     "user": 85,
     "first_names": "Maria",
     "last_name": "Chamberlain",
@@ -10533,7 +10533,7 @@
   "pk": 43,
   "fields": {
     "slug": "RYLxwFpFNAmfwaGmlw42",
-    "application_datetime": "2020-03-29T21:51:15.263Z",
+    "application_datetime": "2020-03-29T16:59:15.263Z",
     "user": 86,
     "first_names": "Jonathon",
     "last_name": "Lopez",
@@ -10572,7 +10572,7 @@
   "pk": 44,
   "fields": {
     "slug": "0oq4LtvuSZs2hjRyuQCo",
-    "application_datetime": "2020-03-29T21:51:15.506Z",
+    "application_datetime": "2020-03-29T12:12:15.506Z",
     "user": 89,
     "first_names": "Floyd",
     "last_name": "Crum",
@@ -10611,7 +10611,7 @@
   "pk": 45,
   "fields": {
     "slug": "SUALs4nv4kNQVMZIPPVI",
-    "application_datetime": "2020-03-29T21:51:15.792Z",
+    "application_datetime": "2020-03-29T23:13:15.792Z",
     "user": 92,
     "first_names": "Cecil",
     "last_name": "Kurter",
@@ -10650,7 +10650,7 @@
   "pk": 46,
   "fields": {
     "slug": "SQOwinxBHyvsJPN8iNGf",
-    "application_datetime": "2020-03-29T21:51:15.872Z",
+    "application_datetime": "2020-03-29T20:48:15.872Z",
     "user": 93,
     "first_names": "Charles",
     "last_name": "Fisher",
@@ -10689,7 +10689,7 @@
   "pk": 47,
   "fields": {
     "slug": "WK5bC1v8q2B8P2W5eGnM",
-    "application_datetime": "2020-03-29T21:51:16.037Z",
+    "application_datetime": "2020-03-29T16:42:16.037Z",
     "user": 95,
     "first_names": "Richard",
     "last_name": "Tebo",
@@ -10728,7 +10728,7 @@
   "pk": 48,
   "fields": {
     "slug": "Qr3IFFF4pvlIzdPOKK9h",
-    "application_datetime": "2020-03-29T21:51:16.198Z",
+    "application_datetime": "2020-03-29T15:18:16.198Z",
     "user": 97,
     "first_names": "Ezequiel",
     "last_name": "Alston",
@@ -10767,7 +10767,7 @@
   "pk": 49,
   "fields": {
     "slug": "8ccUikzIroiDtw5TawwF",
-    "application_datetime": "2020-03-29T21:51:16.281Z",
+    "application_datetime": "2020-03-29T13:15:16.281Z",
     "user": 98,
     "first_names": "Willie",
     "last_name": "Huskey",
@@ -10806,7 +10806,7 @@
   "pk": 50,
   "fields": {
     "slug": "0ZtcSrCEk0QmCh4JTAec",
-    "application_datetime": "2020-03-29T21:51:16.543Z",
+    "application_datetime": "2020-03-29T10:10:16.543Z",
     "user": 101,
     "first_names": "Joe",
     "last_name": "Cooperrider",
@@ -10845,7 +10845,7 @@
   "pk": 51,
   "fields": {
     "slug": "Nij37q1qUa0AXDoQ6Nyw",
-    "application_datetime": "2020-03-29T21:51:16.828Z",
+    "application_datetime": "2020-03-29T12:13:16.828Z",
     "user": 104,
     "first_names": "Janice",
     "last_name": "Hucks",
@@ -10884,7 +10884,7 @@
   "pk": 52,
   "fields": {
     "slug": "nG9rGGsjI25tyLC0mXXf",
-    "application_datetime": "2020-03-29T21:51:16.912Z",
+    "application_datetime": "2020-03-29T20:09:16.912Z",
     "user": 105,
     "first_names": "Lula",
     "last_name": "Ochoa",
@@ -10923,7 +10923,7 @@
   "pk": 53,
   "fields": {
     "slug": "9uIhOJDq0W547pnMZfyy",
-    "application_datetime": "2020-03-29T21:51:17.075Z",
+    "application_datetime": "2020-03-29T17:38:17.075Z",
     "user": 107,
     "first_names": "Molly",
     "last_name": "Crawford",
@@ -10962,7 +10962,7 @@
   "pk": 54,
   "fields": {
     "slug": "QMUe1jhLlxVaOuwZ21PX",
-    "application_datetime": "2020-03-29T21:51:17.234Z",
+    "application_datetime": "2020-03-29T13:51:17.234Z",
     "user": 109,
     "first_names": "Emma",
     "last_name": "Perez",
@@ -11001,7 +11001,7 @@
   "pk": 55,
   "fields": {
     "slug": "juqFFolEjdCKfxgV85o6",
-    "application_datetime": "2020-03-29T21:51:17.330Z",
+    "application_datetime": "2020-03-29T18:31:17.330Z",
     "user": 110,
     "first_names": "Scotty",
     "last_name": "Larson",
@@ -11040,7 +11040,7 @@
   "pk": 56,
   "fields": {
     "slug": "moAWK0ga0tI5bIlOQD7i",
-    "application_datetime": "2020-03-29T21:51:17.562Z",
+    "application_datetime": "2020-03-29T16:55:17.562Z",
     "user": 113,
     "first_names": "Paula",
     "last_name": "Hoskins",
@@ -11079,7 +11079,7 @@
   "pk": 57,
   "fields": {
     "slug": "rwA281Kxju46Q85Mpp6j",
-    "application_datetime": "2020-03-29T21:51:17.801Z",
+    "application_datetime": "2020-03-28T17:11:17.801Z",
     "user": 116,
     "first_names": "James",
     "last_name": "Herring",
@@ -11118,7 +11118,7 @@
   "pk": 58,
   "fields": {
     "slug": "10VWDXrxSsbEdTANdafv",
-    "application_datetime": "2020-03-29T21:51:17.891Z",
+    "application_datetime": "2020-03-28T20:01:17.891Z",
     "user": 117,
     "first_names": "Catherine",
     "last_name": "Darcangelo",
@@ -11157,7 +11157,7 @@
   "pk": 59,
   "fields": {
     "slug": "4fLiMA5Gq1pQH6kYaQyA",
-    "application_datetime": "2020-03-29T21:51:18.060Z",
+    "application_datetime": "2020-03-29T01:00:18.060Z",
     "user": 119,
     "first_names": "Ava",
     "last_name": "Disher",
@@ -11196,7 +11196,7 @@
   "pk": 60,
   "fields": {
     "slug": "nr0Z6xKGo3qp2dYVW8i0",
-    "application_datetime": "2020-03-29T21:51:18.241Z",
+    "application_datetime": "2020-03-29T04:59:18.241Z",
     "user": 121,
     "first_names": "Stanley",
     "last_name": "Landry",
@@ -11235,7 +11235,7 @@
   "pk": 61,
   "fields": {
     "slug": "8J0fsVbl6POmRNLaMNDc",
-    "application_datetime": "2020-03-29T21:51:18.328Z",
+    "application_datetime": "2020-03-29T16:55:18.328Z",
     "user": 122,
     "first_names": "Leon",
     "last_name": "Dufrene",
@@ -11274,7 +11274,7 @@
   "pk": 62,
   "fields": {
     "slug": "5U5sjoUd3b0QmHMGZm5C",
-    "application_datetime": "2020-03-29T21:51:18.566Z",
+    "application_datetime": "2020-03-29T09:20:18.566Z",
     "user": 125,
     "first_names": "Richard",
     "last_name": "Cottrell",
@@ -11313,7 +11313,7 @@
   "pk": 63,
   "fields": {
     "slug": "4ePplKTGmrKWVw8bCTSv",
-    "application_datetime": "2020-03-29T21:51:18.806Z",
+    "application_datetime": "2020-03-29T20:21:18.806Z",
     "user": 128,
     "first_names": "Lisa",
     "last_name": "Beech",
@@ -11352,7 +11352,7 @@
   "pk": 64,
   "fields": {
     "slug": "eNCkUpOjGKXImyc1kAJl",
-    "application_datetime": "2020-03-29T21:51:18.885Z",
+    "application_datetime": "2020-03-28T01:17:18.885Z",
     "user": 129,
     "first_names": "Raymond",
     "last_name": "Rankin",
@@ -11391,7 +11391,7 @@
   "pk": 65,
   "fields": {
     "slug": "9yDXnqdBckaVk6pr7Nrx",
-    "application_datetime": "2020-03-29T21:51:19.045Z",
+    "application_datetime": "2020-03-29T22:12:19.045Z",
     "user": 131,
     "first_names": "Ronald",
     "last_name": "Burgess",
@@ -11430,7 +11430,7 @@
   "pk": 66,
   "fields": {
     "slug": "bYue9DZlNxcl2xkhmMoh",
-    "application_datetime": "2020-03-29T21:51:19.207Z",
+    "application_datetime": "2020-03-28T22:16:19.207Z",
     "user": 133,
     "first_names": "Dennis",
     "last_name": "Moore",
@@ -11469,7 +11469,7 @@
   "pk": 67,
   "fields": {
     "slug": "D4xFyf0h1rxXjHb8d5eb",
-    "application_datetime": "2020-03-29T21:51:19.287Z",
+    "application_datetime": "2020-03-28T13:01:19.287Z",
     "user": 134,
     "first_names": "Henry",
     "last_name": "Ayers",
@@ -11508,7 +11508,7 @@
   "pk": 68,
   "fields": {
     "slug": "7bDZekhoKURxQK80NQkG",
-    "application_datetime": "2020-03-29T21:51:19.538Z",
+    "application_datetime": "2020-03-29T14:00:19.538Z",
     "user": 137,
     "first_names": "Christina",
     "last_name": "Palmore",
@@ -11586,7 +11586,7 @@
   "pk": 70,
   "fields": {
     "slug": "zIOFRoLWvu9Tat82tPRR",
-    "application_datetime": "2020-03-29T21:51:19.887Z",
+    "application_datetime": "2020-03-28T06:57:19.887Z",
     "user": 141,
     "first_names": "Peggy",
     "last_name": "Day",
@@ -11625,7 +11625,7 @@
   "pk": 71,
   "fields": {
     "slug": "GnYtwucVb69d5ErokhbO",
-    "application_datetime": "2020-03-29T21:51:20.066Z",
+    "application_datetime": "2020-03-29T14:01:20.066Z",
     "user": 143,
     "first_names": "Cora",
     "last_name": "Lingle",
@@ -11664,7 +11664,7 @@
   "pk": 72,
   "fields": {
     "slug": "SwYkqtaUnBT3NfiuqZzt",
-    "application_datetime": "2020-03-29T21:51:20.230Z",
+    "application_datetime": "2020-03-25T18:11:20.230Z",
     "user": 145,
     "first_names": "Aretha",
     "last_name": "Linn",
@@ -11703,7 +11703,7 @@
   "pk": 73,
   "fields": {
     "slug": "lA55IrRI81eN8FeoA8iY",
-    "application_datetime": "2020-03-29T21:51:20.320Z",
+    "application_datetime": "2020-03-27T19:58:20.320Z",
     "user": 146,
     "first_names": "Caroline",
     "last_name": "Allen",
@@ -11742,7 +11742,7 @@
   "pk": 74,
   "fields": {
     "slug": "mi3rLMMNSmEcLR1YY00o",
-    "application_datetime": "2020-03-29T21:51:20.566Z",
+    "application_datetime": "2020-03-29T17:50:20.566Z",
     "user": 149,
     "first_names": "Joanna",
     "last_name": "Lamar",
@@ -11781,7 +11781,7 @@
   "pk": 75,
   "fields": {
     "slug": "a4uguQYxKzufMtuiDvic",
-    "application_datetime": "2020-03-29T21:51:20.902Z",
+    "application_datetime": "2020-03-29T15:41:20.902Z",
     "user": 152,
     "first_names": "Janice",
     "last_name": "Vanconant",
@@ -11820,7 +11820,7 @@
   "pk": 76,
   "fields": {
     "slug": "A9U87riokdg0BdahhLZv",
-    "application_datetime": "2020-03-29T21:51:20.987Z",
+    "application_datetime": "2020-03-29T21:15:46.987Z",
     "user": 153,
     "first_names": "Kenneth",
     "last_name": "Morrell",
@@ -11859,7 +11859,7 @@
   "pk": 77,
   "fields": {
     "slug": "7GOVLnOTQrDVz3ipxTra",
-    "application_datetime": "2020-03-29T21:51:21.169Z",
+    "application_datetime": "2020-03-29T14:58:21.169Z",
     "user": 155,
     "first_names": "Kyle",
     "last_name": "Norwood",
@@ -11898,7 +11898,7 @@
   "pk": 78,
   "fields": {
     "slug": "aW2I6CI1L187qGsuzLKv",
-    "application_datetime": "2020-03-29T21:51:21.337Z",
+    "application_datetime": "2020-03-29T13:39:21.337Z",
     "user": 157,
     "first_names": "Jimmy",
     "last_name": "Johnson",
@@ -11937,7 +11937,7 @@
   "pk": 79,
   "fields": {
     "slug": "B6VbwzLSICkzAnzZUhhL",
-    "application_datetime": "2020-03-29T21:51:21.437Z",
+    "application_datetime": "2020-03-29T17:38:21.437Z",
     "user": 158,
     "first_names": "Elise",
     "last_name": "Washington",
@@ -11976,7 +11976,7 @@
   "pk": 80,
   "fields": {
     "slug": "prw6SjswyrbmPfuHWcFq",
-    "application_datetime": "2020-03-29T21:51:21.699Z",
+    "application_datetime": "2020-03-28T19:00:21.699Z",
     "user": 161,
     "first_names": "Bobby",
     "last_name": "Falkner",
@@ -12015,7 +12015,7 @@
   "pk": 81,
   "fields": {
     "slug": "qMNskHKOcrsnpNHJwGKx",
-    "application_datetime": "2020-03-29T21:51:21.955Z",
+    "application_datetime": "2020-03-28T02:55:21.955Z",
     "user": 164,
     "first_names": "Arlene",
     "last_name": "Spence",
@@ -12054,7 +12054,7 @@
   "pk": 82,
   "fields": {
     "slug": "3Ccf0w3ovNEXa7FqvgEO",
-    "application_datetime": "2020-03-29T21:51:22.038Z",
+    "application_datetime": "2020-03-28T12:22:22.038Z",
     "user": 165,
     "first_names": "Joy",
     "last_name": "Ball",
@@ -12093,7 +12093,7 @@
   "pk": 83,
   "fields": {
     "slug": "jUKV3yqHbtKOqRUhh4gZ",
-    "application_datetime": "2020-03-29T21:51:22.200Z",
+    "application_datetime": "2020-03-29T12:06:22.200Z",
     "user": 167,
     "first_names": "Maria",
     "last_name": "Anderson",
@@ -12132,7 +12132,7 @@
   "pk": 84,
   "fields": {
     "slug": "8fzAZgUGaqYLeUYm2sJg",
-    "application_datetime": "2020-03-29T21:51:22.385Z",
+    "application_datetime": "2020-03-29T21:44:22.385Z",
     "user": 169,
     "first_names": "Harold",
     "last_name": "Batchelder",
@@ -12171,7 +12171,7 @@
   "pk": 85,
   "fields": {
     "slug": "XL7Soat8V3dPofXZuoWH",
-    "application_datetime": "2020-03-29T21:51:22.481Z",
+    "application_datetime": "2020-03-29T21:30:22.481Z",
     "user": 170,
     "first_names": "Matthew",
     "last_name": "Swanson",
@@ -12210,7 +12210,7 @@
   "pk": 86,
   "fields": {
     "slug": "TCGrClB1z9VjNPc9i5uV",
-    "application_datetime": "2020-03-29T21:51:22.739Z",
+    "application_datetime": "2020-03-29T02:14:41.739Z",
     "user": 173,
     "first_names": "Anthony",
     "last_name": "Marquez",
@@ -12249,7 +12249,7 @@
   "pk": 87,
   "fields": {
     "slug": "wIRQ8PebBEfEu5UZUOwK",
-    "application_datetime": "2020-03-29T21:51:22.997Z",
+    "application_datetime": "2020-03-29T20:03:22.997Z",
     "user": 176,
     "first_names": "Felicia",
     "last_name": "Brown",
@@ -12288,7 +12288,7 @@
   "pk": 88,
   "fields": {
     "slug": "iUaRIqXqH6SHKTIn8Fmw",
-    "application_datetime": "2020-03-29T21:51:23.081Z",
+    "application_datetime": "2020-03-29T12:31:23.081Z",
     "user": 177,
     "first_names": "Adam",
     "last_name": "Finn",
@@ -12327,7 +12327,7 @@
   "pk": 89,
   "fields": {
     "slug": "dpEA3gMU5ktnLihIowBz",
-    "application_datetime": "2020-03-29T21:51:23.257Z",
+    "application_datetime": "2020-03-28T17:05:23.257Z",
     "user": 179,
     "first_names": "Gary",
     "last_name": "Crouch",
@@ -12366,7 +12366,7 @@
   "pk": 90,
   "fields": {
     "slug": "YQkJBf3T2iOv6EloQlat",
-    "application_datetime": "2020-03-29T21:51:23.427Z",
+    "application_datetime": "2020-03-28T09:40:23.427Z",
     "user": 181,
     "first_names": "Erika",
     "last_name": "Cook",
@@ -12405,7 +12405,7 @@
   "pk": 91,
   "fields": {
     "slug": "V28yIzkaNFvOPs91cn6J",
-    "application_datetime": "2020-03-29T21:51:23.514Z",
+    "application_datetime": "2020-03-29T16:04:23.514Z",
     "user": 182,
     "first_names": "Julia",
     "last_name": "Land",
@@ -12444,7 +12444,7 @@
   "pk": 92,
   "fields": {
     "slug": "vbvXrK5PdJWLVsPOBbBy",
-    "application_datetime": "2020-03-29T21:51:23.817Z",
+    "application_datetime": "2020-03-28T06:17:23.817Z",
     "user": 185,
     "first_names": "Matilda",
     "last_name": "Labruzzo",
@@ -12483,7 +12483,7 @@
   "pk": 93,
   "fields": {
     "slug": "iOO51OwLj97ipR2QWnd6",
-    "application_datetime": "2020-03-29T21:51:24.112Z",
+    "application_datetime": "2020-03-28T18:06:24.112Z",
     "user": 188,
     "first_names": "Martin",
     "last_name": "May",
@@ -12561,7 +12561,7 @@
   "pk": 95,
   "fields": {
     "slug": "CRMWdEFiy7pwg7P9Ign9",
-    "application_datetime": "2020-03-29T21:51:24.413Z",
+    "application_datetime": "2020-03-27T17:37:24.413Z",
     "user": 191,
     "first_names": "Stan",
     "last_name": "Owens",
@@ -12600,7 +12600,7 @@
   "pk": 96,
   "fields": {
     "slug": "2CH46xn5wlKBJO8latRY",
-    "application_datetime": "2020-03-29T21:51:24.591Z",
+    "application_datetime": "2020-03-29T16:39:24.591Z",
     "user": 193,
     "first_names": "Vicki",
     "last_name": "Barbee",
@@ -12639,7 +12639,7 @@
   "pk": 97,
   "fields": {
     "slug": "XTTfrerqfxICQHJG0KWR",
-    "application_datetime": "2020-03-29T21:51:24.683Z",
+    "application_datetime": "2020-03-29T13:49:24.683Z",
     "user": 194,
     "first_names": "Patrica",
     "last_name": "Brack",
@@ -12678,7 +12678,7 @@
   "pk": 98,
   "fields": {
     "slug": "tKoY8VSB3Sq1kxW19gcc",
-    "application_datetime": "2020-03-29T21:51:24.944Z",
+    "application_datetime": "2020-03-29T01:37:24.944Z",
     "user": 197,
     "first_names": "Essie",
     "last_name": "Johnson",
@@ -12717,7 +12717,7 @@
   "pk": 99,
   "fields": {
     "slug": "ouUgmP8kDL47dAZEPKgi",
-    "application_datetime": "2020-03-29T21:51:25.186Z",
+    "application_datetime": "2020-03-29T20:37:25.186Z",
     "user": 200,
     "first_names": "Mark",
     "last_name": "Walter",


### PR DESCRIPTION
In the current user fixtures, many of the application times for credentialed access are identical, which isn't helpful when trying to test whether ordering functionality is correctly implemented (e.g. for testing https://github.com/MIT-LCP/physionet-build/pull/1163). This pull request adds some variation to the application dates. 