### PR TITLE
Updates text for PhysioNet unbranding. ref #1380

### DIFF
--- a/physionet-django/templates/about/share.html
+++ b/physionet-django/templates/about/share.html
@@ -1,5 +1,5 @@
 <section id="pshare" class="indented-box">
-  <p>We invite you to share your resources with the PhysioNet community. Incentives to share include:
+  <p>We invite you to share your resources with the research community. Incentives to share include:
   <ul>
     <li>Improving the discoverability of your work through increased citations.</li>
     <li>Creating opportunities for collaboration.</li>


### PR DESCRIPTION
Updated the text on the Share page under "Sharing on Physionet" heading from "We invite you to share your resources with the PhysioNet community to "We invite you to share your resources with the research community."  This is to help with the unbranding of PhysioNet, similar to #1380. 
