### PR TITLE
Link console to user management pages, instead of public profiles

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -1,6 +1,6 @@
 {# Status section #}
 
-<p>Username: <a href="{% url 'public_profile' application.user.username %}">{{ application.user.username }}</a></br>
+<p>Username: <a href="{% url 'user_management' application.user.username %}">{{ application.user.username }}</a></br>
 Applied: {{ application.application_datetime|date }}</br>
 [<a href="https://www.google.com/search?q={{ application.first_names }} {{ application.last_name }} {{ application.organization_name }}" target="_blank">Search for name and affiliation.</a>]</p>
 

--- a/physionet-django/console/templates/console/complete_application_display_table.html
+++ b/physionet-django/console/templates/console/complete_application_display_table.html
@@ -3,7 +3,7 @@
 
 {# Personal details #}
 
-<p>User: <a href="{% url 'public_profile' application.user.username %}">{{ application.user.username }}</a>
+<p>User: <a href="{% url 'user_management' application.user.username %}">{{ application.user.username }}</a>
 
 PhysioNet e-mail: {{ application.user.email }}<br>
 

--- a/physionet-django/console/templates/console/credential_applications.html
+++ b/physionet-django/console/templates/console/credential_applications.html
@@ -35,7 +35,7 @@
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
                 <td>{{forloop.counter}}</td>
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.application_datetime|date }}</td>

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -54,7 +54,7 @@
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
                 <td>{{forloop.counter}}</td>
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.application_datetime|date }}</td>

--- a/physionet-django/console/templates/console/credentialed_users.html
+++ b/physionet-django/console/templates/console/credentialed_users.html
@@ -23,7 +23,7 @@
           <tbody>
           {% for user in users %}
             <tr>
-              <td><a href="{% url 'public_profile' user.username %}">{{ user.username }}</td>
+              <td><a href="{% url 'user_management' user.username %}">{{ user.username }}</td>
               <td>{{ user.email }}</td>
               <td>{{ user.join_date }}</td>
               <td>{{ user.last_login|date }}</td>

--- a/physionet-django/console/templates/console/editor_home.html
+++ b/physionet-django/console/templates/console/editor_home.html
@@ -33,7 +33,7 @@
           {% for project in decision_projects %}
             <tr>
               <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
-              <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
+              <td><a href="{% url 'user_management' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
               <td>{{ project.submission_datetime|date }}</td>
               <td>
                 {% if project.resubmission_datetime %}
@@ -77,7 +77,7 @@
           {% for project in revision_projects %}
             <tr>
               <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
-              <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
+              <td><a href="{% url 'user_management' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
               <td>{{ project.submission_datetime|date }}</td>
               <td>{{ project.revision_request_datetime|date }}</td>
               <td>{{ project.latest_reminder|date }}</td>

--- a/physionet-django/console/templates/console/past_credential_successful_user_list.html
+++ b/physionet-django/console/templates/console/past_credential_successful_user_list.html
@@ -16,7 +16,7 @@
         <tr>
         {% if application.is_legacy %}
           {% with user=application.migrated_user %}
-            <td><a href="{% url 'public_profile' user.username %}" target="_blank">{{ user.get_full_name }}</td>
+            <td><a href="{% url 'user_management' user.username %}" target="_blank">{{ user.get_full_name }}</td>
             <td>{{ user.email }}</td>
             <td>{{ user.credential_datetime|date }}</td>
             <td>Legacy</td>
@@ -33,7 +33,7 @@
           {% endwith %}
         {% else %}
           {% with user=application.user %}
-            <td><a href="{% url 'public_profile' user.username %}" target="_blank">{{ user.get_full_name }}</td>
+            <td><a href="{% url 'user_management' user.username %}" target="_blank">{{ user.get_full_name }}</td>
             <td>{{ user.email }}</td>
             <td>{{ application.application_datetime|date }}</td>
             <td>{{ application.decision_datetime|date }}</td>

--- a/physionet-django/console/templates/console/past_credential_unsuccessful_user_list.html
+++ b/physionet-django/console/templates/console/past_credential_unsuccessful_user_list.html
@@ -18,7 +18,7 @@
         {% for application in u_applications %}
           <tr>
           {% with user=application.user %}
-            <td><a href="{% url 'public_profile' user.username %}" target="_blank">{{ user.get_full_name }}</td>
+            <td><a href="{% url 'user_management' user.username %}" target="_blank">{{ user.get_full_name }}</td>
             <td>{{ user.email }}</td>
             <td>{{ application.application_datetime|date }}</td>
             <td>{{ application.reference_contact_datetime|date }}</td>


### PR DESCRIPTION
When usernames appear in the admin console, they are currently linked to the (often-bare) public profiles.  In #1154 we added a new user profile page, which is generally more informative than the public profile. This change links the console to the internal profile, instead of the public one.