### PR TITLE
Display link to CITI training if available. Download PDF if not.

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -44,7 +44,11 @@ Applied: {{ application.application_datetime|date }}</br>
 <h5>Training</h5>
 
 <ul>
-  <li>CITI report: <mark><a href="{% url 'training_report' application.slug %}" target="_blank">View file</a></mark></li>
+  {% if application.training_completion_report_url %}
+  <li>Report (CITI): <mark><a href="{{ application.training_completion_report_url }}" target="_blank">View file</a></mark></li>
+  {% else %}
+  <li>Report (Unknown): <mark><a href="{% url 'training_report' application.slug %}" target="_blank">Download</a></mark></li>
+  {% endif %}
 </ul>
 
 <h5>Reference</h5>

--- a/physionet-django/console/templates/console/complete_application_display_table.html
+++ b/physionet-django/console/templates/console/complete_application_display_table.html
@@ -1,5 +1,5 @@
 {# Status section #}
-<p><a href="{% url 'training_report' application.slug %}" target="_blank">Training Completion Report</a><br></p>
+<p><a href="{% url 'training_report_view' application.slug %}" target="_blank">Training Completion Report</a><br></p>
 
 {# Personal details #}
 

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -57,4 +57,6 @@ urlpatterns = [
         views.credential_reference, name='credential_reference'),
     path('credential-applications/<application_slug>/training-report/',
         views.training_report, name='training_report'),
+    path('credential-applications/<application_slug>/training-report/view/',
+        views.training_report_view, name='training_report_view'),
 ]

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -569,6 +569,15 @@ def training_report(request, application_slug, attach=True):
     raise PermissionDenied()
 
 
+@login_required
+def training_report_view(request, application_slug):
+    """
+    Wrapper for training_report. Serves the training report in the browser
+    for KP's custom pages.
+    """
+    return training_report(request, application_slug, attach=False)
+
+
 # @login_required
 def credential_reference(request, application_slug):
     """

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -550,7 +550,7 @@ def credential_application(request):
 
 
 @login_required
-def training_report(request, application_slug):
+def training_report(request, application_slug, attach=True):
     """
     Serve a training report file
     """
@@ -561,7 +561,8 @@ def training_report(request, application_slug):
 
     if request.user == application.user or request.user.is_admin:
         try:
-            return utility.serve_file(application.training_completion_report.path, False)
+            return utility.serve_file(application.training_completion_report.path,
+                                      attach=attach)
         except FileNotFoundError:
             raise Http404()
 


### PR DESCRIPTION
An earlier pull request (https://github.com/MIT-LCP/physionet-build/pull/1026) improved the way that training reports are handled. The improvement included changes that: (1) extract a verification URL from uploaded training reports (2) display this URL (if available) instead of a link to the PDF report and (3) download PDFs instead of viewing them in the browser. We temporarily reverted points 2 and 3 because they would have interfered with KP's custom pages. 

This pull request makes the following changes:

- Adds back the reverted steps so that we (1) Display the CITI verification URL in the reviewing console if available and (2) Display a link to download the PDF if the CITI URL is not available.
- Creates a new view to avoid changing the behavior of KP's custom page.
