### PR TITLE
Add request for users to link to ORCID before completing a credentialing application if they have an iD.

### DIFF
--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -17,6 +17,7 @@
   <p>Please use the form below to apply for PhysioNet credentialing. In order to apply:</p>
   <ul>
     <li>Complete the CITI Program in "Data or Specimens Only Research", an online course that covers ethics of human research and patient privacy. Instructions are provided <a href="{% url 'citi_course' %}">here</a>.</li>
+    <li>If you have an ORCID iD please link to it in your settings (<a href="{% url 'edit_orcid' %}">ORCID settings</a>) as this may help us expedite your application by making it easier to verify your identity.</li>
     <li>Check the form carefully before submission. <strong>Incomplete or erroneous applications will be rejected.</strong></li>
   </ul>
 


### PR DESCRIPTION
When a user is about to fill out a credentialing application we want to suggest that if they have an ORCID iD that they should link to it since this may help to expedite their application.  