### PR TITLE
Adds Orcid to public profile #1234

### DIFF
--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -67,6 +67,18 @@ Profile for {{ public_user.username }}
         </div>
       {% endif %}
 
+      {% if public_user.orcid.orcid_id %}
+        <div class="row mb-1">
+          <div class="col-md-2">
+            Orcid:
+          </div>
+          <div class="col-md-10">
+            <a href="{{ public_user.orcid.get_orcid_url }}/{{ public_user.orcid.orcid_id }}" rel="noopener">
+              {{ public_user.orcid.get_orcid_url }}/{{ public_user.orcid.orcid_id }}</a>
+          </div>
+        </div>
+      {% endif %}
+
       {% if profile.website %}
         <div class="row mb-1">
           <div class="col-md-2">

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -432,7 +432,6 @@ def public_profile(request, username):
     # get list of projects
     projects = PublishedProject.objects.filter(authors__user=public_user).order_by('-publish_datetime')
 
-
     return render(request, 'user/public_profile.html', {
         'public_user':public_user, 'profile':public_user.profile,
         'public_email':public_email, 'projects':projects})


### PR DESCRIPTION
Adds a link to a user's Orcid profile to their PhysioNet public profile (`/users/<username>`). I decided to put it directly beneath their email.

Fixes #1234.