### PR TITLE
Add search bar to the training pages in the console

### DIFF
--- a/physionet-django/console/templates/console/expired_training_table.html
+++ b/physionet-django/console/templates/console/expired_training_table.html
@@ -1,4 +1,4 @@
-<div class="table-responsive">
+<div class="table-responsive" id="searchitems">
     <table class="table table-bordered table-cred">
         <thead>
             <tr class="header">

--- a/physionet-django/console/templates/console/rejected_training_table.html
+++ b/physionet-django/console/templates/console/rejected_training_table.html
@@ -1,4 +1,4 @@
-<div class="table-responsive">
+<div class="table-responsive" id="searchitems">
     <table class="table table-bordered table-cred">
         <thead>
             <tr class="header">

--- a/physionet-django/console/templates/console/review_training_table.html
+++ b/physionet-django/console/templates/console/review_training_table.html
@@ -1,4 +1,4 @@
-<div class="table-responsive">
+<div class="table-responsive" id="searchitems">
     <table class="table table-bordered table-cred">
         <thead>
             <tr class="header">

--- a/physionet-django/console/templates/console/training_list.html
+++ b/physionet-django/console/templates/console/training_list.html
@@ -45,17 +45,14 @@
     <div class="card-body">
       <div class="tab-content">
         {% if trainings %}
+          <input type="search" oninput="search('{% url "training_list" status=status %}', value);" placeholder="Search..." >
           {% if status == 'review' %}
-            <input type="search" oninput="search('{% url "training_list" status="review" %}', value);" placeholder="Search...">
             {% include 'console/review_training_table.html' %}
           {% elif status == 'valid' %}
-            <input type="search" oninput="search('{% url "training_list" status="valid" %}', value);" placeholder="Search...">
             {% include 'console/valid_training_table.html' %}
           {% elif status == 'expired' %}
-            <input type="search" oninput="search('{% url "training_list" status="expired" %}', value);" placeholder="Search...">
             {% include 'console/expired_training_table.html' %}
           {% elif status == 'rejected' %}
-            <input type="search" oninput="search('{% url "training_list" status="rejected" %}', value);" placeholder="Search...">
             {% include 'console/rejected_training_table.html' %}
           {% endif %}
         {% else %}

--- a/physionet-django/console/templates/console/training_list.html
+++ b/physionet-django/console/templates/console/training_list.html
@@ -6,6 +6,12 @@
 
 {% load console_templatetags %}
 
+{% block local_js_top %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'project/js/dynamic-formset.js' %}"></script>
+<script src="{% static 'console/js/search-console.js' %}"></script>
+{% endblock %}
+
 {% block local_css %}
   <link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
 {% endblock %}
@@ -40,12 +46,16 @@
       <div class="tab-content">
         {% if trainings %}
           {% if status == 'review' %}
+            <input type="search" oninput="search('{% url "training_list" status="review" %}', value);" placeholder="Search...">
             {% include 'console/review_training_table.html' %}
           {% elif status == 'valid' %}
+            <input type="search" oninput="search('{% url "training_list" status="valid" %}', value);" placeholder="Search...">
             {% include 'console/valid_training_table.html' %}
           {% elif status == 'expired' %}
+            <input type="search" oninput="search('{% url "training_list" status="expired" %}', value);" placeholder="Search...">
             {% include 'console/expired_training_table.html' %}
           {% elif status == 'rejected' %}
+            <input type="search" oninput="search('{% url "training_list" status="rejected" %}', value);" placeholder="Search...">
             {% include 'console/rejected_training_table.html' %}
           {% endif %}
         {% else %}

--- a/physionet-django/console/templates/console/valid_training_table.html
+++ b/physionet-django/console/templates/console/valid_training_table.html
@@ -1,5 +1,5 @@
 <div class="tab-pane fade show active" id="valid" role="tabpanel" aria-labelledby="valid-tab">
-    <div class="table-responsive">
+    <div class="table-responsive" id="searchitems">
         <table class="table table-bordered table-cred" id="validt">
             <thead>
                 <tr class="header">

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -72,8 +72,8 @@ urlpatterns = [
         views.download_credentialed_users,
         name="download_credentialed_users"),
 
-    path('training/<status>', views.training_list, name='training_list'),
-    path('training/<int:pk>/', views.training_detail, name='training_detail'),
+    path('training/<status>/', views.training_list, name='training_list'),
+    path('training/view/<int:pk>/', views.training_detail, name='training_detail'),
     path('training/process/<int:pk>/', views.training_proccess, name='training_process'),
     path('users/search/<group>/', views.users_search, name='users_list_search'),
     path('users/<group>/', views.users, name='users'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1535,6 +1535,9 @@ def credentialed_user_info(request, username):
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
 def training_list(request, status):
+    """
+    List all training applications.
+    """
     trainings = Training.objects.select_related('user__profile', 'training_type').order_by('application_datetime')
     review_training = trainings.get_review()
     valid_training = trainings.get_valid()
@@ -1553,18 +1556,12 @@ def training_list(request, status):
     if request.method == 'POST':
         if "search" in request.POST:
             display_training = search_training_applications(request, display_training)
-            if status == 'review':
-                return render(request, 'console/review_training_table.html',
-                              {'trainings': display_training, 'status': status})
-            elif status == 'valid':
-                return render(request, 'console/valid_training_table.html',
-                              {'trainings': display_training, 'status': status})
-            elif status == 'expired':
-                return render(request, 'console/expired_training_table.html',
-                              {'trainings': display_training, 'status': status})
-            elif status == 'rejected':
-                return render(request, 'console/rejected_training_table.html',
-                              {'trainings': display_training, 'status': status})
+            template_by_status = {
+                'review': 'console/review_training_table.html',
+                'valid': 'console/valid_training_table.html',
+                'expired': 'console/expired_training_table.html',
+                'rejected': 'console/rejected_training_table.html', }
+            return render(request, template_by_status[status], {'trainings': display_training, 'status': status})
 
     return render(
         request,
@@ -1587,6 +1584,7 @@ def search_training_applications(request, display_training):
 
     Args:
         request (obj): Django WSGIRequest object.
+        display_training (obj): Training queryset.
     """
     search_field = request.POST['search']
     if search_field:


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/1517 we added pagination to the training pages in the console. This fixed the issue of slow loading pages (https://github.com/MIT-LCP/physionet-build/issues/1514) but it is now difficult to find applications because they are distributed across multiple pages.

This pull request: 
1. adds a search bar to the training pages in the console (e.g. http://localhost:8000/console/training/review). Applications can be searched by username, firstname, lastname, and email.
2. lists applications from oldest to newest (rather than newest to oldest) at the request of Sophie.


allow applications to be searched. also order applications from old to new, instead of new to old.