### PR TITLE
Add a custom location for all logs in the background tasks

### DIFF
--- a/deploy/common/etc/rsyslog.d/background_tasks.conf
+++ b/deploy/common/etc/rsyslog.d/background_tasks.conf
@@ -1,0 +1,3 @@
+# Filter to get all background tasks and send them to a custom location
+:msg, contains, "background_task.tasks" -/data/log/background_tasks/django_background_tasks.log
+& ~

--- a/deploy/common/etc/rsyslog.d/background_tasks.conf
+++ b/deploy/common/etc/rsyslog.d/background_tasks.conf
@@ -1,3 +1,0 @@
-# Filter to get all background tasks and send them to a custom location
-:msg, contains, "background_task.tasks" -/data/log/background_tasks/django_background_tasks.log
-& ~

--- a/deploy/production/etc/rsyslog.d/background_tasks.conf
+++ b/deploy/production/etc/rsyslog.d/background_tasks.conf
@@ -1,0 +1,3 @@
+# Filter to get all background tasks and send them to a custom location
+:programname, isequal, "django-background-tasks" -/data/log/background_tasks/django_background_tasks.log
+& stop

--- a/deploy/production/etc/systemd/system/django-background-tasks.service
+++ b/deploy/production/etc/systemd/system/django-background-tasks.service
@@ -5,10 +5,11 @@ After=emperor.uwsgi.service
 [Service]
 Environment=DJANGO_SETTINGS_MODULE=physionet.settings.production
 ExecStart=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py process_tasks --log-std
+StandardError=syslog
+SyslogIdentifier=django-background-tasks
 Restart=always
 KillSignal=SIGINT
 Type=simple
-StandardError=syslog
 NotifyAccess=all
 User=www-data
 Group=www-data

--- a/deploy/staging/etc/rsyslog.d/background_tasks.conf
+++ b/deploy/staging/etc/rsyslog.d/background_tasks.conf
@@ -1,0 +1,3 @@
+# Filter to get all background tasks and send them to a custom location
+:programname, isequal, "django-background-tasks" -/data/log/background_tasks/django_background_tasks.log
+& stop

--- a/deploy/staging/etc/systemd/system/django-background-tasks.service
+++ b/deploy/staging/etc/systemd/system/django-background-tasks.service
@@ -5,10 +5,11 @@ After=emperor.uwsgi.service
 [Service]
 Environment=DJANGO_SETTINGS_MODULE=physionet.settings.staging
 ExecStart=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py process_tasks --log-std
+StandardError=syslog
+SyslogIdentifier=django-background-tasks
 Restart=always
 KillSignal=SIGINT
 Type=simple
-StandardError=syslog
 NotifyAccess=all
 User=www-data
 Group=www-data


### PR DESCRIPTION
At the moment all logs for the Django background tasks are redirected stdout and stderr to the logging system which are kinda lost.

Here I add a custom capture to get all those logs onto the default Django logging location.