### PR TITLE
Reload nginx when new certificates are installed

### DIFF
--- a/deploy/common/etc/letsencrypt/renewal-hooks/deploy/reload-nginx
+++ b/deploy/common/etc/letsencrypt/renewal-hooks/deploy/reload-nginx
@@ -1,0 +1,2 @@
+#!/bin/sh
+systemctl reload nginx.service


### PR DESCRIPTION
When certbot installs a new certificate, nginx needs to be told to "reload" in order to start using it.  When using the "webroot" aka "don't-mess-with-my-server-configuration" renewal mechanism, this reloading doesn't happen automatically.

Of course, it's not easy to test something that only happens every two months.  This script has been installed on the staging server for a few weeks, and appears to have done its job.
