### PR TITLE
Fix credentialing application status displayed to users. Ref #1485.

### DIFF
--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -939,11 +939,11 @@ class CredentialApplication(models.Model):
         """
         if not hasattr(self, 'credential_review'):
             status = 'Awaiting review'
-        elif self.credential_review.status <= 40:
+        elif self.credential_review.status <= 30:
             status = 'Awaiting review'
-        elif self.credential_review.status == 50:
+        elif self.credential_review.status == 40:
             status = 'Awaiting a response from your reference'
-        elif self.credential_review.status >= 60:
+        elif self.credential_review.status >= 50:
             status = 'Awaiting final approval'
 
         return status


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/1485 we added the status of credentialing applications to the user settings page: http://localhost:8000/settings/credentialing/

In https://github.com/MIT-LCP/physionet-build/pull/1464 we removed one of the statuses from the credentialing workflow. As a result, we are now displaying the wrong status to users (specifically, we display "awaiting review" when applications are in fact waiting for response from the referee).

This pull request updates the logic to display the correct status to users.