### PR TITLE
Display a page title on the credentialing pages.

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -2,14 +2,14 @@
 
 {% load static %}
 
-{% block title %}Process Credential Application - {{ app_user.username }}{% endblock %}
+{% block title %}{{ page_title }} - {{ app_user.username }}{% endblock %}
 
 {% block local_js_top %}
 <script src="{% static 'custom/js/copy-to-clipboard.js' %}"></script>
 {% endblock %}
 
 {% block content %}
-<h1>Process Credential Application - {{ app_user.username }}</h1>
+<h1>Credentialing: {{ page_title }} for {{ app_user.profile.first_names }} {{ app_user.profile.last_name }}</h1>
 <hr>
 
 <div class="card-columns row">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1146,6 +1146,10 @@ def process_credential_application(request, application_slug):
 
     process_credential_form = forms.ProcessCredentialForm(responder=request.user,
         instance=application)
+
+    page_title = None
+    title_dict = {a: k for a, k in CredentialReview.REVIEW_STATUS_LABELS}
+    page_title = title_dict[application.credential_review.status]
     if application.credential_review.status == 10:
         intermediate_credential_form = forms.InitialCredentialForm(responder=request.user, instance=application)
     if application.credential_review.status == 20:
@@ -1169,6 +1173,7 @@ def process_credential_application(request, application_slug):
                     notification.process_credential_complete(request, application)
                     return render(request, 'console/process_credential_complete.html',
                             {'application':application})
+                page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.TrainingCredentialForm(
                 responder=request.user, instance=application)
             else:
@@ -1182,6 +1187,7 @@ def process_credential_application(request, application_slug):
                     notification.process_credential_complete(request, application)
                     return render(request, 'console/process_credential_complete.html',
                             {'application':application})
+                page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.PersonalCredentialForm(
                 responder=request.user, instance=application)
             else:
@@ -1195,6 +1201,7 @@ def process_credential_application(request, application_slug):
                     notification.process_credential_complete(request, application)
                     return render(request, 'console/process_credential_complete.html',
                             {'application':application})
+                page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ReferenceCredentialForm(
                     responder=request.user, instance=application)
             else:
@@ -1208,6 +1215,7 @@ def process_credential_application(request, application_slug):
                     notification.process_credential_complete(request, application)
                     return render(request, 'console/process_credential_complete.html',
                             {'application':application})
+                page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ResponseCredentialForm(
                 responder=request.user, instance=application)
             else:
@@ -1221,6 +1229,7 @@ def process_credential_application(request, application_slug):
                     notification.process_credential_complete(request, application)
                     return render(request, 'console/process_credential_complete.html',
                             {'application':application})
+                page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ProcessCredentialForm(
                 responder=request.user, instance=application)
             else:
@@ -1244,7 +1253,7 @@ def process_credential_application(request, application_slug):
         {'application': application, 'app_user': application.user,
          'intermediate_credential_form': intermediate_credential_form,
          'process_credential_form': process_credential_form,
-         'processing_credentials_nav': True})
+         'processing_credentials_nav': True, 'page_title': page_title})
 
 
 @login_required


### PR DESCRIPTION
Currently the pages used to process credentialing applications simply say "Process Credential Application", regardless of  the stage of the application. This change displays the status of the application in the page title (e.g. "Training check", "ID check" etc).