### PR TITLE
Tab completion and history in test-server

### DIFF
--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -72,6 +72,17 @@ su pn -c '
    export DJANGO_SETTINGS_MODULE=physionet.settings.staging
    echo export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE >> .profile
 
+   echo  >.pythonrc "import atexit, os, readline, rlcompleter"
+   echo >>.pythonrc "readline.parse_and_bind(\"tab: complete\")"
+   echo >>.pythonrc "histfile = os.path.expanduser(\"~/.python_history\")"
+   echo >>.pythonrc "try:"
+   echo >>.pythonrc "    readline.read_history_file(histfile)"
+   echo >>.pythonrc "except Exception:"
+   echo >>.pythonrc "    pass"
+   echo >>.pythonrc "atexit.register(readline.write_history_file, histfile)"
+   echo >>.pythonrc "del atexit, histfile, os, readline, rlcompleter"
+   echo export PYTHONSTARTUP=\$HOME/.pythonrc >> .profile
+
    cd /physionet
    echo staging > deploy-branch
    mkdir -p physionet-build python-env deploy


### PR DESCRIPTION
When installing a test server using install-pn-test-server (or ssh-install-pn-test-server), create a Python startup script to work around the default brokenness of virtualenv.  Not a serious issue by any means, just a minor convenience.
