### PR TITLE
Silence disallowed host log messages

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -436,6 +436,11 @@ LOGGING = {
             'handlers': ['custom_logging'],
             'propagate': False,
         },
+        'django.security.DisallowedHost': {
+            'handlers': ['mail_admins'],
+            'level': 'CRITICAL',
+            'propagate': True,
+        },
        'django.request': {
             'handlers': ['verbose_console', 'mail_admins'],
             'level': 'ERROR',

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -441,7 +441,7 @@ LOGGING = {
             'level': 'CRITICAL',
             'propagate': True,
         },
-       'django.request': {
+        'django.request': {
             'handlers': ['verbose_console', 'mail_admins'],
             'level': 'ERROR',
             'propagate': False,


### PR DESCRIPTION
Partially revert aea362a1a7264b43c4b66842c8ac46e17f453df7:

When a client requests a URL from an unknown hostname (one that is not
listed in "ALLOWED_HOSTS"), django generates a log message at level
ERROR.  Since this is not a server bug, it should not result in an
email message to the administrators.  Therefore, raise the log level
for this logger to CRITICAL.
