### PR TITLE
If a reference is not provided, do not display a reference form in the credentialing workflow.

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -133,11 +133,15 @@
           </div>
           <div class="card-body">
             {# Reference #}
-            <form action="" method="post" class="form-signin">
-              {% csrf_token %}
-              {% include "form_snippet.html" with form=intermediate_credential_form %}
-              <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{app_user.id}}" type="submit">Submit Response</button>
-            </form>
+            {% if application.reference_email|length < 1 %}
+              <p>No reference provided.</p>
+            {% else %}
+              <form action="" method="post" class="form-signin">
+                {% csrf_token %}
+                {% include "form_snippet.html" with form=intermediate_credential_form %}
+                <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{app_user.id}}" type="submit">Submit Response</button>
+              </form>
+            {% endif %}
           </div>
         </div>
         {% endif %}


### PR DESCRIPTION
We currently display a form that asks questions about the reference, even when a reference is not provided. This change hides the form if a reference has not been provided.