### PR TITLE
Minor change to credentialing reference email to promote online responses.

### DIFF
--- a/physionet-django/notification/templates/notification/email/contact_reference.html
+++ b/physionet-django/notification/templates/notification/email/contact_reference.html
@@ -2,7 +2,7 @@
 
 {{ applicant_name }} has applied for access to protected data on PhysioNet and listed you as a reference. Are you familiar with {{ applicant_name }}'s research, and in your view would it be reasonable to grant this request?
 
-If you support their application, please indicate your approval using the link below or reply to this email. If you do not support their application, you may ignore this email or update us directly via the link.
+If you support their application, please indicate your approval using the link below. If you do not support their application, you may ignore this email or update us via the link.
 
 {{ url_prefix }}{% url 'credential_reference' application.slug %}
 


### PR DESCRIPTION
This is a minor change (suggested by RGM) to the text of the email that is sent to referees during the credentialing process. Currently we offer the option to respond online or via email. We aren't able to handle the large number of email responses, so this change encourages referees to respond via the online form.