### PR TITLE
Fix typo in project page titles

### DIFF
--- a/physionet-django/project/templates/project/project_overview.html
+++ b/physionet-django/project/templates/project/project_overview.html
@@ -1,6 +1,6 @@
 {% extends "project/project.html" %}
 
-{% block title %}Project Overview - {{ project }}"{% endblock %}
+{% block title %}Project Overview - {{ project }}{% endblock %}
 
 {% load static %}
 {% load project_templatetags %}

--- a/physionet-django/project/templates/project/project_proofread.html
+++ b/physionet-django/project/templates/project/project_proofread.html
@@ -1,6 +1,6 @@
 {% extends "project/project.html" %}
 
-{% block title %}Project Proofread - {{ project }}"{% endblock %}
+{% block title %}Project Proofread - {{ project }}{% endblock %}
 
 {% block main_content %}
 <h2 class="form-signin-heading">6. Project Proofread</h2>

--- a/physionet-django/project/templates/project/project_submission.html
+++ b/physionet-django/project/templates/project/project_submission.html
@@ -1,6 +1,6 @@
 {% extends "project/project.html" %}
 
-{% block title %}Project Submission - {{ project }}"{% endblock %}
+{% block title %}Project Submission - {{ project }}{% endblock %}
 
 {% load static %}
 


### PR DESCRIPTION
In the project overview (/projects/SHuKI1APLrwWCqxSQnSk/overview/), proofread (/projects/SHuKI1APLrwWCqxSQnSk/proofread/), and submission (/projects/SHuKI1APLrwWCqxSQnSk/submission/) pages, there's a stray quotation mark at the end of the page title.
