### PR TITLE
Adds credentialing email as bcc

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -649,8 +649,14 @@ def process_credential_complete(request, application, comments=True):
             'footer': email_footer()
         })
 
-    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-              [application.user.email], fail_silently=False)
+    message = EmailMessage(
+        subject=subject,
+        body=body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[application.user.email],
+        bcc=[settings.CREDENTIAL_EMAIL]
+        )
+    message.send(fail_silently=False)
 
 def credential_application_request(request, application):
     """


### PR DESCRIPTION
This change adds the new credentialing PhysioNet e-mail as a Blind Carbon Copy (BCC) (not seen by the applicant) to begin processing applications under the new workflow. The decision for BCC over CC (seen by the applicant) was to prevent direct interference with the current workflow until the new workflow is finalized. 