### PR TITLE
Modifies credentialing application form #1182

### DIFF
--- a/physionet-django/static/custom/css/form-control-input.css
+++ b/physionet-django/static/custom/css/form-control-input.css
@@ -71,3 +71,8 @@ input::placeholder {
   color: #868e96;
   opacity: 1;
 }
+
+.field-label{
+  position: absolute;
+  bottom: 0;
+}

--- a/physionet-django/templates/descriptive_inline_form_snippet.html
+++ b/physionet-django/templates/descriptive_inline_form_snippet.html
@@ -2,13 +2,15 @@
 {% for field in form.visible_fields %}
   <div class="form-group row">
     <label class="col-md-3" for="{{ field.id_for_label }}">
-      {{ field.label|capfirst }}
-      {% if field.field.required %}
-        <a style="color:red"> *</a>
-      {% endif %}
-      <i class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title="{{ field.help_text }}" data-html="true" style="cursor: pointer;"></i>
+      <div class="field-label">
+        {{ field.label|capfirst }}
+        {% if field.field.required %}
+          <a style="color:red"> *</a>
+        {% endif %}
+      </div>
     </label>
     <div class='col-md-9'>
+      <p>{{ field.help_text }}</p>
       {{ field }}
       {% for error in field.errors %}
         <div class="alert alert-danger">
@@ -17,6 +19,7 @@
       {% endfor %}
     </div>
   </div>
+  <hr>
 {% endfor %}
 {% for error in form.non_field_errors %}
   <div class="alert alert-danger">

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -434,8 +434,9 @@ class ReferenceCAF(forms.ModelForm):
             'reference_category': """Your reference's relationship to you. If 
                 you are a student or postdoc, this must be your supervisor. 
                 Otherwise, you may list a colleague. Do not list yourself 
-                or another student as reference. Remind your reference to respond 
-                promptly as long response times will prevent application approval.""",
+                or another student as reference. Remind your reference to 
+                respond promptly, as long response times will prevent approval 
+                of your application.""",
             'reference_name': 'The full name of your reference.',
             'reference_email': 'The email address of your reference.',
             'reference_title': "Your reference's professional title or position."

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -327,7 +327,7 @@ class PersonalCAF(forms.ModelForm):
             'organization_name', 'job_title', 'city', 'state_province',
             'zip_code', 'country', 'webpage')
         help_texts = {
-            'first_names': """You first name(s). This can be edited in your 
+            'first_names': """Your first name(s). This can be edited in your 
                 profile settings.""",
             'last_name': """Your last (family) name. This can be edited in 
                 your profile settings.""",
@@ -406,8 +406,11 @@ class TrainingCAF(forms.ModelForm):
         model = CredentialApplication
         fields = ('training_completion_report',)
         help_texts = {
-            'training_completion_report': """Upload the completion report from 
-                the CITI 'Data or Specimens Only Research' training program.""",
+            'training_completion_report': """Do not upload the completion 
+                certificate. Upload the completion report from the CITI 
+                'Data or Specimens Only Research' training program which 
+                lists all modules completed, with dates and scores. 
+                Expired reports will not be accepted.""",
         }
 
     def clean_training_completion_report(self):
@@ -429,7 +432,10 @@ class ReferenceCAF(forms.ModelForm):
             'reference_email', 'reference_title')
         help_texts = {
             'reference_category': """Your reference's relationship to you. If 
-                you are a student or postdoc, this must be your supervisor.""",
+                you are a student or postdoc, this must be your supervisor. 
+                Otherwise, you may list a colleague. Do not list yourself 
+                or another student as reference. Remind your reference to respond 
+                promptly as long response times will prevent application approval.""",
             'reference_name': 'The full name of your reference.',
             'reference_email': 'The email address of your reference.',
             'reference_title': "Your reference's professional title or position."

--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -13,20 +13,6 @@
   {% include "message_snippet.html" %}
   <h1>PhysioNet Credentialing Application</h1>
   <hr>
-  <p>The contents of restricted-access clinical databases maintained by PhysioNet were derived from original data that contained protected health information (PHI), as defined by <a href="http://www.hhs.gov/ocr/hipaa/" target="other">HIPAA</a>. The providers of the data have given scrupulous attention to the task of locating and removing all PHI, so that the remaining data can be considered <a href="http://privacyruleandresearch.nih.gov/pr_08.asp#8a" target="other">de-identified</a> and therefore not subject to the HIPAA Privacy Rule restrictions on sharing PHI. Nevertheless, because of the richness and detail of the databases, the data will be released only to legitimate researchers under the terms and conditions described on this page.</p>
-  <p>Use this form to submit a data use agreement and request access to restricted-access clinical databases hosted on PhysioNet. Please be sure to provide all requested information. <em>Submissions that are clearly incomplete, incorrect, or frivolous may be discarded without notice.</em></p>
-  <p>If you are a student or a postdoc, please provide your supervisor's name and contact information. If you are not listed in a directory or other easy-to-find page of your organization’s website, please provide the name and contact information of a reference such as a supervisor or colleague. <em>Do not list yourself as reference</em>.</p>
-  <p><em>If you agree to all of these terms and conditions, access to restricted information within PhysioNet clinical databases may be granted to you <strong>as an individual</strong>. Your colleagues may obtain access to these data as individuals via the same procedure.</em></p>
-
-  <div class="card mb-4">
-    <div class="card-header">
-      {{ license.dua_name }}
-    </div>
-
-    <div class="card-body">
-      {{ license.dua_html_content|safe }}
-    </div>
-  </div>
 
   <p>Please use the form below to apply for PhysioNet credentialing. In order to apply:</p>
   <ul>
@@ -36,7 +22,6 @@
 
   <p>Required fields are indicated by a red asterisk (<a style="color:red">*</a>).</p>
 
-  
   <hr>
   <form action="" method="post" enctype="multipart/form-data" class="form-signin no-pd" autocomplete="off">
     {% csrf_token %}
@@ -46,12 +31,10 @@
     <br>
     <h2>CITI Completion Report</h2>
     <br>
-    <p>Instructions for taking the course are provided <a href="{% url 'citi_course' %}">here</a>. Upload the completion report (PDF file) from the CITI "Data or Specimens Only Research" training program. The completion report lists all modules completed, with dates and scores. Do <em>not</em> upload the completion certificate.</p>
     {% include "descriptive_inline_form_snippet.html" with form=training_form %}
     <br>
     <h2>Reference</h2>
     <br>
-    <p>If you are a student or a postdoc, please provide your supervisor's name and contact information. If you are not listed in a directory or other easy-to-find page of your organization’s website, please provide the name and contact information of a reference such as a supervisor or colleague. <em>Do not list yourself as reference</em>.</p>
     {% include "descriptive_inline_form_snippet.html" with form=reference_form %}
     <br>
     <h2>Research Area</h2>
@@ -62,8 +45,23 @@
         <strong>{{ error|escape }}</strong>
       </div>
     {% endfor %}
-    <p>By submitting this form, you agree to the terms and conditions above.</p>
+    <br>
+    <p>By submitting this form, you agree to the terms and conditions below.</p>
     <hr>
+    <p>The contents of restricted-access clinical databases maintained by PhysioNet were derived from original data that contained protected health information (PHI), as defined by <a href="http://www.hhs.gov/ocr/hipaa/" target="other">HIPAA</a>. The providers of the data have given scrupulous attention to the task of locating and removing all PHI, so that the remaining data can be considered <a href="http://privacyruleandresearch.nih.gov/pr_08.asp#8a" target="other">de-identified</a> and therefore not subject to the HIPAA Privacy Rule restrictions on sharing PHI. Nevertheless, because of the richness and detail of the databases, the data will be released only to legitimate researchers under the terms and conditions described on this page.</p>
+    <p>Use this form to submit a data use agreement and request access to restricted-access clinical databases hosted on PhysioNet. Please be sure to provide all requested information. <em>Submissions that are clearly incomplete, incorrect, or frivolous may be discarded without notice.</em></p>
+    <p><em>If you agree to all of these terms and conditions, access to restricted information within PhysioNet clinical databases may be granted to you <strong>as an individual</strong>. Your colleagues may obtain access to these data as individuals via the same procedure.</em></p>
+
+    <div class="card mb-4">
+      <div class="card-header">
+        {{ license.dua_name }}
+      </div>
+
+      <div class="card-body">
+        {{ license.dua_html_content|safe }}
+      </div>
+    </div>
+
     <button class="btn btn-primary btn-rsp" type="submit">Submit Application</button>
   </form>
 </div>


### PR DESCRIPTION
This change modifies the credentialing application form in the following ways:
- Moves the DUA information to the bottom of the page so users must read it after they finish entering content and before they submit the application
- Moves all help text to above their respective submission field to increase prominence
- Adds additional explanatory text with regards to reference selection and valid completion reports
- Corrects typo in the `first_names` field from `You first name(s)` to `Your first name(s)`

Fixes #1182.