### PR TITLE
Adds reference email to credential processing workflow #1237

### DIFF
--- a/physionet-django/console/static/console/css/console.css
+++ b/physionet-django/console/static/console/css/console.css
@@ -526,3 +526,20 @@ footer.sticky-footer {
   list-style-type: none;
   margin: 1rem;
 }
+
+.table-cred {
+  table-layout: fixed;
+  width: 100%;
+}
+.table-index {
+  width: 5%;
+}
+.table-user {
+  width: 10%;
+}
+.table-elapsed {
+  width: 9%;
+}
+.table-process {
+  width: 11%;
+}

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -35,18 +35,17 @@
       <div class="tab-pane fade show active" id="initial" role="tabpanel" aria-labelledby="initial-tab">
         {% if initial_applications %}
         <div class="table-responsive">
-          <table class="table table-bordered">
+          <table class="table table-bordered table-cred">
             <thead>
               <tr class="header">
-                <th>#</th>
-                <th>User</th>
+                <th class="table-index">#</th>
+                <th class="table-user">User</th>
                 <th>Full Name</th>
                 <th>Email</th>
+                <th>Reference Email</th>
                 <th>Application</th>
-                <th>Reference Contact</th>
-                <th>Reference Verification</th>
-                <th>Time Elapsed</th>
-                <th>Process Application</th>
+                <th class="table-elapsed">Time Elapsed</th>
+                <th class="table-process">Process Application</th>
               </tr>
             </thead>
             <tbody>  
@@ -57,9 +56,8 @@
                 <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
+                <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                <td>{{ application.reference_contact_datetime|date }}</td>
-                <td>{{ application.reference_response_datetime|date }}</td>
                 {% if application.time_elapsed < 2 %}
                   <td>{{ application.time_elapsed }} day</td>
                 {% else %}
@@ -80,18 +78,17 @@
       <div class="tab-pane fade" id="training" role="tabpanel" aria-labelledby="training-tab">
         {% if training_applications %}
         <div class="table-responsive">
-          <table class="table table-bordered">
+          <table class="table table-bordered table-cred">
             <thead>
               <tr class="header">
-                <th>#</th>
-                <th>User</th>
+                <th class="table-index">#</th>
+                <th class="table-user">User</th>
                 <th>Full Name</th>
                 <th>Email</th>
+                <th>Reference Email</th>
                 <th>Application</th>
-                <th>Reference Contact</th>
-                <th>Reference Verification</th>
-                <th>Time Elapsed</th>
-                <th>Process Application</th>
+                <th class="table-elapsed">Time Elapsed</th>
+                <th class="table-process">Process Application</th>
               </tr>
             </thead>
             <tbody>  
@@ -102,9 +99,8 @@
                 <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
+                <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                <td>{{ application.reference_contact_datetime|date }}</td>
-                <td>{{ application.reference_response_datetime|date }}</td>
                 {% if application.time_elapsed < 2 %}
                   <td>{{ application.time_elapsed }} day</td>
                 {% else %}
@@ -125,18 +121,17 @@
       <div class="tab-pane fade" id="personal" role="tabpanel" aria-labelledby="personal-tab">
         {% if personal_applications %}
         <div class="table-responsive">
-          <table class="table table-bordered">
+          <table class="table table-bordered table-cred">
             <thead>
               <tr class="header">
-                <th>#</th>
-                <th>User</th>
+                <th class="table-index">#</th>
+                <th class="table-user">User</th>
                 <th>Full Name</th>
                 <th>Email</th>
+                <th>Reference Email</th>
                 <th>Application</th>
-                <th>Reference Contact</th>
-                <th>Reference Verification</th>
-                <th>Time Elapsed</th>
-                <th>Process Application</th>
+                <th class="table-elapsed">Time Elapsed</th>
+                <th class="table-process">Process Application</th>
               </tr>
             </thead>
             <tbody>  
@@ -147,9 +142,8 @@
                 <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
+                <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                <td>{{ application.reference_contact_datetime|date }}</td>
-                <td>{{ application.reference_response_datetime|date }}</td>
                 {% if application.time_elapsed < 2 %}
                   <td>{{ application.time_elapsed }} day</td>
                 {% else %}
@@ -170,18 +164,17 @@
       <div class="tab-pane fade" id="reference" role="tabpanel" aria-labelledby="reference-tab">
         {% if reference_applications %}
         <div class="table-responsive">
-          <table class="table table-bordered">
+          <table class="table table-bordered table-cred">
             <thead>
               <tr class="header">
-                <th>#</th>
-                <th>User</th>
+                <th class="table-index">#</th>
+                <th class="table-user">User</th>
                 <th>Full Name</th>
                 <th>Email</th>
+                <th>Reference Email</th>
                 <th>Application</th>
-                <th>Reference Contact</th>
-                <th>Reference Verification</th>
-                <th>Time Elapsed</th>
-                <th>Process Application</th>
+                <th class="table-elapsed">Time Elapsed</th>
+                <th class="table-process">Process Application</th>
               </tr>
             </thead>
             <tbody>  
@@ -192,9 +185,8 @@
                 <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
+                <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                <td>{{ application.reference_contact_datetime|date }}</td>
-                <td>{{ application.reference_response_datetime|date }}</td>
                 {% if application.time_elapsed < 2 %}
                   <td>{{ application.time_elapsed }} day</td>
                 {% else %}
@@ -215,18 +207,19 @@
       <div class="tab-pane fade" id="response" role="tabpanel" aria-labelledby="response-tab">
         {% if response_applications %}
         <div class="table-responsive">
-          <table class="table table-bordered">
+          <table class="table table-bordered table-cred">
             <thead>
               <tr class="header">
-                <th>#</th>
-                <th>User</th>
+                <th class="table-index">#</th>
+                <th class="table-user">User</th>
                 <th>Full Name</th>
                 <th>Email</th>
+                <th>Reference Email</th>
                 <th>Application</th>
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
-                <th>Time Elapsed</th>
-                <th>Process Application</th>
+                <th class="table-elapsed">Time Elapsed</th>
+                <th class="table-process">Process Application</th>
               </tr>
             </thead>
             <tbody>  
@@ -237,6 +230,7 @@
                 <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
+                <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
                 <td>{{ application.reference_contact_datetime|date }}</td>
                 <td>{{ application.reference_response_datetime|date }}</td>
@@ -260,18 +254,19 @@
       <div class="tab-pane fade" id="final" role="tabpanel" aria-labelledby="final-tab">
         {% if final_applications %}
         <div class="table-responsive">
-          <table class="table table-bordered">
+          <table class="table table-bordered table-cred">
             <thead>
               <tr class="header">
-                <th>#</th>
-                <th>User</th>
+                <th class="table-index">#</th>
+                <th class="table-user">User</th>
                 <th>Full Name</th>
                 <th>Email</th>
+                <th>Reference Email</th>
                 <th>Application</th>
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
-                <th>Time Elapsed</th>
-                <th>Process Application</th>
+                <th class="table-elapsed">Time Elapsed</th>
+                <th class="table-process">Process Application</th>
               </tr>
             </thead>
             <tbody>  
@@ -282,6 +277,7 @@
                 <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
+                <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
                 <td>{{ application.reference_contact_datetime|date }}</td>
                 <td>{{ application.reference_response_datetime|date }}</td>


### PR DESCRIPTION
This change does multiple things for the credential application processing workflow:
1. Adds the submitted reference email to the table
2. Fixes the layout of the table to stay within the limits of the page (helps when doing half screen)
3. Removes reference contact and verification information prior to the Reference Response stage since it's irrelevant

Fixes #1237.