### PR TITLE
Bump requirements file to match recent dependabot updates to Django and sqlparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,8 +100,9 @@ pyparsing==2.4.7 \
  --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
 
 # required by Django 2.2.3
-sqlparse==0.2.4 \
- --hash=sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4
+sqlparse==0.4.2 \
+    --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
+    --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d
 
 # required by django-ckeditor 5.7.1
 django-js-asset==0.1.1 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ bleach==3.3.0 \
  --hash=sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433
 chardet==3.0.4 \
  --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-Django==2.2.18 \
- --hash=sha256:0eaca08f236bf502a9773e53623f766cc3ceee6453cc41e6de1c8b80f07d2364 \
- --hash=sha256:c9c994f5e0a032cbd45089798b52e4080f4dea7241c58e3e0636c54146480bb4
+Django==2.2.25 \
+ --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+ --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
 django-autocomplete-light==3.3.4 \
  --hash=sha256:cff0b1cad0e233e49c8cce08dff22868951123cbb79a7c1768eda78845044568
 django-background-tasks==1.2.0 \


### PR DESCRIPTION
Dependabot recently opened pull requests to update Python versions of Django (#1454) and sqlparse (#1453). For reasons that are unclear to me, Dependabot didn't update requirements.txt to match. 

This pull request bumps the versions of the two packages in requirements.txt to match those in poetry.lock.

Note that there was already a mismatch in versions between poetry.lock and requirements.txt for both packages. I haven't checked, but I assume this is the case for many other packages too.