### PR TITLE
Changes wording of credentialing application details

### DIFF
--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -57,7 +57,7 @@
     <p>By submitting this form, you agree to the terms and conditions below.</p>
     <hr>
     <p>The contents of restricted-access clinical databases maintained by PhysioNet were derived from original data that contained protected health information (PHI), as defined by <a href="http://www.hhs.gov/ocr/hipaa/" target="other">HIPAA</a>. The providers of the data have given scrupulous attention to the task of locating and removing all PHI, so that the remaining data can be considered <a href="http://privacyruleandresearch.nih.gov/pr_08.asp#8a" target="other">de-identified</a> and therefore not subject to the HIPAA Privacy Rule restrictions on sharing PHI. Nevertheless, because of the richness and detail of the databases, the data will be released only to legitimate researchers under the terms and conditions described on this page.</p>
-    <p>Use this form to submit a data use agreement and request access to restricted-access clinical databases hosted on PhysioNet. Please be sure to provide all requested information. <em>Submissions that are clearly incomplete, incorrect, or frivolous may be discarded without notice.</em></p>
+    <p>Use this form to submit a data use agreement and request access to restricted-access clinical databases hosted on PhysioNet. Please be sure to provide all requested information. <em>Submissions that are clearly incomplete, incorrect, or frivolous will be rejected.</em></p>
     <p><em>If you agree to all of these terms and conditions, access to restricted information within PhysioNet clinical databases may be granted to you <strong>as an individual</strong>. Your colleagues may obtain access to these data as individuals via the same procedure.</em></p>
 
     <div class="card mb-4">


### PR DESCRIPTION
This change modifies the wording given to credential applicants at the time of application completion. The current wording indicates that some applications may be discarded without notice, but this is not currently true since applications should either be accepted or rejected and in both cases they will receive a notification email.