### PR TITLE
Configurable hostname for bulk downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ SECRET_KEY=secret
 ALLOWED_HOSTS=localhost,127.0.0.1
 SITE_ID=4
 
+# Alternate hostname to be used in example download commands
+#BULK_DOWNLOAD_HOSTNAME=downloads.example.org
+
 # Database
 DB_USER=physionet
 DB_PASSWORD=password

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -47,7 +47,7 @@
           <button class="btn btn-lg btn-primary" onclick="copyToClipboard('{{ author_emails }}')">Copy Author Emails</button>
         </p>
         {% if user == project.editor or user.is_admin %}
-        <p>To Download all the files use this command:<br>wget -r -N -c -np --user {{ user }} --ask-password {{ url_prefix }}{% url 'serve_active_project_file_editor' project.slug '' %}</p>
+        <p>To Download all the files use this command:<br>wget -r -N -c -np --user {{ user }} --ask-password {{ bulk_url_prefix }}{% url 'serve_active_project_file_editor' project.slug '' %}</p>
         {% endif %}
       </div>
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -266,12 +266,14 @@ def submission_info(request, project_slug):
                         reassign_editor_form.cleaned_data['editor']))
 
     url_prefix = notification.get_url_prefix(request)
+    bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     return render(request, 'console/submission_info.html',
         {'project': project, 'authors': authors,
          'author_emails': author_emails, 'storage_info': storage_info,
          'edit_logs': edit_logs, 'copyedit_logs': copyedit_logs,
          'latest_version': latest_version, 'passphrase': passphrase,
          'anonymous_url': anonymous_url, 'url_prefix': url_prefix,
+         'bulk_url_prefix': bulk_url_prefix,
          'reassign_editor_form': reassign_editor_form,
          'project_info_nav': True})
 
@@ -318,12 +320,14 @@ def edit_submission(request, project_slug, *args, **kwargs):
 
     authors, author_emails, storage_info, edit_logs, _, latest_version = project.info_card()
     url_prefix = notification.get_url_prefix(request)
+    bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
 
     return render(request, 'console/edit_submission.html',
         {'project': project, 'edit_submission_form': edit_submission_form,
          'authors': authors, 'author_emails': author_emails,
          'storage_info': storage_info, 'edit_logs': edit_logs,
          'latest_version': latest_version, 'url_prefix': url_prefix,
+         'bulk_url_prefix': bulk_url_prefix,
          'editor_home': True, 'reassign_editor_form': reassign_editor_form})
 
 
@@ -434,6 +438,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
 
     edit_url = reverse('edit_content_item', args=[project.slug])
     url_prefix = notification.get_url_prefix(request)
+    bulk_url_prefix = notification.get_url_prefix(request)
 
     response = render(request, 'console/copyedit_submission.html', {
         'project': project, 'description_form': description_form,
@@ -456,6 +461,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         'copyedit_logs': copyedit_logs, 'latest_version': latest_version,
         'add_item_url': edit_url, 'remove_item_url': edit_url,
         'discovery_form': discovery_form, 'url_prefix': url_prefix,
+        'bulk_url_prefix': bulk_url_prefix,
         'reassign_editor_form': reassign_editor_form})
     if description_form_saved:
         set_saved_fields_cookie(description_form, request.path, response)
@@ -494,6 +500,7 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
             project.save()
 
     url_prefix = notification.get_url_prefix(request)
+    bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     yesterday = timezone.now() + timezone.timedelta(days=-1)
 
     return render(request, 'console/awaiting_authors.html',
@@ -501,6 +508,7 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
          'storage_info': storage_info, 'edit_logs': edit_logs,
          'copyedit_logs': copyedit_logs, 'latest_version': latest_version,
          'outstanding_emails': outstanding_emails, 'url_prefix': url_prefix,
+         'bulk_url_prefix': bulk_url_prefix,
          'yesterday': yesterday, 'editor_home': True,
          'reassign_editor_form': reassign_editor_form})
 
@@ -572,6 +580,7 @@ def publish_submission(request, project_slug, *args, **kwargs):
 
     publishable = project.is_publishable()
     url_prefix = notification.get_url_prefix(request)
+    bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     publish_form = forms.PublishForm(project=project)
 
     return render(request, 'console/publish_submission.html',
@@ -580,6 +589,7 @@ def publish_submission(request, project_slug, *args, **kwargs):
          'edit_logs': edit_logs, 'copyedit_logs': copyedit_logs,
          'latest_version': latest_version, 'publish_form': publish_form,
          'max_slug_length': MAX_PROJECT_SLUG_LENGTH, 'url_prefix': url_prefix,
+         'bulk_url_prefix': bulk_url_prefix,
          'reassign_editor_form': reassign_editor_form, 'editor_home': True})
 
 

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -64,18 +64,25 @@ def send_contact_message(contact_form):
 
 # ---------- Project App ---------- #
 
-def get_url_prefix(request):
+def get_url_prefix(request, bulk_download=False):
     """
     Return a URL protocol and host, such as 'https://example.com'.
 
     django.contrib.sites.shortcuts is used to look up a "canonical"
     hostname, if one is defined.
+
+    If bulk_download is true, settings.BULK_DOWNLOAD_HOSTNAME (if
+    defined) is used instead.
     """
-    site = get_current_site(request)
-    if request and not request.is_secure():
-        return 'http://' + site.domain
+    if bulk_download and settings.BULK_DOWNLOAD_HOSTNAME:
+        hostname = settings.BULK_DOWNLOAD_HOSTNAME
     else:
-        return 'https://' + site.domain
+        site = get_current_site(request)
+        hostname = site.domain
+    if request and not request.is_secure():
+        return 'http://' + hostname
+    else:
+        return 'https://' + hostname
 
 def email_project_info(project):
     """

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -169,6 +169,9 @@ GCP_DELEGATION_EMAIL = config('GCP_DELEGATION_EMAIL', default=False)
 GCP_BUCKET_PREFIX = "testing-delete."
 GCP_DOMAIN = "physionet.org"
 
+# Alternate hostname to be used in example download commands
+BULK_DOWNLOAD_HOSTNAME = config('BULK_DOWNLOAD_HOSTNAME', default=None)
+
 # Header tags for the AWS lambda function that grants access to S3 storage
 AWS_HEADER_KEY = config('AWS_KEY', default=False)
 AWS_HEADER_VALUE = config('AWS_VALUE', default=False)

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -349,7 +349,7 @@
             {% endfor %}
           {% endif %}
           {% if is_wget_supported %}
-            <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np --user {{ user }} --ask-password {{ url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
+            <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np --user {{ user }} --ask-password {{ bulk_url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
           {% endif %}
           </ul>
 {# ZIP END #}
@@ -394,7 +394,7 @@
           {% endfor %}
         {% endif %}
           {% if is_wget_supported %}
-            <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np {{ url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
+            <li>Download the files using your terminal: <pre class="shell-command">wget -r -N -c -np {{ bulk_url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre></li>
           {% endif %}
         </ul>
 {# ZIP END #}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1636,7 +1636,7 @@ def published_project(request, project_slug, version, subdir=''):
 
     has_access = project.has_access(user) or has_passphrase
     current_site = get_current_site(request)
-    url_prefix = notification.get_url_prefix(request)
+    bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     all_project_versions = PublishedProject.objects.filter(slug=project_slug).order_by('version_order')
     context = {
         'project': project,
@@ -1648,7 +1648,7 @@ def published_project(request, project_slug, version, subdir=''):
         'contact': contact,
         'has_access': has_access,
         'current_site': current_site,
-        'url_prefix': url_prefix,
+        'bulk_url_prefix': bulk_url_prefix,
         'citations': citations,
         'news': news,
         'all_project_versions': all_project_versions,


### PR DESCRIPTION
I think it's probably a good idea to use a different hostname in the example wget commands (and potentially other places) for bulk downloads.  See issue #1423.

(I haven't defined what that hostname might be, but I was thinking 'dl.physionet.org' for brevity, or maybe 'data.physionet.org' or 'files.physionet.org' or 'download.physionet.org'.)

It might be nice, at the same time, to stick an '-nH' and '--cut-dirs' into the wget command.

This here is a simple kludge and we may want to think about making it more general/flexible, but it should hopefully be a quick fix for the TLS issue.
