### PR TITLE
Fixes credential form formatting error

### DIFF
--- a/physionet-django/console/static/console/css/console.css
+++ b/physionet-django/console/static/console/css/console.css
@@ -516,9 +516,9 @@ footer.sticky-footer {
 }
 
 .form-group ul {
-  display: block;
+  display: inline-flex;
   padding-left: 0;
-  height: 3rem;
+  height: 2rem;
 }
 
 .form-group li {


### PR DESCRIPTION
This change fixes an error that seems to occur at very specific window widths for the credential application review from (see below).

![Screen Shot 2021-02-04 at 8 18 03 AM](https://user-images.githubusercontent.com/39505798/106897959-9afe2400-66c1-11eb-8586-cd9c128ac05a.png)

The new fix attempts to preserve the inline nature of the three radio buttons while shrinking the text size with the window. Now, at its worst, will look like this:
![Screen Shot 2021-02-04 at 8 23 02 AM](https://user-images.githubusercontent.com/39505798/106898452-35f6fe00-66c2-11eb-9806-c7e4a3770b40.png)

 