### PR TITLE
Remove unnecessary "physionet" mentions

### DIFF
--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -71,7 +71,7 @@ def access_description(access_policy):
     descriptions = {
         0: 'Anyone can access the files, as long as they conform to the terms of the specified license.',
         1: 'Only logged in users who sign the specified data use agreement can access the files.',
-        2: 'Only PhysioNet credentialed users who sign the specified DUA can access the files.',
+        2: 'Only credentialed users who sign the specified DUA can access the files.',
     }
     return descriptions[access_policy]
 
@@ -106,7 +106,7 @@ def author_popover(author, show_submitting=False, show_email=False,
     show_all_author_info
     """
     affiliation_info = escape('<b>Affiliations</b><p>{}</p>'.format('<br>'.join(escape(a) for a in author.text_affiliations)))
-    profile_info = '<p><b>PhysioNet Profile</b><br><a href=/users/{} target=_blank>{}</a></p>'.format(author.username, author.username)
+    profile_info = '<p><b>Profile</b><br><a href=/users/{} target=_blank>{}</a></p>'.format(author.username, author.username)
     popover_body = ''.join((affiliation_info, profile_info))
 
     if show_submitting and author.is_submitting:

--- a/physionet-django/user/management/commands/loaddemo.py
+++ b/physionet-django/user/management/commands/loaddemo.py
@@ -43,10 +43,10 @@ class Command(BaseCommand):
                                           'fixtures', 'project-types.json')
         call_command('loaddata', project_types_fixtures, verbosity=1)
 
-        # Load fixtures for default physionet sites
-        physionet_site_fixtures = os.path.join(settings.BASE_DIR, 'physionet',
+        # Load fixtures for default sites
+        site_fixtures = os.path.join(settings.BASE_DIR, 'physionet',
                                           'fixtures', 'sites.json')
-        call_command('loaddata', physionet_site_fixtures, verbosity=1)
+        call_command('loaddata', site_fixtures, verbosity=1)
 
 
         # Load other app fixtures


### PR DESCRIPTION
These small changes remove mentions of "physionet" that are not needed for code functionality or clarity, which is a small step toward addressing #1354.