### PR TITLE
fixed approve on behalf order problem 

### DIFF
--- a/physionet-django/project/templates/project/awaiting_authors_table.html
+++ b/physionet-django/project/templates/project/awaiting_authors_table.html
@@ -27,13 +27,13 @@
       </td>
      {% if is_submitting and not author.approval_datetime and author.user != user %}
       <td>
-        <button id="approve-on-behalf-publication-modal-button" type="button" class="btn btn-success" data-toggle="modal" data-target="#approve-on-behalf-modal">Approve
+        <button id="approve-on-behalf-publication-modal-button" type="button" class="btn btn-success" data-toggle="modal" data-target="#approve-on-behalf-modal-{{ author.id }}">Approve
         </button>
-        <div class="modal fade" id="approve-on-behalf-modal" tabindex="-1" role="dialog" aria-labelledby="approve-on-behalf-modal" aria-hidden="true">
+        <div class="modal fade" id="approve-on-behalf-modal-{{ author.id }}" tabindex="-1" role="dialog" aria-labelledby="approve-on-behalf-label-{{ author.id }}" aria-hidden="true">
           <div class="modal-dialog" role="document">
             <div class="modal-content">
               <div class="modal-header">
-                <h5 class="modal-title">Approve on behalf of {{ author.name }}</h5>
+                <h5 class="modal-title" id="approve-on-behalf-label-{{ author.id }}">Approve on behalf of {{ author.name }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>
@@ -44,7 +44,7 @@
                     <p>If you are satisfied with the final state of the project, you may approve the publication.</p>
                   </div>
                   <div class="modal-footer">
-                    <button id="approve-publication-button" class="btn btn-success" type="submit" value="{{ author.id }}" name="approve_publication">Approve Publication</button>
+                    <button id="approve-publication-button-{{ author.id }}" class="btn btn-success" type="submit" value="{{ author.id }}" name="approve_publication">Approve Publication</button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                   </div>
                 </form>


### PR DESCRIPTION
 Fixed the problem described in issue #1073.

The bug happens at the author approval stage of the project submission. When a submitting author trying to approve the project on behalf of other authors and there is more than one other authors. (Picture below)

<img width="724" alt="Screen Shot 2021-09-21 at 9 54 27 AM" src="https://user-images.githubusercontent.com/16839385/134554995-e019741c-418c-45e2-addf-142af658d335.png">

For the two approve on behalf buttons displayed, whichever got clicked, the pop-up modal will have the author displayed on top displayed. 

The reason for this to happen is because in the template page, the code loop through all the authors' names but the 'approve-on-behalf-modal' doesn't have a unique id, therefore, every time the modal will display the first author's name and pass on the same id. 

Fixed this by adding 'author.id' as part of the 'data-target' object in the approve-on-behalf-modal.

Tested on the demo projects with three authors.