### PR TITLE
Allow admin users to temporarily lock an account using the console

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -317,6 +317,13 @@ class DeprecateFilesForm(forms.Form):
     delete_files = forms.ChoiceField(choices=YES_NO)
 
 
+class DeactivateUserForm(forms.Form):
+    """
+    Deactivate a user profile from the management console.
+    """
+    deactivate_user_btn = forms.BooleanField()
+
+
 class ProcessCredentialForm(forms.ModelForm):
     """
     Form to respond to a credential application

--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -68,6 +68,16 @@
   {% endif %}
 
   <br />
+  <form action="" method="POST">
+    {% csrf_token %}
+    {% if subject.is_active %}
+    <button class="btn btn-danger" onclick="return confirm('Are you sure that you would like to deactivate this user? The action cannot be undone!')" name="deactivate_user_btn" type="submit" value="True">Deactivate user</button>
+    {% else %}
+    <button class="btn btn-danger" onclick="return confirm('Are you sure that you would like to deactivate this user? The action cannot be undone!')" name="deactivate_user_btn" type="submit" value="True" disabled>User is not active</button>
+    {% endif %}
+  </form>
+
+  <br />
   {% for status, group in projects.items %}
   <h3>{{ status }} projects</h3>
     <ul>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -906,7 +906,19 @@ def user_management(request, username):
     """
     Admin page for managing an individual user account.
     """
+
     user = get_object_or_404(User, username__iexact=username)
+
+    if request.method == 'POST':
+        if 'deactivate_user_btn' in request.POST:
+            deactivate_user_form = forms.DeactivateUserForm(request.POST)
+
+            if deactivate_user_form.is_valid():
+                user.deactivate_profile()
+                messages.success(request, 'The user has been deactivated.')
+
+    deactivate_user_form = forms.DeactivateUserForm()
+
 
     emails = {}
     emails['primary'] = AssociatedEmail.objects.filter(user=user,
@@ -927,10 +939,12 @@ def user_management(request, username):
     projects['Published'] = PublishedProject.objects.filter(authors__user=user).order_by('-publish_datetime')
 
 
-    return render(request, 'console/user_management.html', {'subject': user,
-                                                            'profile': user.profile,
-                                                            'emails': emails,
-                                                            'projects': projects})
+    return render(request, 'console/user_management.html',
+                  {'subject': user,
+                   'profile': user.profile,
+                   'emails': emails,
+                   'projects': projects,
+                   'deactivate_user_form': deactivate_user_form})
 
 
 @login_required


### PR DESCRIPTION
We occasionally need to remove a user, usually at the request of the user. It is unsafe doing this through the console, so it is helpful to have a tool available in the admin console. This pull request:

- adds a simple "deactivate_profile" method to the user model
- adds a "deactivate profile" button to the user management page in the console.

To test the functionality, click a username in: http://localhost:8000/console/users/active/ and then click the button on the user management page to deactivate the user.

One issue that I will address later (but not in this pull request for timeliness) is that a deactivated email address will appear publicly if the user is a corresponding author of a published project.
