### PR TITLE
Allow img tags in CKEditor. Ref #183

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -352,6 +352,7 @@ CKEDITOR_CONFIGS = {
             'h4': True,
             'h5': True,
             'h6': True,
+            'img': {'attributes': ['src', 'alt', 'width', 'height']},
             '*': {'attributes': _generic_attributes,
                   'classes': _math_classes},
         },


### PR DESCRIPTION
This pull request relaxes the ckeditor config to allow the img tag to be used. This change is needed because the CinC challenge organisers have several projects that they would like update, and some of these projects include figures.

### Background

There are a few projects that contain figures (2 or 3 challenges, I believe). e.g.:

- https://physionet.org/content/challenge-2019/1.0.0/ 

CKEditor (the project content editor) does not currently allow img tags to be embedded in content, so adding the images was a bit hacky (and involved editing the HTML directly in the database).

We now need to allow the contributors to update the projects. This is an issue because CKEditor will strip the existing img tags in the new version.

A simple fix is to enable to img tags in CKEditor. This allows the user to upload figure images as files and then link to the images using an img tag. There are some limitations with this approach (see #183) but I think it is a reasonable temporary solution.

As discussed in #183, it would be good to come up with a clean way of handling figures in project content. This might involve installing the ckeditor plugin. e.g.:

- https://ckeditor.com/docs/ckeditor4/latest/examples/fileupload.html
- https://ckeditor.com/cke4/addon/uploadimage