### PR TITLE
Adds "Processing" page under "Credentialing"

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -59,7 +59,7 @@
 
       <!-- credentialing -->
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
-      {% if credentials_nav or complete_credentials_nav or past_credentials_nav or known_ref_nav %}
+      {% if credentials_nav or complete_credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
         <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion" aria-expanded="true">
       {% else %}
         <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion" aria-expanded="false">
@@ -68,13 +68,16 @@
           <span class="nav-link-text">Credentialing</span>
         </a>
         <!-- submenu -->
-      {% if credentials_nav or complete_credentials_nav or past_credentials_nav or known_ref_nav %}
+      {% if credentials_nav or complete_credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
         <ul class="sidenav-second-level collapse show" id="credentialComponents">
       {% else %}
         <ul class="sidenav-second-level collapse" id="credentialComponents">
       {% endif %}
           <li class="nav-item {% if complete_credentials_nav %}active{% endif %}">
             <a id="nav_credential_applications" href="{% url 'complete_credential_applications' %}">Management</a>
+          </li>
+          <li class="nav-item {% if processing_credentials_nav %}active{% endif %}">
+            <a id="nav_credential_applications" href="{% url 'credential_processing' %}">Processing</a>
           </li>
           <li class="nav-item {% if credentials_nav %}active{% endif %}">
             <a id="nav_credential_applications" href="{% url 'credential_applications' %}">Ongoing Applications</a>

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -1,0 +1,88 @@
+{% extends "console/base_console.html" %}
+
+{% block title %}Credential Processing{% endblock %}
+
+{% load console_templatetags %}
+
+{% block content %}
+<div class="card">
+  <div class="card-header">
+    <ul class="nav nav-tabs card-header-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" id="initial-tab" data-toggle="tab" href="#initial" role="tab" aria-controls="initial" aria-selected="true">Initial Review</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="training-tab" data-toggle="tab" href="#training" role="tab" aria-controls="training" aria-selected="false">Training Checks</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="personal-tab" data-toggle="tab" href="#personal" role="tab" aria-controls="personal" aria-selected="false">Personal Information Checks</span></a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="reference-tab" data-toggle="tab" href="#reference" role="tab" aria-controls="reference" aria-selected="false">Reference Checks</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="response-tab" data-toggle="tab" href="#response" role="tab" aria-controls="response" aria-selected="false">Awaiting Reference Response</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="final-tab" data-toggle="tab" href="#final" role="tab" aria-controls="final" aria-selected="false">Final Review</a>
+      </li>
+
+    </ul>
+  </div>
+  <div class="card-body">
+    <div class="tab-content">
+      {# Initial review #}
+      <div class="tab-pane fade show active" id="initial" role="tabpanel" aria-labelledby="initial-tab">
+        {% if initial_applications %}
+          <!-- add contents -->
+        {% else %}
+          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
+        {% endif %}
+      </div>
+      {# Training checks #}
+      <div class="tab-pane fade" id="training" role="tabpanel" aria-labelledby="training-tab">
+        {% if training_applications %}
+          <!-- add contents -->
+        {% else %}
+          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
+        {% endif %}
+      </div>
+      {# Personal information checks #}
+      <div class="tab-pane fade" id="personal" role="tabpanel" aria-labelledby="personal-tab">
+        {% if personal_applications %}
+          <!-- add contents -->
+        {% else %}
+          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
+        {% endif %}
+      </div>
+      {# Reference checks #}
+      <div class="tab-pane fade" id="reference" role="tabpanel" aria-labelledby="reference-tab">
+        {% if reference_applications %}
+          <!-- add contents -->
+        {% else %}
+          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
+        {% endif %}
+      </div>
+      {# Awaiting reference response #}
+      <div class="tab-pane fade" id="response" role="tabpanel" aria-labelledby="response-tab">
+        {% if response_applications %}
+          <!-- add contents -->
+        {% else %}
+          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
+        {% endif %}
+      </div>
+      {# Final review #}
+      <div class="tab-pane fade" id="final" role="tabpanel" aria-labelledby="final-tab">
+        {% if final_applications %}
+          <!-- add contents -->
+        {% else %}
+          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+
+
+{% endblock %}
+

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -57,6 +57,8 @@ urlpatterns = [
         name='known_references'),
     path('known-references/search/', views.known_references_search,
         name='known_references_search'),
+    path('credential_processing/', views.credential_processing,
+        name='credential_processing'),
 
     path('credentialed-users/<username>/',
         views.credentialed_user_info, name='credentialed_user_info'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1177,6 +1177,16 @@ def process_credential_application(request, application_slug):
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
+def credential_processing(request):
+    """
+    List of active credentialing applications.
+    """
+    return render(request, 'console/credential_processing.html',
+        {'processing_credentials_nav': True})
+
+
+@login_required
+@user_passes_test(is_admin, redirect_field_name='project_home')
 def view_credential_application(request, application_slug):
     """
     View a credential application in any status.


### PR DESCRIPTION
This is the first of a series of changes to address #1185. To work toward a simple implementation of the credentialing workflow, I've added a "Processing" tab under the "Credentialing" dropdown menu (pictured below). For now, clicking on it goes to a page with a series of tabs across the top, similar to the project management tool, though the tabs are empty since the logic for displaying applications has not yet been implemented. I'd be open to feedback on what's currently here!

<img width="1424" alt="Screen Shot 2021-01-08 at 4 15 18 PM" src="https://user-images.githubusercontent.com/26937569/104071443-ce3ab980-51ce-11eb-97a1-c7f683aa99f5.png">