### PR TITLE
Adjusts credential reject email to clarify comments

### DIFF
--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ applicant_name }},
 
-{% if application.status == 1 %}Thank you for applying for credentialed access to PhysioNet. Your application was not approved. This may be for one of the following reasons:
+{% if application.status == 1 %}Thank you for applying for credentialed access to PhysioNet. Your application was not approved. This may be for the following reason(s):
 {% if comments %}
 
 {{ application.responder_comments }}
@@ -16,7 +16,7 @@ Dear {{ applicant_name }},
 
 {% endif %}
 
-If you are able to address these issues, please open a new credentialing application at {{ url_prefix }}{% url 'credential_application' %}.
+If you are able to address the issue(s), please open a new credentialing application at {{ url_prefix }}{% url 'credential_application' %}.
 {% elif application.status == 2 %}Thank you for your interest in the PhysioNet Clinical Databases. We are pleased to say that your application for credentialed access has been approved. You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access MIMIC-III by following the steps below:
 
 - Go to the project page at {{ url_prefix }}{% url 'published_project_latest' 'mimiciii' %}

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -2,6 +2,11 @@
 Dear {{ applicant_name }},
 
 {% if application.status == 1 %}Thank you for applying for credentialed access to PhysioNet. Your application was not approved. This may be for one of the following reasons:
+{% if comments %}
+
+{{ application.responder_comments }}
+
+{% else %}
 
 - It was incomplete, or included obviously incorrect information (perhaps as a result of browser auto-fill).
 - You did not submit the required CITI completion report, listing the training modules you completed, with dates and scores.
@@ -9,12 +14,9 @@ Dear {{ applicant_name }},
 - You are a student, postdoc, intern, or trainee, but did not list your supervisor (a faculty member or someone with a senior research appointment at your institution) as reference.
 - Your research summary did not include sufficient information, or was in some other way inadequate.
 
-{% if comments and application.status == 1 %}The following comments were added to your application:
-
-{{ application.responder_comments }}
+{% endif %}
 
 If you are able to address these issues, please open a new credentialing application at {{ url_prefix }}{% url 'credential_application' %}.
-{% endif %}
 {% elif application.status == 2 %}Thank you for your interest in the PhysioNet Clinical Databases. We are pleased to say that your application for credentialed access has been approved. You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access MIMIC-III by following the steps below:
 
 - Go to the project page at {{ url_prefix }}{% url 'published_project_latest' 'mimiciii' %}


### PR DESCRIPTION
This change adjusts the reject email which is sent when credential applications are rejected. Currently, the comments written by the reviewer are hidden beneath the standard list of suggestions which makes it difficult to understand exactly went wrong with the application since most of the things on the list would have been competed correctly.

This change only displays that list for cases where comments are disabled (KP's workflow in which comments are for internal use only). For the new workflow, since the reviewer is required to submit comments in order to reject an application, these comments will be the only things added to the email, not the list as it is currently.

It also keeps this line present for both emails (which was only present in the new workflow previously):
```
If you are able to address these issues, please open a new
credentialing application at
https://physionet.org/credential-application/.
```