### PR TITLE
Avoid overlapping efforts when reviewing credentialing applications

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1063,6 +1063,14 @@ def complete_credential_applications(request):
 
     applications = CredentialApplication.objects.filter(status=0)
 
+    # TODO: Remove this temporary step. Filter applications that are being
+    # handled in the credential processing workflow.
+    no_review = Q(credential_review__isnull=True)
+    not_underway_list = [x[0] for x in CredentialReview.REVIEW_STATUS_LABELS
+                         if x[0] and x[0] <= 10]
+    not_underway = Q(credential_review__status__in=not_underway_list)
+    applications = applications.filter(no_review or not_underway)
+
     # Get list of references who have been contacted before
     # These are "known_refs" but using the ref_known_flag() method is slow
     known_refs_new = CredentialApplication.objects.filter(

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1262,6 +1262,13 @@ def credential_processing(request):
     List of active credentialing applications.
     """
     applications = CredentialApplication.objects.filter(status=0)
+
+    # TODO: remove this filter. If KP has contacted the reference, remove
+    # the application from our list. Temporary step to avoid overlapping efforts.
+    no_review = Q(credential_review__isnull=True)
+    ref_contacted = Q(reference_contact_datetime__isnull=True)
+    applications = applications.filter(no_review and ref_contacted)
+
     applications = applications.order_by('application_datetime')
 
     # Awaiting initial review


### PR DESCRIPTION
This makes a couple of minor changes to the "Management" and "Processing" pages to avoid overlapping efforts when reviewing credentialing applications.

- If a referee has been contacted from the management page (i.e. there `no_review=True` and `ref_contacted=True`), remove it from the processing workflow.
- If a review is being handled in the processing workflow, remove it from the management page. We do this by only displaying applications that either don't have a review object (`no_review=True`) or which have a review object but it is not started (credential_review__status <= 10).