### PR TITLE
Add email notifications for (1) submission of training reports and (2) "immediate acceptance" of credentialing applications

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1327,6 +1327,7 @@ def process_credential_application(request, application_slug):
         elif 'immediate_accept' in request.POST:
             application.accept(responder=request.user)
             messages.success(request, 'The application has been accepted')
+            notification.process_credential_complete(request, application)
             return redirect(credential_processing)
     return render(request, 'console/process_credential_application.html',
         {'application': application, 'app_user': application.user,

--- a/physionet-django/notification/templates/notification/email/notify_training_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_training_request.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ applicant_name }},
 
-Thank you for submitting your request for training to {{ SITE_NAME }}. If your request is approved, you will gain access to certain datasets.
+Thank you for submitting your training report to {{ SITE_NAME }}. If your request is approved, you will gain access to certain datasets.
 
 Please note that each dataset may have its own data usage terms and/or training requirements. The specific training requirements and data usage terms for each dataset are listed in the project description.
 

--- a/physionet-django/notification/templates/notification/email/notify_training_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_training_request.html
@@ -1,0 +1,13 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+Dear {{ applicant_name }},
+
+Thank you for submitting your request for training to {{ SITE_NAME }}. If your request is approved, you will gain access to certain datasets.
+
+Please note that each dataset may have its own data usage terms and/or training requirements. The specific training requirements and data usage terms for each dataset are listed in the project description.
+
+It may take several weeks to process your request. Thank you for your understanding and patience. You can follow the status of your application at: {{ url_prefix }}{% url 'edit_training' %}.
+
+{{ signature }}
+
+{{ footer }}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -693,6 +693,23 @@ def process_training_complete(request, training, include_comments=True):
     message.send(fail_silently=False)
 
 
+def training_application_request(request, training):
+    """ Notify user of training submit """
+
+    subject = f'{settings.SITE_NAME} training application notification'
+    body = loader.render_to_string(
+        'notification/email/notify_training_request.html', {
+            'training': training,
+            'applicant_name': training.user.get_full_name(),
+            'domain': get_current_site(request),
+            'url_prefix': get_url_prefix(request),
+            'signature': settings.EMAIL_SIGNATURE,
+            'footer': email_footer(), 'SITE_NAME': settings.SITE_NAME
+        })
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
+              [training.user.email], fail_silently=False)
+
+
 def credential_application_request(request, application):
     """
     Notify user of credentialing decision

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -30,6 +30,7 @@ from notification.utility import (
     get_url_prefix,
     notify_account_registration,
     process_credential_complete,
+    training_application_request,
 )
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from physionet import utility
@@ -698,6 +699,7 @@ def edit_training(request):
         if training_form.is_valid():
             training_form.save()
             messages.success(request, 'The training has been submitted successfully.')
+            training_application_request(request, training_form)
             training_form = forms.TrainingForm(user=request.user)
         else:
             messages.error(request, 'Invalid submission. Check the errors below.')


### PR DESCRIPTION
Add email notifications after approving the credential application and after submitting training.

Email is now sent when:
-user submits a credentialing application
-user submits a training application
-credentialing application is approved/rejected
-training application is approved/rejected