### PR TITLE
Only check for style errors in modified lines

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -95,10 +95,11 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git rev-parse --verify ${{ github.event.pull_request.base.sha }}
-          git diff ${{ github.event.pull_request.base.sha }} HEAD | flake8 --diff
+          git diff -U0 ${{ github.event.pull_request.base.sha }} HEAD | \
+              flake8 --diff
 
       - name: Run code style check relative to local dev branch
         if: github.event_name != 'pull_request'
         run: |
           git fetch origin dev
-          git diff origin/dev HEAD | flake8 --diff
+          git diff -U0 origin/dev HEAD | flake8 --diff


### PR DESCRIPTION
"flake8 --diff" will report style errors in the lines *surrounding* the patch, not only the lines you modified.

I initially didn't think this would be a problem but after hitting it twice in a row in pretty trivial patches, I think it's not a great idea and we should only enforce style on lines that were modified.
