### PR TITLE
Update language for general inquiries on the challenge overview page

### DIFF
--- a/physionet-django/templates/about/challenge_content.html
+++ b/physionet-django/templates/about/challenge_content.html
@@ -70,7 +70,7 @@
 
 <section id="general-information">
     <h2>General Information</h2>
-  <p>If you have a question that isn't specific to a Moody PhysioNet Challenge or a Community Challenge please contact
-    us at contact@physionet.org.
+  <p>If you need support for a Community Challenge or have a general question which isn’t related to a Moody PhysioNet
+    Challenge, please contact us at contact@physionet.org.
       </p>
 </section>


### PR DESCRIPTION
This updates the language in the general inquiries paragraph on the challenge overview page to make it clear when to use contact@physionet.org instead of moody-challenge@physionet.org. 