### PR TITLE
Maintaining pending approval panel for submitting authors when not all author approves the publication

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -213,8 +213,11 @@ def project_home(request):
     pending_revisions = []
     for p in projects:
         if (p.submission_status == 50
-                and not p.authors.get(user=user).approval_datetime):
-            pending_author_approvals.append(p)
+                and not p.all_authors_approved()):
+            if p.authors.get(user=user).is_submitting:
+                pending_author_approvals.append(p)
+            elif not p.authors.get(user=user).approval_datetime:
+                pending_author_approvals.append(p)
         if (p.submission_status == 30
                 and p.authors.get(user=user).is_submitting):
             pending_revisions.append(p)


### PR DESCRIPTION
When the submitting author is viewing the project page. If not all authors approve the publication, the submitting author will see and have access to the approval for publication page for other authors. 

Related issue #1364 