### PR TITLE
Remove example project link from edit_cloud template

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -719,7 +719,7 @@ def project_access(request, project_slug, **kwargs):
         access_form = forms.AccessMetadataForm(data=request.POST, instance=project, editable=editable)
         if access_form.is_valid():
             access_form.save()
-            messages.success(request, 'Your access metdata has been updated.')
+            messages.success(request, 'Your access metadata has been updated.')
         else:
             messages.error(request, 'Invalid submission. See errors below.')
     else:

--- a/physionet-django/user/templates/user/edit_cloud.html
+++ b/physionet-django/user/templates/user/edit_cloud.html
@@ -8,7 +8,7 @@
 <p>{{ SITE_NAME }} is integrated with several cloud services. To access data via these services, you will need to:</p>
 <ul>
     <li>Provide the appropriate account identifier using the form below.</li>
-    <li>Navigate to the "Files" section of the relevant project</li>
+    <li>Navigate to the "Files" section of the relevant project.</li>
     <li>Follow the instructions to request access. If instructions for cloud access are not shown, the project is not currently available on the cloud.</li>
 </ul>
 

--- a/physionet-django/user/templates/user/edit_cloud.html
+++ b/physionet-django/user/templates/user/edit_cloud.html
@@ -7,9 +7,9 @@
 
 <p>{{ SITE_NAME }} is integrated with several cloud services. To access data via these services, you will need to:</p>
 <ul>
-<li>Provide the appropriate account identifier using the form below.</li>
-<li>Navigate to the "Files" section of the relevant project (for example, https://physionet.org/content/eicu-crd-demo/#files).</li>
-<li>Follow the instructions to request access. If instructions for cloud access are not shown, the project is not currently available on the cloud.</li>
+    <li>Provide the appropriate account identifier using the form below.</li>
+    <li>Navigate to the "Files" section of the relevant project</li>
+    <li>Follow the instructions to request access. If instructions for cloud access are not shown, the project is not currently available on the cloud.</li>
 </ul>
 
 <form action="{% url 'edit_cloud' %}" method="post" class="form-signin no-pd">


### PR DESCRIPTION
In this PR I create EXAMPLE_PROJECT_FILES_LINK variable with default value: None. It can be configured with env file.
In the .env.example file I put the previous used url. 

Note: Please let's first merge [#1536](https://github.com/MIT-LCP/physionet-build/pull/1536). Then I will resolve conflicts in this PR.