### PR TITLE
Fix static pages console views url params

### DIFF
--- a/physionet-django/console/templates/console/static_page_sections.html
+++ b/physionet-django/console/templates/console/static_page_sections.html
@@ -36,10 +36,10 @@
                         </form>
                     </td>
                     <td>
-                        <a href="{% url 'static_page_sections_edit' page section.id %}" class="btn btn-sm btn-primary" role="button">Edit</a>
+                        <a href="{% url 'static_page_sections_edit' page.pk section.id %}" class="btn btn-sm btn-primary" role="button">Edit</a>
                     </td>
                     <td>
-                        <form method="post" action="{% url 'static_page_sections_delete' page section.id %}">
+                        <form method="post" action="{% url 'static_page_sections_delete' page.pk section.id %}">
                             {% csrf_token %}
                             <button type="submit" class="btn btn-sm btn-danger" role="button">Remove</button>
                         </form>
@@ -56,7 +56,7 @@
         Create new section
     </div>
     <div class="card-body">
-        <form method="post" action="{% url 'static_page_sections' page %}">
+        <form method="post" action="{% url 'static_page_sections' page.pk %}">
             {% include "inline_form_snippet.html" with form=section_form %}
             <button class="btn btn-primary btn-fixed" name="set_legacy_author" type="submit">Create</button>
         </form>

--- a/physionet-django/console/templates/console/static_page_sections_edit.html
+++ b/physionet-django/console/templates/console/static_page_sections_edit.html
@@ -10,7 +10,7 @@
         {{ section.title }} - edit
     </div>
     <div class="card-body">
-        <form method="post" action="{% url 'static_page_sections_edit' page section.id %}">
+        <form method="post" action="{% url 'static_page_sections_edit' page.pk section.id %}">
             {% include "inline_form_snippet.html" with form=section_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/console/templates/console/static_pages.html
+++ b/physionet-django/console/templates/console/static_pages.html
@@ -22,7 +22,7 @@
         {% for page in pages %}
             <tr>
                 <td>{{ page|title }} page</td>
-                <td><a href="{% url 'static_page_sections' page %}" class="btn btn-sm btn-primary" role="button">Manage</a></td>
+                <td><a href="{% url 'static_page_sections' page.pk %}" class="btn btn-sm btn-primary" role="button">Manage</a></td>
             </tr>
         {% endfor %}
         </tbody>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -94,11 +94,15 @@ urlpatterns = [
     path('usage/submission/stats/', views.submission_stats, name='submission_stats'),
     # static pages
     path('static-pages/', views.static_pages, name='static_pages'),
-    path('static-pages/<str:page>/', views.static_page_sections, name='static_page_sections'),
+    path('static-pages/<int:page_pk>/', views.static_page_sections, name='static_page_sections'),
     path(
-        'static-pages/<str:page>/<int:pk>/delete/',
+        'static-pages/<int:page_pk>/<int:section_pk>/delete/',
         views.static_page_sections_delete,
         name='static_page_sections_delete',
     ),
-    path('static-pages/<str:page>/<int:pk>/edit/', views.static_page_sections_edit, name='static_page_sections_edit'),
+    path(
+        'static-pages/<int:page_pk>/<int:section_pk>/edit/',
+        views.static_page_sections_edit,
+        name='static_page_sections_edit',
+    ),
 ]

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1991,14 +1991,14 @@ def known_references(request):
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
 def static_pages(request):
-    pages = StaticPage.objects.all().values_list('url', flat=True)
+    pages = StaticPage.objects.all()
     return render(request, 'console/static_pages.html', {'pages': pages, 'static_pages_nav': True})
 
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
-def static_page_sections(request, page):
-    static_page = get_object_or_404(StaticPage, url=page)
+def static_page_sections(request, page_pk):
+    static_page = get_object_or_404(StaticPage, pk=page_pk)
     if request.method == 'POST':
         section_form = forms.SectionForm(data=request.POST, static_page=static_page)
         if section_form.is_valid():
@@ -2021,37 +2021,37 @@ def static_page_sections(request, page):
     return render(
         request,
         'console/static_page_sections.html',
-        {'sections': sections, 'page': static_page.title, 'section_form': section_form, 'static_pages_nav': True},
+        {'sections': sections, 'page': static_page, 'section_form': section_form, 'static_pages_nav': True},
     )
 
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
-def static_page_sections_delete(request, page, pk):
-    static_page = get_object_or_404(StaticPage, url=page)
+def static_page_sections_delete(request, page_pk, section_pk):
+    static_page = get_object_or_404(StaticPage, pk=page_pk)
     if request.method == 'POST':
-        section = get_object_or_404(Section, static_page=static_page, pk=pk)
+        section = get_object_or_404(Section, static_page=static_page, pk=section_pk)
         section.delete()
         Section.objects.filter(static_page=static_page, order__gt=section.order).update(order=F('order') - 1)
 
-    return redirect('static_page_sections', page=static_page)
+    return redirect('static_page_sections', page_pk=static_page.pk)
 
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
-def static_page_sections_edit(request, page, pk):
-    static_page = get_object_or_404(StaticPage, url=page)
-    section = get_object_or_404(Section, static_page=static_page, pk=pk)
+def static_page_sections_edit(request, page_pk, section_pk):
+    static_page = get_object_or_404(StaticPage, pk=page_pk)
+    section = get_object_or_404(Section, static_page=static_page, pk=section_pk)
     if request.method == 'POST':
         section_form = forms.SectionForm(instance=section, data=request.POST, static_page=static_page)
         if section_form.is_valid():
             section_form.save()
-            return redirect('static_page_sections', page=static_page)
+            return redirect('static_page_sections', page_pk=static_page.pk)
     else:
         section_form = forms.SectionForm(instance=section, static_page=static_page)
 
     return render(
         request,
         'console/static_page_sections_edit.html',
-        {'section_form': section_form, 'static_pages_nav': True, 'page': static_page.title, 'section': section},
+        {'section_form': section_form, 'static_pages_nav': True, 'page': static_page, 'section': section},
     )


### PR DESCRIPTION
I found some issues with the new static pages changes in the admin console. #1436 introduces a new static page so I had to fix it anyway to test that PR's changes.

## Issues

### `str` url params
Static pages are accessed by their url in the admin console:
https://github.com/MIT-LCP/physionet-build/blob/83b29d9124ab80253d1678feeffaf05afa9b5a57/physionet-django/console/views.py#L1991-L1995

The first problem is that the url expects an `str` param which won't match slashes (and static page urls contain slashes)
https://github.com/MIT-LCP/physionet-build/blob/83b29d9124ab80253d1678feeffaf05afa9b5a57/physionet-django/console/urls.py#L97

<img width="1440" alt="Screenshot 2022-03-04 at 11 46 05" src="https://user-images.githubusercontent.com/43988137/156750399-c74c5b81-debb-4cf8-b53f-762815472b93.png">

Using `<path:xxx>` params won't fix the issue since then urls like https://github.com/MIT-LCP/physionet-build/blob/83b29d9124ab80253d1678feeffaf05afa9b5a57/physionet-django/console/urls.py#L103 won't be matched correctly.

### Mixing `page.title` with `page.url`
The other issue is the fact that sometimes the pages are linked by the `title` while the views expect the `url` which creates errors as well. Example:

#### View expects url
https://github.com/MIT-LCP/physionet-build/blob/83b29d9124ab80253d1678feeffaf05afa9b5a57/physionet-django/console/views.py#L2042-L2043

#### Title being sent
https://github.com/MIT-LCP/physionet-build/blob/83b29d9124ab80253d1678feeffaf05afa9b5a57/physionet-django/console/views.py#L2053-L2057

https://github.com/MIT-LCP/physionet-build/blob/83b29d9124ab80253d1678feeffaf05afa9b5a57/physionet-django/console/templates/console/static_page_sections_edit.html#L13


### Solution
I just used the PK in the url param instead of the url. Alternatively title could be used but I think it doesn't fit semantically for the title to unambiguously identify a page (e.g. in case of two pages with the same title)