### PR TITLE
Debug Toolbar - Ignore INTERNAL_IPS in development

### DIFF
--- a/physionet-django/physionet/settings/settings.py
+++ b/physionet-django/physionet/settings/settings.py
@@ -27,6 +27,11 @@ if DEBUG:
     INSTALLED_APPS += ['debug_toolbar']
     MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
+    if ENVIRONMENT == 'development' and not RUNNING_TEST_SUITE:
+        DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': 'physionet.settings.settings.show_toolbar'}
+        def show_toolbar(request):
+            return True
+
 # When ready, use the following:
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' if DEBUG else 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = config('EMAIL_HOST', default='localhost')


### PR DESCRIPTION
Currently, the debug toolbar is invisible when developing using Docker. I changed it so that in the `development` environment `INTERNAL_IPS` are not taken into account and the toolbar is always visible when `DEBUG = True`. In other environments (`staging`, `production`) `INTERNAL_IPS` has to be set to prevent unauthorized access to the debug info.