### PR TITLE
Display ORCID in the profile information used for credentialing

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -1,4 +1,5 @@
 {# Status section #}
+{% load static %}
 
 <p>Username: <a href="{% url 'user_management' application.user.username %}">{{ application.user.username }}</a></br>
 Applied: {{ application.application_datetime|date }}</br>
@@ -29,6 +30,11 @@ Applied: {{ application.application_datetime|date }}</br>
   <li>Email: <mark>{{ application.user.email }}</mark></li>
   <li>Position: <mark>{{ application.job_title }}</mark></li>
   <li>Research category: <mark>{{ application.get_researcher_category_display }}</mark></li>
+  <li>ORCID: <mark>
+    {% if application.user.orcid %}<img src='{% static "images/ORCIDiD_icon24x24.png" %}' />
+      <a href="{{ application.user.orcid.get_orcid_url }}/{{ application.user.orcid.orcid_id }}" rel="noopener">{{ application.user.orcid.get_orcid_url }}/{{ application.user.orcid.orcid_id }}</a>
+    {% else %}No ORCID iD linked{% endif %}
+  </mark></li>
 </ul>
 
 <h5>Location</h5>

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -9759,6 +9759,22 @@
   }
 },
 {
+  "model": "user.orcid",
+  "pk": 1,
+  "fields": {
+    "user": [
+      "george"
+    ],
+    "orcid_id": "12345",
+    "name": "",
+    "access_token": "",
+    "refresh_token": "",
+    "token_type": "",
+    "token_scope": "",
+    "token_expiration": "0E-40"
+  }
+},
+{
   "model": "user.credentialapplication",
   "pk": 1,
   "fields": {


### PR DESCRIPTION
ORCIDs can now be added to user profiles (thanks @briangow!). This is a minor change to display the ORCID in the credentialing workflow on the profile page for the applicant. An ORCID is also added to the demo fixture for user "george".

To view the change, go to http://localhost:8000/console/credential_processing/ and then click "process" for an application.

Example of a linked ORCID:

![Screen Shot 2021-02-18 at 16 01 21](https://user-images.githubusercontent.com/822601/108422434-87e06d80-7204-11eb-92c3-02e44561a160.png)

Example if an ORCID is not linked:

![Screen Shot 2021-02-18 at 16 01 42](https://user-images.githubusercontent.com/822601/108422459-929b0280-7204-11eb-9a94-a3efa4aca772.png)

