### PR TITLE
Remove radio buttons from the reference response stage of the credentialing workflow

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -563,13 +563,9 @@ class ResponseCredentialForm(forms.ModelForm):
 
     class Meta:
         model = CredentialReview
-        fields = ('ref_knows_applicant', 'ref_approves',
-                  'ref_understands_privacy', 'responder_comments', 'decision')
+        fields = ('responder_comments', 'decision')
 
         labels = {
-            'ref_knows_applicant': 'Does the reference know the applicant?',
-            'ref_approves': 'Does the reference approve the applicant for use of restricted data?',
-            'ref_understands_privacy': 'Does the response indicate an understanding that data must not be shared (e.g. no plural pronouns such as "we", "us", etc.)?',
             'responder_comments': 'Comments (required for rejected applications). This will be sent to the applicant.',
             'decision': 'Decision',
         }
@@ -584,25 +580,12 @@ class ResponseCredentialForm(forms.ModelForm):
 
     def __init__(self, responder, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # This will be used in clean
-        self.quality_assurance_fields = ('ref_knows_applicant',
-                                         'ref_approves',
-                                         'ref_understands_privacy')
-
         self.responder = responder
         self.fields['decision'].choices = REVIEW_RESPONSE_CHOICES
 
     def clean(self):
         if self.errors:
             return
-
-        if self.cleaned_data['decision'] == '1':
-            for field in self.quality_assurance_fields:
-                if not self.cleaned_data[field]:
-                    raise forms.ValidationError(
-                        'The quality assurance fields must all pass '
-                        'before you approve the application')
 
         if self.cleaned_data['decision'] == '0' and not self.cleaned_data['responder_comments']:
             raise forms.ValidationError('If you reject, you must explain why.')

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -161,6 +161,19 @@
             </form>
           </div>
         </div>
+        <div class="card mb-4">
+          <div class="card-header">
+            Guidelines
+          </div>
+          <div class="card-body">
+            {# Guidelines #}
+            <ul>
+              <li>Does the referee know the applicant?</li>
+              <li>Does the referee approve the applicant?</li>
+              <li>Does the referee understand that data must not be shared?</li>
+            </ul>
+          </div>
+        </div>
         {% endif %}
         {% if application.credential_review.status == 40 %}
         <div class="card mb-4">

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -44,11 +44,13 @@
             {% else %}
               <p>The reference has not been contacted.</p>
             {% endif %}
+            {% if not application.reference_email|length < 1 %}
             <form action="" method="post" class="form-signin">
               {% csrf_token %}
               {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="contact_reference" submit_value=app_user.id submit_text="Contact Reference" %}
               <button type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact Reference</button>
             </form>
+            {% endif %}
             {# Reference already responded #}
             {% if application.reference_response_datetime %}
               <p><i class="fas fa-check" style="color:green"></i> The reference verified the applicant on {{ application.reference_response_datetime }}</p>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -158,7 +158,6 @@
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
               <button class="btn btn-primary btn-fixed" name="approve_response" value="{{app_user.id}}" type="submit">Submit Response</button>
-              <button class="btn btn-primary btn-fixed" name="approve_response_all" value="{{app_user.id}}" type="submit">Approve All</button>
             </form>
           </div>
         </div>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1208,23 +1208,6 @@ def process_credential_application(request, application_slug):
                     responder=request.user, instance=application)
             else:
                 messages.error(request, 'Invalid review. See form below.')
-        elif 'approve_response_all' in request.POST:
-            if request.POST['decision'] == '0':
-                messages.error(request, 'You selected Reject. Did you mean to Approve All?')
-            else:
-                data_copy = request.POST.copy()
-                valid_fields = set(request.POST.keys())
-                valid_fields.difference_update({'csrfmiddlewaretoken',
-                                                'responder_comments',
-                                                'approve_response_all'})
-                for field in valid_fields:
-                    data_copy[field] = '1'
-                intermediate_credential_form = forms.ResponseCredentialForm(
-                    responder=request.user, data=data_copy, instance=application)
-                intermediate_credential_form.save()
-                page_title = title_dict[application.credential_review.status]
-                intermediate_credential_form = forms.ProcessCredentialReviewForm(
-                    responder=request.user, instance=application)
         elif 'contact_reference' in request.POST:
             contact_cred_ref_form = forms.ContactCredentialRefForm(
                 data=request.POST)

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -1001,10 +1001,12 @@ class CredentialReview(models.Model):
     ref_skipped = models.NullBooleanField(null=True)
 
     # Reference response check questions
+    # No longer checked. Consider removing these.
     ref_knows_applicant = models.NullBooleanField(null=True)
     ref_approves = models.NullBooleanField(null=True)
     ref_understands_privacy = models.NullBooleanField(null=True)
 
+    # Reference response check questions
     responder_comments = models.CharField(max_length=500, default='',
                                           blank=True)
 


### PR DESCRIPTION
This pull request does the same as https://github.com/MIT-LCP/physionet-build/pull/1568 and https://github.com/MIT-LCP/physionet-build/pull/1569 but for the "reference response" stage. The goal is to remove time-consuming button clicks.

This change removes the radio buttons from the reference response stage of the credentialing workflow. The points are instead displayed in a "Guidelines" box. The guidelines should be improved later.

Side note, it feels like the credentialing workflow is missing a step when a response from a referee has been received. I may add this step in a later PR.