### PR TITLE
Fixes editor assignment for projects with single quotes

### DIFF
--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -49,7 +49,7 @@
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.submission_datetime|date }}</td>
-                  <td><a href='#' data-toggle="modal" data-target="#assignModal" onclick="set_project_id('{{ project.id }}','{{ project }}')" class="btn btn-primary btn-sm" role="button">Assign Editor</a></td>
+                  <td><a href='#' data-toggle="modal" data-target="#assignModal" onclick="set_project_id('{{ project.id }}','{{ project|escapejs }}')" class="btn btn-primary btn-sm" role="button">Assign Editor</a></td>
                 </tr>
               {% endfor %}
               </tbody>


### PR DESCRIPTION
This change fixes the Editor Assignment button for projects where the title includes a single quotation (e.g. `Lucas's Project`). Currently, the single quote is being rendered as `&#39;` in the HTML which causes problems so I added the `escapejs` filter which turned it to `\u0027` which fixes the issue.