### PR TITLE
Fix bug that shows total uncompressed file size is 0B 

### DIFF
--- a/physionet-django/physionet/gcs.py
+++ b/physionet-django/physionet/gcs.py
@@ -95,7 +95,8 @@ class GCSObject:
     def size(self):
         """Size of the object/all objects in the dictionary, in bytes."""
         if self.is_dir():
-            return sum(obj.size for obj in self.bucket.list_blobs(prefix=self.name))
+            prefix = '' if self.name == '/' else self.name
+            return sum(obj.size for obj in self.bucket.list_blobs(prefix=prefix))
 
         file = self.bucket.get_blob(self.blob.name)
         if not file:


### PR DESCRIPTION
Note: Please, do not merge yet(need more investigation)

After creating project with files, Project view shows: "Total uncompressed file size: 0B ".
My solution is to call function that calculates project's file size after publishing.