### PR TITLE
Display 'ID check' tab by default on credentialing page

### DIFF
--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -16,7 +16,7 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
-        <a class="nav-link" id="personal-tab" data-toggle="tab" href="#personal" role="tab" aria-controls="personal" aria-selected="false">ID Check {{ personal_applications|task_count_badge|safe }}</span></a>
+        <a class="nav-link active" id="personal-tab" data-toggle="tab" href="#personal" role="tab" aria-controls="personal" aria-selected="true">ID Check {{ personal_applications|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
         <a class="nav-link" id="reference-tab" data-toggle="tab" href="#reference" role="tab" aria-controls="reference" aria-selected="false">Reference Check {{ reference_applications|task_count_badge|safe }}</a>
@@ -33,7 +33,7 @@
   <div class="card-body">
     <div class="tab-content">
       {# ID check #}
-      <div class="tab-pane fade" id="personal" role="tabpanel" aria-labelledby="personal-tab">
+      <div class="tab-pane fade show active" id="personal" role="tabpanel" aria-labelledby="personal-tab">
         {% if personal_applications %}
         <div class="table-responsive">
           <table class="table table-bordered table-cred" id="personalt">


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/1556, we removed the "initial review" stage from the credentialing page of the console (http://localhost:8000/console/credential_processing/).

Before the change, visiting http://localhost:8000/console/credential_processing/ would display a list of applications at the "initial review" stage by default. 

We did not set a new default list of applications, so now the page is empty when loaded (and the user must select a tab to view).  This change displays the "ID check" list by default.