### PR TITLE
Remove Shippable references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The new PhysioNet platform built using Django. The new site is currently hosted at [https://physionet.org/](https://physionet.org/)
 
-Dev branch: [![Run Status](https://api.shippable.com/projects/59e7d1baaf0a170700d5b5b0/badge?branch=dev)](https://app.shippable.com/github/MIT-LCP/physionet-build) [![Coverage Badge](https://api.shippable.com/projects/59e7d1baaf0a170700d5b5b0/coverageBadge?branch=dev)](https://app.shippable.com/github/MIT-LCP/physionet-build)
-
 ## Running Local Instance Using Django Server
 
 - Install sqlite3: `sudo apt-get install sqlite3`.


### PR DESCRIPTION
This change removes the Shippable references from the README now that it is deprecated (see #1258). Maybe we should think about finding a way to reproduce these with Github Actions?

This may help: https://dev.to/thejaredwilcurt/coverage-badge-with-github-actions-finally-59fa