### PR TITLE
Remove radio buttons from the ID check stage of the credentialing workflow

### DIFF
--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -80,6 +80,29 @@
           </form>
           </div>
         </div>
+
+        <div class="card mb-4">
+          <div class="card-header">
+            Guidelines
+          </div>
+          <div class="card-body">
+            {# Guidance for ID check #}
+            <ul>
+              <li>Do you find search results for the applicant's name</li>
+              <li>Can you find publications linked to the applicant?</li>
+              <li>Is the research summary sufficiently descriptive?</li>
+              <li>Does the applicant understand that data must not be shared?</li>
+              <li>Is the information consistent?
+                <ul>
+                <li>Independent researcher should not list an organization</li>
+                <li>Students should be listed as "student" or "postdoc"</li>
+                <li>MD's with a hospital as their organization should be "hospital researcher"</li>
+              </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+
         {% endif %}
         {% if application.credential_review.status == 20 %}
         <div class="card mb-4">

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -71,13 +71,12 @@
             <form action="" method="post" class="form-signin">
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
-              <button class="btn btn-primary btn-fixed" name="approve_personal" value="{{app_user.id}}" type="submit">Submit Response</button>
-              <button class="btn btn-primary btn-fixed" name="approve_personal_all" value="{{app_user.id}}" type="submit">Approve All</button>
+              <button class="btn btn-primary btn-fixed" name="approve_personal" value="{{ app_user.id }}" type="submit">Submit response</button>
             </form>
             <br />
             <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
                 {% csrf_token %}
-               <button class="btn btn-danger btn-fixed" name="immediate_accept" value="{{app_user.id}}" type="submit">Immediate Accept</button>
+               <button class="btn btn-danger btn-fixed" name="immediate_accept" value="{{ app_user.id }}" type="submit">Full approve</button>
           </form>
           </div>
         </div>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1178,23 +1178,6 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
-        elif 'approve_personal_all' in request.POST:
-            if request.POST['decision'] == '0':
-                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
-            else:
-                data_copy = request.POST.copy()
-                valid_fields = set(request.POST.keys())
-                valid_fields.difference_update({'csrfmiddlewaretoken',
-                                                'responder_comments',
-                                                'approve_personal_all'})
-                for field in valid_fields:
-                    data_copy[field] = '1'
-                intermediate_credential_form = forms.PersonalCredentialForm(
-                    responder=request.user, data=data_copy, instance=application)
-                intermediate_credential_form.save()
-                page_title = title_dict[application.credential_review.status]
-                intermediate_credential_form = forms.ReferenceCredentialForm(
-                    responder=request.user, instance=application)
         elif 'approve_reference' in request.POST:
             intermediate_credential_form = forms.ReferenceCredentialForm(
                 responder=request.user, data=request.POST, instance=application)

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -980,6 +980,7 @@ class CredentialReview(models.Model):
     lang_understandable = models.NullBooleanField(null=True)
 
     # ID check questions
+    # No longer checked. Consider removing these.
     user_searchable = models.NullBooleanField(null=True)
     user_has_papers = models.NullBooleanField(null=True)
     research_summary_clear = models.NullBooleanField(null=True)


### PR DESCRIPTION
Currently credentialing involves a lot of button clicking! This is slow and tiresome for credentialing admin. An example of the current questions is shown below:

![Screen Shot 2022-05-03 at 10 52 24](https://user-images.githubusercontent.com/822601/166477800-9791998e-eced-45e3-9e2c-1f492ca440bb.png)

This change removes the radio buttons from the ID check stage of the credentialing workflow. The points are instead displayed in a "Guidelines" box. The guidelines should be improved later.

One of the nice things about moving the ID check points from the database to a free text section is that it makes the system more flexible (i.e. it is much easier to add/change the guidelines now that they are not tracked in the database).

An example of a new ID check page is shown below (this can be accessed at: http://localhost:8000/console/credential-applications/qMNskHKOcrsnpNHJwGKx/process/?).

![Screen Shot 2022-05-03 at 10 55 58](https://user-images.githubusercontent.com/822601/166478479-cb3d5d81-2a59-442a-a802-a200b269a953.png)


 