### PR TITLE
Make github source code link configurable

### DIFF
--- a/physionet-django/notification/templates/notification/news.html
+++ b/physionet-django/notification/templates/notification/news.html
@@ -28,7 +28,7 @@
           <div class="card-body">
             <ul class="list-unstyled mb-0">
               <li>
-                <a href="https://github.com/MIT-LCP/" style="text-decoration: none; color: #000000;"><i class="fab fa-github"></i> Github</a>
+                <a href="{{ SOURCE_CODE_REPOSITORY_LINK }}" target="_blank" style="text-decoration: none; color: #000000;"><i class="fab fa-github"></i> Github</a>
               </li>
             </ul>
           </div>

--- a/physionet-django/physionet/context_processors.py
+++ b/physionet-django/physionet/context_processors.py
@@ -18,4 +18,5 @@ def platform_config(request):
         'FOOTER_SUPPORTED_BY': settings.FOOTER_SUPPORTED_BY,
         'FOOTER_ACCESSIBILITY_PAGE': settings.FOOTER_ACCESSIBILITY_PAGE,
         'STRAPLINE': settings.STRAPLINE,
+        'SOURCE_CODE_REPOSITORY_LINK': settings.SOURCE_CODE_REPOSITORY_LINK
     }

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -526,3 +526,6 @@ PLATFORM_WIDE_CITATION = {
     'HARVARD': config('PLATFORM_WIDE_CITATION_HARVARD', default=None),
     'VANCOUVER': config('PLATFORM_WIDE_CITATION_VANCOUVER', default=None),
 }
+
+SOURCE_CODE_REPOSITORY_LINK = config('SOURCE_CODE_REPOSITORY_LINK',
+                                     default='https://github.com/MIT-LCP/physionet-build')


### PR DESCRIPTION
I made SOURCE_CODE_REPOSITORY_LINK variable with default value to this repository. It can be configurable in env file.