### PR TITLE
Fix demo ArchivedProject slug and files

### DIFF
--- a/demo-files/media/archived-projects/t2ASGLbIBoWaTJvPrM2A/hello
+++ b/demo-files/media/archived-projects/t2ASGLbIBoWaTJvPrM2A/hello
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Hello world"

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -951,7 +951,7 @@
     "version_order": 0,
     "modified_datetime": "2020-05-11T16:07:36.681Z",
     "is_new_version": false,
-    "slug": "demopsnm",
+    "slug": "t2ASGLbIBoWaTJvPrM2A",
     "latest_reminder": null,
     "doi": null,
     "archive_datetime": "2020-05-21T16:07:36.681Z",


### PR DESCRIPTION
In the demo database, there is an example ArchivedProject (a project that was "submitted" and "rejected" by the editor.)

This example project

(a) didn't have a valid slug, and

(b) didn't have a project directory in demo-files/media/archived-projects.

Update these things so the demo projects appear "correct" for testing.
