### PR TITLE
Made simple change towards unbranding

### DIFF
--- a/physionet-django/templates/about/submission_overview.html
+++ b/physionet-django/templates/about/submission_overview.html
@@ -33,7 +33,7 @@
 
 <section id="editorial" class="indented-box">
   <h2>Editorial process</h2>
-  <p>Once your project is submitted to PhysioNet, it will be reviewed by one or more content specialists. Based on this review, you will be provided with an initial editorial decision within four weeks from submission. The possible decisions are:</p>
+  <p>Once your project is submitted, it will be reviewed by one or more content specialists. Based on this review, you will be provided with an initial editorial decision within four weeks from submission. The possible decisions are:</p>
   <ol>
     <li><strong>Accept</strong>: The editor is mostly satisfied with the content. The submission
         continues into the copyedit stage.</li>


### PR DESCRIPTION
This is my first commit to Physionet-building. I would like to start with something small before jumping onto the real issues. 

This change is very simple, just got rid of the unnecessary words "to Physionet" in the sentence. The intuition is this may help with unbranding, and makes the platform generalizable. 




