### PR TITLE
Send notification emails in the credentialing workflow.

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1180,6 +1180,8 @@ def process_credential_application(request, application_slug):
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
                 if intermediate_credential_form.cleaned_data['decision'] == '0':
+                    notification.process_credential_complete(request,
+                                                             application)
                     return redirect(credential_processing)
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.TrainingCredentialForm(
@@ -1192,6 +1194,8 @@ def process_credential_application(request, application_slug):
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
                 if intermediate_credential_form.cleaned_data['decision'] == '0':
+                    notification.process_credential_complete(request,
+                                                             application)
                     return redirect(credential_processing)
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.PersonalCredentialForm(
@@ -1204,6 +1208,8 @@ def process_credential_application(request, application_slug):
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
                 if intermediate_credential_form.cleaned_data['decision'] == '0':
+                    notification.process_credential_complete(request,
+                                                             application)
                     return redirect(credential_processing)
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ReferenceCredentialForm(
@@ -1216,6 +1222,8 @@ def process_credential_application(request, application_slug):
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
                 if intermediate_credential_form.cleaned_data['decision'] == '0':
+                    notification.process_credential_complete(request,
+                                                             application)
                     return redirect(credential_processing)
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ResponseCredentialForm(
@@ -1228,6 +1236,8 @@ def process_credential_application(request, application_slug):
             if intermediate_credential_form.is_valid():
                 intermediate_credential_form.save()
                 if intermediate_credential_form.cleaned_data['decision'] == '0':
+                    notification.process_credential_complete(request,
+                                                             application)
                     return redirect(credential_processing)
                 page_title = title_dict[application.credential_review.status]
                 intermediate_credential_form = forms.ProcessCredentialForm(


### PR DESCRIPTION
Currently, when applications are rejected in the credentialing workflow, notifications are not sent (the notifications were removed in https://github.com/MIT-LCP/physionet-build/pull/1205/). This adds them back. The current text is:

```
Dear Geraldine Pennington,

Thank you for applying for credentialed access to PhysioNet. Your
application was not approved. This may be for one of the following
reasons:

- It was incomplete, or included obviously incorrect information
(perhaps as a result of browser auto-fill).
- You did not submit the required CITI completion report, listing the
training modules you completed, with dates and scores.
- Your CITI training is out of date.
- You are a student, postdoc, intern, or trainee, but did not list
your supervisor (a faculty member or someone with a senior research
appointment at your institution) as reference.
- Your research summary did not include sufficient information, or was
in some other way inadequate.

The following comments were added to your application:

"Please upload your training report."

If you are able to address these issues, please open a new
credentialing application at
http://localhost:8000/credential-application/.

Regards,

The PhysioNet Team,
MIT Laboratory for Computational Physiology,
Institute for Medical Engineering and Science,
MIT, E25-505 77 Massachusetts Ave. Cambridge, MA 02139
```