### PR TITLE
Fix GCSUserFiles treating directories as blobs

### DIFF
--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -417,9 +417,10 @@ class User(AbstractBaseUser):
 
     def file_root(self, relative=False):
         "Where the user's files are stored"
+        # GCSUserFiles expects trailing slash for directories
         if relative:
-            return os.path.join(User.RELATIVE_FILE_ROOT, self.username)
-        return os.path.join(User.FILE_ROOT, self.username)
+            return os.path.join(User.RELATIVE_FILE_ROOT, self.username, '')
+        return os.path.join(User.FILE_ROOT, self.username, '')
 
 
 class UserLogin(models.Model):


### PR DESCRIPTION
We noticed that when using GCSUserFiles strategy, there is a bug when editing username. GCSUserFile expects trailing slash for directories.