### PR TITLE
Display 'contact reference' form on correct page

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -28,7 +28,7 @@
   <div class="col-sm-5">
     <div class="row">
 
-      {% if application.credential_review.status == 40 %}
+      {% if application.credential_review.status == 30 %}
         <div class="card mb-4">
           <div class="card-header">
             Contact Reference


### PR DESCRIPTION
In an earlier pull request (https://github.com/MIT-LCP/physionet-build/pull/1556), we removed the "initial review" stage of the credentialing workflow. 

When we made this change, we failed to move the "Contact Reference" form to the earlier stage of the credentialing workflow. 

As a result, the contact reference form is incorrectly displayed on the "Final review" page. This change moves the contact reference form to the correct stage of the credentialing workflow.

![Screen Shot 2022-04-20 at 17 22 08](https://user-images.githubusercontent.com/822601/164325714-f4a609d9-f276-47b4-a120-50a02b382fd8.png)


