### PR TITLE
Fix errors after recent merges

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -794,10 +794,10 @@ class AccessMetadataForm(forms.ModelForm):
         if self.access_policy is None and data is not None:
             self.access_policy = int(data.get('access_policy'))
 
+        super().__init__(*args, **kwargs)
+
         if not settings.ENABLE_FILE_DOWNLOADS_OPTION:
             del self.fields['allow_file_downloads']
-
-        super().__init__(*args, **kwargs)
 
         if self.access_policy is None:
             self.access_policy = self.instance.access_policy

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -778,7 +778,7 @@ def credential_reference(request, application_slug):
             # their application.
             if application.reference_response == 1:
                 process_credential_complete(request, application,
-                                            comments=False)
+                                            include_comments=False)
 
             response = 'verifying' if application.reference_response == 2 else 'denying'
             return render(request, 'user/credential_reference_complete.html',


### PR DESCRIPTION
## comments renamed to include_comment - 31dea39ee4c7f4b1d51c4b0d61b42c6c414346e5
Renamed in function definition but not in function call in kwargs. Fixes:
```
Internal Server Error: /credential-reference/z1qhqaUtbPULwG39BR01/
```


## fields attribute accesses before form initialization - faca77711e95948e2dd47e574207d799f6c0e1b5
Fixes:
```
Internal Server Error: /projects/XuoYEWqXoaRhLqCt2Me5/access/
```