### PR TITLE
Tweaks reference response page to sort by verification status

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1386,7 +1386,8 @@ def credential_processing(request):
         credential_review__status=40).order_by('application_datetime')
     # Awaiting reference response
     response_applications = applications.filter(
-        credential_review__status=50).order_by('application_datetime')
+        credential_review__status=50).order_by('-reference_response',
+                                               'application_datetime')
     # Awaiting final review
     final_applications = applications.filter(
         credential_review__status=60).order_by('application_datetime')


### PR DESCRIPTION
This change tweaks the reference response step to sort by reference response verification status. Simply, applications where the reference has responded will be placed at the top. Currently, the applications are sorted by submission date, which is nice for the other stages, but we won't be passing on the applications in this stage without hearing from a reference so this kind of sort is nice.