### PR TITLE
Adds last name search for previous credential applications

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1521,21 +1521,25 @@ def search_credential_applications(request):
             Q(migrated_user__is_credentialed=True) &
             (Q(migrated_user__username__icontains=search_field) |
             Q(migrated_user__profile__first_names__icontains=search_field) |
+            Q(migrated_user__profile__last_name__icontains=search_field) |
             Q(migrated_user__email__icontains=search_field))).order_by('-migration_date')
 
         successful_apps = CredentialApplication.objects.filter(
             Q(status=2) & (Q(user__username__icontains=search_field) |
             Q(user__profile__first_names__icontains=search_field) |
+            Q(user__profile__last_name__icontains=search_field) |
             Q(user__email__icontains=search_field))).order_by('-application_datetime')
 
         unsuccessful_apps = CredentialApplication.objects.filter(
             Q(status__in=[1, 3]) & (Q(user__username__icontains=search_field) |
             Q(user__profile__first_names__icontains=search_field) |
+            Q(user__profile__last_name__icontains=search_field) |
             Q(user__email__icontains=search_field))).order_by('-application_datetime')
 
         pending_apps = CredentialApplication.objects.filter(
             Q(status=0) & (Q(user__username__icontains=search_field) |
             Q(user__profile__first_names__icontains=search_field) |
+            Q(user__profile__last_name__icontains=search_field) |
             Q(user__email__icontains=search_field))).order_by('-application_datetime')
 
         # Merge legacy applications with new applications


### PR DESCRIPTION
This change adds the options to search users based on their last name for credential applications. Currently, searching by last name on the live site at https://physionet.org/console/credential-applications/successful appears to not work (although I could not reproduce this problem locally even after changing the email and names of the credentialed user).