### PR TITLE
Fix sorting issue on KP's custom credentialing page

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1073,12 +1073,12 @@ def complete_credential_applications(request):
     # 1. reference not contacted, but with reference known
     known_ref_no_contact = applications.filter(
         reference_contact_datetime__isnull=True,
-        reference_email__in=known_refs).order_by('application_datetime')
+        reference_email__lower__in=known_refs).order_by('application_datetime')
 
     # 2. reference not contacted, but with reference unknown
     unknown_ref_no_contact = applications.filter(
         reference_contact_datetime__isnull=True).exclude(
-        reference_email__in=known_refs).order_by('application_datetime')
+        reference_email__lower__in=known_refs).order_by('application_datetime')
 
     # 3. reference contacted
     contacted = applications.filter(

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1076,11 +1076,9 @@ def complete_credential_applications(request):
         reference_email__in=known_refs).order_by('application_datetime')
 
     # 2. reference not contacted, but with reference unknown
-    unknown_refs = [x.reference_email for x in applications
-                    if x.reference_email not in known_refs]
     unknown_ref_no_contact = applications.filter(
-        reference_contact_datetime__isnull=True,
-        reference_email__in=unknown_refs).order_by('application_datetime')
+        reference_contact_datetime__isnull=True).exclude(
+        reference_email__in=known_refs).order_by('application_datetime')
 
     # 3. reference contacted
     contacted = applications.filter(

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -12,6 +12,8 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import models, DatabaseError, transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.db.models import CharField
+from django.db.models.functions import Lower
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 from django.core.validators import (EmailValidator, validate_integer,
@@ -21,6 +23,9 @@ from django.utils.translation import ugettext as _
 from user import validators
 
 logger = logging.getLogger(__name__)
+
+# Support the LOWER() keyword in querysets (e.g. 'Q(email__lower__in)')
+CharField.register_lookup(Lower, "lower")
 
 COUNTRIES = (
     ("AF", _("Afghanistan")),


### PR DESCRIPTION
Credentialing applications on KP's custom page (http://localhost:8000/console/complete-credential-applications/) are intended to be ordered in the following subgroups:

1. reference not contacted and reference is known
2. reference not contacted and reference is unknown
3. reference contacted

Some applications that were expected to appear in group 1 would actually appear in group 2 because the queryset used a case sensitive search. See the staging server for some examples.

The "Reference is known" label that is displayed in the template is independent of the queryset and it was already generated using a case insensitive check, which sometimes led to a mismatch between the "Reference is known" label and the group (1-3) in which the application appeared.

There is no case insensitive "in" keyword available in Django querysets. Instead, I registered a new lookup keyword ("LOWER") and make a lower case comparison. I have tested this change on the staging server.




