### PR TITLE
Catch server error ("EditLog matching query does not exist") in project review workflow

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -32,7 +32,7 @@ from physionet.middleware.maintenance import ServiceUnavailable
 from physionet.utility import paginate
 import project.forms as project_forms
 from project.models import (ActiveProject, ArchivedProject, StorageRequest,
-    Reference, Topic, Publication, PublishedProject,
+    Reference, Topic, Publication, PublishedProject, EditLog,
     exists_project_slug, GCP, DUASignature, DataAccess)
 from project.utility import readable_size
 from project.validators import MAX_PROJECT_SLUG_LENGTH
@@ -269,7 +269,12 @@ def edit_submission(request, project_slug, *args, **kwargs):
     Page to respond to a particular submission, as an editor
     """
     project = kwargs['project']
-    edit_log = project.edit_logs.get(decision_datetime__isnull=True)
+
+    try:
+        edit_log = project.edit_logs.get(decision_datetime__isnull=True)
+    except EditLog.DoesNotExist:
+        return redirect('editor_home')
+
     reassign_editor_form = forms.ReassignEditorForm(request.user)
 
     # The user must be the editor


### PR DESCRIPTION
Currently a server error is raised if a managing editor attempts to view the review page for a submission that has already been processed. This most commonly happens in the following case:

1. Editor views the list of projects that are awaiting review (http://127.0.0.1:8000/console/editor-home/).

![Screen Shot 2021-03-26 at 13 15 33](https://user-images.githubusercontent.com/822601/112669805-807d3700-8e36-11eb-9e61-7de056312a0a.png)

2. Editor opens the project review page in a new browser tab (e.g. by shift + clicking the "Edit project" button.
3. Editor submits the review form (accepting, rejecting, etc the project).
4. Editor switches back to their original browser tab (with the unrefreshed list of projects) and then clicks "Edit project" for the project they have just processed.

This change catches the error and returns the editor to their "Editor home". 

### Traceback for the error:

```
Traceback:

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
 34.             response = get_response(request)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
 115.                 response = self.process_exception_by_middleware(e, request)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
 113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
 21.                 return view_func(request, *args, **kwargs)

File "./console/views.py" in handling_view
 90.                 return base_view(request, *args, **kwargs)

File "./console/views.py" in edit_submission
 272.     edit_log = project.edit_logs.get(decision_datetime__isnull=True)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/db/models/manager.py" in manager_method
 82.                 return getattr(self.get_queryset(), name)(*args, **kwargs)

File "/physionet/python-env/physionet/lib/python3.7/site-packages/django/db/models/query.py" in get
 408.                 self.model._meta.object_name

Exception Type: DoesNotExist at /console/submitted-projects/tgoF1DVpQIXegSwWItGI/edit/
Exception Value: EditLog matching query does not exist.
```