### PR TITLE
Fix server error raised when anonymous users attempt to view project history

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1322,7 +1322,7 @@ def published_submission_history(request, project_slug, version):
         if not user.is_admin:
             raise Http404()
         project = get_object_or_404(PublishedProject, slug=project_slug,
-                                    archive_reason=3)
+                                    version=version)
 
     edit_logs = project.edit_log_history()
     for e in edit_logs:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1272,10 +1272,11 @@ def rejected_submission_history(request, project_slug):
                                               archive_reason=3,
                                               authors__user=user)
     except ArchivedProject.DoesNotExist:
-        if not user.is_admin:
+        if user.is_admin:
+            project = get_object_or_404(ArchivedProject, slug=project_slug,
+                                        archive_reason=3)
+        else:
             raise Http404()
-        project = get_object_or_404(ArchivedProject, slug=project_slug,
-                                    archive_reason=3)
 
     edit_logs = project.edit_log_history()
     for e in edit_logs:
@@ -1319,10 +1320,11 @@ def published_submission_history(request, project_slug, version):
                                                version=version,
                                                authors__user=user)
     except PublishedProject.DoesNotExist:
-        if not user.is_admin:
+        if user.is_admin:
+            project = get_object_or_404(PublishedProject, slug=project_slug,
+                                        version=version)
+        else:
             raise Http404()
-        project = get_object_or_404(PublishedProject, slug=project_slug,
-                                    version=version)
 
     edit_logs = project.edit_log_history()
     for e in edit_logs:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1260,6 +1260,7 @@ def project_submission(request, project_slug, **kwargs):
         'awaiting_user_approval':awaiting_user_approval})
 
 
+@login_required
 def rejected_submission_history(request, project_slug):
     """
     Submission history for a rejected project
@@ -1302,6 +1303,7 @@ def published_versions(request, project_slug):
          'current_site':get_current_site(request)})
 
 
+@login_required
 def published_submission_history(request, project_slug, version):
     """
     Submission history for a published project


### PR DESCRIPTION
If an anonymous user (i.e. a user who is not logged in) attempts to view the history of a project, a server error is raised. For example, clicking one of the following links as an anonymous user will raise a server error:

http://localhost:8000/projects/published/demowave/1.0.0/submission-history/
http://localhost:8000/projects/rejected/demopsnm/submission-history/

This change redirects the user to the login page if they attempt to view the history. If the user does not have permission to view the page after logging in, they will receive a 404.