### PR TITLE
Display status of credentialing application to user. Ref #1469

### DIFF
--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -941,13 +941,14 @@ class CredentialApplication(models.Model):
         Get the current review status of a credentialing application. Hacky.
         Could be simplified to return self.credential_review.status later.
         """
-        if hasattr(self, 'credential_review') and self.credential_review.status >= 10:
-            title_dict = {a: k for a, k in CredentialReview.REVIEW_STATUS_LABELS}
-            status = title_dict[self.credential_review.status]
-            if "review" not in status and "check" not in status:
-                status = status + " review"
-        else:
+        if not hasattr(self, 'credential_review'):
             status = 'Awaiting review'
+        elif self.credential_review.status <= 40:
+            status = 'Awaiting review'
+        elif self.credential_review.status == 50:
+            status = 'Awaiting a response from your reference'
+        elif self.credential_review.status >= 60:
+            status = 'Awaiting final approval'
 
         return status
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -936,6 +936,21 @@ class CredentialApplication(models.Model):
         self.credential_review.status = review_status
         self.credential_review.save()
 
+    def get_review_status(self):
+        """
+        Get the current review status of a credentialing application. Hacky.
+        Could be simplified to return self.credential_review.status later.
+        """
+        if hasattr(self, 'credential_review') and self.credential_review.status >= 10:
+            title_dict = {a: k for a, k in CredentialReview.REVIEW_STATUS_LABELS}
+            status = title_dict[self.credential_review.status]
+            if "review" not in status and "check" not in status:
+                status = status + " review"
+        else:
+            status = 'Awaiting review'
+
+        return status
+
 
 class CredentialReview(models.Model):
     """

--- a/physionet-django/user/templates/user/edit_credentialing.html
+++ b/physionet-django/user/templates/user/edit_credentialing.html
@@ -21,8 +21,12 @@
 {% if user.is_credentialed %}
   <p><i class="fas fa-check" style="color:green"></i> Your account was successfully credentialed on {{ user.credential_datetime }}</p>
 {% elif current_application %}
-  <p><i class="fa fa-clock"></i> Your credentialing application was submitted on {{ current_application.application_datetime }}.</p>
-  <p>We aim to reach a decision within four weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.</p>
+  <div class="alert alert-warning">
+    <p><b>Your credentialing application was submitted on {{ current_application.application_datetime }}</b>.</p>
+    <p>Status of your application: {{ current_application.get_review_status }}.</p>
+    <p>We aim to reach a decision within four weeks. If you have not received a decision within this time, it is likely that we are awaiting a response from your reference.</p>
+  </div>
+  
 {% else %}
   <p>Your account is not credentialed. 
 


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/1469, we would like to display the status of credentialing applications to users. This pull request displays the status to users on the application page (http://localhost:8000/settings/credentialing/). 

e.g.:

![Screen Shot 2022-02-23 at 18 44 39](https://user-images.githubusercontent.com/822601/155431342-032e7d72-ec0d-4b96-bd6d-10e14241344f.png)

The `get_review_status` logic is slightly hacky because the `REVIEW_STATUS_LABELS` are not well suited to being displayed publicly:

```
    REVIEW_STATUS_LABELS = (
        ('', '-----------'),
        (0,  'Not in review'),
        (10, 'Initial review'),
        (20, 'Training'),
        (30, 'ID check'),
        (40, 'Reference'),
        (50, 'Reference response'),
        (60, 'Final review')
    )
```

Instead of modifying the labels - which would require a migration - I have left them as they are for now. We can implement something cleaner once the forthcoming updates to the credentialing system are merged.
