### PR TITLE
Fix test suite on development system with lightwave

### DIFF
--- a/physionet-django/lightwave/views.py
+++ b/physionet-django/lightwave/views.py
@@ -13,13 +13,11 @@ from project.views import project_auth
 
 
 # PUBLIC_ROOT: chroot directory for public databases
-if settings.STATIC_ROOT:
-    PUBLIC_ROOT = settings.STATIC_ROOT
-else:
-    PUBLIC_ROOT = os.path.join(settings.BASE_DIR, 'static')
+# (note that all files located within this directory are treated as public)
+PUBLIC_ROOT = os.path.dirname(PublishedProject.PUBLIC_FILE_ROOT)
 
 # PUBLIC_DBPATH: path to main database directory within PUBLIC_ROOT
-PUBLIC_DBPATH = 'published-projects'
+PUBLIC_DBPATH = os.path.basename(PublishedProject.PUBLIC_FILE_ROOT)
 
 # ORIGINAL_DBCAL_FILE: absolute path to the wfdbcal file from WFDB
 ORIGINAL_DBCAL_FILE = '/usr/local/database/wfdbcal'

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -46,6 +46,9 @@ class PublishedProject(Metadata, SubmissionInfo):
     # Where all the published project files are kept, depending on access.
     PROTECTED_FILE_ROOT = os.path.join(settings.MEDIA_ROOT, 'published-projects')
     # Workaround for development
+    # Note that all files located within the *parent directory* of
+    # PUBLIC_FILE_ROOT are treated as public (see
+    # physionet-django/lightwave/views.py).
     if settings.STATIC_ROOT is None:
         PUBLIC_FILE_ROOT = os.path.join(settings.STATICFILES_DIRS[0], 'published-projects')
     else:


### PR DESCRIPTION
Running the test suite (in development config, on a system with WFDB installed) was broken because:

- loaddemo creates "physionet-django/static/wfdbcal", and then TestMixin.setUp tries to overwrite that same file and chokes.

- When running the test suite, lightwave shouldn't be accessing "physionet-django/static" anyway; it should be using "physionet-django/static/test" instead.

- Putting DBCAL_FILE in the right place causes TestMixin.tearDown to choke because it's trying to chmod a file we don't own.

- TestMixin.setUp chokes if the test wasn't previously torn down properly.

So clearly this has been broken for a while, I don't know how long.  But these changes should make things more robust.

