### PR TITLE
Reverts comment box to single line

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -351,9 +351,9 @@ class ProcessCredentialForm(forms.ModelForm):
             'responder_comments':'Comments (required for rejected applications). This will be sent to the applicant.',
             'status':'Decision',
         }
-        widgets = {
-            'responder_comments': forms.Textarea(attrs={'rows': 5}),
-        }
+        # widgets = {
+        #     'responder_comments': forms.Textarea(attrs={'rows': 5}),
+        # }
 
     def __init__(self, responder, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This change reverts the comment box on the final stage of reviewing a credential application back to a fixed single line instead of variable five line text box.