### PR TITLE
Display all verified email addresses in the credentialing workflow. Ref #1276

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -1,5 +1,6 @@
 {# Status section #}
 {% load static %}
+{% load console_templatetags %}
 
 <p>Username: <a href="{% url 'user_management' application.user.username %}">{{ application.user.username }}</a></br>
 Applied: {{ application.application_datetime|date }}</p>
@@ -26,7 +27,15 @@ Applied: {{ application.application_datetime|date }}</p>
   <li>First name: <mark>{{ application.first_names }}</mark></mark></li>
   <li>Last name: <mark>{{ application.last_name }}</mark></li>
   {% if application.suffix %}<li>Suffix: {{ application.suffix }}</mark></li>{% endif %}
-  <li>Email: <mark>{{ application.user.email }}</mark></li>
+  <li>Email (primary): <mark>{{ application.user.email }}</mark></li>
+  <li>Emails (other): 
+    {% with associated_emails=application.user|get_verified_emails %}
+    {% for email in associated_emails %}
+      <mark>{{ email }}</mark>{% if not forloop.last %}, {% endif %}
+    {% empty %}N/A
+    {% endfor %}
+    {% endwith %}
+  </li>
   <li>Position: <mark>{{ application.job_title }}</mark></li>
   <li>Research category: <mark>{{ application.get_researcher_category_display }}</mark></li>
   <li>ORCID: <mark>

--- a/physionet-django/console/templatetags/console_templatetags.py
+++ b/physionet-django/console/templatetags/console_templatetags.py
@@ -17,3 +17,11 @@ def task_count_badge(item):
         context_class = 'success'
     return '<span class="badge badge-pill badge-{}">{}</span>'.format(
         context_class, len(item))
+
+
+@register.filter(name='get_verified_emails')
+def get_verified_emails(user):
+    """
+    Get a list of non-primary, verified email addresses.
+    """
+    return user.get_emails(is_verified=True, include_primary=False)

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -372,9 +372,21 @@ class User(AbstractBaseUser):
         return self.is_admin
 
     # Custom fields and methods
-    def get_emails(self):
-        "Get list of all email strings"
-        return [ae.email for ae in self.associated_emails.filter(is_verified=True)]
+    def get_emails(self, is_verified=True, include_primary=True):
+        """
+        Get list of email address strings.
+
+        Args:
+            is_verified (bool): If True, return verified email addresses only.
+            include_primary (bool): If True, include the primary email address
+                in the list.
+        """
+        if include_primary:
+            emails = self.associated_emails.filter(is_verified=is_verified)
+        else:
+            emails = self.associated_emails.filter(is_verified=is_verified,
+                                                   is_primary_email=False)
+        return [ae.email for ae in emails]
 
     def get_primary_email(self):
         """


### PR DESCRIPTION
This pull request addresses #1276 by displaying all user email addresses in the credentialing workflow. An application from a user with multiple verified email addresses will now look like this:

![Screen Shot 2021-02-25 at 13 40 40](https://user-images.githubusercontent.com/822601/109201041-52d99b00-776f-11eb-9cca-298bdb59cd58.png)
