### PR TITLE
Allows credential application reviewers to reset reviews #1248

### DIFF
--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -63,7 +63,11 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
-                <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
+                <td>
+                  <form action="{% url 'process_credential_application' application.slug %}">
+                    <input class="btn btn-success" type="submit" value="Process"/>
+                  </form>
+                </td>
               {% endwith %}
               </tr>
             {% endfor %}
@@ -113,7 +117,11 @@
                     <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
                   </form>
                 </td>
-                <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
+                <td>
+                  <form action="{% url 'process_credential_application' application.slug %}">
+                    <input class="btn btn-success" type="submit" value="Process"/>
+                  </form>
+                </td>
               {% endwith %}
               </tr>
             {% endfor %}
@@ -163,7 +171,11 @@
                     <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
                   </form>
                 </td>
-                <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
+                <td>
+                  <form action="{% url 'process_credential_application' application.slug %}">
+                    <input class="btn btn-success" type="submit" value="Process"/>
+                  </form>
+                </td>
               {% endwith %}
               </tr>
             {% endfor %}
@@ -213,7 +225,11 @@
                     <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
                   </form>
                 </td>
-                <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
+                <td>
+                  <form action="{% url 'process_credential_application' application.slug %}">
+                    <input class="btn btn-success" type="submit" value="Process"/>
+                  </form>
+                </td>
               {% endwith %}
               </tr>
             {% endfor %}
@@ -260,7 +276,11 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
-                <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
+                <td>
+                  <form action="{% url 'process_credential_application' application.slug %}">
+                    <input class="btn btn-success" type="submit" value="Process"/>
+                  </form>
+                </td>
               {% endwith %}
               </tr>
             {% endfor %}
@@ -307,7 +327,11 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
-                <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
+                <td>
+                  <form action="{% url 'process_credential_application' application.slug %}">
+                    <input class="btn btn-success" type="submit" value="Process"/>
+                  </form>
+                </td>
               {% endwith %}
               </tr>
             {% endfor %}

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -88,6 +88,7 @@
                 <th>Reference Email</th>
                 <th>Application</th>
                 <th class="table-elapsed">Time Elapsed</th>
+                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -106,6 +107,12 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
+                <td>
+                  <form action="" method="post">
+                    {% csrf_token %}
+                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
+                  </form>
+                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>
@@ -131,6 +138,7 @@
                 <th>Reference Email</th>
                 <th>Application</th>
                 <th class="table-elapsed">Time Elapsed</th>
+                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -149,6 +157,12 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
+                <td>
+                  <form action="" method="post">
+                    {% csrf_token %}
+                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
+                  </form>
+                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>
@@ -174,6 +188,7 @@
                 <th>Reference Email</th>
                 <th>Application</th>
                 <th class="table-elapsed">Time Elapsed</th>
+                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -192,6 +207,12 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
+                <td>
+                  <form action="" method="post">
+                    {% csrf_token %}
+                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
+                  </form>
+                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>
@@ -219,6 +240,7 @@
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
                 <th class="table-elapsed">Time Elapsed</th>
+                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -239,6 +261,12 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
+                <td>
+                  <form action="" method="post">
+                    {% csrf_token %}
+                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
+                  </form>
+                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>
@@ -266,6 +294,7 @@
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
                 <th class="table-elapsed">Time Elapsed</th>
+                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -286,6 +315,12 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
+                <td>
+                  <form action="" method="post">
+                    {% csrf_token %}
+                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
+                  </form>
+                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -240,7 +240,6 @@
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
                 <th class="table-elapsed">Time Elapsed</th>
-                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -261,12 +260,6 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
-                <td>
-                  <form action="" method="post">
-                    {% csrf_token %}
-                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
-                  </form>
-                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>
@@ -294,7 +287,6 @@
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
                 <th class="table-elapsed">Time Elapsed</th>
-                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -315,12 +307,6 @@
                 {% else %}
                   <td>{{ application.time_elapsed }} days</td>
                 {% endif %}
-                <td>
-                  <form action="" method="post">
-                    {% csrf_token %}
-                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
-                  </form>
-                </td>
                 <td><a href="{% url 'process_credential_application' application.slug %}">Process</a></td>
               {% endwith %}
               </tr>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1412,6 +1412,7 @@ def credential_processing(request):
             application.credential_review.delete()
             new_review = CredentialReview.objects.create(application=application)
             application.save()
+            messages.success(request, 'The application has been reset')
 
     return render(request, 'console/credential_processing.html',
         {'applications': applications,

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1403,6 +1403,16 @@ def credential_processing(request):
     final_applications = applications.filter(
         credential_review__status=60).order_by('application_datetime')
 
+    if request.method == 'POST':
+        if 'reset_application' in request.POST:
+            try:
+                application = CredentialApplication.objects.get(slug=request.POST['reset_application'])
+            except CredentialApplication.DoesNotExist:
+                raise Http404()
+            application.credential_review.delete()
+            application.reference_contact_datetime = None
+            application.save()
+
     return render(request, 'console/credential_processing.html',
         {'applications': applications,
         'initial_applications': initial_applications,

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1410,7 +1410,7 @@ def credential_processing(request):
             except CredentialApplication.DoesNotExist:
                 raise Http404()
             application.credential_review.delete()
-            application.reference_contact_datetime = None
+            new_review = CredentialReview.objects.create(application=application)
             application.save()
 
     return render(request, 'console/credential_processing.html',

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1410,8 +1410,6 @@ def credential_processing(request):
             except CredentialApplication.DoesNotExist:
                 raise Http404()
             application.credential_review.delete()
-            new_review = CredentialReview.objects.create(application=application)
-            application.save()
             messages.success(request, 'The application has been reset')
 
     return render(request, 'console/credential_processing.html',

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -941,6 +941,13 @@ class CredentialApplication(models.Model):
 class CredentialReview(models.Model):
     """
     Reviews for the CredentialApplications.
+
+    NOTES
+    -----
+    This relational model will be deleted in the case that a credential
+    reviewer decides to "reset" the application, meaning reset it back to the
+    "initial review" stage.
+
     """
     REVIEW_STATUS_LABELS = (
         ('', '-----------'),


### PR DESCRIPTION
This small change allows credential application reviewers to "reset" their review of the application. Essentially, in the backend, this just deletes its connected credential review which sends it back to the Initial Review stage. Once reset, it will show back up on KP's management page.

One thing to note is that if we contact an applicant's reference then reset the application, the application will still show up on KP's management page but it will say the reference has not been contacted. This may lead us to double contact the reference but I don't think this will happen very often.

Fixes #1248.