### PR TITLE
Fix internal links used by the second level navigation menu on the Publish page

### DIFF
--- a/physionet-django/templates/about/about.html
+++ b/physionet-django/templates/about/about.html
@@ -27,18 +27,17 @@ About
           </ul>
         </div>
       </div>
-    </div><div class="main-content">
-      <div>
-        {% for section in sections %}
-          <section id="{{ section.order }}">
-            <h1>{{ section.title }}</h1>
-            <div class="indented-box">
-              {{ section.content|safe }}
-            </div>
-          </section>
-          <br>
-        {% endfor %}
-      </div>
+    </div>
+    <div class="main-content">
+      {% for section in sections %}
+        <section id="{{ section.order }}">
+          <h1>{{ section.title }}</h1>
+          <div class="indented-box">
+            {{ section.content|safe }}
+          </div>
+        </section>
+        <br>
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/physionet-django/templates/about/publish.html
+++ b/physionet-django/templates/about/publish.html
@@ -30,10 +30,12 @@ Publish
     </div>
     <div class="main-content">
       {% for section in sections %}
-        <h1>{{ section.title }}</h1>
-        <div class="indented-box">
-          {{ section.content|safe }}
-        </div>
+        <section id="{{ section.order }}">
+          <h1>{{ section.title }}</h1>
+          <div class="indented-box">
+            {{ section.content|safe }}
+          </div>
+        </section>
         <br>
       {% endfor %}
     </div>


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/1429 we moved content from the [About page](https://physionet.org/about/) and the [Sharing page](https://physionet.org/about/publish/) to the database. 

The menu items on the [About page](https://physionet.org/about/) correctly refer the user to relevant content within the page using internal hyperlink links, but the chunk of code that generates these links was mistakenly omitted from the [Sharing page](https://physionet.org/about/publish/). 

This small pull request corrects the omission. Slightly unrelated, but there was an unnecessary `<div>` ... `</div>` on the About page that I removed at the same time.