### PR TITLE
Adjusts credential webpage suggestions

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -344,9 +344,9 @@ class PersonalCAF(forms.ModelForm):
             'state_province': "The state or province where you live. (Required for residents of Canada or the US.)",
             'zip_code': "The zip code of the city where you live.",
             'country': "The country where you live.",
-            'webpage': """Your organization's webpage. If possible, please 
-                include a link to a webpage with your biography or other 
-                personal details.""",
+            'webpage': """Please include a link to a webpage with your
+                biography or other personal details (ORCID, LinkedIn,
+                Github, etc.).""",
             'research_summary': """Brief description of your proposed research. 
                 If you will be using the data for a class, please include 
                 course name and number in your description.""",


### PR DESCRIPTION
This change adjusts the text used to describe what we would like when credential applicants provide a webpage. Here, I suggest some examples (ORCID, LinkedIn, Github, etc.) which I believe would be helpful to know during the credential application review process. Some thought needs to be devoted to decide whether or not this field should eventually be required though this can be for another day.

I decided to remove us suggesting they provide a link to their organization's webpage since 99% of the time this can be googled based on the institution they list previously in the application.