### PR TITLE
bump max filename length from 50 to 60 characters

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -3,7 +3,7 @@ import re
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
-MAX_FILENAME_LENGTH = 50
+MAX_FILENAME_LENGTH = 60
 MAX_PROJECT_SLUG_LENGTH = 30
 
 _good_name_pattern = re.compile(r'\w+([\w\-\.]*\w+)?', re.ASCII)


### PR DESCRIPTION
Currently project files and folders must be a maximum of 50 characters long. This arbitrary limit is mostly fine, but I am reviewing a project with a large number of folders and files, many of which exceed the limit. To avoid having to ask the contributors to reorganise their files, I would like to bump the limit from 50 to 60. 