### PR TITLE
Allows credential reviewer to contact reference multiple times

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -35,7 +35,7 @@
           </div>
           <div class="card-body">
             {% if application.reference_email|length < 1 %}
-            <p>A reference was not provided.</p>
+              <p>A reference was not provided.</p>
             {% elif application.reference_contact_datetime %}
               <p><i class="fas fa-envelope"></i> The reference was contacted on {{ application.reference_contact_datetime }}</p>
               {% if not application.reference_response_datetime %}
@@ -43,20 +43,20 @@
               {% endif %}
             {% else %}
               <p>The reference has not been contacted.</p>
-              <form action="" method="post" class="form-signin">
-                {% csrf_token %}
-                {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="contact_reference" submit_value=app_user.id submit_text="Contact Reference" %}
-                <button type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact Reference</button>
-              </form>
-              {% endif %}
-              {# Reference already responded #}
-              {% if application.reference_response_datetime %}
-                <p><i class="fas fa-check" style="color:green"></i> The reference verified the applicant on {{ application.reference_response_datetime }}</p>
-                {% if application.reference_response_text %}
+            {% endif %}
+            <form action="" method="post" class="form-signin">
+              {% csrf_token %}
+              {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="contact_reference" submit_value=app_user.id submit_text="Contact Reference" %}
+              <button type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact Reference</button>
+            </form>
+            {# Reference already responded #}
+            {% if application.reference_response_datetime %}
+              <p><i class="fas fa-check" style="color:green"></i> The reference verified the applicant on {{ application.reference_response_datetime }}</p>
+              {% if application.reference_response_text %}
                 <h2 style='font-size:20px;'>Reference comments:</h2>
                 <p style='margin-left:2em'>{{ application.reference_response_text }}</p>
-                {% endif %}
               {% endif %}
+            {% endif %}
           </div>
         {% endif %}
 


### PR DESCRIPTION
This change allows the credential application reviewer to contact the reference multiple times. Each time the reference is contacted, the `reference_contact_datetime` attribute will be updated to `timezone.now()` rather than preserving all previous contact times. I figured that storing all previous contact times was not worth the trouble to modify the model and respective views. I'm not sure the behavior of the temporary link it sends but from my testing so far I see that it sends the exact same link so no trouble should be encountered. 