### PR TITLE
Run test-upgrade.sh as part of test suite

### DIFF
--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -1,0 +1,60 @@
+name: Debian / Upgrade Test
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  testupgrade:
+    name: Upgrade Test
+    runs-on: ubuntu-latest
+    container: debian:10
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update --yes
+          apt-get install --yes \
+                  build-essential \
+                  flake8 \
+                  git \
+                  libpq-dev \
+                  libseccomp-dev \
+                  python3-dev \
+                  sudo \
+                  virtualenv \
+                  wget \
+                  zip
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install WFDB
+        run: |
+          wget https://github.com/bemoody/wfdb/archive/10.6.2.tar.gz \
+               -O wfdb.tar.gz
+          tar -xf wfdb.tar.gz
+          (cd wfdb-* && ./configure --without-netfiles)
+          make -C wfdb-*/lib install
+          make -C wfdb-*/data install
+          ldconfig
+
+      - name: Install lightwave
+        run: |
+          wget https://github.com/bemoody/lightwave/archive/0.69.tar.gz \
+               -O lightwave.tar.gz
+          tar -xf lightwave.tar.gz
+          (cd lightwave-* && make CGIDIR=/usr/local/bin sandboxed-server)
+
+      - name: Create .env file
+        run: |
+          ln -sT .env.example .env
+
+      - name: Test PhysioNet server setup and upgrade
+        run: |
+          ./test-upgrade.sh -v origin/production

--- a/physionet-django/physionet/test_gcs.py
+++ b/physionet-django/physionet/test_gcs.py
@@ -10,11 +10,12 @@ from google.cloud.storage import Blob, Bucket, Client
 from physionet.gcs import GCSObject, GCSObjectException
 from physionet.settings.base import StorageTypes
 
-SKIP_GCS_INTEGRATION = not config('TEST_GCS_INTEGRATION', default=True, cast=bool)
+TEST_GCS_INTEGRATION = config('TEST_GCS_INTEGRATION', default=True, cast=bool)
+GCS_HOST = config('GCS_HOST', default=None)
 
 
 @skipIf(
-    SKIP_GCS_INTEGRATION,
+    (GCS_HOST is None or not TEST_GCS_INTEGRATION),
     'Test GCS-backend integration only on dockerized CI/CD pipeline.',
 )
 @override_settings(


### PR DESCRIPTION
This adds another GitHub workflow script to run `test-upgrade.sh`.

(The purpose of this script is to test that the server can be "live-upgraded", i.e. that it will work when installing to the live server using `git push`.  For example, it tests that migrations don't break the running server.)

This assumes there is a branch called `origin/production` corresponding to the current version from which we are upgrading.

This workflow duplicates some of the functionality of `physionet-build-test.yml`, but it doesn't *entirely* duplicate it.  Notable differences:

- `physionet-build-test.yml` tests the postgresql backend
- `physionet-upgrade-test.yml` tests the sqlite backend
- `physionet-upgrade-test.yml` tests random query ordering
- `physionet-build-test.yml` tests setup using poetry (as well as using pip)
- `physionet-build-test.yml` runs coverage tests
- `physionet-build-test.yml` runs code style tests

Moreover, this workflow has the significant limitation that it will not be automatically re-run when the `production` branch is pushed.

So there's a lot that could be improved here, but I still think adding this workflow would be beneficial.
