### PR TITLE
Adds button to approve all fields in credential application review form

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -72,6 +72,7 @@
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
               <button class="btn btn-primary btn-fixed" name="approve_initial" value="{{app_user.id}}" type="submit">Submit Response</button>
+              <button class="btn btn-primary btn-fixed" name="approve_initial_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
           </div>
         </div>
@@ -90,6 +91,7 @@
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
               <button class="btn btn-primary btn-fixed" name="approve_training" value="{{app_user.id}}" type="submit">Submit Response</button>
+              <button class="btn btn-primary btn-fixed" name="approve_training_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
           </div>
         </div>
@@ -105,6 +107,7 @@
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
               <button class="btn btn-primary btn-fixed" name="approve_personal" value="{{app_user.id}}" type="submit">Submit Response</button>
+              <button class="btn btn-primary btn-fixed" name="approve_personal_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
           </div>
         </div>
@@ -140,6 +143,7 @@
                 {% csrf_token %}
                 {% include "form_snippet.html" with form=intermediate_credential_form %}
                 <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{app_user.id}}" type="submit">Submit Response</button>
+                <button class="btn btn-primary btn-fixed" name="approve_reference_all" value="{{app_user.id}}" type="submit">Approve All</button>
               </form>
             {% endif %}
           </div>
@@ -156,6 +160,7 @@
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
               <button class="btn btn-primary btn-fixed" name="approve_response" value="{{app_user.id}}" type="submit">Submit Response</button>
+              <button class="btn btn-primary btn-fixed" name="approve_response_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
           </div>
         </div>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1189,6 +1189,23 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
+        elif 'approve_initial_all' in request.POST:
+            if request.POST['decision'] == '0':
+                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
+            else:
+                data_copy = request.POST.copy()
+                valid_fields = set(request.POST.keys())
+                valid_fields.difference_update({'csrfmiddlewaretoken',
+                                                'responder_comments',
+                                                'approve_initial_all'})
+                for field in valid_fields:
+                    data_copy[field] = '1'
+                intermediate_credential_form = forms.InitialCredentialForm(
+                    responder=request.user, data=data_copy, instance=application)
+                intermediate_credential_form.save()
+                page_title = title_dict[application.credential_review.status]
+                intermediate_credential_form = forms.TrainingCredentialForm(
+                    responder=request.user, instance=application)
         elif 'approve_training' in request.POST:
             intermediate_credential_form = forms.TrainingCredentialForm(
                 responder=request.user, data=request.POST, instance=application)
@@ -1204,6 +1221,23 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
+        elif 'approve_training_all' in request.POST:
+            if request.POST['decision'] == '0':
+                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
+            else:
+                data_copy = request.POST.copy()
+                valid_fields = set(request.POST.keys())
+                valid_fields.difference_update({'csrfmiddlewaretoken',
+                                                'responder_comments',
+                                                'approve_training_all'})
+                for field in valid_fields:
+                    data_copy[field] = '1'
+                intermediate_credential_form = forms.TrainingCredentialForm(
+                    responder=request.user, data=data_copy, instance=application)
+                intermediate_credential_form.save()
+                page_title = title_dict[application.credential_review.status]
+                intermediate_credential_form = forms.PersonalCredentialForm(
+                    responder=request.user, instance=application)
         elif 'approve_personal' in request.POST:
             intermediate_credential_form = forms.PersonalCredentialForm(
                 responder=request.user, data=request.POST, instance=application)
@@ -1219,6 +1253,23 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
+        elif 'approve_personal_all' in request.POST:
+            if request.POST['decision'] == '0':
+                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
+            else:
+                data_copy = request.POST.copy()
+                valid_fields = set(request.POST.keys())
+                valid_fields.difference_update({'csrfmiddlewaretoken',
+                                                'responder_comments',
+                                                'approve_personal_all'})
+                for field in valid_fields:
+                    data_copy[field] = '1'
+                intermediate_credential_form = forms.PersonalCredentialForm(
+                    responder=request.user, data=data_copy, instance=application)
+                intermediate_credential_form.save()
+                page_title = title_dict[application.credential_review.status]
+                intermediate_credential_form = forms.ReferenceCredentialForm(
+                    responder=request.user, instance=application)
         elif 'approve_reference' in request.POST:
             intermediate_credential_form = forms.ReferenceCredentialForm(
                 responder=request.user, data=request.POST, instance=application)
@@ -1234,6 +1285,23 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
+        elif 'approve_reference_all' in request.POST:
+            if request.POST['decision'] == '0':
+                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
+            else:
+                data_copy = request.POST.copy()
+                valid_fields = set(request.POST.keys())
+                valid_fields.difference_update({'csrfmiddlewaretoken',
+                                                'responder_comments',
+                                                'approve_reference_all'})
+                for field in valid_fields:
+                    data_copy[field] = '1'
+                intermediate_credential_form = forms.ReferenceCredentialForm(
+                    responder=request.user, data=data_copy, instance=application)
+                intermediate_credential_form.save()
+                page_title = title_dict[application.credential_review.status]
+                intermediate_credential_form = forms.ResponseCredentialForm(
+                    responder=request.user, instance=application)
         elif 'approve_response' in request.POST:
             intermediate_credential_form = forms.ResponseCredentialForm(
                 responder=request.user, data=request.POST, instance=application)
@@ -1249,6 +1317,23 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
+        elif 'approve_response_all' in request.POST:
+            if request.POST['decision'] == '0':
+                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
+            else:
+                data_copy = request.POST.copy()
+                valid_fields = set(request.POST.keys())
+                valid_fields.difference_update({'csrfmiddlewaretoken',
+                                                'responder_comments',
+                                                'approve_response_all'})
+                for field in valid_fields:
+                    data_copy[field] = '1'
+                intermediate_credential_form = forms.ResponseCredentialForm(
+                    responder=request.user, data=data_copy, instance=application)
+                intermediate_credential_form.save()
+                page_title = title_dict[application.credential_review.status]
+                intermediate_credential_form = forms.ProcessCredentialReviewForm(
+                    responder=request.user, instance=application)
         elif 'contact_reference' in request.POST:
             contact_cred_ref_form = forms.ContactCredentialRefForm(
                 data=request.POST)


### PR DESCRIPTION
This change adds a button to the credential application review form which allows the reviewer to automatically skip all the fields in the current step. The reviewer must still select their decision as "Pass to Next Stage" ("Reject" will return an error) in order to avoid changing the models and to provide some kind of safe-check to prevent both accidental button clicks and it becoming too easy to pass an application all the way through the review process.