### PR TITLE
Quickfix: Change the source for downloading zipfiles from Google Cloud to local servers

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -364,7 +364,12 @@
         <ul>
           {% if project.gcp %}
             {% if project.gcp.sent_zip %}
-              <li><a href="https://storage.googleapis.com/{{ project.gcp.bucket_name }}/{{ project.zip_name }}">Download the ZIP file</a> ({{ compressed_size }}).</a>
+            <!-- Temporary fix: Change default location to local servers -->
+            <!-- 
+              <li><a href="https://storage.googleapis.com/{{ project.gcp.bucket_name }}/{{ project.zip_name }}">
+                  Download the ZIP file</a> ({{ compressed_size }}).</a></li>
+             -->
+              <li><a href="{% static project.zip_url %}">Download the ZIP file</a> ({{ compressed_size }})</li>
             {% elif project.compressed_storage_size %}
               <li><a href="{% static project.zip_url %}">Download the ZIP file</a> ({{ compressed_size }})</li>
             {% endif %}


### PR DESCRIPTION
Users can choose to download a zipfile contained the contents of a project. If the project has been uploaded to Google Cloud, then a cloud bucket is the default source for download. 

![Screen Shot 2021-05-12 at 11 38 56](https://user-images.githubusercontent.com/822601/118003511-a5f6cf00-b316-11eb-8738-8f8ad4e16903.png)

Due to budget constraints, this is a temporary change that switches the default download server to local storage. 