### PR TITLE
Display a list of signed data use agreements in the user profile menu

### DIFF
--- a/physionet-django/static/custom/css/settings.css
+++ b/physionet-django/static/custom/css/settings.css
@@ -102,3 +102,47 @@ input::placeholder {
     margin-top: -25px;
   }
 }
+
+/*
+ * Data Use Agreement
+ * --------------------------------------------------
+ */
+
+#agreement {
+  margin: 10px 10px 10px 10px;
+  font-family: Georgia, serif;
+  text-align: center;
+}
+
+#agreement p, #agreement ol {
+  text-align: left;
+}
+
+#outer-border {
+  width: 850px;
+  height: 950px;
+  padding: 20px;
+  border-width: 8px;
+  border-style: solid;
+  border-color: #515151;
+}
+
+#inner-border {
+  width: 800px;
+  height: 900px;
+  padding: 30px;
+  border-width: 4px;
+  border-style: solid;
+  border-color: #515151;
+}
+
+@media print {
+  .printbutton {
+    visibility: hidden;
+    display: none;
+  }
+}
+
+.printbutton {
+  border: 0px;
+}

--- a/physionet-django/templates/base_blank.html
+++ b/physionet-django/templates/base_blank.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>{% block title %}{% endblock %}</title>
+    {% block meta %}{% endblock %}
+    {% include "base_css.html" %}
+    {% block local_css %}{% endblock %}
+    {% include "base_js_top.html" %}
+    {% block local_js_top %}{% endblock %}
+    <link rel="shortcut icon" type="image/png" href="{% static 'favicon.ico' %}"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+
+  {% block body %}
+  <body class="flexbody">
+    {% include "navbar.html" %}
+
+    <main>{% block content %}{% endblock %}</main>
+
+    {% include 'footer.html' %}
+
+    {% include "base_js_bottom.html" %}
+    {% block local_js_bottom %}{% endblock %}
+    {% block meta_bottom %}{% endblock %}
+  </body>
+  {% endblock %}
+</html>

--- a/physionet-django/user/templates/user/settings.html
+++ b/physionet-django/user/templates/user/settings.html
@@ -13,7 +13,7 @@
   <div class="row row-offcanvas row-offcanvas-right">
     <div class="col-6 col-md-3 sidebar-offcanvas sett-side" id="sidebar">
       <div class="list-group">
-        {% with 'profile password emails username cloud credentialing' as setting_options %}
+        {% with 'profile password emails username cloud credentialing agreements' as setting_options %}
             {% for setting in setting_options.split %}
               {% url 'edit_'|add:setting as settings_url %}
               <a href={{ settings_url }} class="list-group-item list-group-item-action{% if settings_url == request.path %} active{% endif %}">{{ setting|title }}</a>

--- a/physionet-django/user/templates/user/view_agreements.html
+++ b/physionet-django/user/templates/user/view_agreements.html
@@ -1,0 +1,37 @@
+{% extends "user/settings.html" %}
+
+{% block title %} Agreements {% endblock %}
+
+{% block main_content %}
+<h1>Data Use Agreements</h1>
+
+{% if signed %} 
+<p>You have signed the following Data Use Agreements:</p>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Date of Agreement</th>
+          <th>Agreement</th>
+          <th>Project</th>
+          <th>View Agreement</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for agreement in signed %}  
+        <tr>
+          <td>{{ agreement.sign_datetime|date }}</td>
+          <td>{{ agreement.project.license.dua_name }}</td>
+          <td>{{ agreement.project.title }} (v{{ agreement.project.version }})</td>
+          <td><a href="{% url 'view_signed_agreement' agreement.id %}">View</a></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% else %}
+<p>No agreements found.</p>
+{% endif %} 
+
+
+{% endblock %}

--- a/physionet-django/user/templates/user/view_signed_agreement.html
+++ b/physionet-django/user/templates/user/view_signed_agreement.html
@@ -1,0 +1,38 @@
+{% extends "base_blank.html" %}
+
+{% load static %}
+
+{% block title %}
+Signed Data Use Agreement
+{% endblock %}
+
+{% block local_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'custom/css/settings.css' %}"/>
+{% endblock %}
+
+{% block body %}
+<div id="container">
+
+  <div id="print-button-div">
+    <input type="button" onClick="window.print()" class="printbutton" value="Print Agreement"/>
+  </div>
+
+  <div id="agreement">
+    <div id="outer-border">
+      <div id="inner-border">
+        <h1>{{ signed.project.license.dua_name|wordwrap:30|linebreaksbr }}</h1>
+        <h2>Data Use Agreement for the<br />
+            {{ signed.project.title }} (v{{ signed.project.version }})</h2>
+        <br />
+        {{ signed.project.license.dua_html_content|safe }}
+        <br />
+        <p>SIGNED: <b>{{ signed.user.get_full_name }}</b></p>
+        <br />
+        <p>DATED: <b>{{ signed.sign_datetime|date }}</b></p>
+      </div>
+    </div>  
+  </div>
+
+</div>
+
+{% endblock %}

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -36,6 +36,9 @@ urlpatterns = [
     path('settings/credentialing/', views.edit_credentialing, name='edit_credentialing'),
     path('settings/credentialing/applications/',
         views.user_credential_applications, name='user_credential_applications'),
+    path('settings/agreements/', views.view_agreements, name='edit_agreements'),
+    path('settings/agreements/<id>/',
+        views.view_signed_agreement, name='view_signed_agreement'),
 
     # Current tokens are 20 characters long and consist of 0-9A-Za-z
     # Obsolete tokens are 34 characters long and also include a hyphen

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -33,7 +33,7 @@ from physionet import utility
 from physionet.middleware.maintenance import (allow_post_during_maintenance,
                                               disallow_during_maintenance,
                                               ServiceUnavailable)
-from project.models import Author, License, PublishedProject
+from project.models import Author, License, PublishedProject, DUASignature
 from notification.utility import (process_credential_complete,
                                   credential_application_request,
                                   get_url_prefix, notify_account_registration)
@@ -609,3 +609,24 @@ def edit_cloud(request):
 
     return render(request, 'user/edit_cloud.html', {'form':form, 'user':user})
 
+@login_required
+def view_agreements(request):
+    """
+    View signed agreements in the user profile
+    """
+    user = request.user
+    signed = DUASignature.objects.filter(user=user).order_by('sign_datetime')
+
+    return render(request, 'user/view_agreements.html', {'user': user,
+                                                         'signed': signed})
+
+@login_required
+def view_signed_agreement(request, id):
+    """
+    View signed agreements in the user profile
+    """
+    user = request.user
+    signed = DUASignature.objects.get(user=user, id=id)
+
+    return render(request, 'user/view_signed_agreement.html',
+                  {'user': user, 'signed': signed})


### PR DESCRIPTION
Users should have a straightforward way of viewing the data use agreements that they have signed. This change adds a new "Agreements" tab to the user profile, which lists all agreements that have been signed by the user. The list also links to printable copies of the agreements (added in response to a recent email request).

Example of the printable agreement:

<img width="581" alt="Screen Shot 2020-12-05 at 23 58 25" src="https://user-images.githubusercontent.com/822601/101272292-e5faca00-3758-11eb-9648-ff84c7e9ecf3.png">

There are improvements that could be made in the way DUAs are managed in the database (better logging, clearer provenance, etc), so this should be looked into at some point.