### PR TITLE
Adds guidance for gcp bucket command line permissions. fixes #1344

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
@@ -9,6 +9,10 @@ https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}
 You can use the following command to copy the content of the bucket to your computer:
 gsutil -m -u YOUR_PROJECT_ID cp -r gs://{{ project.gcp.bucket_name }} DESTINATION
 
+To access this bucket from the command line, you will need to set
+up Google Cloud credentials as described here:
+https://cloud.google.com/storage/docs/gsutil_install#authenticate
+
 {% else %}
 You have requested access to use {{ project }} in GCP BigQuery.
 


### PR DESCRIPTION
As noted in #1344, it would be useful for users to be given information on how to add authentication details to google cloud command line tools, to enable download of data from the command line.

This pull request adds the following text to the email sent to users when they request access to gcp buckets:
```
To access this bucket from the command line, you will need to set
up Google Cloud credentials as described here:
https://cloud.google.com/storage/docs/gsutil_install#authenticate
```
