### PR TITLE
Makes ORCID link open in new page

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -40,7 +40,7 @@ Applied: {{ application.application_datetime|date }}</p>
   <li>Research category: <mark>{{ application.get_researcher_category_display }}</mark></li>
   <li>ORCID: <mark>
     {% if application.user.orcid %}<img src='{% static "images/ORCIDiD_icon24x24.png" %}' />
-      <a href="{{ application.user.orcid.get_orcid_url }}/{{ application.user.orcid.orcid_id }}" rel="noopener">{{ application.user.orcid.get_orcid_url }}/{{ application.user.orcid.orcid_id }}</a>
+      <a href="{{ application.user.orcid.get_orcid_url }}/{{ application.user.orcid.orcid_id }}" rel="noopener" target="_blank">{{ application.user.orcid.get_orcid_url }}/{{ application.user.orcid.orcid_id }}</a>
     {% else %}No ORCID iD linked{% endif %}
   </mark></li>
 </ul>


### PR DESCRIPTION
This change makes the ORCID link in the credential applicant processing page open in a new tab. This is consistent with the other links and also prevents accidental exiting out of the PhysioNet session.