### PR TITLE
Clear autosave data when a form is submitted

### DIFF
--- a/physionet-django/console/templates/console/copyedit_submission.html
+++ b/physionet-django/console/templates/console/copyedit_submission.html
@@ -10,6 +10,7 @@
 
 {% block local_js_top %}
 <script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'custom/js/clear-autosave.js' %}"></script>
 <script src="{% static 'project/js/dynamic-formset.js' %}"></script>
 <script src="{% static 'custom/js/copy-to-clipboard.js' %}"></script>
 {% endblock %}

--- a/physionet-django/console/templates/console/news_console.html
+++ b/physionet-django/console/templates/console/news_console.html
@@ -4,6 +4,11 @@
 
 {% block title %}News Items{% endblock %}
 
+{% block local_js_top %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'custom/js/clear-autosave.js' %}"></script>
+{% endblock %}
+
 {% block local_css %}
 <link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
 {% endblock %}

--- a/physionet-django/console/templates/console/news_edit.html
+++ b/physionet-django/console/templates/console/news_edit.html
@@ -4,6 +4,11 @@
 
 {% block title %}Edit News Item{% endblock %}
 
+{% block local_js_top %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'custom/js/clear-autosave.js' %}"></script>
+{% endblock %}
+
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -346,6 +346,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
     access_form = project_forms.AccessMetadataForm(instance=project)
     discovery_form = project_forms.DiscoveryForm(resource_type=project.resource_type.id,
         instance=project)
+    description_form_saved = False
 
     access_form.set_license_queryset(access_policy=project.access_policy)
     reference_formset = ReferenceFormSet(instance=project)
@@ -382,6 +383,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
                 topic_formset.save()
                 messages.success(request,
                     'The project metadata has been updated.')
+                description_form_saved = True
                 # Reload formsets
                 reference_formset = ReferenceFormSet(instance=project)
                 publication_formset = PublicationFormSet(instance=project)
@@ -421,7 +423,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
     edit_url = reverse('edit_content_item', args=[project.slug])
     url_prefix = notification.get_url_prefix(request)
 
-    return render(request, 'console/copyedit_submission.html', {
+    response = render(request, 'console/copyedit_submission.html', {
         'project': project, 'description_form': description_form,
         'individual_size_limit': readable_size(ActiveProject.INDIVIDUAL_FILE_SIZE_LIMIT),
         'access_form': access_form, 'reference_formset':reference_formset,
@@ -443,6 +445,9 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         'add_item_url': edit_url, 'remove_item_url': edit_url,
         'discovery_form': discovery_form, 'url_prefix': url_prefix,
         'reassign_editor_form': reassign_editor_form})
+    if description_form_saved:
+        set_saved_fields_cookie(description_form, request.path, response)
+    return response
 
 
 @handling_editor

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -28,6 +28,7 @@ from dal import autocomplete
 
 from notification.models import News
 import notification.utility as notification
+from physionet.forms import set_saved_fields_cookie
 from physionet.middleware.maintenance import ServiceUnavailable
 from physionet.utility import paginate
 import project.forms as project_forms
@@ -1575,7 +1576,8 @@ def news_add(request):
         if form.is_valid():
             form.save()
             messages.success(request, 'The news item has been added')
-            return redirect('news_console')
+            return set_saved_fields_cookie(form, request.path,
+                                           redirect('news_console'))
     else:
         form = forms.NewsForm()
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1608,10 +1608,12 @@ def news_edit(request, news_id):
         news = News.objects.get(id=news_id)
     except News.DoesNotExist:
         raise Http404()
+    saved = False
     if request.method == 'POST':
         if 'update' in request.POST:
             form = forms.NewsForm(data=request.POST, instance=news)
             if form.is_valid():
+                saved = True
                 form.save()
                 messages.success(request, 'The news item has been updated')
         elif 'delete' in request.POST:
@@ -1621,8 +1623,11 @@ def news_edit(request, news_id):
     else:
         form = forms.NewsForm(instance=news)
 
-    return render(request, 'console/news_edit.html', {'news': news,
+    response = render(request, 'console/news_edit.html', {'news': news,
         'form': form, 'news_nav': True})
+    if saved:
+        set_saved_fields_cookie(form, request.path, response)
+    return response
 
 
 @login_required

--- a/physionet-django/physionet/forms.py
+++ b/physionet-django/physionet/forms.py
@@ -1,0 +1,50 @@
+import json
+import urllib.parse
+
+import ckeditor.fields
+from django.conf import settings
+
+
+def set_saved_fields_cookie(form, form_url, response):
+    """
+    Set a cookie to indicate that rich text fields have been saved.
+
+    The ckeditor autosave plugin will attempt to automatically save
+    form fields that have been modified; once the form is actually
+    saved to the server, we want to clear the autosave state so that
+    the plugin won't try to restore it when the same form is loaded
+    again.
+
+    This requires that:
+     - the view that handles the POST request should invoke this
+       function on the HTTP response
+     - the page that is loaded after submitting the form should
+       include /static/custom/js/clear-autosave.js
+
+    form should be the django.forms.Form that was just saved.
+
+    form_url should be the path to the page on which the form fields
+    appear (which is usually, but not necessarily, the same as the URL
+    to which the form is POSTed.)
+
+    response should be a django.http.HttpResponse.
+    """
+
+    # Find all rich text fields in the form
+    field_names = []
+    for (name, field) in form.fields.items():
+        if isinstance(field, ckeditor.fields.RichTextFormField):
+            # This is a bit weird and confusing, but I think it's
+            # correct: bound_field.id_for_label is the 'id' attribute
+            # of the textarea element, and that is what ckeditor uses
+            # as 'editor.name', and that is what the autosave plugin
+            # uses to construct the local storage key.
+            bound_field = field.get_bound_field(form, name)
+            html_id = bound_field.id_for_label
+            field_names.append(html_id)
+
+    value = json.dumps({'url': form_url, 'fields': field_names})
+    value = urllib.parse.quote(value, safe='')
+    response.set_cookie('saved_cke_fields', value, max_age=(10 * 60),
+                        samesite='strict', secure=(not settings.DEBUG))
+    return response

--- a/physionet-django/project/templates/project/data_access_request_submitted.html
+++ b/physionet-django/project/templates/project/data_access_request_submitted.html
@@ -4,6 +4,11 @@
 
 {% block title %}Data Access Request Submitted{% endblock %}
 
+{% block local_js_top %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'custom/js/clear-autosave.js' %}"></script>
+{% endblock %}
+
 {% block content %}
 <div class="container">
   <h1>Data Access Request Submitted</h1>

--- a/physionet-django/project/templates/project/project_content.html
+++ b/physionet-django/project/templates/project/project_content.html
@@ -6,6 +6,7 @@
 
 {% block local_js_top %}
 <script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'custom/js/clear-autosave.js' %}"></script>
 <script src="{% static 'project/js/dynamic-formset.js' %}"></script>
 {% endblock %}
 

--- a/physionet-django/project/templates/project/project_overview.html
+++ b/physionet-django/project/templates/project/project_overview.html
@@ -2,7 +2,13 @@
 
 {% block title %}Project Overview - {{ project }}"{% endblock %}
 
+{% load static %}
 {% load project_templatetags %}
+
+{% block local_js_top %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'custom/js/clear-autosave.js' %}"></script>
+{% endblock %}
 
 {% block main_content %}
 <h2 class="form-signin-heading">Project Overview</h2>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -648,6 +648,7 @@ def project_content(request, project_slug, **kwargs):
     description_form = forms.ContentForm(resource_type=project.resource_type.id,
                                          instance=project, editable=editable)
     reference_formset = ReferenceFormSet(instance=project)
+    saved = False
 
     if request.method == 'POST':
         description_form = forms.ContentForm(
@@ -655,6 +656,7 @@ def project_content(request, project_slug, **kwargs):
             instance=project, editable=editable)
         reference_formset = ReferenceFormSet(request.POST, instance=project)
         if description_form.is_valid() and reference_formset.is_valid():
+            saved = True
             description_form.save()
             reference_formset.save()
             messages.success(request, 'Your project content has been updated.')
@@ -664,11 +666,14 @@ def project_content(request, project_slug, **kwargs):
                 'Invalid submission. See errors below.')
     edit_url = reverse('edit_content_item', args=[project.slug])
 
-    return render(request, 'project/project_content.html', {'project':project,
+    response = render(request, 'project/project_content.html', {'project':project,
         'description_form':description_form, 'reference_formset':reference_formset,
         'messages':messages.get_messages(request),
         'is_submitting':is_submitting,
         'add_item_url':edit_url, 'remove_item_url':edit_url})
+    if saved:
+        set_saved_fields_cookie(description_form, request.path, response)
+    return response
 
 
 @project_auth(auth_mode=0, post_auth_mode=2)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1703,8 +1703,12 @@ def request_data_access(request, project_slug, version):
                                                           request.scheme,
                                                           request.get_host())
 
-            return render(request, 'project/data_access_request_submitted.html',
-                          {'project': proj})
+            response = render(
+                request, 'project/data_access_request_submitted.html',
+                {'project': proj})
+            set_saved_fields_cookie(project_request_form,
+                                    request.path, response)
+            return response
     else:
         project_request_form = forms.DataAccessRequestForm(project=proj,
                                                            requester=user,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -35,6 +35,7 @@ from project.models import (Affiliation, Author, AuthorInvitation, License,
 from project import utility
 from project.validators import validate_filename
 import notification.utility as notification
+from physionet.forms import set_saved_fields_cookie
 from physionet.middleware.maintenance import ServiceUnavailable
 from physionet.utility import serve_file
 from user.forms import ProfileForm, AssociatedEmailChoiceForm
@@ -252,7 +253,9 @@ def create_project(request):
         form = forms.CreateProjectForm(user=user, data=request.POST)
         if form.is_valid():
             project = form.save()
-            return redirect('project_overview', project_slug=project.slug)
+            response = redirect('project_overview', project_slug=project.slug)
+            set_saved_fields_cookie(form, request.path, response)
+            return response
     else:
         form = forms.CreateProjectForm(user=user)
 

--- a/physionet-django/static/custom/js/clear-autosave.js
+++ b/physionet-django/static/custom/js/clear-autosave.js
@@ -1,0 +1,34 @@
+// Remove data saved by the ckeditor autosave plugin once the server
+// has acknowledged that the form has been saved.
+// Requires: /static/custom/js/cookie.js
+(function() {
+    'use strict';
+
+    // The saved_cke_fields cookie should contain a URL-encoded JSON
+    // object such as
+    // {"url": "/projects/create/", "fields": ["id_abstract"]}
+    var saved = getCookie('saved_cke_fields');
+    if (saved !== null) {
+        saved = JSON.parse(saved);
+
+        // convert to absolute URL
+        var a = document.createElement('a');
+        a.href = saved.url;
+        var form_url = a.href;
+
+        // Each field is saved under a key such as
+        // autosave_https://physionet.org/projects/create/_abstract
+        // (see /static/ckeditor/ckeditor/plugins/autosave/plugin.js)
+        for (var i = 0; i < saved.fields.length; i++) {
+            var field = saved.fields[i];
+            var key = 'autosave_' + form_url + '_' + field;
+            try {
+                localStorage.removeItem(key);
+            }
+            catch (e) {
+            }
+        }
+    }
+    document.cookie = 'saved_cke_fields=;path=/;SameSite=strict;' +
+        'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+})();


### PR DESCRIPTION
The autosave plugin will automatically save rich text fields to your browser's local storage.  (Well, most of the time it will.  Sometimes it seems to just not do anything and I'm not sure why.)  If you close the window, and reopen the form later, it will ask if you want to restore the autosaved text.

However, when the form is actually *saved* to the server, we want to remove the old autosave data, because the text on a subsequent page load may be different (either because the text was modified by bleach or other server-side filters, or because it's modified by ckeditor, or because you edited the same project in another browser, etc.)

So we add an additional script, which should be loaded as part of the *next* page (the page that's loaded when you submit the form - not necessarily the same page containing the form itself), that deletes the autosaved content.  We tell it which autosaved content to delete by setting a cookie in the response to the POST request.

This handles the following forms:

 - creating a project (/projects/create/)
 - editing a project (/projects/*/content/)
 - creating a news item (/console/news/add/)
 - editing a news item (/console/news/edit/*/)
 - making a data acccess request (/request-access/*/*/)
 - copyediting a project (/console/submitted-projects/*/copyedit/)

This does *not* handle any of the Django admin forms.  If you have access to the admin forms you are expected to know what you're doing.

One thing I am not entirely sure about is whether this script will correctly delete the cookie if the cookie is marked as "secure".  It might be that you need to do something like:

    document.cookie = 'saved_cke_fields=;path=/;SameSite=strict;' +
        'expires=Thu, 01 Jan 1970 00:00:00 GMT;secure';

if the existing cookie is secure, and:

    document.cookie = 'saved_cke_fields=;path=/;SameSite=strict;' +
        'expires=Thu, 01 Jan 1970 00:00:00 GMT';

if it isn't.  I haven't yet tested that.

This should fix issue #1312.
