### PR TITLE
Adds search reference feature for credential application processing

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -48,6 +48,7 @@ Applied: {{ application.application_datetime|date }}</p>
 
 <h5>Reference</h5>
 
+[<a href="https://www.google.com/search?q={{ application.reference_name }} {{ application.reference_email }}" target="_blank">Search for reference name and email.</a>]</p>
 <ul>
   <li>Name: <mark>{{ application.reference_name }}</mark></li>
   <li>Email: <mark>{{ application.reference_email }}</mark></li>


### PR DESCRIPTION
This change adds a "Search reference" link which Google searches a credential reference's personal information, specifically `search?q = reference_name reference_email`. This google search is opened in a new browser tab so the current page is not lost.