### PR TITLE
Update template for restricted access projects. Fix #1475

### DIFF
--- a/physionet-django/project/templates/project/published_project_unauthorized.html
+++ b/physionet-django/project/templates/project/published_project_unauthorized.html
@@ -10,6 +10,12 @@
           <a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project
         </li>
       {% endif %}
+    {% elif project.access_policy == AccessPolicy.RESTRICTED %}
+      {% if not has_signed_dua %}
+        <li>
+          <a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project
+        </li>
+     {% endif %}
     {% elif project.access_policy == AccessPolicy.CONTRIBUTOR_REVIEW %}
       {% if not user.is_credentialed %}
         <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>


### PR DESCRIPTION
Restricted access projects require a DUA to be signed. The project template was modified in #1442 and the step was unintentionally removed. 

This pull request updates the Published Project template to add back the requirement for users to sign a Data Use Agreement for restricted access projects.