### PR TITLE
Adds user activation status on user profile page. ref #1155

### DIFF
--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -18,6 +18,14 @@
       {{ subject.get_full_name }}
     </div>
   </div>
+  <div class="row mb-1">
+    <div class="col-md-3">
+      Activation status:
+    </div>
+    <div class="col-md-9">
+      {{ subject.is_active }}
+    </div>
+  </div>
 
   {% if profile.affiliation %}
     <div class="row mb-1">


### PR DESCRIPTION
As noted in #1155, this update is the first step towards adding the activation status for a user on this page (http://127.0.0.1:8000/console/user/manage/adamfinn/) for example.

The page for a specific user can be accessed from this page (http://127.0.0.1:8000/console/users/all/) from the Users>All Users tab by clicking on a specific username under the Username column.

The update uses the is_active attribute that returns True or False for a specific user object under class User (AbstractBaseUser).

`python manage.py shell` is used to interface with the database to access the User class from physionet-build/physionet-django/user/models.py path, run methods/attributes on an object, run django queries and save any changes to a user's activation status.

The Bootstrap's CSS framework is used to make the change on the physionet-django>console>templates>console>
templates>console>user_management.html page:

```
<div class="row mb-1">
    <div class="col-md-3">
      Activation status:
    </div>
    <div class="col-md-9">
      {{ subject.is_active }}
    </div>
</div>
```
















