### PR TITLE
Displays debug toolbar when in development mode #1156

### DIFF
--- a/physionet-django/physionet/settings/development/base.py
+++ b/physionet-django/physionet/settings/development/base.py
@@ -12,6 +12,10 @@ INSTALLED_APPS += [
     'debug_toolbar',
 ]
 
+INTERNAL_IPS = [
+    '127.0.0.1',
+]
+
 MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import include
 from django.contrib import admin
 from django.urls import path
@@ -66,3 +67,8 @@ urlpatterns = [
     path('robots.txt', lambda x: HttpResponse("User-Agent: *\Allow: /", 
         content_type="text/plain"), name="robots_file"),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    # debug toolbar
+    urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))


### PR DESCRIPTION
This change displays the debug toolbar when in development mode. Metrics displayed here include things such as SQL queries, number of static files, CPU time, etc.

Fixes #1156.