### PR TITLE
Adds "Skip reference check" button for credentialing application processing

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -431,8 +431,8 @@ class InitialCredentialForm(forms.ModelForm):
             for field in self.quality_assurance_fields:
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
-                        '(The quality assurance fields must all pass '
-                          'before you accept the project')
+                        'The quality assurance fields must all pass '
+                          'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -504,8 +504,8 @@ class TrainingCredentialForm(forms.ModelForm):
             for field in self.quality_assurance_fields:
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
-                        '(The quality assurance fields must all pass '
-                          'before you accept the project')
+                        'The quality assurance fields must all pass '
+                          'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -580,8 +580,8 @@ class PersonalCredentialForm(forms.ModelForm):
             for field in self.quality_assurance_fields:
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
-                        '(The quality assurance fields must all pass '
-                          'before you accept the project')
+                        'The quality assurance fields must all pass '
+                          'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -651,8 +651,8 @@ class ReferenceCredentialForm(forms.ModelForm):
             for field in self.quality_assurance_fields:
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
-                        '(The quality assurance fields must all pass '
-                          'before you accept the project')
+                        'The quality assurance fields must all pass '
+                          'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -720,8 +720,8 @@ class ResponseCredentialForm(forms.ModelForm):
             for field in self.quality_assurance_fields:
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
-                        '(The quality assurance fields must all pass '
-                          'before you accept the project')
+                        'The quality assurance fields must all pass '
+                          'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -112,6 +112,23 @@
         {% if application.credential_review.status == 40 %}
         <div class="card mb-4">
           <div class="card-header">
+            Skip Reference Check
+          </div>
+          <div class="card-body">
+            {# Skip reference check #}
+            <p>Clicking the button below will allow the application to proceed straight to the Final Review stage. The reference check can be skipped if:</p>
+            <ul>
+              <li>the user is not a student or postdoc</li>
+              <li>the identity of the user is clear</li>
+            </ul>
+            <form action="" method="post" class="form-signin">
+              {% csrf_token %}
+              <button class="btn btn-primary btn-fixed" name="skip_reference" value="{{app_user.id}}" type="submit">Skip Reference Check</button>
+            </form>
+          </div>
+        </div>
+        <div class="card mb-4">
+          <div class="card-header">
             Reference Check
           </div>
           <div class="card-body">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1255,6 +1255,9 @@ def process_credential_application(request, application_slug):
                 notification.contact_reference(request, application,
                                                subject=subject, body=body)
                 messages.success(request, 'The reference has been contacted.')
+        elif 'skip_reference' in request.POST:
+            application.update_review_status(60)
+            application.save()
         elif 'process_application' in request.POST:
             process_credential_form = forms.ProcessCredentialForm(
                 responder=request.user, data=request.POST, instance=application)


### PR DESCRIPTION
These changes add a "Skip Reference Check" section and button that appears during the Reference Check stage of the credentialing workflow (#1185). This allows the application to proceed directly to the Final Review stage. There is also a minor tweak to allow selection of the "N/A" option in credentialing forms to allow applications to proceed to the next stage, as well as fixing a small typo in the error message when quality assurance fields aren't passed.

<img width="478" alt="Screen Shot 2021-01-25 at 3 25 28 PM" src="https://user-images.githubusercontent.com/26937569/105768232-b3cc4400-5f21-11eb-962a-c73bf71520dd.png">

Edit: Reverted the "Fix N/A logic" commit to consider other solutions.