### PR TITLE
Link to pending training and credentialing applications in the user console. Fix "skip reference check" bug

### DIFF
--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -135,10 +135,10 @@
   {% for cred_app in credentialing_app %}
     <li><strong>Submitted: {{ cred_app.application_datetime }}</strong><br />
     {% if cred_app.status == 0 %} 
-      Status: Pending<br />
+      Status: Pending <a href="{% url 'process_credential_application' cred_app.slug %}">(View application)</a>
     {% else %}
-      Status: {{ cred_app.get_status_display }}<br />
-    {% endif %}
+      Status: {{ cred_app.get_status_display }}
+    {% endif %}<br />
     Reviewer: 
       {% if cred_app.responder %}
         {{ cred_app.responder }}

--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -121,6 +121,9 @@
         {% for train in training %}
           <li>
             {{ train.training_type.name }}
+            {% if status == "Under review" %}
+              <a href="{% url 'training_process' train.id %}">(View training)</a>
+            {% endif %}
           </li>
         {% empty %}
           <li> N/A </li>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -75,7 +75,7 @@ urlpatterns = [
 
     path('training/<status>/', views.training_list, name='training_list'),
     path('training/view/<int:pk>/', views.training_detail, name='training_detail'),
-    path('training/process/<int:pk>/', views.training_proccess, name='training_process'),
+    path('training/process/<int:pk>/', views.training_process, name='training_process'),
     path('users/search/<group>/', views.users_search, name='users_list_search'),
     path('users/<group>/', views.users, name='users'),
     path('user/manage/<username>/', views.user_management,

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1271,7 +1271,7 @@ def process_credential_application(request, application_slug):
                                                subject=subject, body=body)
                 messages.success(request, 'The reference has been contacted.')
         elif 'skip_reference' in request.POST:
-            application.update_review_status(50)
+            application.update_review_status(40)
             application.save()
         elif 'process_application' in request.POST:
             process_credential_form = forms.ProcessCredentialReviewForm(

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1556,7 +1556,7 @@ def search_training_applications(request, display_training):
 
 @login_required
 @user_passes_test(is_admin, redirect_field_name='project_home')
-def training_proccess(request, pk):
+def training_process(request, pk):
     training = get_object_or_404(Training.objects.select_related('training_type', 'user__profile').get_review(), pk=pk)
 
     TrainingQuestionFormSet = modelformset_factory(


### PR DESCRIPTION
This pull request makes a couple of minor updates to the credentialing system:

1. Adds link to pending training and credentialing applications from the user console (e.g. see: http://localhost:8000/console/user/manage/george/)
2. Fixes a bug with the "skip reference check" button. Currently the button moves the application to "status=50". This is incorrect because the final review staging has a status of 40.