### PR TITLE
Display the 'processing' item in the menu when processing an application

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1244,7 +1244,7 @@ def process_credential_application(request, application_slug):
         {'application': application, 'app_user': application.user,
          'intermediate_credential_form': intermediate_credential_form,
          'process_credential_form': process_credential_form,
-         'credentials_nav': True})
+         'processing_credentials_nav': True})
 
 
 @login_required


### PR DESCRIPTION
Minor change to display the "Processing" tab in the menu when processing an application (rather than the "Ongoing Applications" tab).

<img width="303" alt="Screen Shot 2021-01-22 at 16 37 40" src="https://user-images.githubusercontent.com/822601/105557710-d9b3d780-5cda-11eb-934b-6ea5372595a4.png">
