### PR TITLE
Ensure all applications are listed in the 'initial review' phase

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1257,7 +1257,9 @@ def credential_processing(request):
     applications = applications.order_by('application_datetime')
 
     # Awaiting initial review
-    initial_applications = applications.filter(credential_review__isnull=True)
+    initial_1 = Q(credential_review__isnull=True)
+    initial_2 = Q(credential_review__status=10)
+    initial_applications = applications.filter(initial_1 or initial_2)
     # Awaiting training check
     training_applications = applications.filter(credential_review__status=20)
     # Awaiting ID check


### PR DESCRIPTION
Currently, applications will disappear from the review workflow if the "Process" button is clicked, but initial review is not completed. This change ensures that all unprocessed applications are listed in the "Initial review" page of the workflow (http://localhost:8000/console/credential_processing/).