### PR TITLE
Minor .env.example documentation update for ORCID integration.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,7 @@ DATACITE_TEST_PASS=SECRET
 
 # Orcid information
 # These variables are required to request / exchange a token from ORCID in a effort to get a users ORCID iD, etc.
-# The _LOCAL_ variables are used by base.py while the _PHYSIO_ variables are used by staging.py and production.py.
+# The _TEST_ variables are used by base.py while the variables without _TEST_ are used by staging.py and production.py.
 # To obtain valid CLIENT_ID and CLIENT_SECRET values you must register an account or use an account from your
 # institution to obtain valid codes.  When doing development work off of base.py, register an account at
 # sandbox.orcid.org and when using staging.py or production.py register at orcid.org.  After registering you can go to


### PR DESCRIPTION
This updates the variable names in the .env.example documentation to match the final variable names used in the ORCID code.