### PR TITLE
Sends reference check emails from admin credentialing email address

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1258,8 +1258,7 @@ def process_credential_application(request, application_slug):
                 subject = contact_cred_ref_form.cleaned_data['subject']
                 body = contact_cred_ref_form.cleaned_data['body']
                 notification.contact_reference(request, application,
-                                               subject=subject, body=body,
-                                               cc=settings.CREDENTIAL_EMAIL)
+                                               subject=subject, body=body)
                 messages.success(request, 'The reference has been contacted.')
         elif 'skip_reference' in request.POST:
             application.update_review_status(60)

--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -2,7 +2,7 @@
 
 {{ applicant_name }} has applied for access to protected data on PhysioNet and listed you as a reference. Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
 
-If you support their application, please indicate your approval using the link below or "reply all" to this email. If you do not support their application, you may ignore this email or update us directly via the link.
+If you support their application, please indicate your approval using the link below or reply to this email. If you do not support their application, you may ignore this email or update us directly via the link.
 
 {{ url_prefix }}{% url 'credential_reference' application.slug %}
 

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -475,7 +475,7 @@ def contact_applicant(request, application, comments):
 
 
 def contact_reference(request, application, send=True, wordwrap=True,
-                      subject="", body="", cc=None):
+                      subject="", body=""):
     """
     Request verification from a credentialing applicant's reference.
 
@@ -485,7 +485,6 @@ def contact_reference(request, application, send=True, wordwrap=True,
         wordwrap : If True, wraps body at 70 characters.
         subject : Subject line.
         body : Body text.
-        cc : The address to be CC'd to the email.
 
     Returns:
         dict : email name, subject, body
@@ -510,14 +509,8 @@ def contact_reference(request, application, send=True, wordwrap=True,
         body = defaultfilters.wordwrap(body, 70)
 
     if send:
-        message = EmailMessage(
-            subject=subject,
-            body=body,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[application.reference_email],
-            cc=[cc]
-        )
-        message.send(fail_silently=False)
+        send_mail(subject, body, settings.CREDENTIAL_EMAIL,
+                  [application.reference_email], fail_silently=False)
 
     return {"subject": subject, "body": body}
 


### PR DESCRIPTION
This change sends the reference check emails from the admin credentialing email address instead of currently being CC'd along with the noreply email. We will no longer receive the check when it is sent but will definitely receive the reply if they choose to do so via email.