### PR TITLE
Allow applications for credentialed access to be paused.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ ALLOWED_HOSTS=[]
 #SYSTEM_MAINTENANCE_NO_UPLOAD=1
 #SYSTEM_MAINTENANCE_MESSAGE=PhysioNet is undergoing maintenance, and projects cannot be edited. The site will be back online at 16:00 GMT.
 
+# Credentialing
+PAUSE_CREDENTIALING=0
+PAUSE_CREDENTIALING_MESSAGE=PhysioNet will not be taking new applications for credentialed access until 4 January 2021. We apologize for the inconvenience.
+
 # GCP
 # USED to store ALL the published projects to GCP Buckets and BigQuery
 # The delegation email, might be possible to change in the:

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -149,6 +149,10 @@ SYSTEM_MAINTENANCE_NO_UPLOAD = config('SYSTEM_MAINTENANCE_NO_UPLOAD',
 SYSTEM_MAINTENANCE_MESSAGE = config('SYSTEM_MAINTENANCE_MESSAGE',
                                     default=None)
 
+# Prevent new applications for credentialed access
+PAUSE_CREDENTIALING = config('PAUSE_CREDENTIALING', cast=bool, default=False)
+PAUSE_CREDENTIALING_MESSAGE = config('PAUSE_CREDENTIALING_MESSAGE',
+                                     default=None)
 
 # Google G suite Groups service account and Private Key file
 SERVICE_ACCOUNT_EMAIL = 'gcp-physionet-groups@physionet-data.iam.gserviceaccount.com'

--- a/physionet-django/user/templates/user/edit_credentialing.html
+++ b/physionet-django/user/templates/user/edit_credentialing.html
@@ -5,6 +5,13 @@
 {% block main_content %}
 <h1>PhysioNet Credentialing</h1>
 <hr>
+
+{% if pause_applications %}
+  <div class="alert alert-form alert-warning alert-dismissible">
+    {{ pause_message }}
+  </div>
+{% endif %}
+
 <p>In order to use the restricted-access clinical databases hosted on PhysioNet, users must:</p>
 <ol>
   <li>Have a credentialed PhysioNet account.</li>
@@ -17,7 +24,12 @@
   <p><i class="fa fa-clock"></i> Your credentialing application was submitted on {{ current_application.application_datetime }}.</p>
   <p>We aim to reach a decision within two weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.</p>
 {% else %}
-  <p>Your account is not credentialed. You may <a href="{% url 'credential_application' %}">apply for access</a>.</p>
+  <p>Your account is not credentialed. 
+
+    {% if not pause_applications %}
+    You may <a href="{% url 'credential_application' %}">apply for access</a>.
+    {% endif %}</p>
+
   <p><strong>If your account on the old PhysioNet site is already credentialed</strong>, please add the email address from the old site to this account. Your credentialed status will be automatically transferred when your email is verified.</p>
 {% endif %}
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -462,6 +462,16 @@ def edit_credentialing(request):
     """
     Credentials settings page.
     """
+    if settings.PAUSE_CREDENTIALING:
+        pause_applications = True
+        pause_message = settings.PAUSE_CREDENTIALING_MESSAGE or (
+            "We are not currently accepting new applications "
+            "for credentialed access."
+        )
+    else:
+        pause_applications = False
+        pause_message = None
+
     applications = CredentialApplication.objects.filter(user=request.user)
     current_application = applications.filter(status=0).first()
 
@@ -474,6 +484,8 @@ def edit_credentialing(request):
 
     return render(request, 'user/edit_credentialing.html', {
         'applications': applications,
+        'pause_applications': pause_applications,
+        'pause_message': pause_message,
         'current_application': current_application})
 
 


### PR DESCRIPTION
Adds a PAUSE_CREDENTIALING flag to the environment file. If the flag is true, we display a message saying that credentialing is paused and remove the link to the application form. This change does not prevent the form being submitted, but it does prevent the most common route to accessing the form.

It may be a good idea to disable the form too, but for speediness I think this should go into a new pull request. @bemoody's suggestion below:

> While it's disabled we would want to disable loading the credential
form (you might consider extending service_unavailable to take a
custom error message), and probably also remove the link from
/settings/credentialing/ and anywhere else it appears.

> I'd probably make it a "soft" block so credential_application would
still accept POST requests (you can submit the form if you've already
filled it out) but trying to reload the form would fail.