### PR TITLE
Formatting changes to the application information in the credentialing workflow

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -2,8 +2,7 @@
 {% load static %}
 
 <p>Username: <a href="{% url 'user_management' application.user.username %}">{{ application.user.username }}</a></br>
-Applied: {{ application.application_datetime|date }}</br>
-[<a href="https://www.google.com/search?q={{ application.first_names }} {{ application.last_name }} {{ application.organization_name }}" target="_blank">Search for name and affiliation.</a>]</p>
+Applied: {{ application.application_datetime|date }}</p>
 
 {% if application.reference_contact_datetime %}
   Reference contact date: {{ application.reference_contact_datetime|date }}<br />
@@ -22,7 +21,7 @@ Applied: {{ application.application_datetime|date }}</br>
 {% endif %}
 
 <h5>Personal</h5>
-
+<p>[<a href="https://www.google.com/search?q={{ application.first_names }} {{ application.last_name }} {{ application.organization_name }}" target="_blank">Search for name and affiliation.</a>]</p>
 <ul>
   <li>First name: <mark>{{ application.first_names }}</mark></mark></li>
   <li>Last name: <mark>{{ application.last_name }}</mark></li>
@@ -60,7 +59,7 @@ Applied: {{ application.application_datetime|date }}</br>
 <h5>Reference</h5>
 
 {% if application.reference_email %}
-  [<a href="https://www.google.com/search?q={{ application.reference_name }} {{ application.reference_email }}" target="_blank">Search for reference name and email.</a>]</p>
+  <p>[<a href="https://www.google.com/search?q={{ application.reference_name }} {{ application.reference_email }}" target="_blank">Search for reference name and email.</a>]</p>
   <ul>
     <li>Name: <mark>{{ application.reference_name }}</mark></li>
     <li>Email: <mark>{{ application.reference_email }}</mark></li>

--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -59,21 +59,25 @@ Applied: {{ application.application_datetime|date }}</br>
 
 <h5>Reference</h5>
 
-[<a href="https://www.google.com/search?q={{ application.reference_name }} {{ application.reference_email }}" target="_blank">Search for reference name and email.</a>]</p>
-<ul>
-  <li>Name: <mark>{{ application.reference_name }}</mark></li>
-  <li>Email: <mark>{{ application.reference_email }}</mark></li>
-  <li>Organization: <mark>{{ application.reference_organization }}</mark></li>
-  <li>Position: <mark>{{ application.reference_title }}</mark></li>
-  <li>Relationship: <mark>{{ application.get_reference_category_display }}</mark></li>
-  <li>Active User: <mark>{{ application.ref_user_flag|yesno:"Yes,No" }}</mark></li>
-  <li>Credentialed User: <mark>{{ application.ref_credentialed_flag|yesno:"Yes,No" }}</mark></li>
-  <li>ORCID: <mark>
-    {% if application.get_reference_user.orcid %}<img src='{% static "images/ORCIDiD_icon24x24.png" %}' />
-      <a href="{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}" rel="noopener">{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}</a>
-    {% else %}No ORCID iD linked{% endif %}
-  </mark></li>
-</ul>
+{% if application.reference_email %}
+  [<a href="https://www.google.com/search?q={{ application.reference_name }} {{ application.reference_email }}" target="_blank">Search for reference name and email.</a>]</p>
+  <ul>
+    <li>Name: <mark>{{ application.reference_name }}</mark></li>
+    <li>Email: <mark>{{ application.reference_email }}</mark></li>
+    <li>Organization: <mark>{{ application.reference_organization }}</mark></li>
+    <li>Position: <mark>{{ application.reference_title }}</mark></li>
+    <li>Relationship: <mark>{{ application.get_reference_category_display }}</mark></li>
+    <li>Active User: <mark>{{ application.ref_user_flag|yesno:"Yes,No" }}</mark></li>
+    <li>Credentialed User: <mark>{{ application.ref_credentialed_flag|yesno:"Yes,No" }}</mark></li>
+    <li>ORCID: <mark>
+      {% if application.get_reference_user.orcid %}<img src='{% static "images/ORCIDiD_icon24x24.png" %}' />
+        <a href="{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}" rel="noopener">{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}</a>
+      {% else %}No ORCID iD linked{% endif %}
+    </mark></li>
+  </ul>
+{% else %}
+<ul><li>No reference provided</li></ul>
+{% endif %}
 
 <h5>Research</h5>
 

--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -66,16 +66,8 @@ Applied: {{ application.application_datetime|date }}</br>
   <li>Organization: <mark>{{ application.reference_organization }}</mark></li>
   <li>Position: <mark>{{ application.reference_title }}</mark></li>
   <li>Relationship: <mark>{{ application.get_reference_category_display }}</mark></li>
-  {% if application.ref_user_flag %}
-    <li><mark>Active User?: Yes</mark></li>
-  {% else %}
-    <li><mark>Active User?: No</mark></li>
-  {% endif %}
-  {% if application.ref_credentialed_flag %}
-    <li><mark>Credentialed User?: Yes</mark></li>
-  {% else %}
-    <li><mark>Credentialed User?: No</mark></li>
-  {% endif %}
+  <li>Active User: <mark>{{ application.ref_user_flag|yesno:"Yes,No" }}</mark></li>
+  <li>Credentialed User: <mark>{{ application.ref_credentialed_flag|yesno:"Yes,No" }}</mark></li>
   <li>ORCID: <mark>
     {% if application.get_reference_user.orcid %}<img src='{% static "images/ORCIDiD_icon24x24.png" %}' />
       <a href="{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}" rel="noopener">{{ application.get_reference_user.orcid.get_orcid_url }}/{{ application.get_reference_user.orcid.orcid_id }}</a>


### PR DESCRIPTION
Follows up on https://github.com/MIT-LCP/physionet-build/pull/1273 with a few minor formatting changes to the application information that is displayed in the credentialing workflow:

1. Fixes the text highlighting for "Active User" and "Credentialed User", so that only the status is highlighted rather than the whole line.

![Screen Shot 2021-02-23 at 19 57 43](https://user-images.githubusercontent.com/822601/108929091-67a01c80-7611-11eb-8e8d-8c04815e7cb2.png)

2. Only displays reference information if a reference is provided (otherwise displays "No reference provided")

![Screen Shot 2021-02-23 at 19 53 19](https://user-images.githubusercontent.com/822601/108929036-4d663e80-7611-11eb-9fe6-cc40bf95cbcc.png)

3. Moves the "[Search for name and affiliation]" link to the "Profile" section for consistency with the Reference section.

![Screen Shot 2021-02-23 at 19 58 02](https://user-images.githubusercontent.com/822601/108929117-72f34800-7611-11eb-8b0a-47e10e56e973.png)

