### PR TITLE
Removes application days elapsed from credential processing table

### DIFF
--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -49,8 +49,7 @@
                 <th onclick="sortTable(1,'initialt')">Full Name <i class="fas fa-sort" id="icon_1_initialt"></i></th>
                 <th onclick="sortTable(2,'initialt')">Email <i class="fas fa-sort" id="icon_2_initialt"></i></th>
                 <th onclick="sortTable(3,'initialt')">Reference Email <i class="fas fa-sort" id="icon_3_initialt"></i></th>
-                <th>Application</th>
-                <th class="table-elapsed" onclick="sortTable(5,'initialt')">Time Elapsed <i class="fas fa-sort" id="icon_5_initialt"></i></th>
+                <th class="table-elapsed" onclick="sortTable(4,'initialt')">Application <i class="fas fa-sort" id="icon_4_initialt"></i></th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -63,11 +62,6 @@
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                {% if application.time_elapsed < 2 %}
-                  <td>{{ application.time_elapsed }} day</td>
-                {% else %}
-                  <td>{{ application.time_elapsed }} days</td>
-                {% endif %}
                 <td>
                   <form action="{% url 'process_credential_application' application.slug %}">
                     <input class="btn btn-success" type="submit" value="Process"/>
@@ -94,8 +88,7 @@
                 <th onclick="sortTable(1,'trainingt')">Full Name <i class="fas fa-sort" id="icon_1_trainingt"></i></th>
                 <th onclick="sortTable(2,'trainingt')">Email <i class="fas fa-sort" id="icon_2_trainingt"></i></th>
                 <th onclick="sortTable(3,'trainingt')">Reference Email <i class="fas fa-sort" id="icon_3_trainingt"></i></th>
-                <th>Application</th>
-                <th class="table-elapsed" onclick="sortTable(5,'trainingt')">Time Elapsed <i class="fas fa-sort" id="icon_5_trainingt"></i></th>
+                <th class="table-elapsed" onclick="sortTable(4,'trainingt')">Application <i class="fas fa-sort" id="icon_4_trainingt"></i></th>
                 <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
@@ -109,11 +102,6 @@
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                {% if application.time_elapsed < 2 %}
-                  <td>{{ application.time_elapsed }} day</td>
-                {% else %}
-                  <td>{{ application.time_elapsed }} days</td>
-                {% endif %}
                 <td>
                   <form action="" method="post">
                     {% csrf_token %}
@@ -146,8 +134,7 @@
                 <th onclick="sortTable(1,'personalt')">Full Name <i class="fas fa-sort" id="icon_1_personalt"></i></th>
                 <th onclick="sortTable(2,'personalt')">Email <i class="fas fa-sort" id="icon_2_personalt"></i></th>
                 <th onclick="sortTable(3,'personalt')">Reference Email <i class="fas fa-sort" id="icon_3_personalt"></i></th>
-                <th>Application</th>
-                <th class="table-elapsed" onclick="sortTable(5,'personalt')">Time Elapsed <i class="fas fa-sort" id="icon_5_personalt"></i></th>
+                <th class="table-elapsed" onclick="sortTable(4,'personalt')">Application <i class="fas fa-sort" id="icon_4_personalt"></i></th>
                 <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
@@ -161,11 +148,6 @@
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                {% if application.time_elapsed < 2 %}
-                  <td>{{ application.time_elapsed }} day</td>
-                {% else %}
-                  <td>{{ application.time_elapsed }} days</td>
-                {% endif %}
                 <td>
                   <form action="" method="post">
                     {% csrf_token %}
@@ -198,8 +180,7 @@
                 <th onclick="sortTable(1,'referencet')">Full Name <i class="fas fa-sort" id="icon_1_referencet"></i></th>
                 <th onclick="sortTable(2,'referencet')">Email <i class="fas fa-sort" id="icon_2_referencet"></i></th>
                 <th onclick="sortTable(3,'referencet')">Reference Email <i class="fas fa-sort" id="icon_3_referencet"></i></th>
-                <th>Application</th>
-                <th class="table-elapsed" onclick="sortTable(5,'referencet')">Time Elapsed <i class="fas fa-sort" id="icon_5_referencet"></i></th>
+                <th class="table-elapsed" onclick="sortTable(4,'referencet')">Application <i class="fas fa-sort" id="icon_4_referencet"></i></th>
                 <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
@@ -213,11 +194,6 @@
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                {% if application.time_elapsed < 2 %}
-                  <td>{{ application.time_elapsed }} day</td>
-                {% else %}
-                  <td>{{ application.time_elapsed }} days</td>
-                {% endif %}
                 <td>
                   <form action="" method="post">
                     {% csrf_token %}
@@ -250,10 +226,9 @@
                 <th onclick="sortTable(1,'responset')">Full Name <i class="fas fa-sort" id="icon_1_responset"></i></th>
                 <th onclick="sortTable(2,'responset')">Email <i class="fas fa-sort" id="icon_2_responset"></i></th>
                 <th onclick="sortTable(3,'responset')">Reference Email <i class="fas fa-sort" id="icon_3_responset"></i></th>
-                <th>Application</th>
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
-                <th class="table-elapsed" onclick="sortTable(7,'responset')">Time Elapsed <i class="fas fa-sort" id="icon_7_responset"></i></th>
+                <th class="table-elapsed" onclick="sortTable(6,'responset')">Application <i class="fas fa-sort" id="icon_6_responset"></i></th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -265,14 +240,9 @@
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
-                <td>{{ application.application_datetime|date }}</td>
                 <td>{{ application.reference_contact_datetime|date }}</td>
                 <td>{{ application.reference_response_datetime|date }}</td>
-                {% if application.time_elapsed < 2 %}
-                  <td>{{ application.time_elapsed }} day</td>
-                {% else %}
-                  <td>{{ application.time_elapsed }} days</td>
-                {% endif %}
+                <td>{{ application.application_datetime|date }}</td>
                 <td>
                   <form action="{% url 'process_credential_application' application.slug %}">
                     <input class="btn btn-success" type="submit" value="Process"/>
@@ -299,10 +269,9 @@
                 <th onclick="sortTable(1,'finalt')">Full Name <i class="fas fa-sort" id="icon_1_finalt"></i></th>
                 <th onclick="sortTable(2,'finalt')">Email <i class="fas fa-sort" id="icon_2_finalt"></i></th>
                 <th onclick="sortTable(3,'finalt')">Reference Email <i class="fas fa-sort" id="icon_3_finalt"></i></th>
-                <th>Application</th>
                 <th>Reference Contact</th>
                 <th>Reference Verification</th>
-                <th class="table-elapsed" onclick="sortTable(7,'finalt')">Time Elapsed <i class="fas fa-sort" id="icon_7_finalt"></i></th>
+                <th class="table-elapsed" onclick="sortTable(6,'finalt')">Application <i class="fas fa-sort" id="icon_6_finalt"></i></th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -314,14 +283,9 @@
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
-                <td>{{ application.application_datetime|date }}</td>
                 <td>{{ application.reference_contact_datetime|date }}</td>
                 <td>{{ application.reference_response_datetime|date }}</td>
-                {% if application.time_elapsed < 2 %}
-                  <td>{{ application.time_elapsed }} day</td>
-                {% else %}
-                  <td>{{ application.time_elapsed }} days</td>
-                {% endif %}
+                <td>{{ application.application_datetime|date }}</td>
                 <td>
                   <form action="{% url 'process_credential_application' application.slug %}">
                     <input class="btn btn-success" type="submit" value="Process"/>

--- a/physionet-django/static/custom/js/sort-table.js
+++ b/physionet-django/static/custom/js/sort-table.js
@@ -8,9 +8,9 @@ function sortTable(n, table_name) {
     document.getElementById(id_name).className = "fas fa-sort-down";
   }
   if ((table_name == "responset") || (table_name == "finalt")) {
-    var valid_ids = [0,1,2,3,7];
+    var valid_ids = [0,1,2,3,6];
   } else {
-    var valid_ids = [0,1,2,3,5];
+    var valid_ids = [0,1,2,3,4];
   }
   for (var i=0; i<valid_ids.length; i++) {
     if (valid_ids[i] != n) {
@@ -30,9 +30,9 @@ function sortTable(n, table_name) {
       should_switch = false;
       x = rows[i].getElementsByTagName("TD")[n];
       y = rows[i+1].getElementsByTagName("TD")[n];
-      if ((n == 5) || (n == 7)) {
-        x_sort = parseInt(x.innerHTML);
-        y_sort = parseInt(y.innerHTML);
+      if ((n == 4) || (n == 6)) {
+        x_sort = Date.parse(x.innerHTML);
+        y_sort = Date.parse(y.innerHTML);
       } else {
         x_sort = x.innerHTML.toLowerCase();
         y_sort = y.innerHTML.toLowerCase();


### PR DESCRIPTION
This change removes the application date from the credential processing page. This frees up space in the table and also removes the redundancy of having both the application date and elapsed days.