### PR TITLE
Remove radio buttons from the reference check stage of the credentialing workflow 

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -516,55 +516,26 @@ class ReferenceCredentialForm(forms.ModelForm):
 
     class Meta:
         model = CredentialReview
-        fields = ('ref_appropriate', 'ref_searchable', 'ref_has_papers',
-                  'ref_is_supervisor', 'ref_course_list',
-                  'responder_comments', 'decision')
+        fields = ('responder_comments', 'decision')
 
         labels = {
-            'ref_appropriate': 'Is the reference appropriate?',
-            'ref_searchable': 'Is the reference easily searchable?',
-            'ref_has_papers': 'Can you find publications linked to the reference?',
-            'ref_is_supervisor': 'If applicable (for students and postdocs only), is the reference in a supervisory position?',
-            'ref_course_list': 'If applicable (for students and postdocs only), is the applicant included in a list of course participants?',
             'responder_comments': 'Comments (required for rejected applications). This will be sent to the applicant.',
             'decision': 'Decision',
         }
 
         widgets = {
-            'ref_appropriate': forms.RadioSelect(choices=YES_NO_UNDETERMINED_REVIEW),
-            'ref_searchable': forms.RadioSelect(choices=YES_NO_NA_UNDETERMINED),
-            'ref_has_papers': forms.RadioSelect(choices=YES_NO_NA_UNDETERMINED),
-            'ref_is_supervisor': forms.RadioSelect(choices=YES_NO_NA_UNDETERMINED),
-            'ref_course_list': forms.RadioSelect(choices=YES_NO_NA_UNDETERMINED),
             'responder_comments': forms.Textarea(attrs={'rows': 5}),
             'decision': forms.RadioSelect(choices=REVIEW_RESPONSE_CHOICES)
         }
 
     def __init__(self, responder, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # This will be used in clean
-        self.quality_assurance_fields = ('ref_appropriate',)
-        self.categorical_fields = ('ref_searchable', 'ref_has_papers', 'ref_is_supervisor', 'ref_course_list')
-
         self.responder = responder
         self.fields['decision'].choices = REVIEW_RESPONSE_CHOICES
 
     def clean(self):
         if self.errors:
             return
-
-        if self.cleaned_data['decision'] == '1':
-            for field in self.quality_assurance_fields:
-                if not self.cleaned_data[field]:
-                    raise forms.ValidationError(
-                        'The quality assurance fields must all pass '
-                        'before you approve the application')
-            for field in self.categorical_fields:
-                if self.cleaned_data[field] is False:
-                    raise forms.ValidationError(
-                        'The quality assurance fields must all pass '
-                        'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -107,23 +107,6 @@
         {% if application.credential_review.status == 20 %}
         <div class="card mb-4">
           <div class="card-header">
-            Skip Reference Check
-          </div>
-          <div class="card-body">
-            {# Skip reference check #}
-            <p>Clicking the button below will allow the application to proceed straight to the Final Review stage. The reference check can be skipped if:</p>
-            <ul>
-              <li>the user is not a student or postdoc</li>
-              <li>the identity of the user is clear</li>
-            </ul>
-            <form action="" method="post" class="form-signin">
-              {% csrf_token %}
-              <button class="btn btn-primary btn-fixed" name="skip_reference" value="{{app_user.id}}" type="submit">Skip Reference Check</button>
-            </form>
-          </div>
-        </div>
-        <div class="card mb-4">
-          <div class="card-header">
             Reference Check
           </div>
           <div class="card-body">
@@ -134,9 +117,13 @@
               <form action="" method="post" class="form-signin">
                 {% csrf_token %}
                 {% include "form_snippet.html" with form=intermediate_credential_form %}
-                <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{app_user.id}}" type="submit">Submit Response</button>
-                <button class="btn btn-primary btn-fixed" name="approve_reference_all" value="{{app_user.id}}" type="submit">Approve All</button>
+                <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{ app_user.id }}" type="submit">Submit Response</button>
               </form>
+              <br />
+              <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
+                {% csrf_token %}
+                <button class="btn btn-primary btn-danger" name="skip_reference" value="{{ app_user.id }}" type="submit">Skip Reference Check</button>
+             </form>
             {% endif %}
           </div>
         </div>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -111,20 +111,39 @@
           </div>
           <div class="card-body">
             {# Reference #}
-            {% if application.reference_email|length < 1 %}
-              <p>No reference provided.</p>
-            {% else %}
-              <form action="" method="post" class="form-signin">
-                {% csrf_token %}
-                {% include "form_snippet.html" with form=intermediate_credential_form %}
-                <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{ app_user.id }}" type="submit">Submit Response</button>
-              </form>
-              <br />
-              <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
-                {% csrf_token %}
-                <button class="btn btn-primary btn-danger" name="skip_reference" value="{{ app_user.id }}" type="submit">Skip Reference Check</button>
-             </form>
-            {% endif %}
+            <form action="" method="post" class="form-signin">
+              {% csrf_token %}
+              {% include "form_snippet.html" with form=intermediate_credential_form %}
+              <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{ app_user.id }}" type="submit">Submit Response</button>
+            </form>
+            <br />
+            <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
+              {% csrf_token %}
+              <button class="btn btn-primary btn-danger" name="skip_reference" value="{{ app_user.id }}" type="submit">Skip Reference Check</button>
+            </form>
+          </div>
+        </div>
+        <div class="card mb-4">
+          <div class="card-header">
+            Guidelines
+          </div>
+          <div class="card-body">
+            {# Skip reference check #}
+            <ul>
+              <li>Is the reference searchable and appropriate?</li>
+              <li>Can you find publications linked to the reference?</li>
+              <li>For students and postdocs only:
+                <ul>
+                  <li>Is the reference in a supervisory position?</li>
+                  <li>Is the applicant included in a list of course participants?</li>
+                </ul>
+              </li>
+              <li>The check can be skipped if:</li>
+              <ul>
+                <li>the user is not a student or postdoc</li>
+                <li>the identity of the user is clear</li>
+              </ul>
+            </ul>
           </div>
         </div>
         {% endif %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1193,23 +1193,6 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
-        elif 'approve_reference_all' in request.POST:
-            if request.POST['decision'] == '0':
-                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
-            else:
-                data_copy = request.POST.copy()
-                valid_fields = set(request.POST.keys())
-                valid_fields.difference_update({'csrfmiddlewaretoken',
-                                                'responder_comments',
-                                                'approve_reference_all'})
-                for field in valid_fields:
-                    data_copy[field] = '1'
-                intermediate_credential_form = forms.ReferenceCredentialForm(
-                    responder=request.user, data=data_copy, instance=application)
-                intermediate_credential_form.save()
-                page_title = title_dict[application.credential_review.status]
-                intermediate_credential_form = forms.ResponseCredentialForm(
-                    responder=request.user, instance=application)
         elif 'approve_response' in request.POST:
             intermediate_credential_form = forms.ResponseCredentialForm(
                 responder=request.user, data=request.POST, instance=application)

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -990,11 +990,14 @@ class CredentialReview(models.Model):
     user_details_consistent = models.NullBooleanField(null=True)
 
     # Reference check questions
+    # No longer checked. Consider removing these.
     ref_appropriate = models.NullBooleanField(null=True)
     ref_searchable = models.NullBooleanField(null=True)
     ref_has_papers = models.NullBooleanField(null=True)
     ref_is_supervisor = models.NullBooleanField(null=True)
     ref_course_list = models.NullBooleanField(null=True)
+
+    # Log skipped reference
     ref_skipped = models.NullBooleanField(null=True)
 
     # Reference response check questions


### PR DESCRIPTION
This pull request does the same as https://github.com/MIT-LCP/physionet-build/pull/1568 but for the "reference check" stage. The goal is to remove time-consuming button clicks.

This change removes the radio buttons from the reference check stage of the credentialing workflow. The points are instead displayed in a "Guidelines" box. The guidelines should be improved later.


