### PR TITLE
Adds indicator of known reference #1233

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -59,6 +59,16 @@ Applied: {{ application.application_datetime|date }}</br>
   <li>Email: <mark>{{ application.reference_email }}</mark></li>
   <li>Position: <mark>{{ application.reference_title }}</mark></li>
   <li>Relationship: <mark>{{ application.get_reference_category_display }}</mark></li>
+  {% if known_active %}
+    <li><mark>Active User?: Yes</mark></li>
+  {% else %}
+    <li><mark>Active User?: No</mark></li>
+  {% endif %}
+  {% if known_cred %}
+    <li><mark>Credentialed User?: Yes</mark></li>
+  {% else %}
+    <li><mark>Credentialed User?: No</mark></li>
+  {% endif %}
 </ul>
 
 <h5>Research</h5>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1159,7 +1159,7 @@ def process_credential_application(request, application_slug):
     contact_cred_ref_form = forms.ContactCredentialRefForm(initial=ref_email)
 
     try:
-        ref = User.objects.get(associated_emails__email=application.reference_email.lower(),
+        ref = User.objects.get(associated_emails__email__iexact=application.reference_email,
                                associated_emails__is_verified=True)
         known_active = True
         known_cred = ref.is_credentialed


### PR DESCRIPTION
This change adds an indicator of a known reference to a credential application review. This is done by simply adding a "Known Reference" highlighted text in the Reference section of the application display:
![Screen Shot 2021-02-04 at 12 34 53 PM](https://user-images.githubusercontent.com/39505798/106932333-9c414800-66e5-11eb-849b-b6e865e5e812.png)
Nothing is done if the reference is not known.
Fixes #1233.