### PR TITLE
Adds option to reject credential applications based on template

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -60,6 +60,26 @@ YES_NO_NA_UNDETERMINED = (
     (None, 'N/A or Undetermined')
 )
 
+REJECT_REASONS = (
+    (15, 'CITI: Incorrect CITI course / wrong PDF'),
+    (14, 'CITI: CITI Certificate'),
+    (13, 'CITI: No HIPAA section'),
+    (12, 'CITI: Failed HIPAA section'),
+    (11, 'CITI: Inconsistent CITI report email'),
+    (10, 'Concerns: DUA violation'),
+    (9, 'Identity: Inconsistent information'),
+    (8, 'Identity: Can not verify identity'),
+    (7, 'Institution: Industry Researcher without institution'),
+    (6, 'Institution: Hospital Researcher without institution'),
+    (5, 'Institution: Student without institution'),
+    (4, 'Institution: MIT Affiliates as institution'),
+    (3, 'Reference: Incorrect reference name'),
+    (2, 'Reference: Listed self as reference'),
+    (1, 'Reference: Inactive reference email'),
+    (0, 'Other'),
+)
+
+
 class AssignEditorForm(forms.Form):
     """
     Assign an editor to a project under submission
@@ -339,6 +359,13 @@ class ContactCredentialRefForm(forms.Form):
     """
     subject = forms.CharField(required=True)
     body = forms.CharField(widget=forms.Textarea)
+
+
+class CredentialRejectForm(forms.Form):
+    """
+    Decide the reason for rejecting a credentialing application.
+    """
+    reason = forms.ChoiceField(choices=REJECT_REASONS)
 
 
 class ProcessCredentialForm(forms.ModelForm):

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -179,8 +179,30 @@
           </div>
         </div>
         {% endif %}
+        <div class="card mb-4">
+          <div class="card-header">
+            Reject with a template.
+          </div>
+          <div class="card-body">
+            <form action="" method="post" class="form-signin">
+              {% csrf_token %}
+              {% include "form_snippet.html" with form=reject_credential_form %}
+              <button class="btn btn-primary btn-lg" name="reject_template" value="{{app_user.id}}" type="submit">Reject</button>
+            </form>
+          </div>
+        </div>
+        {% if modal_id == "reject-template-modal" %}
+          {% include "console/email_modal.html" with form=form app_user=app_user modal_id=modal_id modal_title=modal_title submit_name=submit_name submit_value=submit_value submit_text=submit_text %}
+        {% endif %}
       </div>
   </div>
 </div>
 
+{% if modal_id == "reject-template-modal" %}
+  <script>
+    $(document).ready(function(){
+      $("#{{modal_id}}").modal('show');
+    });
+  </script>
+{% endif %}
 {% endblock %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -14,7 +14,24 @@ from django.utils import timezone
 from project.models import DataAccessRequest, License
 
 RESPONSE_ACTIONS = {0:'rejected', 1:'accepted'}
-
+RESPONSE_COMMENTS = {
+    15: 'It looks like you did not complete the correct CITI course. The correct course is "Data or Specimens Only Research". Please resubmit with the correct information.',
+    14: 'You submitted the CITI Certificate instead of the Completion Report (it should include a list of courses and scores). Please resubmit with the correct report.',
+    13: 'The HIPAA module is missing from your CITI completion report.',
+    12: 'Please retake the CITI course paying particular attention to the section on HIPAA Privacy Protections.',
+    11: 'The email on your CITI report does not match your application email. You can not share CITI training reports.',
+    10: 'Access is provided to individuals. Your research summary suggests that data may be shared within the group. Please resubmit your application, making it clear that the Data Use Agreement will be followed. If your colleagues plan to access the data, then they will need to apply for access independently.',
+    9: 'Some of the information on your application does not make sense. Please resubmit with the correct information.',
+    8: 'We cannot identify you or your reference in our web search. Can you resubmit and provide references to your publications, personal webpage, or associations with known organizations?',
+    7: 'You list your research category as Industry Researcher but did not list an institution. Please update your institution or if you are not associated with an institution or select Independent Researcher as your research category.',
+    6: 'You listed yourself as a Hospital Researcher but did not list an institution. Please resubmit with the correct information.',
+    5: 'You listed yourself as a Student but did not list an institution. Please resubmit with the correct information.',
+    4: '"Massachusetts Institute of Technology Affiliates" should not be listed as your institution. This is for the CITI course step only. Please resubmit with the correct information.',
+    3: 'The name for your reference does not seem correct. Please resubmit with the correct information.',
+    2: 'You listed yourself as a reference. Please resubmit with another valid reference.',
+    1: 'The email address listed for your reference is not active (emails sent to this address are undelivered).',
+    0: ''
+}
 
 def mailto_url(*recipients, **params):
     """
@@ -631,23 +648,36 @@ def mailto_administrators(project, error):
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
               [settings.CONTACT_EMAIL], fail_silently=False)
 
-def process_credential_complete(request, application, comments=True):
+def process_credential_complete(request, application, send=True, comments=True,
+                                response_choice=-1, subject='', body=''):
     """
     Notify user of credentialing decision
     """
     applicant_name = application.get_full_name()
     response = 'rejected' if application.status == 1 else 'accepted'
-    subject = 'Your application for PhysioNet credentialing'
-    body = loader.render_to_string(
-        'notification/email/process_credential_complete.html', {
-            'application': application,
-            'applicant_name': applicant_name,
-            'domain': get_current_site(request),
-            'url_prefix': get_url_prefix(request),
-            'comments': comments,
-            'signature': email_signature(),
-            'footer': email_footer()
-        })
+    if not subject:
+        subject = 'Your application for PhysioNet credentialing'
+    if (comments == True) and (response_choice >= 0):
+        response = 'rejected'
+        application.status = 1
+        application.responder_comments = RESPONSE_COMMENTS[response_choice]
+        application.save()
+
+    if not body:
+        body = loader.render_to_string(
+            'notification/email/process_credential_complete.html', {
+                'application': application,
+                'applicant_name': applicant_name,
+                'domain': get_current_site(request),
+                'url_prefix': get_url_prefix(request),
+                'comments': comments,
+                'signature': email_signature(),
+                'footer': email_footer()
+            })
+
+    if (comments == True) and (response_choice >= 0) and (not send):
+        application.status = 0
+        application.save()
 
     message = EmailMessage(
         subject=subject,
@@ -656,7 +686,11 @@ def process_credential_complete(request, application, comments=True):
         to=[application.user.email],
         bcc=[settings.CREDENTIAL_EMAIL]
         )
-    message.send(fail_silently=False)
+
+    if send:
+        message.send(fail_silently=False)
+
+    return {'subject': subject, 'body': body}
 
 def credential_application_request(request, application):
     """


### PR DESCRIPTION
This change adds the option to reject a credential application during the review stage via a template. The options I have included can be seen in the screenshot here:
![Screen Shot 2021-02-11 at 2 47 23 PM](https://user-images.githubusercontent.com/39505798/107771830-5dc11400-6d09-11eb-8e23-6cfa6cba0376.png)
Once an option is chosen, one of the following comments gets added to the email as the responder comments to be sent to the applicant:
```
1. Inconsistent information: 
	Some of the information on your application does not make sense.
        Please resubmit with the correct information.
2. Incorrect CITI course / wrong PDF:
	It looks like you did not complete the correct CITI course. The correct
        course is "Data or Specimens Only Research". Please resubmit with
        the correct information.
3. CITI Certificate:
	You submitted the CITI Certificate instead of the Completion
        Report (it should include a list of courses and scores). Please
        resubmit with the correct report.
4. No HIPAA section:
	The HIPAA module is missing from your CITI completion report.
5. Failed HIPAA section:
	Please retake the CITI course paying particular attention to the
        section on HIPAA Privacy Protections.
6. Inconsistent CITI report email:
	The email on your CITI report does not match your application
        email. You can not share CITI training reports.
7. Industry Researcher without institution:
	You list your research category as Industry Researcher but did
        not list an institution. Please update your institution or if you are
        not associated with an institution or select Independent Researcher
        as your research category.
8. Hospital Researcher without institution:
	You listed yourself as a Hospital Researcher but did not list an
        institution. Please resubmit with the correct information.
9. Student without institution:
	You listed yourself as a Student but did not list an institution.
        Please resubmit with the correct information.
10. MIT Affiliates as institution:
	"Massachusetts Institute of Technology Affiliates" should not
        be listed as your institution. This is for the CITI course step only.
        Please resubmit with the correct information.
11. Incorrect reference name:
	The name for your reference does not seem correct. Please
        resubmit with the correct information.
12. Listed self as reference:
	You listed yourself as a reference. Please resubmit with
        another valid reference.
13. Inactive reference email:
	The email address listed for your reference is not
        active (emails sent to this address are undelivered).
14. Can not verify identity:
	We cannot identify you or your reference in our web search. Can
        you resubmit and provide references to your publications, personal
        webpage, or associations with known organizations?
15. DUA violation:
	Access is provided to individuals. Your research summary suggests
        that data may be shared within the group. Please resubmit your
        application, making it clear that the Data Use Agreement will be followed. If
        your colleagues plan to access the data, then they will need to apply for
        access independently.
16. Other:
	""
```
For this change, the current process is not changed, this is just a feature for the reviewers who prefer it.