### PR TITLE
Fixed error when deprecating published projects and deleting files

### DIFF
--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -189,7 +189,8 @@ def clear_directory(directory):
     """
     Delete all files and folders in a directory.
     """
-    remove_items(os.path.join(directory, i) for i in os.listdir(directory))
+    for i in os.listdir(directory):
+        remove_items([os.path.join(directory, i)])
 
 def rename_file(old_path, new_path):
     """


### PR DESCRIPTION
This commit fixed the problem mentioned in issue #1178. 

The problem with that issue is: a sequence of error messages will pop up when deprecating a published project and chose "Yes" in deleting the files. However, the deprecating process will be completed despite the error. 

With Tom's help, we found that the "item" that is associated with the files that are to be deleted have the types  "Generatortype" but the code only checks for "tuple" or "list". 

Adding "Generatortype" fixed the problem. 