### PR TITLE
Handle unknown access policies in template tags

### DIFF
--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -66,7 +66,10 @@ def access_badge(access_policy):
         1: '<span class="badge badge-warning"><i class="fas fa-unlock-alt"></i> Restricted Access</span>',
         2: '<span class="badge badge-danger"><i class="fas fa-lock"></i> Credentialed Access</span>',
     }
-    return badges[access_policy]
+    try:
+        return badges[access_policy]
+    except KeyError:
+        return format_html('<!-- unknown access_policy: {} -->', access_policy)
 
 @register.filter(name='access_description')
 def access_description(access_policy):
@@ -75,7 +78,10 @@ def access_description(access_policy):
         1: 'Only logged in users who sign the specified data use agreement can access the files.',
         2: 'Only credentialed users who sign the specified DUA can access the files.',
     }
-    return descriptions[access_policy]
+    try:
+        return descriptions[access_policy]
+    except KeyError:
+        return format_html('<!-- unknown access_policy: {} -->', access_policy)
 
 @register.filter(name='bytes_to_gb')
 def bytes_to_gb(n_bytes):


### PR DESCRIPTION
The access_badge and access_description template tags should not crash if a project access policy is set to an unknown value.  We want to allow for the possibility of adding new access policy values, so ensure the site won't crash if we do so.

This is a prerequisite for making the upgrade tests pass in pull #1442 (i.e., we should merge this change to production first.)

Of course, there may be other places that make the implicit assumption that access policy is 0, 1, or 2.  In particular, PublishedProject.has_access is quite fragile.  However, I don't think this is an immediate concern for pull #1442, and that pull rewrites has_access to be more robust for the future.
