### PR TITLE
Prevents user from adding themselves as a references

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -445,6 +445,12 @@ class ReferenceCAF(forms.ModelForm):
             'reference_title': 'Reference job title or position'
         }
 
+    def __init__(self, user, *args, **kwargs):
+        """
+        This form is only for processing post requests.
+        """
+        super().__init__(*args, **kwargs)
+        self.user = user
 
     def clean_reference_name(self):
         reference_name = self.cleaned_data.get('reference_name')
@@ -454,7 +460,11 @@ class ReferenceCAF(forms.ModelForm):
     def clean_reference_email(self):
         reference_email = self.cleaned_data.get('reference_email')
         if reference_email:
-            return reference_email.strip()
+            if reference_email in self.user.get_emails():
+                raise forms.ValidationError("""You can not put yourself
+                    as a reference.""")
+            else:
+                return reference_email.strip()
 
     def clean_reference_title(self):
         reference_title = self.cleaned_data.get('reference_title')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -522,7 +522,7 @@ def credential_application(request):
         training_form = forms.TrainingCAF(data=request.POST,
             files=request.FILES, prefix="application")
         research_form = forms.ResearchCAF(data=request.POST, prefix="application")
-        reference_form = forms.ReferenceCAF(data=request.POST, prefix="application")
+        reference_form = forms.ReferenceCAF(data=request.POST, prefix="application", user=user)
 
         form = forms.CredentialApplicationForm(user=user, data=request.POST,
             files=request.FILES,  prefix="application")
@@ -539,7 +539,7 @@ def credential_application(request):
     else:
         personal_form = forms.PersonalCAF(user=user, prefix="application")
         training_form = forms.TrainingCAF(prefix="application")
-        reference_form = forms.ReferenceCAF(prefix="application")
+        reference_form = forms.ReferenceCAF(prefix="application", user=user)
         research_form = forms.ResearchCAF(prefix="application")
         form = None
 


### PR DESCRIPTION
This change prevents the submitting user of a new credential application form from placing their reference email as one which is associated with their account. For this, I pass the `request.user` into the form and check that it's not in the `user.get_emails()` list.