### PR TITLE
Fix the console navbar for the editorial stats page

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -182,6 +182,7 @@
         <ul class="sidenav-second-level collapse" id="statsComponents">
         {% endif %}
           <li>
+          <li class="nav-item {% if submenu == 'editorial' %}active{% endif %}">
             <a href="{% url 'editorial_stats' %}">Editorial</a>
           </li>
           <li class="nav-item {% if submenu == 'credential' %}active{% endif %}">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1500,8 +1500,8 @@ def editorial_stats(request):
         except StatisticsError:
             stats[y].append(None)
 
-    return render(request, 'console/editorial_stats.html',
-        {'stats': stats})
+    return render(request, 'console/editorial_stats.html', {'stats_nav': True,
+                  'submenu': 'editorial', 'stats': stats})
 
 
 @login_required


### PR DESCRIPTION
When viewing the editorial stats page (https://physionet.org/console/usage/editorial/stats/), the console navbar should indicate that this page is being viewed, but it does not. This change highlights the relevant page in the navbar when viewing the stats page, as shown below:

![Screen Shot 2020-11-25 at 01 02 16](https://user-images.githubusercontent.com/822601/100244778-5279fb80-2f05-11eb-8df5-342c4bbe071b.png)




