### PR TITLE
Changes dropdown text for moving credential applications to next stage

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -31,7 +31,7 @@ SUBMISSION_RESPONSE_CHOICES = (
 
 REVIEW_RESPONSE_CHOICES = (
     ('', '-----------'),
-    (1, 'Approve'),
+    (1, 'Pass to Next Stage'),
     (0, 'Reject'),
 )
 


### PR DESCRIPTION
This change adjusts the language used in the dropdown used to move credential applications to the next stage from "Approve" to "Pass to Next Stage" to make clear that it will not fully accept the application, but only move it to the next stage.