### PR TITLE
dev-entrypoint.sh: only wait for GCS_HOST if set

### DIFF
--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -6,7 +6,9 @@ mkdir -p $STATIC_ROOT/published-projects
 mkdir -p $MEDIA_ROOT/{active-projects,archived-projects,credential-applications,published-projects,users}
 
 ./docker/wait-for-it.sh $DB_HOST:5432
-./docker/wait-for-it.sh $GCS_HOST:4443
+if [ -n "$GCS_HOST" ]; then
+    ./docker/wait-for-it.sh $GCS_HOST:4443
+fi
 
 python physionet-django/manage.py migrate
 


### PR DESCRIPTION
Right now you can't run the development docker-compose configuration without using GCS.

This PR ensures that the startup scripts waits for the GCS_HOST to be available only if the GCS_HOST environment variable. is present