### PR TITLE
Credentialing application form: Recommendations for a timely review

### DIFF
--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -11,16 +11,23 @@
 {% block content %}
 <div class="container">
   {% include "message_snippet.html" %}
-  <h1>PhysioNet Credentialing Application</h1>
+  <h1>Application for Credentialed Access</h1>
   <hr>
 
   <p>Please use the form below to apply for PhysioNet credentialing. In order to apply:</p>
   <ul>
     <li>Complete the CITI Program in "Data or Specimens Only Research", an online course that covers ethics of human research and patient privacy. Instructions are provided <a href="{% url 'citi_course' %}">here</a>.</li>
     <li>If you have an ORCID iD please link to it in your settings (<a href="{% url 'edit_orcid' %}">ORCID settings</a>) as this may help us expedite your application by making it easier to verify your identity.</li>
-    <li>Check the form carefully before submission. <strong>Incomplete or erroneous applications will be rejected.</strong></li>
   </ul>
 
+  <h2>Recommendations for a timely review</h2>
+  <hr>
+  <p>The following steps will help to ensure a timely review of your application:</p>
+  <ul>
+    <li>Listing a reference is always helpful. Remember to prompt your reference to expect an email about your application.</li>
+    <li>It is also helpful if your reference is a registered user and they have linked their ORCID iD to their profile. Please provide the email associated with their account.</li>
+    <li>Check the form carefully before submission. <strong>Incomplete or erroneous applications will be rejected.</strong></li>
+  </ul>
   <p>Required fields are indicated by a red asterisk (<a style="color:red">*</a>).</p>
 
   <hr>


### PR DESCRIPTION
Follows previous changes to display ORCID IDs for references as well as applicants (ref https://github.com/MIT-LCP/physionet-build/pull/1274) in the credentialing workflow. 

This pull request tweaks the text on the application form (http://localhost:8000/credential-application/), adding "Recommendations for a timely review". One of the points is that it is helpful if the reference is registered and they have linked their ORCID ID.