### PR TITLE
Clarify expected timeline for credentialing applications in email to applicant

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_credential_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_credential_request.html
@@ -5,7 +5,7 @@ Thank you for submitting your data use agreement. If it is approved, you will be
 
 Below is a copy of the agreement you submitted. Please review it for accuracy, looking especially for inaccuracies caused by browser auto-fill.
 
-It may take a week or longer to process your request. Thank you for your understanding and patience.
+It may take several weeks to process your request. Thank you for your understanding and patience.
 
 {{ signature }}
 


### PR DESCRIPTION
When someone applies for credentialed access, they receive an email that contains the following text:

> It may take a week or longer to process your request. Thank you for your understanding and patience.

Currently applications generally take several weeks to process, so this change modifies the text to manage expectations:

> It may take several weeks to process your request. Thank you for your understanding and patience.