### PR TITLE
Removes extra whitespace for credential application review forms

### DIFF
--- a/physionet-django/console/static/console/css/console.css
+++ b/physionet-django/console/static/console/css/console.css
@@ -518,6 +518,7 @@ footer.sticky-footer {
 .form-group ul {
   display: block;
   padding-left: 0;
+  height: 3rem;
 }
 
 .form-group li {


### PR DESCRIPTION
This change removes the extra whitespace around the radio buttons in the credential application review forms.

Before            |  After
:-------------------------:|:-------------------------:
![Screen Shot 2021-02-01 at 8 55 28 AM](https://user-images.githubusercontent.com/39505798/106467925-495c5c00-646b-11eb-9a68-2034f53716fb.png)  |  ![Screen Shot 2021-02-01 at 8 55 16 AM](https://user-images.githubusercontent.com/39505798/106467931-4bbeb600-646b-11eb-995e-dcf9549e013a.png)