### PR TITLE
Fix GCS ProjectFiles issues

### DIFF
--- a/physionet-django/physionet/gcs.py
+++ b/physionet-django/physionet/gcs.py
@@ -200,7 +200,7 @@ class GCSObject:
                 self.bucket.copy_blob(
                     blob,
                     gcs_obj.bucket,
-                    new_name=new_name.strip('/'),
+                    new_name=new_name.lstrip('/'),
                 )
         except ValueError:
             pass

--- a/physionet-django/project/projectfiles/gcs.py
+++ b/physionet-django/project/projectfiles/gcs.py
@@ -197,11 +197,11 @@ class GCSProjectFiles(BaseProjectFiles):
         return files, dirs
 
     def _dir_path(self, path):
-        return path if path.endswith('/') else path + '/'
+        return path if path == '' or path.endswith('/') else path + '/'
 
     def _local_filesystem_path_to_gcs_path(self, path):
         bucket_name, *object_name = os.path.normpath(path).split('/', 1)
 
-        object_name = object_name[0] if object_name else '/'
+        object_name = object_name[0] if object_name else ''
 
         return bucket_name, object_name

--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -93,8 +93,6 @@
   </form>
 
   <script>
-    Dropzone.autoDiscover = false;
-
     $(document).ready(() => {
       const dropzoneObj = {
             method: 'PUT',
@@ -130,8 +128,8 @@
                 });
             }
         };
-        $("#myDropzone").dropzone(dropzoneObj);
         $("#myDropzone").addClass("dropzone");
+        $("#myDropzone").dropzone(dropzoneObj);
     });
 </script>
 

--- a/physionet-django/project/templates/project/project_files_form.html
+++ b/physionet-django/project/templates/project/project_files_form.html
@@ -37,7 +37,7 @@
           <div class="modal-body">
             <p>Individual file size limit: {{ individual_size_limit }}.</p>
               {% if storage_type == "GCP" %}
-                <div class="dropzone" id="myDropzone"></div>
+                <div id="myDropzone"></div>
               {% else %}
                 {{ upload_files_form.file_field }}
               {% endif %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -961,6 +961,7 @@ def project_files_panel(request, project_slug, **kwargs):
             'is_submitting': is_submitting,
             'is_editor': is_editor,
             'files_editable': files_editable,
+            'individual_size_limit': utility.readable_size(ActiveProject.INDIVIDUAL_FILE_SIZE_LIMIT),
         },
     )
 


### PR DESCRIPTION
Fixes for the ProjectFiles issues I briefly mentioned during our meeting.

## GCS ProjectFiles Only

#### 600eb5714b03f44e58f08c6ab9ce074dc1682be6 - last characters of folders in a bucket missing
Object paths do not start with a slash, so root-level object_name should be `''` and not `'/'`.
https://github.com/MIT-LCP/physionet-build/blob/1135af4153e3a038ad8ce4748c2c3c7e06c201af/physionet-django/project/projectfiles/gcs.py#L191-L192
This line removes both the object_name (slash in the current implementation) and the last character. So when object_name is `'/'`, for a folder called `foo/` it's going to remove the trailing slash and the last character, resulting in `fo`.

#### 39cffe1f3af6e8d921bfa5313dfbc6394b70c17a - empty files created next to folders after publishing a project
GCS creates an empty blob for each "folder", e.g. a `random/` blob if there is file named `random/foo` etc. When publishing a project each blob is copied with stripped slashes - this makes it impossible to distinguish between an empty text-file and a folder, leading to duplication in the end:

<img width="1108" alt="duplicatefiles" src="https://user-images.githubusercontent.com/43988137/157627880-05aad6f5-b481-485e-93b6-c331a8ff780b.png">

#### 73ab44791cc799b324b03316866e41c1fba744f8 - file upload not working without creating a folder/navigating

GCS file uploads uses the dropzone.js library. Dropzone has a mechanism of autodiscovering DOM nodes (by the `dropzone` class from what I was able to tell) to mount itself automatically. This causes an error currently because the plugin gets mounted twice, leading to the `Dropzone already attached.` error that only goes away after e.g. navigating directories. The current line
```javascript
Dropzone.autoDiscover = false;
```
does not work because that script runs after the DOM was loaded and dropzone already did it's magic (so no point in disabling autoDiscovery when it already did it). I tried moving that line directly below the dropzone script but it did not fix the issue. Dynamically adding the dropzone class *after* mounting our customized instance did the trick though.

## General ProjectFiles

#### 1135af4153e3a038ad8ce4748c2c3c7e06c201af - individual size limit missing after navigating
When navigating directories in the upload panel, it's HTML gets dynamically replaced:
https://github.com/MIT-LCP/physionet-build/blob/8f4a5548e1b54266b2c37fa4923e74e08a9bd2fe/physionet-django/project/templates/project/files_panel.html#L77-L88
The view that renders it is missing the `individual_size_limit` context though so it's lost after navigation:
<img width="498" alt="Screenshot 2022-03-10 at 10 17 40" src="https://user-images.githubusercontent.com/43988137/157632609-e5026f44-95ab-4826-875d-2785acd17ade.png">
