### PR TITLE
Updates url links for users from public to private profiles on the credentialing processing page & adds credentialing history to the user's private profile page. 

### DIFF
--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -104,7 +104,7 @@
             {% for application in training_applications %}
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
@@ -156,7 +156,7 @@
             {% for application in personal_applications %}
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
@@ -208,7 +208,7 @@
             {% for application in reference_applications %}
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
@@ -261,7 +261,7 @@
             {% for application in response_applications %}
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
@@ -310,7 +310,7 @@
             {% for application in final_applications %}
               <tr class="header" id='application_{{application.user.email}}'>
               {% with user=application.user %}
-                <td><a href="{% url 'public_profile' user.username %}">{{ user }}</td>
+                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
                 <td>{{ user.get_full_name }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>

--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -76,8 +76,9 @@
   {% endif %}
 
   <br />
+  <h3>Projects</h3>
   {% for status, group in projects.items %}
-  <h3>{{ status }} projects</h3>
+  <h4>{{ status }} projects</h4>
     <ul>
       {% for project in group %}
         {% if status == "Unsubmitted" %}
@@ -99,5 +100,23 @@
     </ul>
   {% endfor %}
 
+  <h3>Credentialing history</h3>
+  <ul>
+  {% for cred_app in credentialing_app %}
+    <li><strong> Application {{ forloop.counter }}</strong><br />
+    Date: {{ cred_app.application_datetime }}<br />
+    {% if cred_app.status == 0 %} 
+      Status: Pending<br />
+    {% else %}
+      Status: {{ cred_app.get_status_display }}<br />
+    {% endif %}
+    Reviewer: {{ cred_app.responder }}<br />
+    Reviewer comments: {{ cred_app.responder_comments }}
+    </li>
+  {% empty %}
+    <li>No applications found.</li>
+  {% endfor %}
+  </ul>
+  
 </div>
 {% endblock %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -938,12 +938,13 @@ def user_management(request, username):
     projects['Archived'] = ArchivedProject.objects.filter(authors__user=user).order_by('-archive_datetime')
     projects['Published'] = PublishedProject.objects.filter(authors__user=user).order_by('-publish_datetime')
 
-
+    credentialing_app = CredentialApplication.objects.filter(user=user).order_by("application_datetime")
     return render(request, 'console/user_management.html', {'subject': user,
                                                             'profile': user.profile,
                                                             'emails': emails,
-                                                            'projects': projects})
-
+                                                            'projects': projects,
+                                                            'credentialing_app': credentialing_app})
+    
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')


### PR DESCRIPTION
In this pull request two changes are made to improve the credentialing system:

1. Updating user's public profiles to private profiles that can be accessed by reviewers (admin users).
>On the credentialing processing page, http://localhost:8000/console/credential_processing/, the links attached to the username under the `user` column are changed to link to private user profiles instead of public user profiles across all tabs including `Initial review`, `Training check`, `ID check`,  `Reference check`, `Reference response`, and `Final Review`. 

2. Providing an intra-reviewer feed to help other reviewers track the log of previous reviewers.
>The credentialing history is added to the private profile page, e.g. http://localhost:8000/console/user/manage/rgmark/.
Under the `Credentialing History` heading, all the user's submitted credentialing applications are listed from the latest to the oldest. Information on the date the credentialing application was submitted, the status of the application, the reviewer and the reviewer comments are also included to guide reviewers during the credentialing process.