### PR TITLE
Add training details to the credentialing pages

### DIFF
--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -47,6 +47,27 @@ Applied: {{ application.application_datetime|date }}</p>
       {{ application.webpage }}</a>{% else %}N/A{% endif %}</mark></li>
 </ul>
 
+<h5>Training</h5>
+  <ul>
+    {% for status, training in training_list.items %}
+      <li><h6>{{ status }}</h6>
+        <ul>
+          {% for train in training %}
+            <li>
+              {{ train.training_type.name }}
+              {% if status == "Under review" %}
+                <a href="{% url 'training_process' train.id %}">(Review training)</a>
+              {% endif %}
+            </li>
+          {% empty %}
+            <li> N/A </li>
+          {% endfor %}
+        </ul>
+      </li>
+    {% endfor %}
+  </ul>
+
+
 <h5>Reference</h5>
 
 {% if application.reference_contact_datetime %}

--- a/physionet-django/console/templates/console/application_display_table.html
+++ b/physionet-django/console/templates/console/application_display_table.html
@@ -5,14 +5,6 @@
 <p>Username: <a href="{% url 'user_management' application.user.username %}">{{ application.user.username }}</a></br>
 Applied: {{ application.application_datetime|date }}</p>
 
-{% if application.reference_contact_datetime %}
-  Reference contact date: {{ application.reference_contact_datetime|date }}<br />
-  {% if application.reference_response_datetime %}
-    Reference response date: {{ application.reference_response_datetime|date }}<br />
-    Reference verified: {{ application.get_reference_response_display }}<br />
-  {% endif %}
-{% endif %}
-
 {% if application.decision_datetime %}
   Decision date: {{ application.decision_datetime|date }}<br />
 {% endif %}
@@ -56,6 +48,20 @@ Applied: {{ application.application_datetime|date }}</p>
 </ul>
 
 <h5>Reference</h5>
+
+{% if application.reference_contact_datetime %}
+  <ul><li>Contact date: {{ application.reference_contact_datetime|date }}<br />
+  {% if application.reference_response_datetime %}
+    Response date: {{ application.reference_response_datetime|date }}<br />
+    Approved: {{ application.get_reference_response_display }}<br />
+    Comments: {{ application.reference_response_text }}
+  {% else %}
+    Response date: Awaiting response.<br />
+    Approved: Awaiting response.<br />
+  {% endif %}
+  </li>
+  </ul>
+{% endif %}
 
 {% if application.reference_email %}
   <p>[<a href="https://www.google.com/search?q={{ application.reference_name }} {{ application.reference_email }}" target="_blank">Search for reference name and email.</a>]</p>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -39,7 +39,7 @@
             {% elif application.reference_contact_datetime %}
               <p><i class="fas fa-envelope"></i> The reference was contacted on {{ application.reference_contact_datetime }}</p>
               {% if not application.reference_response_datetime %}
-                <p><i class="fas fa-clock"></i> Awaiting reference response.</p>
+                <p><i class="fas fa-clock"></i> Awaiting response.</p>
               {% endif %}
             {% else %}
               <p>The reference has not been contacted.</p>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1142,6 +1142,14 @@ def process_credential_application(request, application_slug):
             handled by another administrator.""")
         return redirect('credential_applications', status='pending')
 
+    # get training list
+    _training = Training.objects.select_related('training_type').filter(user=application.user).order_by('-status')
+    training = {}
+    training['Active'] = _training.get_valid()
+    training['Under review'] = _training.get_review()
+    training['Expired'] = _training.get_expired()
+    training['Rejected'] = _training.get_rejected()
+
     process_credential_form = forms.ProcessCredentialReviewForm(responder=request.user,
         instance=application)
 
@@ -1242,7 +1250,8 @@ def process_credential_application(request, application_slug):
          'intermediate_credential_form': intermediate_credential_form,
          'process_credential_form': process_credential_form,
          'processing_credentials_nav': True, 'page_title': page_title,
-         'contact_cred_ref_form': contact_cred_ref_form})
+         'contact_cred_ref_form': contact_cred_ref_form,
+         'training_list': training})
 
 
 @permission_required('user.change_credentialapplication', raise_exception=True)


### PR DESCRIPTION
This change adds a list of training details to the "Application information" that is displayed in the credentialing workflow. An example of this information is shown below (for http://localhost:8000/console/credential-applications/iOO51OwLj97ipR2QWnd6/process/?):

![Screen Shot 2022-05-03 at 13 32 53](https://user-images.githubusercontent.com/822601/166507515-5c16544f-89c5-43cb-b13f-ea913014fbf1.png)

If the status of the training is "under review" a link will be displayed takes the reviewer to the training review page.

