### PR TITLE
Add IntelliJ/JetBrains/PyCharm .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ physionet-django/*credentials*
 # Disk images
 *.img
 *.iso
+
+# Pycharm / JetBrains / IntelliJ project specific settings folder
+.idea/


### PR DESCRIPTION
IntelliJ/JetBrains/PyCharm products create a project specific settings folder, .idea, which should be ignored when making commits.  This adds `.idea/` to the .gitignore file.