### PR TITLE
Change "two weeks" to "four weeks"

### DIFF
--- a/physionet-django/user/templates/user/edit_credentialing.html
+++ b/physionet-django/user/templates/user/edit_credentialing.html
@@ -22,7 +22,7 @@
   <p><i class="fas fa-check" style="color:green"></i> Your account was successfully credentialed on {{ user.credential_datetime }}</p>
 {% elif current_application %}
   <p><i class="fa fa-clock"></i> Your credentialing application was submitted on {{ current_application.application_datetime }}.</p>
-  <p>We aim to reach a decision within two weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.</p>
+  <p>We aim to reach a decision within four weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.</p>
 {% else %}
   <p>Your account is not credentialed. 
 


### PR DESCRIPTION
In the credentialing guidelines, we currently say "We aim to reach a decision within two weeks". Four weeks seems more realistic at the moment, so this change tweaks the text.