### PR TITLE
Add and configure Sentry

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -439,6 +439,17 @@ logging.config.dictConfig({
     },
 })
 
+if config('SENTRY_DSN', default=None):
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(
+        dsn=config('SENTRY_DSN'),
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=config('SENTRY_SAMPLE_RATE', default=1.0, cast=float),
+        send_default_pii=False
+    )
+
 # If this environment variable is set, acquire a shared lock on the
 # named file.  The file descriptor is left open, but is
 # non-inheritable (close-on-exec), so the lock will be inherited by

--- a/poetry.lock
+++ b/poetry.lock
@@ -547,6 +547,35 @@ python-versions = "*"
 urllib3 = "*"
 
 [[package]]
+name = "sentry-sdk"
+version = "1.4.3"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+chalice = ["chalice (>=1.16.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+httpx = ["httpx (>=0.16.0)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -610,7 +639,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c710aac8540408d825aa75c1357d5f488409fd0b8c4a70482b4217b2e8670df3"
+content-hash = "0127181b38a269d765c7d9105358bf2a31f5eb1ce8c946c2e660faacd7149dd6"
 
 [metadata.files]
 bleach = [
@@ -1017,6 +1046,10 @@ rsa = [
 selenium = [
     {file = "selenium-3.141.0-py2.py3-none-any.whl", hash = "sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c"},
     {file = "selenium-3.141.0.tar.gz", hash = "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"},
+]
+sentry-sdk = [
+    {file = "sentry-sdk-1.4.3.tar.gz", hash = "sha256:b9844751e40710e84a457c5bc29b21c383ccb2b63d76eeaad72f7f1c808c8828"},
+    {file = "sentry_sdk-1.4.3-py2.py3-none-any.whl", hash = "sha256:c091cc7115ff25fe3a0e410dbecd7a996f81a3f6137d2272daef32d6c3cfa6dc"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ psycopg2 = "~2.8.6"
 httplib2 = "^0.19.0"
 oauthlib = "^3.1.0"
 requests-oauthlib = "^1.3.0"
+sentry-sdk = "^1.4.3"
 
 [tool.poetry.dev-dependencies]
 coverage = "^4.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,9 @@ pyOpenSSL==19.0.0 \
  --hash=sha256:c727930ad54b10fc157015014b666f2d8b41f70c0d03e83ab67624fd3dd5d1e6
 google-api-python-client==1.7.9 \
  --hash=sha256:5def5a485b1cbc998b8f869456c7bde0c0e6d3d0a5ea1f300b5ef57cb4b1ce8f
+sentry-sdk==1.4.3 \
+ --hash=sha256:b9844751e40710e84a457c5bc29b21c383ccb2b63d76eeaad72f7f1c808c8828\
+ --hash=sha256:c091cc7115ff25fe3a0e410dbecd7a996f81a3f6137d2272daef32d6c3cfa6dc
 
 #### Required for postgresql database backend ####
 


### PR DESCRIPTION
Setup sentry according to this guide: https://docs.sentry.io/platforms/python/guides/django/.

To use the integration one has to set the `SENTRY_DSN` environment variable (the value is available after creating a project in Sentry). To control how many events are sent to Sentry set the `SENTRY_SAMPLE_RATE` to a smaller fraction (eg. 0.1 would send 1 out of 10 errors to Sentry). Setting the uWSGI option `enable-threads` is also recommended.