### PR TITLE
Display ORCID for credentialing references, if available

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -66,12 +66,12 @@ Applied: {{ application.application_datetime|date }}</br>
   <li>Organization: <mark>{{ application.reference_organization }}</mark></li>
   <li>Position: <mark>{{ application.reference_title }}</mark></li>
   <li>Relationship: <mark>{{ application.get_reference_category_display }}</mark></li>
-  {% if known_active %}
+  {% if application.ref_user_flag %}
     <li><mark>Active User?: Yes</mark></li>
   {% else %}
     <li><mark>Active User?: No</mark></li>
   {% endif %}
-  {% if known_cred %}
+  {% if application.ref_credentialed_flag %}
     <li><mark>Credentialed User?: Yes</mark></li>
   {% else %}
     <li><mark>Credentialed User?: No</mark></li>

--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -76,6 +76,11 @@ Applied: {{ application.application_datetime|date }}</br>
   {% else %}
     <li><mark>Credentialed User?: No</mark></li>
   {% endif %}
+  <li>ORCID: <mark>
+    {% if application.get_reference_user.orcid %}<img src='{% static "images/ORCIDiD_icon24x24.png" %}' />
+      <a href="{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}" rel="noopener">{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}</a>
+    {% else %}No ORCID iD linked{% endif %}
+  </mark></li>
 </ul>
 
 <h5>Research</h5>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1146,15 +1146,6 @@ def process_credential_application(request, application_slug):
                                                send=False,  wordwrap=False)
     contact_cred_ref_form = forms.ContactCredentialRefForm(initial=ref_email)
 
-    try:
-        ref = User.objects.get(associated_emails__email__iexact=application.reference_email,
-                               associated_emails__is_verified=True)
-        known_active = True
-        known_cred = ref.is_credentialed
-    except ObjectDoesNotExist:
-        known_active = False
-        known_cred = False
-
     page_title = None
     title_dict = {a: k for a, k in CredentialReview.REVIEW_STATUS_LABELS}
     page_title = title_dict[application.credential_review.status]
@@ -1361,8 +1352,7 @@ def process_credential_application(request, application_slug):
          'intermediate_credential_form': intermediate_credential_form,
          'process_credential_form': process_credential_form,
          'processing_credentials_nav': True, 'page_title': page_title,
-         'contact_cred_ref_form': contact_cred_ref_form,
-         'known_active': known_active, 'known_cred': known_cred})
+         'contact_cred_ref_form': contact_cred_ref_form})
 
 
 @login_required

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -857,6 +857,19 @@ class CredentialApplication(models.Model):
         except ObjectDoesNotExist:
             return False
 
+    def get_reference_user(self):
+        """
+        Returns reference User if the reference is a registered user,
+        else None.
+        """
+        try:
+            ref = User.objects.get(
+                    associated_emails__email__iexact=self.reference_email,
+                    associated_emails__is_verified=True)
+            return ref
+        except ObjectDoesNotExist:
+            return None
+
     def ref_credentialed_flag(self):
         """
         Returns True if the reference is a credentialed registered user,

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -8,7 +8,7 @@ from django.contrib import messages
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 # from django.contrib.auth. import user_logged_in
 from django.contrib.auth import get_user_model, signals
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import models, DatabaseError, transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -843,6 +843,31 @@ class CredentialApplication(models.Model):
             reference_email=''):
             return True
         else:
+            return False
+
+    def ref_user_flag(self):
+        """
+        Returns True if the reference is a registered user, else False.
+        """
+        try:
+            ref = User.objects.get(
+                    associated_emails__email__iexact=self.reference_email,
+                    associated_emails__is_verified=True)
+            return True
+        except ObjectDoesNotExist:
+            return False
+
+    def ref_credentialed_flag(self):
+        """
+        Returns True if the reference is a credentialed registered user,
+        else False.
+        """
+        try:
+            ref = User.objects.get(
+                    associated_emails__email__iexact=self.reference_email,
+                    associated_emails__is_verified=True)
+            return ref.is_credentialed
+        except ObjectDoesNotExist:
             return False
 
     def revoke(self):


### PR DESCRIPTION
When reviewing applications for credentialed access, it is helpful to know if the reference has an associated ORCID. This pull request:

1) Adds three methods to the `CredentialReview` model: (a) `ref_user_flag` which can be used to determine if the reference is a registered user (b) `ref_credentialed_flag` which can be used to determine if the reference is credentialed and (c) `get_reference_user` which can be used to retrieve the user object for the reference.

2) Displays an ORCID in the "Reference" section of credentialing applications if an ORCID is linked to the reference's user profile.

![Screen Shot 2021-02-23 at 17 58 59](https://user-images.githubusercontent.com/822601/108919327-d1fc9100-7600-11eb-8af3-362bec7f77fc.png)

I'll follow up with another pull request with a minor clean up to the formatting for the chunk displayed in the screenshot above.