### PR TITLE
Change unix socket to uwsgi tcp socket in docker

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -4,8 +4,11 @@
 # the base directory
 chdir = /code/physionet-django
 
-# Port
+# HTTP Port
 http-socket = :8000
+
+# UWSGI Port
+uwsgi-socket = :8001
 
 # Django's wsgi file
 module = physionet.wsgi
@@ -22,11 +25,6 @@ processes = 5
 
 # python threading support
 enable-threads = true
-
-# the socket
-socket = /uwsgi.sock
-# ... with appropriate permissions - may be needed
-chmod = 664
 
 # clear environment on exit
 vacuum = true


### PR DESCRIPTION
It's more convenient to use a TCP socket for the uwsgi protocol instead of a UNIX socket when using containers. This allows for easy communication with a separate container with Nginx to communicate with the uWSGI server easily using `uwsgi_pass`. I chose port 8001 for no particular reason.