### PR TITLE
Updates awaiting authors revision in the outstanding tasks panel. ref #1363

### DIFF
--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -38,8 +38,7 @@
           <div class="col-md-2"><strong>Date</strong></div>
           <div class="col-md-2"></div>
         </div>
-      </li>
-    
+      </li>    
     {% if invitation_response_formset|length %}
       <form action="" method="post">
         {{ invitation_response_formset.management_form }}
@@ -101,18 +100,18 @@
       {% endfor %}
     {% endif %}
     {% if pending_revisions|length %}
-    {% for project in pending_revisions %}
-      <li class="list-group-item">
-        <div class="row">
-          <div class="col-md-5"><a href="{% url 'project_overview' project.slug %}">{{ project.title  }}</a></div>
-          <div class="col-md-3">Revisions requested</div>
-          <div class="col-md-2">{{ project.revision_request_datetime|date }}</div>
-          <div class="col-md-2">
-            <a href="{% url 'project_submission' project.slug %}" class="btn btn-sm btn-primary">Resubmit project</a>
+      {% for project in pending_revisions %}
+        <li class="list-group-item">
+          <div class="row">
+            <div class="col-md-5"><a href="{% url 'project_overview' project.slug %}">{{ project.title }}</a></div>
+            <div class="col-md-3">Revisions requested</div>
+            <div class="col-md-2">{{ project.revision_request_datetime|date }}</div>
+            <div class="col-md-2">
+              <a href="{% url 'project_submission' project.slug %}" class="btn btn-sm btn-primary">Resubmit project</a>
+            </div>
           </div>
-        </div>
-      </li>
-    {% endfor %}
+        </li>
+      {% endfor %}
     {% endif %}
     {% if pending_author_approvals|length %}
       {% for project in pending_author_approvals %}

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -24,7 +24,7 @@
   </div>
 
 <!-- Outstanding tasks -->
-{% if invitation_response_formset|length or pending_author_approvals|length or missing_affiliations|length or data_access_requests|length %}
+{% if pending_revisions|length or invitation_response_formset|length or pending_author_approvals|length or missing_affiliations|length or data_access_requests|length %}
   <div class="card" >
     <div class="card-header">
       <h2>Outstanding Tasks</h2>
@@ -39,6 +39,7 @@
           <div class="col-md-2"></div>
         </div>
       </li>
+    
     {% if invitation_response_formset|length %}
       <form action="" method="post">
         {{ invitation_response_formset.management_form }}
@@ -98,6 +99,20 @@
           </div>
         </li>
       {% endfor %}
+    {% endif %}
+    {% if pending_revisions|length %}
+    {% for project in pending_revisions %}
+      <li class="list-group-item">
+        <div class="row">
+          <div class="col-md-5"><a href="{% url 'project_overview' project.slug %}">{{ project.title  }}</a></div>
+          <div class="col-md-3">Revisions requested</div>
+          <div class="col-md-2">{{ project.revision_request_datetime|date }}</div>
+          <div class="col-md-2">
+            <a href="{% url 'project_submission' project.slug %}" class="btn btn-sm btn-primary">Resubmit project</a>
+          </div>
+        </div>
+      </li>
+    {% endfor %}
     {% endif %}
     {% if pending_author_approvals|length %}
       {% for project in pending_author_approvals %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -210,10 +210,14 @@ def project_home(request):
 
     pending_author_approvals = []
     missing_affiliations = []
+    pending_revisions = []
     for p in projects:
         if (p.submission_status == 50
                 and not p.authors.get(user=user).approval_datetime):
             pending_author_approvals.append(p)
+        if (p.submission_status == 30
+                and p.authors.get(user=user).is_submitting):
+            pending_revisions.append(p)
         if (p.submission_status == 0
                 and p.authors.get(user=user).affiliations.count() == 0):
             missing_affiliations.append(
@@ -233,7 +237,8 @@ def project_home(request):
         'missing_affiliations': missing_affiliations,
         'pending_author_approvals': pending_author_approvals,
         'invitation_response_formset': invitation_response_formset,
-        'data_access_requests': data_access_requests
+        'data_access_requests': data_access_requests,
+        'pending_revisions': pending_revisions
     })
 
 @login_required


### PR DESCRIPTION
This update allows the submitting author to view the date a revision was requested for a submitted project and it also allows the submitting author to resubmit their project for revision as part of the outstanding tasks panel, ref #1363. 

The outstanding tasks panel can be viewed on this page (http://localhost:8000/projects/) and the project can be resubmitted on this page (http://localhost:8000/projects/p7TCIMkltNswuOB9FZH1/submission/).