### PR TITLE
"Contact reference" section should only be displayed on the "Reference" page

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -27,35 +27,39 @@
   </div>
   <div class="col-sm-5">
     <div class="row">
-      <div class="card mb-4">
-        <div class="card-header">
-          Contact Reference
-        </div>
-        <div class="card-body">
-          {% if application.reference_email|length < 1 %}
-          <p>A reference was not provided.</p>
-          {% elif application.reference_contact_datetime %}
-            <p><i class="fas fa-envelope"></i> The reference was contacted on {{ application.reference_contact_datetime }}</p>
-            {% if not application.reference_response_datetime %}
-              <p><i class="fas fa-clock"></i> Awaiting reference response.</p>
-            {% endif %}
-          {% else %}
-            <p>The reference has not been contacted.</p>
-            <form action="" method="post" class="form-signin">
-              {% csrf_token %}
-                {% include "form_snippet.html" with form=communication %}
-              <button class="btn btn-primary btn-fixed" name="contact_reference" value="{{app_user.id}}" type="submit">Contact Reference</button>
-            </form>
-            {% endif %}
-            {# Reference already responded #}
-            {% if application.reference_response_datetime %}
-              <p><i class="fas fa-check" style="color:green"></i> The reference verified the applicant on {{ application.reference_response_datetime }}</p>
-              {% if application.reference_response_text %}
-              <h2 style='font-size:20px;'>Reference comments:</h2>
-              <p style='margin-left:2em'>{{ application.reference_response_text }}</p>
+
+      {% if application.credential_review.status == 40 %}
+        <div class="card mb-4">
+          <div class="card-header">
+            Contact Reference
+          </div>
+          <div class="card-body">
+            {% if application.reference_email|length < 1 %}
+            <p>A reference was not provided.</p>
+            {% elif application.reference_contact_datetime %}
+              <p><i class="fas fa-envelope"></i> The reference was contacted on {{ application.reference_contact_datetime }}</p>
+              {% if not application.reference_response_datetime %}
+                <p><i class="fas fa-clock"></i> Awaiting reference response.</p>
               {% endif %}
-            {% endif %}
-        </div>
+            {% else %}
+              <p>The reference has not been contacted.</p>
+              <form action="" method="post" class="form-signin">
+                {% csrf_token %}
+                  {% include "form_snippet.html" with form=communication %}
+                <button class="btn btn-primary btn-fixed" name="contact_reference" value="{{app_user.id}}" type="submit">Contact Reference</button>
+              </form>
+              {% endif %}
+              {# Reference already responded #}
+              {% if application.reference_response_datetime %}
+                <p><i class="fas fa-check" style="color:green"></i> The reference verified the applicant on {{ application.reference_response_datetime }}</p>
+                {% if application.reference_response_text %}
+                <h2 style='font-size:20px;'>Reference comments:</h2>
+                <p style='margin-left:2em'>{{ application.reference_response_text }}</p>
+                {% endif %}
+              {% endif %}
+          </div>
+        {% endif %}
+
       </div>
         {% if application.credential_review.status == 10 %}
         <div class="card mb-4">


### PR DESCRIPTION
Currently there is a "Contact reference" section that is displayed on all steps of the credentialing review workflow. This change removes the "Contact reference" section from all steps, except for the "Reference" page.