### PR TITLE
Define ERROR_EMAIL

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -161,9 +161,6 @@ PAUSE_CREDENTIALING = config('PAUSE_CREDENTIALING', cast=bool, default=False)
 PAUSE_CREDENTIALING_MESSAGE = config('PAUSE_CREDENTIALING_MESSAGE',
                                      default=None)
 
-# Set the credentialing email address
-CREDENTIAL_EMAIL = 'PhysioNet Credentialing <credentialing@physionet.org>'
-
 GCP_DELEGATION_EMAIL = config('GCP_DELEGATION_EMAIL', default=False)
 
 GCP_BUCKET_PREFIX = 'testing-delete.'

--- a/physionet-django/physionet/settings/development/base.py
+++ b/physionet-django/physionet/settings/development/base.py
@@ -25,6 +25,7 @@ EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@dev.physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@dev.physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@dev.physionet.org>'
+CREDENTIAL_EMAIL = 'PhysioNet Credentialing <credentialing@dev.physionet.org>'
 ERROR_EMAIL = 'contact@dev.physionet.org'
 
 ADMINS = [('PhysioNet Technical', 'technical@dev.physionet.org')]

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -33,6 +33,7 @@ EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@physionet.org>'
+ERROR_EMAIL = 'contact@physionet.org'
 
 ADMINS = [('PhysioNet Technical', 'technical@physionet.org')]
 

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -33,6 +33,7 @@ EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@physionet.org>'
+CREDENTIAL_EMAIL = 'PhysioNet Credentialing <credentialing@physionet.org>'
 ERROR_EMAIL = 'contact@physionet.org'
 
 ADMINS = [('PhysioNet Technical', 'technical@physionet.org')]

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -33,6 +33,7 @@ EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@staging.physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@staging.physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@staging.physionet.org>'
+CREDENTIAL_EMAIL = 'PhysioNet Credentialing <credentialing@staging.physionet.org>'
 ERROR_EMAIL = 'contact@staging.physionet.org'
 
 ADMINS = [('PhysioNet Technical', 'technical@staging.physionet.org')]

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -33,6 +33,7 @@ EMAIL_FROM_DOMAINS = ['physionet.org']
 DEFAULT_FROM_EMAIL = 'PhysioNet Automated System <noreply@staging.physionet.org>'
 CONTACT_EMAIL = 'PhysioNet Contact <contact@staging.physionet.org>'
 SERVER_EMAIL = 'PhysioNet System <root@staging.physionet.org>'
+ERROR_EMAIL = 'contact@staging.physionet.org'
 
 ADMINS = [('PhysioNet Technical', 'technical@staging.physionet.org')]
 


### PR DESCRIPTION
Define the ERROR_EMAIL variable so that we can generate appropriate 404 / 403 / etc. error pages.  Fix issue #1491.

The way this stuff is configured is not the best; it'd be good to clean it up so we only have to define the hostname in one place.  (I don't think we can/should rely on Site objects when defining variables here in the settings module.)

Of course what we really want to be aiming for is to unify staging / production / settings so we can use physionet.settings.settings everywhere...
