### PR TITLE
Show correct URL prefix for "anonymous access" link

### DIFF
--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -65,7 +65,7 @@
           <br>
           {% if anonymous_url %}
             The URL for reviewer access is:
-            <a href="{% url 'anonymous_login' anonymous_url %}" target="_blank">{{ request.get_host }}{% url 'anonymous_login' anonymous_url %}</a>
+            <a href="{% url 'anonymous_login' anonymous_url %}" target="_blank">{{ url_prefix }}{% url 'anonymous_login' anonymous_url %}</a>
           {% endif %}
         </p>
         <div


### PR DESCRIPTION
When an *unpublished project* has an anonymous-access URL, administrators can see it in the submission info pages.

For example, if you're an administrator and look at https://www.physionet.org/console/submitted-projects/8DzLG4n8q0HmKa7KCfTb/info/, you'll see the following:

> You can generate a passphrase that will allow anonymous access to the preview of this project. This is useful if the authors are submitting an article to a peer-reviewed journal and access to a PhysioNet resource is needed during the review process.
> The URL for reviewer access is:
> www.physionet.org/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/

Notice that the above text lacks the rather important "https://" prefix, so it's easy to make a mistake when copying and pasting.  Notice also that the text doesn't use the canonical hostname ("physionet.org").

(In contrast, "manage_published_project.html" correctly uses "{{ url_prefix }}".)
