### PR TITLE
Improve content types

### DIFF
--- a/deploy/common/etc/nginx/custom-mime.types
+++ b/deploy/common/etc/nginx/custom-mime.types
@@ -1,5 +1,8 @@
 include mime.types;
 types {
+    application/gzip gz;
+    application/pgp-signature sig;
+
     application/octet-stream 16a;
     application/octet-stream abp;
     application/octet-stream al;


### PR DESCRIPTION
At some point, I thought it was a good idea to set nginx to use a Content-Type of `text/plain` for unrecognized files.  (Probably because otherwise lots of things were being forced to download rather than being displayed in the browser.)

This doesn't work so well for actual binary files, though. :)

nginx's /etc/nginx/mime.types knows about a small number of file types (much smaller than what's listed in /etc/mime.types), which includes `application/zip` for `*.zip`, but doesn't include `application/gzip` for `*.gz`, or `application/pgp-signature` for `*.sig`.

We should probably think about adding other types too.
