### PR TITLE
Make .env readable only by www-data group

### DIFF
--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -135,6 +135,8 @@ su pn -c '
    grep -v ^SECRET_KEY= < .env.example > .env
    printf SECRET_KEY=%s\\n "$SECRET_KEY" >> .env
    printf DATABASES_PASSWORD=%s\\n "$DBPASSWORD" >> .env
+   chgrp www-data .env
+   chmod 640 .env
 
    mkdir -p /data/pn-static/published-projects
    mkdir -p /data/pn-media


### PR DESCRIPTION
The file .env contains extremely sensitive information and should not be world-readable.  It'd be better to have a special group just for accessing this file (and maybe the rest of /physionet/), but for now, the simplest thing is to make this file readable only by members of the www-data group.  (All of the admin users are members of www-data.)

This is now done on the staging/production/live servers; do the same in install-pn-test-server for consistency.
