### PR TITLE
Adds credentialing email as CC when contacting references #1224

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1258,7 +1258,8 @@ def process_credential_application(request, application_slug):
                 subject = contact_cred_ref_form.cleaned_data['subject']
                 body = contact_cred_ref_form.cleaned_data['body']
                 notification.contact_reference(request, application,
-                                               subject=subject, body=body)
+                                               subject=subject, body=body,
+                                               cc=settings.CREDENTIAL_EMAIL)
                 messages.success(request, 'The reference has been contacted.')
         elif 'skip_reference' in request.POST:
             application.update_review_status(60)

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -2,7 +2,7 @@
 
 {{ applicant_name }} has applied for access to protected data on PhysioNet and listed you as a reference. Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
 
-If you support their application, please indicate your approval using the link below or reply to this email. If you do not support their application, you may ignore this email or update us directly via the link.
+If you support their application, please indicate your approval using the link below or "reply all" to this email. If you do not support their application, you may ignore this email or update us directly via the link.
 
 {{ url_prefix }}{% url 'credential_reference' application.slug %}
 

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -475,7 +475,7 @@ def contact_applicant(request, application, comments):
 
 
 def contact_reference(request, application, send=True, wordwrap=True,
-                      subject="", body=""):
+                      subject="", body="", cc=None):
     """
     Request verification from a credentialing applicant's reference.
 
@@ -485,6 +485,7 @@ def contact_reference(request, application, send=True, wordwrap=True,
         wordwrap : If True, wraps body at 70 characters.
         subject : Subject line.
         body : Body text.
+        cc : The address to be CC'd to the email.
 
     Returns:
         dict : email name, subject, body
@@ -509,8 +510,14 @@ def contact_reference(request, application, send=True, wordwrap=True,
         body = defaultfilters.wordwrap(body, 70)
 
     if send:
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-                  [application.reference_email], fail_silently=False)
+        message = EmailMessage(
+            subject=subject,
+            body=body,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            to=[application.reference_email],
+            cc=[cc]
+        )
+        message.send(fail_silently=False)
 
     return {"subject": subject, "body": body}
 


### PR DESCRIPTION
This change adds the admin credentialing email account as a CC to the email sent to the reference. The instructions in the email are changed from `reply` to `reply all` so that the reference knows to also include this account in their email response should they choose to do so.

Fixes #1224.