### PR TITLE
add alternative imports as preparation for upgrading django_background_tasks

### DIFF
--- a/physionet-django/project/admin.py
+++ b/physionet-django/project/admin.py
@@ -1,5 +1,8 @@
 from background_task.models import Task
-from background_task.models_completed import CompletedTask
+try:
+    from background_task.models_completed import CompletedTask
+except ImportError:
+    from background_task.models import CompletedTask
 from ckeditor.fields import RichTextField
 from ckeditor.widgets import CKEditorWidget
 from django.contrib import admin

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -4,10 +4,13 @@ import re
 from functools import reduce
 
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.db.models import Case, Count, IntegerField, Q, Sum, Value, When
 from django.http import Http404
 from django.shortcuts import redirect, render, reverse
+try:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+except ImportError:
+    from django.templatetags.static import static
 from physionet.utility import paginate
 from project.models import PublishedProject, PublishedTopic
 from project.projectfiles import ProjectFiles


### PR DESCRIPTION
In #1501, tests fail because the code is run against the existing production branch, which is using v1.2.0 of django_background_tasks. This pull request adds support for both import statements (old v1.2.0 vs new v1.2.5).

Once this pull request is merged, we should be able to bump the version of django_background_tasks to v1.2.5.