### PR TITLE
Update the email address for general inquires from the challenge overview page. 

### DIFF
--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -68,9 +68,9 @@
 
 <br>
 
-<section id="general-challenge-information">
-    <h2>General Challenge Information</h2>
-      <p>If you have a question about a challenge that isn't specific to a Moody PhysioNet Challenge or a Community
-        Challenge please contact us at challenge-info@physionet.org.
+<section id="general-information">
+    <h2>General Information</h2>
+  <p>If you have a question that isn't specific to a Moody PhysioNet Challenge or a Community Challenge please contact
+    us at contact@physionet.org.
       </p>
 </section>

--- a/physionet-django/templates/about/challenge_index.html
+++ b/physionet-django/templates/about/challenge_index.html
@@ -27,7 +27,7 @@ Challenges Overview
               <li><a href="#challenges-overview">Challenges Overview</a></li>
               <li><a href="#moody-challenges">Moody PhysioNet Challenges</a></li>
               <li><a href="#community-challenges">Community Challenges</a></li>
-              <li><a href="#general-challenge-information">General Challenge Information</a></li>
+              <li><a href="#general-information">General Information</a></li>
             </ul>
 
         </div>


### PR DESCRIPTION
This updates the suggested email address to use for general inquires from the challenge overview page from challenge-info@physionet.org to contact@physionet.org. 