### PR TITLE
Added Submissions page to admin console to track when projects reached milestones

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -188,6 +188,9 @@
           <li class="nav-item {% if submenu == 'credential' %}active{% endif %}">
             <a href="{% url 'credentialing_stats' %}">Credentialing</a>
           </li>
+          <li class="nav-item {% if submenu == 'submissions' %}active{% endif %}">
+            <a href="{% url 'submission_stats' %}">Submissions</a>
+          </li>
         </ul>
       </li>
 

--- a/physionet-django/console/templates/console/submission_stats.html
+++ b/physionet-django/console/templates/console/submission_stats.html
@@ -14,7 +14,7 @@
           <th>Year</th>
           <th>Month</th>
           <th>Projects Created</th>
-          <th>Submissions</th>
+          <th>New Submissions</th>
           <th>Resubmissions</th>
           <th>Publications</th>
         </tr>

--- a/physionet-django/console/templates/console/submission_stats.html
+++ b/physionet-django/console/templates/console/submission_stats.html
@@ -1,0 +1,42 @@
+{% extends "console/base_console.html" %}
+{% load static %}
+
+{% block content %}
+<div class="card mb-3">
+  <div class="card-header">
+    Project statistics over previous 18 months
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+
+      <table class="table table-bordered">
+        <tr>
+          <th>Year</th>
+          <th>Month</th>
+          <th>Projects Created</th>
+          <th>Submissions</th>
+          <th>Resubmissions</th>
+          <th>Publications</th>
+        </tr>
+        {% for year, month_list in stats.items%}
+          {% for month, val in month_list.items%}
+          <tr>
+            {% if forloop.first %}
+              <td style="font-weight:bold">{{ year }}</td>
+            {% else %}
+              <td> </td>
+            {% endif %}
+            <td>{{ month }}</td>
+            <td>{{ val.0 }}</td>
+            <td>{{ val.1 }}</td>
+            <td>{{ val.2 }}</td>
+            <td>{{ val.3 }}</td>
+          </tr>
+          {% endfor %}
+        {% endfor %}
+      </table>
+
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -95,4 +95,5 @@ urlpatterns = [
     path('usage/editorial/stats/', views.editorial_stats, name='editorial_stats'),
     path('usage/credentialing/stats/', views.credentialing_stats,
          name='credentialing_stats'),
+    path('usage/submission/stats/', views.submission_stats, name='submission_stats'),
 ]

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1851,7 +1851,8 @@ def credentialing_stats(request):
 def submission_stats(request):
     stats = OrderedDict()
     todays_date = datetime.today()
-    all_projects = [PublishedProject.objects.filter(is_legacy=False), ActiveProject.objects.all()]
+    all_projects = [PublishedProject.objects.filter(is_legacy=False), ActiveProject.objects.all(),
+                    ArchivedProject.objects.all()]
     cur_year = todays_date.year
     cur_month = todays_date.month
 
@@ -1888,33 +1889,8 @@ def submission_stats(request):
                 pub_mo = project.publish_datetime.strftime("%B")
                 if pub_yr in stats:
                     stats[pub_yr][pub_mo][3] += 1
-            except:
+            except AttributeError:
                 pass
-
-    for project_set in all_projects:
-        for project in project_set:
-            edit_logs = project.edit_log_history()
-            for log in edit_logs:
-                if log.is_resubmission:
-                    print("{0:<5} {1}".format(log.submission_datetime.strftime("%d %b %Y"), log.project))
-
-    for year, monthlist in stats.items():
-        for month, value in monthlist.items():
-            print("{0} {1} {2} {3}".format(value[0], value[1], value[2], value[3]))
-
-
-    # Get submissions per month per year
-    # for i in published_projects:
-    #     edit_logs = i.edit_log_history()
-    #     for e in edit_logs:
-    #         print("Title: {0}\t Resubmission Datetime: {1}\t Is resubmission: {2}".\
-    #               format(e.project, e.resubmission_datetime.strftime("%d %B %Y"), e.is_resubmission))
-    #
-    #     proj_year = i.publish_datetime.year
-    #     proj_month = i.publish_datetime.month
-    #     date = datetime(proj_year, proj_month, 1).strftime("%B")
-    #     if proj_year in stats:
-    #        stats[proj_year][date] += 1
 
     return render(request, 'console/submission_stats.html',
                   {'stats_nav': True, 'submenu': 'submission', 'stats': stats})


### PR DESCRIPTION
Page can be accessed under Admin Console > Usage Stats > Submissions

For all ActiveProjects and PublishedProjects, the dates that they were created, submitted, resubmitted (if applicable)
and published (if applicable) are tracked and counted up for each month over the last 18 months.

Currently does not consider projects that have never been submitted