### PR TITLE
changed 'new project' to 'new version' in the notification email

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -185,7 +185,10 @@ def submit_notify(project):
                   [email], fail_silently=False)
 
     # notify editorial team
-    subject = 'A new project has been submitted: {0}'.format(project.title)
+    if project.core_project.publishedprojects.exists():
+        subject = 'A new version has been submitted: {0}'.format(project.title)
+    else:
+        subject = 'A new project has been submitted: {0}'.format(project.title)
     email_context['name'] = "Colleague"
     body = loader.render_to_string(
         'notification/email/submit_notify_team.html', email_context)


### PR DESCRIPTION
If a project has been previously submitted. The notification email will have the title" A new project has been updated" instead of "A new project has been submitted"

Solves issue #1160 