### PR TITLE
Remove the 'initial review' stage from the credentialing process.

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -76,11 +76,12 @@ YES_NO_NA_UNDETERMINED = (
     (None, 'N/A or Undetermined')
 )
 
+
 class AssignEditorForm(forms.Form):
     """
     Assign an editor to a project under submission
     """
-    project = forms.IntegerField(widget = forms.HiddenInput())
+    project = forms.IntegerField(widget=forms.HiddenInput())
     editor = forms.ModelChoiceField(queryset=User.objects.filter(
         is_admin=True))
 
@@ -250,8 +251,8 @@ class CopyeditForm(forms.ModelForm):
         model = CopyeditLog
         fields = ('made_changes', 'changelog_summary')
         widgets = {
-            'made_changes':forms.Select(choices=YES_NO),
-            'changelog_summary':forms.Textarea()
+            'made_changes': forms.Select(choices=YES_NO),
+            'changelog_summary': forms.Textarea()
         }
 
     def __init__(self, *args, **kwargs):
@@ -322,7 +323,7 @@ class TopicForm(forms.Form):
     Form to set tags for a published project
     """
     topics = forms.CharField(required=False, max_length=800,
-        label='Comma delimited topics')
+                             label='Comma delimited topics')
 
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -351,8 +352,8 @@ class TopicForm(forms.Form):
         for t in topics:
             if not re.fullmatch(r'[\w][\w\ -]*', t):
                 raise forms.ValidationError('Each topic must contain letters, '
-                    'numbers, spaces, underscores, and hyphens only, and '
-                    'begin with a letter or number.')
+                                            'numbers, spaces, underscores, and hyphens only, and '
+                                            'begin with a letter or number.')
 
         self.topic_descriptions = [t.lower() for t in topics]
         return data
@@ -382,8 +383,8 @@ class ProcessCredentialForm(forms.ModelForm):
         model = CredentialApplication
         fields = ('responder_comments', 'status')
         labels = {
-            'responder_comments':'Comments (required for rejected applications). This will be sent to the applicant.',
-            'status':'Decision',
+            'responder_comments': 'Comments (required for rejected applications). This will be sent to the applicant.',
+            'status': 'Decision',
         }
         # widgets = {
         #     'responder_comments': forms.Textarea(attrs={'rows': 5}),
@@ -425,8 +426,8 @@ class ProcessCredentialReviewForm(forms.ModelForm):
         model = CredentialApplication
         fields = ('responder_comments', 'status')
         labels = {
-            'responder_comments':'Comments (required for rejected applications). This will be sent to the applicant.',
-            'status':'Decision',
+            'responder_comments': 'Comments (required for rejected applications). This will be sent to the applicant.',
+            'status': 'Decision',
         }
         widgets = {
             'responder_comments': forms.Textarea(attrs={'rows': 5}),
@@ -459,78 +460,13 @@ class ProcessCredentialReviewForm(forms.ModelForm):
         return application
 
 
-class InitialCredentialForm(forms.ModelForm):
-    """
-    Form to respond to a credential application in the initial review stage
-    """
-
-    decision = forms.ChoiceField(choices=REVIEW_RESPONSE_CHOICES,
-            widget=forms.RadioSelect)
-
-    class Meta:
-        model = CredentialReview
-        fields = ('fields_complete', 'appears_correct', 'lang_understandable',
-                  'responder_comments', 'decision')
-
-        labels = {
-            'fields_complete': 'Are all of the required fields complete?',
-            'appears_correct': 'Does the application clearly avoid frivolous text such as "aa"?',
-            'lang_understandable': 'Is any non-English text (e.g. job titles) easily translated?',
-            'responder_comments': 'Comments (required for rejected applications). This will be sent to the applicant.',
-            'decision': 'Decision',
-        }
-
-        widgets = {
-            'fields_complete': forms.RadioSelect(choices=YES_NO_UNDETERMINED_REVIEW),
-            'appears_correct': forms.RadioSelect(choices=YES_NO_UNDETERMINED_REVIEW),
-            'lang_understandable': forms.RadioSelect(choices=YES_NO_UNDETERMINED_REVIEW),
-            'responder_comments': forms.Textarea(attrs={'rows': 5}),
-            'decision': forms.RadioSelect(choices=REVIEW_RESPONSE_CHOICES)
-        }
-
-    def __init__(self, responder, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # This will be used in clean
-        self.quality_assurance_fields = ('fields_complete', 'appears_correct',
-                                         'lang_understandable')
-
-        self.responder = responder
-        self.fields['decision'].choices = REVIEW_RESPONSE_CHOICES
-
-    def clean(self):
-        if self.errors:
-            return
-
-        if self.cleaned_data['decision'] == '1':
-            for field in self.quality_assurance_fields:
-                if not self.cleaned_data[field]:
-                    raise forms.ValidationError(
-                        'The quality assurance fields must all pass '
-                          'before you approve the application')
-
-        if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
-            raise forms.ValidationError('If you reject, you must explain why.')
-
-    def save(self):
-        application = super().save()
-        if self.cleaned_data['decision'] == '0':
-            application.reject(self.responder)
-        elif self.cleaned_data['decision'] == '1':
-            application.update_review_status(20)
-        else:
-            raise forms.ValidationError('Application status not valid.')
-
-        return application
-
-
 class PersonalCredentialForm(forms.ModelForm):
     """
     Form to respond to a credential application in the ID check stage
     """
 
     decision = forms.ChoiceField(choices=REVIEW_RESPONSE_CHOICES,
-            widget=forms.RadioSelect)
+                                 widget=forms.RadioSelect)
 
     class Meta:
         model = CredentialReview
@@ -567,7 +503,8 @@ class PersonalCredentialForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         # This will be used in clean
-        self.quality_assurance_fields = ('research_summary_clear', 'user_understands_privacy', 'user_org_known', 'user_details_consistent')
+        self.quality_assurance_fields = ('research_summary_clear', 'user_understands_privacy',
+                                         'user_org_known', 'user_details_consistent')
         self.categorical_fields = ('user_searchable', 'user_has_papers', 'course_name_provided')
 
         self.responder = responder
@@ -582,12 +519,12 @@ class PersonalCredentialForm(forms.ModelForm):
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
                         'The quality assurance fields must all pass '
-                          'before you approve the application')
+                        'before you approve the application')
             for field in self.categorical_fields:
                 if self.cleaned_data[field] is False:
                     raise forms.ValidationError(
                         'The quality assurance fields must all pass '
-                          'before you approve the application')
+                        'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -597,7 +534,7 @@ class PersonalCredentialForm(forms.ModelForm):
         if self.cleaned_data['decision'] == '0':
             application.reject(self.responder)
         elif self.cleaned_data['decision'] == '1':
-            application.update_review_status(30)
+            application.update_review_status(20)
         else:
             raise forms.ValidationError('Application status not valid.')
 
@@ -610,7 +547,7 @@ class ReferenceCredentialForm(forms.ModelForm):
     """
 
     decision = forms.ChoiceField(choices=REVIEW_RESPONSE_CHOICES,
-            widget=forms.RadioSelect)
+                                 widget=forms.RadioSelect)
 
     class Meta:
         model = CredentialReview
@@ -657,12 +594,12 @@ class ReferenceCredentialForm(forms.ModelForm):
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
                         'The quality assurance fields must all pass '
-                          'before you approve the application')
+                        'before you approve the application')
             for field in self.categorical_fields:
                 if self.cleaned_data[field] is False:
                     raise forms.ValidationError(
                         'The quality assurance fields must all pass '
-                          'before you approve the application')
+                        'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -672,7 +609,7 @@ class ReferenceCredentialForm(forms.ModelForm):
         if self.cleaned_data['decision'] == '0':
             application.reject(self.responder)
         elif self.cleaned_data['decision'] == '1':
-            application.update_review_status(40)
+            application.update_review_status(30)
         else:
             raise forms.ValidationError('Application status not valid.')
 
@@ -686,7 +623,7 @@ class ResponseCredentialForm(forms.ModelForm):
     """
 
     decision = forms.ChoiceField(choices=REVIEW_RESPONSE_CHOICES,
-            widget=forms.RadioSelect)
+                                 widget=forms.RadioSelect)
 
     class Meta:
         model = CredentialReview
@@ -729,7 +666,7 @@ class ResponseCredentialForm(forms.ModelForm):
                 if not self.cleaned_data[field]:
                     raise forms.ValidationError(
                         'The quality assurance fields must all pass '
-                          'before you approve the application')
+                        'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')
@@ -739,7 +676,7 @@ class ResponseCredentialForm(forms.ModelForm):
         if self.cleaned_data['decision'] == '0':
             application.reject(self.responder)
         elif self.cleaned_data['decision'] == '1':
-            application.update_review_status(50)
+            application.update_review_status(40)
         else:
             raise forms.ValidationError('Application status not valid.')
 
@@ -789,7 +726,7 @@ class DataAccessForm(forms.ModelForm):
                            Bucket name for aws-s3:<br> s3://BUCKET_NAME<br><br>
                            Organizational Google Group managing access for gcp-bucket:<br> EMAIL@ORGANIZATION<br><br>
                            Organizational Google Group managing access for gcp-bigquery:<br> EMAIL@ORGANIZATION""",
-            }
+        }
 
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -16,9 +16,6 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
-        <a class="nav-link active" id="initial-tab" data-toggle="tab" href="#initial" role="tab" aria-controls="initial" aria-selected="true">Initial Review {{ initial_applications|task_count_badge|safe }}</a>
-      </li>
-      <li class="nav-item">
         <a class="nav-link" id="personal-tab" data-toggle="tab" href="#personal" role="tab" aria-controls="personal" aria-selected="false">ID Check {{ personal_applications|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
@@ -35,45 +32,6 @@
   </div>
   <div class="card-body">
     <div class="tab-content">
-      {# Initial review #}
-      <div class="tab-pane fade show active" id="initial" role="tabpanel" aria-labelledby="initial-tab">
-        {% if initial_applications %}
-        <div class="table-responsive">
-          <table class="table table-bordered table-cred" id="initialt">
-            <thead>
-              <tr class="header">
-                <th class="table-user" onclick="sortTable(0,'initialt')">User <i class="fas fa-sort" id="icon_0_initialt"></i></th>
-                <th onclick="sortTable(1,'initialt')">Full Name <i class="fas fa-sort" id="icon_1_initialt"></i></th>
-                <th onclick="sortTable(2,'initialt')">Email <i class="fas fa-sort" id="icon_2_initialt"></i></th>
-                <th onclick="sortTable(3,'initialt')">Reference Email <i class="fas fa-sort" id="icon_3_initialt"></i></th>
-                <th class="table-elapsed" onclick="sortTable(4,'initialt')">Application <i class="fas fa-sort" id="icon_4_initialt"></i></th>
-                <th class="table-process">Process Application</th>
-              </tr>
-            </thead>
-            <tbody>  
-            {% for application in initial_applications %}
-              <tr class="header" id='application_{{application.user.email}}'>
-              {% with user=application.user %}
-                <td><a href="{% url 'user_management' user.username %}">{{ user }}</td>
-                <td>{{ user.get_full_name }}</td>
-                <td>{{ user.email }}</td>
-                <td>{{ application.reference_email }}</td>
-                <td>{{ application.application_datetime|date }}</td>
-                <td>
-                  <form action="{% url 'process_credential_application' application.slug %}">
-                    <input class="btn btn-success" type="submit" value="Process"/>
-                  </form>
-                </td>
-              {% endwith %}
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
-        {% else %}
-          <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
-        {% endif %}
-      </div>
       {# ID check #}
       <div class="tab-pane fade" id="personal" role="tabpanel" aria-labelledby="personal-tab">
         {% if personal_applications %}
@@ -86,7 +44,6 @@
                 <th onclick="sortTable(2,'personalt')">Email <i class="fas fa-sort" id="icon_2_personalt"></i></th>
                 <th onclick="sortTable(3,'personalt')">Reference Email <i class="fas fa-sort" id="icon_3_personalt"></i></th>
                 <th class="table-elapsed" onclick="sortTable(4,'personalt')">Application <i class="fas fa-sort" id="icon_4_personalt"></i></th>
-                <th>Reset Application</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>
@@ -99,12 +56,6 @@
                 <td>{{ user.email }}</td>
                 <td>{{ application.reference_email }}</td>
                 <td>{{ application.application_datetime|date }}</td>
-                <td>
-                  <form action="" method="post">
-                    {% csrf_token %}
-                    <button class="btn btn-danger" name="reset_application" value="{{ application.slug }}" type="submit">Reset</button>
-                  </form>
-                </td>
                 <td>
                   <form action="{% url 'process_credential_application' application.slug %}">
                     <input class="btn btn-success" type="submit" value="Process"/>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -64,27 +64,6 @@
         {% if application.credential_review.status == 10 %}
         <div class="card mb-4">
           <div class="card-header">
-            Initial Review
-          </div>
-          <div class="card-body">
-            {# Initial #}
-            <form action="" method="post" class="form-signin">
-              {% csrf_token %}
-              {% include "form_snippet.html" with form=intermediate_credential_form %}
-              <button class="btn btn-primary btn-fixed" name="approve_initial" value="{{app_user.id}}" type="submit">Submit Response</button>
-              <button class="btn btn-primary btn-fixed" name="approve_initial_all" value="{{app_user.id}}" type="submit">Approve All</button>
-            </form>
-          <br />
-            <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
-                {% csrf_token %}
-               <button class="btn btn-danger btn-fixed" name="immediate_accept" value="{{app_user.id}}" type="submit">Immediate Accept</button>
-          </form>
-          </div>
-        </div>
-        {% endif %}
-        {% if application.credential_review.status == 20 %}
-        <div class="card mb-4">
-          <div class="card-header">
             Update ID Check Status
           </div>
           <div class="card-body">
@@ -95,10 +74,15 @@
               <button class="btn btn-primary btn-fixed" name="approve_personal" value="{{app_user.id}}" type="submit">Submit Response</button>
               <button class="btn btn-primary btn-fixed" name="approve_personal_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
+            <br />
+            <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
+                {% csrf_token %}
+               <button class="btn btn-danger btn-fixed" name="immediate_accept" value="{{app_user.id}}" type="submit">Immediate Accept</button>
+          </form>
           </div>
         </div>
         {% endif %}
-        {% if application.credential_review.status == 30 %}
+        {% if application.credential_review.status == 20 %}
         <div class="card mb-4">
           <div class="card-header">
             Skip Reference Check
@@ -135,7 +119,7 @@
           </div>
         </div>
         {% endif %}
-        {% if application.credential_review.status == 40 %}
+        {% if application.credential_review.status == 30 %}
         <div class="card mb-4">
           <div class="card-header">
             Awaiting Reference Response
@@ -151,7 +135,7 @@
           </div>
         </div>
         {% endif %}
-        {% if application.credential_review.status == 50 %}
+        {% if application.credential_review.status == 40 %}
         <div class="card mb-4">
           <div class="card-header">
             Process Application

--- a/physionet-django/user/migrations/0043_auto_20220406_1229.py
+++ b/physionet-django/user/migrations/0043_auto_20220406_1229.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+def migrate_forward(apps, schema_editor):
+    CredentialReview = apps.get_model('user', 'CredentialReview')
+    CredentialReview.objects.filter(status__gte=20).update(status=models.F('status') - 10)
+
+
+def migrate_backward(apps, schema_editor):
+    CredentialReview = apps.get_model('user', 'CredentialReview')
+    CredentialReview.objects.filter(status__gte=20).update(status=models.F('status') + 10)
+
+
+class Migration(migrations.Migration):
+    MIGRATE_AFTER_INSTALL = True
+
+    dependencies = [
+        ('user', '0042_permissions_2'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='credentialreview',
+            name='status',
+            field=models.PositiveSmallIntegerField(
+                choices=[(
+                    '', '-----------'),
+                    (0, 'Not in review'),
+                    (10, 'ID check'),
+                    (20, 'Reference'),
+                    (30, 'Reference response'),
+                    (40, 'Final review')
+                ],
+                default=10),
+        ),
+        migrations.RunPython(migrate_forward, migrate_backward),
+    ]

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -939,11 +939,11 @@ class CredentialApplication(models.Model):
         """
         if not hasattr(self, 'credential_review'):
             status = 'Awaiting review'
-        elif self.credential_review.status <= 30:
+        elif self.credential_review.status <= 20:
             status = 'Awaiting review'
-        elif self.credential_review.status == 40:
+        elif self.credential_review.status == 30:
             status = 'Awaiting a response from your reference'
-        elif self.credential_review.status >= 50:
+        elif self.credential_review.status >= 40:
             status = 'Awaiting final approval'
 
         return status
@@ -957,17 +957,16 @@ class CredentialReview(models.Model):
     -----
     This relational model will be deleted in the case that a credential
     reviewer decides to "reset" the application, meaning reset it back to the
-    "initial review" stage.
+    "Not in review" stage.
 
     """
     REVIEW_STATUS_LABELS = (
         ('', '-----------'),
         (0,  'Not in review'),
-        (10, 'Initial review'),
-        (20, 'ID check'),
-        (30, 'Reference'),
-        (40, 'Reference response'),
-        (50, 'Final review'),
+        (10, 'ID check'),
+        (20, 'Reference'),
+        (30, 'Reference response'),
+        (40, 'Final review'),
     )
 
     application = models.OneToOneField('user.CredentialApplication',
@@ -978,6 +977,7 @@ class CredentialReview(models.Model):
         choices=REVIEW_STATUS_LABELS)
 
     # Initial review questions
+    # No longer checked. Consider removing these.
     fields_complete = models.NullBooleanField(null=True)
     appears_correct = models.NullBooleanField(null=True)
     lang_understandable = models.NullBooleanField(null=True)


### PR DESCRIPTION
The initial review stage in the credentialing process displays the following questions:

![Screen Shot 2022-04-06 at 12 54 40](https://user-images.githubusercontent.com/822601/162034370-aabca423-2110-4b47-b484-d09f7643a6e6.png)

Based on feedback from people doing the credentialing, this step is not necessary. It just adds an extra couple of clicks to the credentialing process.

In this pull request, I:
1. Remove the initial review stage of the credentialing workflow
2. Ensure that the statuses of existing credentialing applications are updated (by subtracting 10 when appropriate).