### PR TITLE
Fixes large CSV viewing

### DIFF
--- a/physionet-django/project/templates/project/file_view.html
+++ b/physionet-django/project/templates/project/file_view.html
@@ -39,7 +39,7 @@
         </li>
       </ul>
     </div>
-    <div class="card-body">
+    <div class="card-body data-card">
       {% block file_content %}
       <div class="text-center">
         This file cannot be viewed in the browser.

--- a/physionet-django/project/templates/project/file_view_csv.html
+++ b/physionet-django/project/templates/project/file_view_csv.html
@@ -40,6 +40,10 @@
 
 {% block local_css %}
 <style>
+  .data-card {
+    overflow-x: auto;
+    max-height: 80vh;
+  }
   .data-table {
     margin: 0px;
     background-color: #fff;


### PR DESCRIPTION
Currently, large CSVs are rendered to cover the entire page even expanding past its parent's div's CSS width and height leading to very wide and long pages. This change fixes that by setting overflow behavior to scroll instead of expanding past the page.