### PR TITLE
Update editorial guidelines with advice on weblinks

### DIFF
--- a/physionet-django/templates/about/author_guidelines.html
+++ b/physionet-django/templates/about/author_guidelines.html
@@ -27,6 +27,7 @@
     <li><strong>Conflicts of interest</strong>: A statement on potential conflicts of interest is required. If the authors have no conflicts of interest, the section should say "The author(s) have no conflicts of interest to declare".</li>
     <li><strong>Version</strong>: The version number of the resource. <a href="https://semver.org/">Semantic versioning</a> is encouraged (major version, minor version, patch version). If unsure, put "1.0.0".</li>
     <li><strong>References</strong>: Please use the <a href="https://en.wikipedia.org/wiki/Vancouver_system">Vancouver reference style</a>. All citations should be numbered sequentially in the text in square brackets. For example, the first citation [1], the second citation [2], and the third and fourth citations [3,4]. Entries in the reference list should be in the following style: <em>1. Xu YZ, Geng DC, Mao HQ, Zhu XS, Yang HL (2010). "A comparison of the proximal femoral nail antirotation device and dynamic hip screw in the treatment of unstable pertrochanteric fracture". J Int Med Res. 38: 1266–1275. PMID 20925999.</em></li>
+    <li><strong>Weblinks</strong>: Please do not include URLs/weblinks/hyperlinks in the main text. All external resources (including websites, publications, datasets, and GitHub repositories) should be added to the References section and cited in the main text in the style [1], [2-4].</li>
   </ul>
 </section>
 


### PR DESCRIPTION
This is a minor change to add a new bullet to the author guidelines at: https://physionet.org/about/publish/#guidelines with guidance on weblinks/URLs (requested by @li-lcp).

The bullet says:

> Please do not include URLs/weblinks/hyperlinks in the main text. All external resources (including websites, publications, datasets, and GitHub repositories) should be added to the References section and cited in the main text in the style [1], [2-4].

There are several benefits of keeping weblinks in the references section:
- allows us to adopt an approach like webcite to support persistent links 
-  helps us move towards consistent use of 'accessed on [date]' for links
-  helps to keep descriptions clean, readable, and free of broken links