### PR TITLE
Support new databases for WFDB

### DIFF
--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -4,6 +4,16 @@ upstream django {
     server unix:///physionet/deploy/physionet.sock;
 }
 
+# Set $pn_static_csp to the Content-Security-Policy for static files.
+map $uri $pn_static_csp {
+    # Temporary workaround: Chromium doesn't permit viewing PDF files
+    # in sandboxed mode:
+    # https://bugs.chromium.org/p/chromium/issues/detail?id=271452
+    # Until this is fixed, disable CSP sandbox for trusted PDF files.
+    "~\.pdf$" "";
+    default "sandbox; default-src 'self'";
+}
+
 ## configuration of the server
 server {
     server_name physionet.org physionet-production.ecg.mit.edu;
@@ -26,22 +36,13 @@ server {
 
     location /static {
         alias /data/pn-static;
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
-
-        location ~ \.pdf$ {
-            # Temporary workaround: Chromium doesn't permit viewing PDF
-            # files in sandboxed mode:
-            # https://bugs.chromium.org/p/chromium/issues/detail?id=271452
-            # Until this is fixed, disable CSP sandbox for published
-            # PDF files.
-        }
-        location ~ . {
-            add_header Content-Security-Policy "sandbox; default-src 'self'";
-        }
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /favicon.ico {
@@ -51,6 +52,7 @@ server {
     location /physiobank/database {
         autoindex on;
         alias /data/pn-static/physiobank/database;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiobank/database/ always redirects to /data/
         location = /physiobank/database/ {
             return 301 https://$host/data/;
@@ -68,6 +70,7 @@ server {
     location /physiotools {
         autoindex on;
         alias /data/pn-static/physiotools;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiotools/ always redirects to /software/
         location = /physiotools/ {
             return 301 https://$host/software/;
@@ -147,11 +150,13 @@ server {
 
     location /static {
         alias /data/pn-static;
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /favicon.ico {
@@ -161,6 +166,7 @@ server {
     location /physiobank/database {
         autoindex on;
         alias /data/pn-static/physiobank/database;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiobank/database/ always redirects to /data/
         location = /physiobank/database/ {
             return 301 https://$host/data/;
@@ -178,6 +184,7 @@ server {
     location /physiotools {
         autoindex on;
         alias /data/pn-static/physiotools;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiotools/ always redirects to /software/
         location = /physiotools/ {
             return 301 https://$host/software/;

--- a/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/production/etc/nginx/sites-available/physionet_nginx.conf
@@ -65,6 +65,15 @@ server {
         }
         # other files/directories are served normally; 404 is handled
         # by nginx
+        location ~ /physiobank/database/(.*)$ {
+            set $fpath $1;
+            alias /;
+            try_files "data/pn-static/published-projects/$fpath"
+                      "data/pn-static/published-projects/$fpath/"
+                      "data/pn-static/physiobank/database/$fpath"
+                      "data/pn-static/physiobank/database/$fpath/"
+                      =404;
+        }
     }
 
     location /physiotools {
@@ -179,6 +188,15 @@ server {
         }
         # other files/directories are served normally; 404 is handled
         # by nginx
+        location ~ /physiobank/database/(.*)$ {
+            set $fpath $1;
+            alias /;
+            try_files "data/pn-static/published-projects/$fpath"
+                      "data/pn-static/published-projects/$fpath/"
+                      "data/pn-static/physiobank/database/$fpath"
+                      "data/pn-static/physiobank/database/$fpath/"
+                      =404;
+        }
     }
 
     location /physiotools {

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -65,6 +65,15 @@ server {
         }
         # other files/directories are served normally; 404 is handled
         # by nginx
+        location ~ /physiobank/database/(.*)$ {
+            set $fpath $1;
+            alias /;
+            try_files "data/pn-static/published-projects/$fpath"
+                      "data/pn-static/published-projects/$fpath/"
+                      "data/pn-static/physiobank/database/$fpath"
+                      "data/pn-static/physiobank/database/$fpath/"
+                      =404;
+        }
     }
 
     location /physiotools {
@@ -179,6 +188,15 @@ server {
         }
         # other files/directories are served normally; 404 is handled
         # by nginx
+        location ~ /physiobank/database/(.*)$ {
+            set $fpath $1;
+            alias /;
+            try_files "data/pn-static/published-projects/$fpath"
+                      "data/pn-static/published-projects/$fpath/"
+                      "data/pn-static/physiobank/database/$fpath"
+                      "data/pn-static/physiobank/database/$fpath/"
+                      =404;
+        }
     }
 
     location /physiotools {

--- a/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/staging/etc/nginx/sites-available/physionet_nginx.conf
@@ -4,6 +4,16 @@ upstream django {
     server unix:///physionet/deploy/physionet.sock;
 }
 
+# Set $pn_static_csp to the Content-Security-Policy for static files.
+map $uri $pn_static_csp {
+    # Temporary workaround: Chromium doesn't permit viewing PDF files
+    # in sandboxed mode:
+    # https://bugs.chromium.org/p/chromium/issues/detail?id=271452
+    # Until this is fixed, disable CSP sandbox for trusted PDF files.
+    "~\.pdf$" "";
+    default "sandbox; default-src 'self'";
+}
+
 ## configuration of the server
 server {
     server_name staging.physionet.org physionet-staging.ecg.mit.edu;
@@ -26,22 +36,13 @@ server {
 
     location /static {
         alias /data/pn-static;
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
-
-        location ~ \.pdf$ {
-            # Temporary workaround: Chromium doesn't permit viewing PDF
-            # files in sandboxed mode:
-            # https://bugs.chromium.org/p/chromium/issues/detail?id=271452
-            # Until this is fixed, disable CSP sandbox for published
-            # PDF files.
-        }
-        location ~ . {
-            add_header Content-Security-Policy "sandbox; default-src 'self'";
-        }
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /favicon.ico {
@@ -51,6 +52,7 @@ server {
     location /physiobank/database {
         autoindex on;
         alias /data/pn-static/physiobank/database;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiobank/database/ always redirects to /data/
         location = /physiobank/database/ {
             return 301 https://$host/data/;
@@ -68,6 +70,7 @@ server {
     location /physiotools {
         autoindex on;
         alias /data/pn-static/physiotools;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiotools/ always redirects to /software/
         location = /physiotools/ {
             return 301 https://$host/software/;
@@ -147,11 +150,13 @@ server {
 
     location /static {
         alias /data/pn-static;
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /static/published-projects {
         autoindex on;
         alias /data/pn-static/published-projects;
+        add_header Content-Security-Policy $pn_static_csp;
     }
 
     location /favicon.ico {
@@ -161,6 +166,7 @@ server {
     location /physiobank/database {
         autoindex on;
         alias /data/pn-static/physiobank/database;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiobank/database/ always redirects to /data/
         location = /physiobank/database/ {
             return 301 https://$host/data/;
@@ -178,6 +184,7 @@ server {
     location /physiotools {
         autoindex on;
         alias /data/pn-static/physiotools;
+        add_header Content-Security-Policy $pn_static_csp;
         # /physiotools/ always redirects to /software/
         location = /physiotools/ {
             return 301 https://$host/software/;


### PR DESCRIPTION
This allows access to new public databases via the traditional API, so that WFDB can be used to read them, e.g. via 'rdsamp -r mitdb/1.0.0/100' instead of 'rdsamp -r mitdb/100'.

In addition, consolidate the handling of Content-Security-Policy and make sure it applies to all static files.

nginx 'try_files' is always confusing, but I'm pretty sure this will work. :)

Given the files:

    /data/pn-static/published-projects/demobsn/1.0/scripts/lib.py
    /data/pn-static/published-projects/demobsn/1.0/foo.pdf
    /data/pn-static/physiobank/database/demobsn/udb/100s.hea
    /data/pn-static/physiobank/database/demobsn/foo.pdf

the following command:

    for path in \
      /physiobank/database/demobsn \
      /physiobank/database/demobsn/ \
      /physiobank/database/demobsn/foo.pdf \
      /physiobank/database/demobsn/udb \
      /physiobank/database/demobsn/udb/ \
      /physiobank/database/demobsn/udb/100s.hea \
      /physiobank/database/demobsn/1.0 \
      /physiobank/database/demobsn/1.0/ \
      /physiobank/database/demobsn/1.0/foo.pdf \
      /physiobank/database/demobsn/1.0/scripts \
      /physiobank/database/demobsn/1.0/scripts/ \
      /physiobank/database/demobsn/1.0/scripts/lib.py \
    ; do for url in http://localhost$path https://localhost$path; do
      echo $url;
      curl -s -I -k $url | tr -d \\r | \
          egrep -i '^HTTP|^Location:|^Content-Security-Policy:';
      echo; done; done

produces the output:
```
http://localhost/physiobank/database/demobsn
HTTP/1.1 301 Moved Permanently
Location: http://localhost/physiobank/database/demobsn/
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn
HTTP/2 301 
location: https://localhost/physiobank/database/demobsn/
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/
HTTP/1.1 301 Moved Permanently
Location: https://localhost/physiobank/database/demobsn/

https://localhost/physiobank/database/demobsn/
HTTP/2 302 
location: /content/demobsn/

http://localhost/physiobank/database/demobsn/foo.pdf
HTTP/1.1 200 OK

https://localhost/physiobank/database/demobsn/foo.pdf
HTTP/2 200 

http://localhost/physiobank/database/demobsn/udb
HTTP/1.1 301 Moved Permanently
Location: http://localhost/physiobank/database/demobsn/udb/
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/udb
HTTP/2 301 
location: https://localhost/physiobank/database/demobsn/udb/
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/udb/
HTTP/1.1 200 OK
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/udb/
HTTP/2 200 
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/udb/100s.hea
HTTP/1.1 200 OK
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/udb/100s.hea
HTTP/2 200 
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/1.0
HTTP/1.1 301 Moved Permanently
Location: http://localhost/physiobank/database/demobsn/1.0/
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/1.0
HTTP/2 301 
location: https://localhost/physiobank/database/demobsn/1.0/
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/1.0/
HTTP/1.1 200 OK
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/1.0/
HTTP/2 200 
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/1.0/foo.pdf
HTTP/1.1 200 OK

https://localhost/physiobank/database/demobsn/1.0/foo.pdf
HTTP/2 200 

http://localhost/physiobank/database/demobsn/1.0/scripts
HTTP/1.1 301 Moved Permanently
Location: http://localhost/physiobank/database/demobsn/1.0/scripts/
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/1.0/scripts
HTTP/2 301 
location: https://localhost/physiobank/database/demobsn/1.0/scripts/
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/1.0/scripts/
HTTP/1.1 200 OK
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/1.0/scripts/
HTTP/2 200 
content-security-policy: sandbox; default-src 'self'

http://localhost/physiobank/database/demobsn/1.0/scripts/lib.py
HTTP/1.1 200 OK
Content-Security-Policy: sandbox; default-src 'self'

https://localhost/physiobank/database/demobsn/1.0/scripts/lib.py
HTTP/2 200 
content-security-policy: sandbox; default-src 'self'

```
