### PR TITLE
Adds Immediate Accept button to the Intial Review page on the Processing page for credential applications.

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -74,6 +74,11 @@
               <button class="btn btn-primary btn-fixed" name="approve_initial" value="{{app_user.id}}" type="submit">Submit Response</button>
               <button class="btn btn-primary btn-fixed" name="approve_initial_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
+          <br />
+            <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
+                {% csrf_token %}
+               <button class="btn btn-danger btn-fixed" name="immediate_accept" value="{{app_user.id}}" type="submit">Immediate Accept</button>
+          </form>
           </div>
         </div>
         {% endif %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1323,6 +1323,10 @@ def process_credential_application(request, application_slug):
                     {'application':application})
             else:
                 messages.error(request, 'Invalid submission. See form below.')
+        elif 'immediate_accept' in request.POST:
+            application.accept(responder=request.user)
+            messages.success(request, 'The application has been accepted')
+            return redirect(credential_processing)
     return render(request, 'console/process_credential_application.html',
         {'application': application, 'app_user': application.user,
          'intermediate_credential_form': intermediate_credential_form,


### PR DESCRIPTION
This pull request adds an `Immediate Accept` red button to the initial review page (http://localhost:8000/console/credential-applications/qdOWz3Bn0k8FkqtcLpdu/process/) to allow admin to accept a credential application with a single click.
![credential_applications_process](https://user-images.githubusercontent.com/49573192/156046373-661a5c3a-83a9-48e1-b009-46a602047bfc.png)

This page can be reached by clicking on the `Process` button under `Manage` column in the table on the credential processing page (http://localhost:8000/console/credential_processing/).
![credential_applications_pending](https://user-images.githubusercontent.com/49573192/156046188-d107f695-78d7-412d-8c90-37a5777f0547.png)

The `Immediate Accept` button includes an `Are you sure?` confirmation popup.
![are_you_sure](https://user-images.githubusercontent.com/49573192/156046540-71dd2033-b558-4f9c-8d7c-cb32a40ce4a5.png)

This step allows admin to click `ok` to accept the request after which a success message is shown, `The application has been accepted`, on the redirected credential processing page (http://localhost:8000/console/credential_processing/) to enable processing of other credential applications. 
![success_message](https://user-images.githubusercontent.com/49573192/156046707-11a77b3f-3a9d-404b-8130-b86649bada03.png)

Successful applicants can also be viewed on this page (http://localhost:8000/console/credential-applications/successful).
![credential_applications_successful](https://user-images.githubusercontent.com/49573192/156046958-d230662f-2803-4700-9636-c19b14e19c1d.png)

There is also an option to cancel the acceptance by clicking on the `cancel` button which does not process the application and keeps admin on the initial review page (http://localhost:8000/console/credential-applications/qdOWz3Bn0k8FkqtcLpdu/process/).
![credential_applications_process](https://user-images.githubusercontent.com/49573192/156048636-119e1bb8-87ff-4dfc-a208-f2fcc94b1e85.png)

Upon temporary request, this addition helps reduce the number of clicks to process the credential applications.

