### PR TITLE
Fix sentry sample rates configuration

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -440,7 +440,8 @@ if config('SENTRY_DSN', default=None):
     sentry_sdk.init(
         dsn=config('SENTRY_DSN'),
         integrations=[DjangoIntegration()],
-        traces_sample_rate=config('SENTRY_SAMPLE_RATE', default=1.0, cast=float),
+        sample_rate=config('SENTRY_SAMPLE_RATE', default=1.0, cast=float),
+        traces_sample_rate=config('SENTRY_TRACES_SAMPLE_RATE', default=0.0, cast=float),
         send_default_pii=False
     )
 


### PR DESCRIPTION
Configure (error) sample rates and trace sample rates separately with traces disabled by default.