### PR TITLE
Fixes application review filter #1226

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1387,9 +1387,12 @@ def credential_processing(request):
 
     # TODO: Remove this step. If KP has contacted the reference, exclude the
     # application from our list. Avoid toes.
-    no_review = Q(credential_review__isnull=True)
+    review_not_underway = (Q(credential_review__status__lte=10) |
+                           Q(credential_review__isnull=True))
+
     ref_contacted = Q(reference_contact_datetime__isnull=False)
-    applications = applications.exclude(no_review, ref_contacted)
+
+    applications = applications.exclude(review_not_underway, ref_contacted)
 
     # Awaiting initial review
     initial_1 = Q(credential_review__isnull=True)


### PR DESCRIPTION
Currently, the logic for filtering out credential applications in which the reference has been contacted is to use an `.exclude()` filter with multiple arguments which uses the logical AND operator (https://docs.djangoproject.com/en/3.1/ref/models/querysets/#exclude). Unfortunately, it appears that cases show up where we need the OR operator to perfectly exclude everything so this fixes that.

Fixes #1226.