### PR TITLE
Adds search applicant feature for credential application processing

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -1,7 +1,8 @@
 {# Status section #}
 
 <p>Username: <a href="{% url 'public_profile' application.user.username %}">{{ application.user.username }}</a></br>
-Applied: {{ application.application_datetime|date }}</p>
+Applied: {{ application.application_datetime|date }}</br>
+[<a href="https://www.google.com/search?q={{ application.first_names }} {{ application.last_name }} {{ application.organization_name }}" target="_blank">Search for name and affiliation.</a>]</p>
 
 {% if application.reference_contact_datetime %}
   Reference contact date: {{ application.reference_contact_datetime|date }}<br />


### PR DESCRIPTION
This change adds a "Search applicant" link which Google searches a credential applicant's personal information, specifically `search?q = first_names last_name organization_name`. This google search is opened in a new browser tab so the current page is not lost.