### PR TITLE
[1418] PEP8 Style Check on Modified Code Only

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -25,15 +25,22 @@ jobs:
       matrix:
         pip3: ['poetry', 'requirements.txt']
     steps:
-      - name: Checkout physionet-build repo
-        uses: actions/checkout@v2
 
       - name: Update packages
         run: apt-get update --yes
 
       - name: Install and configure needed software
         run: |
-          apt-get install sudo python3-dev python3-pip build-essential libpq-dev postgresql zip wget python-virtualenv --yes
+          apt-get install sudo git python3-dev python3-pip build-essential libpq-dev postgresql zip wget flake8 python-virtualenv --yes
+
+      # Note: run checkout after updating git
+      - name: Checkout physionet-build repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create .env file
+        run: |
           ln -sT .env.example .env
 
       - name: Install repo dependencies
@@ -83,3 +90,15 @@ jobs:
           python manage.py loaddemo
           coverage run --source='.' manage.py test --verbosity=3 --keepdb
           coverage report -m
+
+      - name: Run code style check on changed files relative to PR base branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git rev-parse --verify ${{ github.event.pull_request.base.sha }}
+          git diff ${{ github.event.pull_request.base.sha }} HEAD | flake8 --diff
+
+      - name: Run code style check relative to local dev branch
+        if: github.event_name != 'pull_request'
+        run: |
+          git fetch origin dev
+          git diff origin/dev HEAD | flake8 --diff

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ If using docker, all of the commands should run inside the test container (`dock
 - Unit tests for each app are kept in their `test*.py` files.
 - To run the unit tests, change to the `physionet-django` directory and run `python manage.py test`.
 - To check test coverage, change to the `physionet-django` directory and run `coverage run --source='.' manage.py test`. Next run `coverage html` to generate an html output of the coverage results.
+- To check code style, change to the `physionet-django` directory and run `flake8 [PATH_TO_FILE(s)]`. As part of the `physionet-build-test` workflow, flake8 will be run only against modified code relative to `dev` or the base PR branch. 
+Note: `flake8` is only installed in the workflow. To install it for local testing, see [here](https://flake8.pycqa.org/en/latest/).
 - To run the browser tests in the `test_browser.py` files, selenium and the [firefox driver](https://github.com/mozilla/geckodriver/releases) are required. If you want to see the test run in your browser, remove the `options.set_headless(True)` lines in the `setUpClass` of the browser testing modules.
 
 ## Database Content During Development


### PR DESCRIPTION
# Issue
#1418 

# Description
This PR adds the [flake8](https://flake8.pycqa.org/en/latest/) to project dev dependencies and introduces a code style check for *new lines of code* either being PR'ed or merged into dev.

# Modified Code
Minor changes had to be made to the existing physionet-build-test workflow:
1. `git` needs to be installed and updated. Otherwise, the `actions/checkout@v2` has different behavior and the `git` command will not be found in the container.
2. `actions/checkout@v2` must be moved to after `git` is updated. 
3. We add in a `fetch_depth: 0` for the checkout action. This will fetch the entire git history during the clone step as opposed to a shallow copy. We need this in order to compare modified code between branches and older commits. (Note: the entire history may not be necessary as described [here](https://stackoverflow.com/questions/65944700/how-to-run-git-diff-in-github-actions). I kept it as 0 to keep it more robust but if this runs into notable performance issues, we can change it to a smaller depth).

# Solution
The solution is straightforward. If the workflow event trigger is a pull request, we fetch the PR base branch from the original repository. This is necessary if the incoming PR is from a forked repo. We then simply have to run `git diff` to get the modified lines and pipe the result into `flake8`. 

I added a similar step to run on non PRs events to just run flake8 on modified lines relative to the same repository's `dev` branch. This is useful in case developers are triggering the physionet-build-test workflow on other branches for testing before PR. 

# Steps to Validate Solution:
0. Fork physionet-build repo
1. Copy this branch to get workflow changes
2. Introduce PEP8 error
3. Create PR
4. Workflow should fail on `Run code style check on changed files relative to PR base branch` step

To test the second change,
5. [Add manual trigger to physionet-build-test workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
6. Manually trigger physionet-build-test workflow on branch
7. Workflow should fail on `Run code style check relative to local dev branch` step

