### PR TITLE
Tweaks to the test VM setup script

### DIFF
--- a/deploy/test-server/kvm-pntest-create
+++ b/deploy/test-server/kvm-pntest-create
@@ -56,7 +56,7 @@ if ! qemu-system-x86_64 \
      $kvm_arg -smp 2 \
      -m 2000 \
      -vga vmware -device virtio-rng-pci \
-     -drive file=$IMAGE,cache=unsafe \
+     -drive file=$IMAGE,if=virtio,cache=unsafe \
      -cdrom $INSTALLER_IMAGE \
      -kernel $tdir/vmlinuz \
      -initrd $tdir/initrd ; then

--- a/deploy/test-server/kvm-pntest-create
+++ b/deploy/test-server/kvm-pntest-create
@@ -59,7 +59,7 @@ if ! qemu-system-x86_64 \
      -drive file=$IMAGE,if=virtio,cache=unsafe \
      -cdrom $INSTALLER_IMAGE \
      -kernel $tdir/vmlinuz \
-     -initrd $tdir/initrd ; then
+     -initrd $tdir/initrd "$@" ; then
     echo " *** Unable to launch qemu."
     rm -f $IMAGE
     exit 1


### PR DESCRIPTION
Recently, or maybe not so recently, there was an update to the grub package in Debian, and if you had an old physionet-test.img, then when trying to run `ssh-install-pn-test-server`, you would get:

```
/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001 does not exist, so cannot grub-install to it!
You must correct your GRUB install devices before proceeding:

  DEBIAN_FRONTEND=dialog dpkg --configure grub-pc
  dpkg --configure -a
dpkg: error processing package grub-pc (--configure):
 installed grub-pc package post-installation script subprocess returned error exit status 1
```

To fix this, you would need to rebuild the template using kvm-pntest-create, or else log in to the template and reconfigure grub with the correct device name.  To avoid this in the future, use `if=virtio` in kvm-pntest-create as well as in kvm-pntest.  Of course, it's a good idea anyway to re-run kvm-pntest-create now and again, so you don't have to upgrade lots of packages every time... :)

Secondarily, enable I-like-to-live-dangerously mode (`./kvm-pntest-create -display none`) to make it easier to install over SSH.
