### PR TITLE
Add "contact reference" template email to the credentialing workflow (+ minor tweaks)

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -331,6 +331,37 @@ class DeprecateFilesForm(forms.Form):
     delete_files = forms.ChoiceField(choices=YES_NO)
 
 
+class ContactApplicantCredentialForm(forms.ModelForm):
+    """
+    Form to contact the applicant of a credential application
+    """
+
+    class Meta:
+        model = CredentialApplication
+        fields = ('app_contact_comments',)
+        labels = {
+            'app_contact_comments':'Comments (required to contact applicant)'
+        }
+        widgets = {
+            'app_contact_comments':forms.Textarea(attrs={'rows': 3}),
+        }
+
+    def __init__(self, responder, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.responder = responder
+
+    def clean(self):
+        if self.errors:
+            return
+
+        if not self.cleaned_data['app_contact_comments']:
+            raise forms.ValidationError('If you contact the applicant, you explain why.')
+
+    def save(self):
+        application = super().save()
+        return application
+
+
 class ProcessCredentialForm(forms.ModelForm):
     """
     Form to respond to a credential application

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -331,35 +331,12 @@ class DeprecateFilesForm(forms.Form):
     delete_files = forms.ChoiceField(choices=YES_NO)
 
 
-class ContactApplicantCredentialForm(forms.ModelForm):
+class ContactCredentialRefForm(forms.Form):
     """
-    Form to contact the applicant of a credential application
+    Contact the reference for a credentialing application.
     """
-
-    class Meta:
-        model = CredentialApplication
-        fields = ('app_contact_comments',)
-        labels = {
-            'app_contact_comments':'Comments (required to contact applicant)'
-        }
-        widgets = {
-            'app_contact_comments':forms.Textarea(attrs={'rows': 3}),
-        }
-
-    def __init__(self, responder, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.responder = responder
-
-    def clean(self):
-        if self.errors:
-            return
-
-        if not self.cleaned_data['app_contact_comments']:
-            raise forms.ValidationError('If you contact the applicant, you explain why.')
-
-    def save(self):
-        application = super().save()
-        return application
+    subject = forms.CharField(required=True)
+    body = forms.CharField(widget=forms.Textarea)
 
 
 class ProcessCredentialForm(forms.ModelForm):

--- a/physionet-django/console/templates/console/email_modal.html
+++ b/physionet-django/console/templates/console/email_modal.html
@@ -1,0 +1,24 @@
+<!-- pop-up modal for email -->
+
+<div class="modal fade" id={{ modal_id }} tabindex="-1" role="dialog" aria-labelledby={{ modal_id }} aria-hidden="true">
+<div class="modal-dialog" role="document">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title">{{ modal_title }}</h5>
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <form action="" method="post">
+      <div class="modal-body">
+        {% csrf_token %}
+        {% include "form_snippet.html" with form=form %}
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-primary btn-fixed" name="{{ submit_name }}" value="{{ submit_value }}" type="submit">{{ submit_text }}</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </form>
+  </div>
+</div>
+</div>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -28,7 +28,7 @@
   <div class="col-sm-5">
     <div class="row">
 
-      {% if application.credential_review.status == 40 %}
+      {% if application.credential_review.status == 50 %}
         <div class="card mb-4">
           <div class="card-header">
             Contact Reference
@@ -45,8 +45,8 @@
               <p>The reference has not been contacted.</p>
               <form action="" method="post" class="form-signin">
                 {% csrf_token %}
-                  {% include "form_snippet.html" with form=communication %}
-                <button class="btn btn-primary btn-fixed" name="contact_reference" value="{{app_user.id}}" type="submit">Contact Reference</button>
+                {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="contact_reference" submit_value=app_user.id submit_text="Contact Reference" %}
+                <button type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact Reference</button>
               </form>
               {% endif %}
               {# Reference already responded #}

--- a/physionet-django/console/templates/console/process_credential_complete.html
+++ b/physionet-django/console/templates/console/process_credential_complete.html
@@ -9,7 +9,7 @@
   </div>
   <div class="card-body">
     <p>You have {% if application.status == 1 %}rejected{% elif application.status == 2 %}accepted{% else %}withdrawn{% endif %} the credentialing application of {{ application.user.get_full_name }}.</p>
-    <p>You may return to the <a href="{% url 'credential_applications' %}">outstanding applications.</p>
+    <p>You may return to the <a href="{% url 'credential_processing' %}">outstanding applications.</p>
   </div>
 </div>
 {% endblock %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1177,13 +1177,9 @@ def process_credential_application(request, application_slug):
                 responder=request.user, data=request.POST, instance=application)
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
-                if application.status == 1:
-                    notification.process_credential_complete(request, application)
-                    return render(request, 'console/process_credential_complete.html',
-                            {'application':application})
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.TrainingCredentialForm(
-                responder=request.user, instance=application)
+                    responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
         elif 'approve_training' in request.POST:
@@ -1191,13 +1187,9 @@ def process_credential_application(request, application_slug):
                 responder=request.user, data=request.POST, instance=application)
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
-                if application.status == 1:
-                    notification.process_credential_complete(request, application)
-                    return render(request, 'console/process_credential_complete.html',
-                            {'application':application})
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.PersonalCredentialForm(
-                responder=request.user, instance=application)
+                    responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
         elif 'approve_personal' in request.POST:
@@ -1205,10 +1197,6 @@ def process_credential_application(request, application_slug):
                 responder=request.user, data=request.POST, instance=application)
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
-                if application.status == 1:
-                    notification.process_credential_complete(request, application)
-                    return render(request, 'console/process_credential_complete.html',
-                            {'application':application})
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ReferenceCredentialForm(
                     responder=request.user, instance=application)
@@ -1219,13 +1207,9 @@ def process_credential_application(request, application_slug):
                 responder=request.user, data=request.POST, instance=application)
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
-                if application.status == 1:
-                    notification.process_credential_complete(request, application)
-                    return render(request, 'console/process_credential_complete.html',
-                            {'application':application})
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ResponseCredentialForm(
-                responder=request.user, instance=application)
+                    responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
         elif 'approve_response' in request.POST:
@@ -1233,13 +1217,9 @@ def process_credential_application(request, application_slug):
                 responder=request.user, data=request.POST, instance=application)
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
-                if application.status == 1:
-                    notification.process_credential_complete(request, application)
-                    return render(request, 'console/process_credential_complete.html',
-                            {'application':application})
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ProcessCredentialForm(
-                responder=request.user, instance=application)
+                    responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
         elif 'contact_reference' in request.POST:

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1003,7 +1003,6 @@ def credential_applications(request):
     Ongoing credential applications
     """
     applications = CredentialApplication.objects.filter(status=0)
-    # Do the proper sort
     applications = applications.order_by('application_datetime')
 
     return render(request, 'console/credential_applications.html',
@@ -1013,7 +1012,7 @@ def credential_applications(request):
 @user_passes_test(is_admin, redirect_field_name='project_home')
 def complete_credential_applications(request):
     """
-    Ongoing credential applications
+    KP's custom management page for credentialing.
     """
     process_credential_form = forms.ProcessCredentialForm(
         responder=request.user)
@@ -1063,13 +1062,12 @@ def complete_credential_applications(request):
 
     applications = CredentialApplication.objects.filter(status=0)
 
-    # TODO: Remove this temporary step. Filter applications that are being
-    # handled in the credential processing workflow.
-    no_review = Q(credential_review__isnull=True)
-    not_underway_list = [x[0] for x in CredentialReview.REVIEW_STATUS_LABELS
-                         if x[0] and x[0] <= 10]
-    not_underway = Q(credential_review__status__in=not_underway_list)
-    applications = applications.filter(no_review or not_underway)
+    # TODO: Remove this step. Exclude applications that are being handled in
+    # the credential processing workflow. Avoid toes.
+    review_underway_list = [x[0] for x in CredentialReview.REVIEW_STATUS_LABELS
+                            if x[0] and x[0] > 10]
+    review_underway = Q(credential_review__status__in=review_underway_list)
+    applications = applications.exclude(review_underway)
 
     # Get list of references who have been contacted before
     # These are "known_refs" but using the ref_known_flag() method is slow
@@ -1155,6 +1153,10 @@ def process_credential_application(request, application_slug):
     process_credential_form = forms.ProcessCredentialForm(responder=request.user,
         instance=application)
 
+    ref_email = notification.contact_reference(request, application,
+                                               send=False,  wordwrap=False)
+    contact_cred_ref_form = forms.ContactCredentialRefForm(initial=ref_email)
+
     page_title = None
     title_dict = {a: k for a, k in CredentialReview.REVIEW_STATUS_LABELS}
     page_title = title_dict[application.credential_review.status]
@@ -1223,10 +1225,16 @@ def process_credential_application(request, application_slug):
             else:
                 messages.error(request, 'Invalid review. See form below.')
         elif 'contact_reference' in request.POST:
-            application.reference_contact_datetime = timezone.now()
-            application.save()
-            notification.contact_reference(request, application)
-            messages.success(request, 'The reference has been contacted.')
+            contact_cred_ref_form = forms.ContactCredentialRefForm(
+                data=request.POST)
+            if contact_cred_ref_form.is_valid():
+                application.reference_contact_datetime = timezone.now()
+                application.save()
+                subject = contact_cred_ref_form.cleaned_data['subject']
+                body = contact_cred_ref_form.cleaned_data['body']
+                notification.contact_reference(request, application,
+                                               subject=subject, body=body)
+                messages.success(request, 'The reference has been contacted.')
         elif 'process_application' in request.POST:
             process_credential_form = forms.ProcessCredentialForm(
                 responder=request.user, data=request.POST, instance=application)
@@ -1241,39 +1249,44 @@ def process_credential_application(request, application_slug):
         {'application': application, 'app_user': application.user,
          'intermediate_credential_form': intermediate_credential_form,
          'process_credential_form': process_credential_form,
-         'processing_credentials_nav': True, 'page_title': page_title})
+         'processing_credentials_nav': True, 'page_title': page_title,
+         'contact_cred_ref_form': contact_cred_ref_form})
 
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
 def credential_processing(request):
     """
-    List of active credentialing applications.
+    Process applications for credentialed access.
     """
     applications = CredentialApplication.objects.filter(status=0)
 
-    # TODO: remove this filter. If KP has contacted the reference, remove
-    # the application from our list. Temporary step to avoid overlapping efforts.
+    # TODO: Remove this step. If KP has contacted the reference, exclude the
+    # application from our list. Avoid toes.
     no_review = Q(credential_review__isnull=True)
-    ref_contacted = Q(reference_contact_datetime__isnull=True)
-    applications = applications.filter(no_review and ref_contacted)
-
-    applications = applications.order_by('application_datetime')
+    ref_contacted = Q(reference_contact_datetime__isnull=False)
+    applications = applications.exclude(no_review, ref_contacted)
 
     # Awaiting initial review
     initial_1 = Q(credential_review__isnull=True)
     initial_2 = Q(credential_review__status=10)
-    initial_applications = applications.filter(initial_1 or initial_2)
+    initial_applications = applications.filter(
+        initial_1 | initial_2).order_by('application_datetime')
     # Awaiting training check
-    training_applications = applications.filter(credential_review__status=20)
+    training_applications = applications.filter(
+        credential_review__status=20).order_by('application_datetime')
     # Awaiting ID check
-    personal_applications = applications.filter(credential_review__status=30)
+    personal_applications = applications.filter(
+        credential_review__status=30).order_by('application_datetime')
     # Awaiting reference check
-    reference_applications = applications.filter(credential_review__status=40)
+    reference_applications = applications.filter(
+        credential_review__status=40).order_by('application_datetime')
     # Awaiting reference response
-    response_applications = applications.filter(credential_review__status=50)
+    response_applications = applications.filter(
+        credential_review__status=50).order_by('application_datetime')
     # Awaiting final review
-    final_applications = applications.filter(credential_review__status=60)
+    final_applications = applications.filter(
+        credential_review__status=60).order_by('application_datetime')
 
     return render(request, 'console/credential_processing.html',
         {'applications': applications,

--- a/physionet-django/notification/templates/notification/email/contact_applicant.html
+++ b/physionet-django/notification/templates/notification/email/contact_applicant.html
@@ -1,0 +1,15 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+Dear {{ applicant_name }},
+
+Thank you for applying for credentialed access to PhysioNet. We have reviewed your application and have the following feedback:
+
+{{ comments }}
+
+You may respond directly to this e-mail to address the comments/suggestions.
+
+You may also view your application here for reference:
+
+{{ url_prefix }}{% url 'user_credential_applications' %}
+
+{{ signature }}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -6,7 +6,7 @@ If you support their application, please indicate your approval using the link b
 
 {{ url_prefix }}{% url 'credential_reference' application.slug %}
 
-For your reference, {{ applicant_name }} provided the following reason for requesting access: 
+{{ applicant_name }} provided the following reason for requesting access: 
 
 {{ application.research_summary.strip }}
 

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -1,15 +1,13 @@
-{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
-Dear {{ application.reference_name }},
+{% load i18n %}{% autoescape off %}Dear {{ application.reference_name }},
 
-{{ applicant_name }} is applying for credentialed access to PhysioNet, the website for sharing biomedical data. He/she has listed you as a reference for the application and has summarized the research project as follows:
+{{ applicant_name }} has applied for access to protected data on PhysioNet and listed you as a reference. Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
 
-{{application.research_summary}}
-
-Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
-
-If you support this application for credentialed access, please indicate your approval using the link below. If you do not support the application, please ignore this email or update us directly via the link.
+If you support their application, please indicate your approval using the link below or reply to this email. If you do not support their application, you may ignore this email or update us directly via the link.
 
 {{ url_prefix }}{% url 'credential_reference' application.slug %}
 
-{{ signature }}
-{% endfilter %}{% endautoescape %}
+For your reference, {{ applicant_name }} provided the following reason for requesting access: 
+
+{{ application.research_summary.strip }}
+
+{{ signature }}{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -454,6 +454,26 @@ def storage_response_notify(storage_request):
               [email], fail_silently=False)
 
 
+def contact_applicant(request, application, comments):
+    """
+    Request applicant feedback regarding their credentialing application
+    """
+    applicant_name = ' '.join([application.first_names, application.last_name])
+    subject = 'Feedback regarding your PhysioNet credentialing application'
+    respond_email = settings.CREDENTIAL_EMAIL
+    body = loader.render_to_string(
+        'notification/email/contact_applicant.html', {
+            'application': application,
+            'applicant_name': applicant_name,
+            'comments': comments,
+            'url_prefix': get_url_prefix(request),
+            'signature': email_signature()
+        })
+
+    send_mail(subject, body, respond_email, [application.user.email],
+              fail_silently=False)
+
+
 def contact_reference(request, application):
     """
     Request verification from a credentialing applicant's reference

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -7,7 +7,7 @@ from email.utils import formataddr
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMessage, send_mail, mail_admins
-from django.template import loader
+from django.template import loader, defaultfilters
 from django.utils import timezone
 
 
@@ -474,25 +474,46 @@ def contact_applicant(request, application, comments):
               fail_silently=False)
 
 
-def contact_reference(request, application):
+def contact_reference(request, application, send=True, wordwrap=True,
+                      subject="", body=""):
     """
-    Request verification from a credentialing applicant's reference
+    Request verification from a credentialing applicant's reference.
+
+    Args:
+        application : CredentialApplication object.
+        send : If True, send the email.
+        wordwrap : If True, wraps body at 70 characters.
+        subject : Subject line.
+        body : Body text.
+
+    Returns:
+        dict : email name, subject, body
     """
     applicant_name = ' '.join([application.first_names, application.last_name])
-    subject = 'Please verify {} for PhysioNet credentialing'.format(
-        applicant_name)
-    body = loader.render_to_string(
-        'notification/email/contact_reference.html', {
-            'application': application,
-            'applicant_name': applicant_name,
-            'domain': get_current_site(request),
-            'url_prefix': get_url_prefix(request),
-            'signature': email_signature(),
-            'footer': email_footer()
-        })
 
-    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-              [application.reference_email], fail_silently=False)
+    if not subject:
+        subject = 'Reference requested for {}'.format(
+            applicant_name)
+    if not body:
+        body = loader.render_to_string(
+            'notification/email/contact_reference.html', {
+                'application': application,
+                'applicant_name': applicant_name,
+                'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
+                'signature': email_signature(),
+                'footer': email_footer()
+            })
+
+    if wordwrap:
+        body = defaultfilters.wordwrap(body, 70)
+
+    if send:
+        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+                  [application.reference_email], fail_silently=False)
+
+    return {"subject": subject, "body": body}
+
 
 def contact_supervisor(request, application):
     """

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -154,6 +154,9 @@ PAUSE_CREDENTIALING = config('PAUSE_CREDENTIALING', cast=bool, default=False)
 PAUSE_CREDENTIALING_MESSAGE = config('PAUSE_CREDENTIALING_MESSAGE',
                                      default=None)
 
+# Set the credentialing email address
+CREDENTIAL_EMAIL = 'PhysioNet Credentialing <credentialing@physionet.org>'
+
 # Google G suite Groups service account and Private Key file
 SERVICE_ACCOUNT_EMAIL = 'gcp-physionet-groups@physionet-data.iam.gserviceaccount.com'
 


### PR DESCRIPTION
Builds on https://github.com/MIT-LCP/physionet-build/pull/1199 to add email templates to the credentialing workflow. This step adds a single "Contact reference" template as a pop-up modal. Also

- Fixes the sorting of applications on the credentialing pages (avoids overlaps between lists on the processing and management pages).
- Edits the text of the reference email.

@Lucas-Mc please could you take a look? Sorry about the messy commit history. We can use the same approach to add a pop up email to other pages of the workflow.