### PR TITLE
Change license for self managed project.

### DIFF
--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -1408,7 +1408,7 @@
     "release_notes": "",
     "short_description": "",
     "access_policy": 3,
-    "license": 10,
+    "license": 11,
     "project_home_page": "",
     "core_project": "77951d15-e473-4a98-a24f-4fad05ed967b",
     "editor": [


### PR DESCRIPTION
The license should be set to 11 instead of 10 for the self managed project.