### PR TITLE
Adding an empty config folder as a step towards creating a configurable platform.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+# Configuring the publishing platform
+
+Configuration files should be placed in this folder.


### PR DESCRIPTION
This is a minor change that adds a "config" folder to the repository, which is a tiny step towards our goal of separating the code that runs PhysioNet from local configuration details (ref #1342). The work should enable other groups (e.g. Toronto TCAIREM) to reuse the platform more easily (and importantly help to focus development efforts around a single codebase).

Our intention is that site-specific configuration details will be tracked in a separate repository (e.g. https://github.com/MIT-LCP/physionet-config). The config repository will need to be cloned into the config folder.

Efforts towards unbranding will be tracked at: https://github.com/MIT-LCP/physionet-build/projects/4. As work progresses, some or all of https://github.com/MIT-LCP/physionet-build/tree/dev/deploy and https://github.com/MIT-LCP/physionet-build/tree/dev/physionet-django/physionet/settings will be migrated to the config repo.
