### PR TITLE
Adds final reviewer when viewing previous credential applications #1223

### DIFF
--- a/physionet-django/console/templates/console/past_credential_unsuccessful_user_list.html
+++ b/physionet-django/console/templates/console/past_credential_unsuccessful_user_list.html
@@ -9,6 +9,7 @@
           <th>Decision Date</th>
           <th>Decision</th>
           <th>Comment</th>
+          <th>Reviewer</th>
           <th>View Details</th>
           <th>Manage</th>
         </tr>
@@ -24,6 +25,7 @@
             <td>{{ application.decision_datetime|date }}</td>
             <td>{{ application.get_status_display }}</td>
             <td>{{ application.responder_comments }}</td>
+            <td>{{ application.responder }}</td>
             <td><a href="{% url 'view_credential_application' application.slug %}" target="_blank">View</a></td>
             <td>
               {% if application.user.is_credentialed %}


### PR DESCRIPTION
This change includes the final reviewer identity when looking at previous credential applications here: 

http://localhost:8000/console/past-credential-applications/successful
http://localhost:8000/console/past-credential-applications/unsuccessful

Fixes #1223.