### PR TITLE
Ensure files are closed after use.

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -59,10 +59,10 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
             for f in files:
                 with open(os.path.join(root, f), 'rb') as file:
                     fline = file.read(2)
-                    if fline[:2] == b'#!':
-                        os.chmod(os.path.join(root, f), 0o555)
+                    if fline == b'#!':
+                        os.chmod(file.fileno(), 0o555)
                     else:
-                        os.chmod(os.path.join(root, f), 0o444)
+                        os.chmod(file.fileno(), 0o444)
 
             for d in dirs:
                 os.chmod(os.path.join(root, d), 0o555)

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -57,11 +57,12 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
         file_root = published_project.project_file_root()
         for root, dirs, files in os.walk(file_root):
             for f in files:
-                fline = open(os.path.join(root, f), 'rb').read(2)
-                if fline[:2] == b'#!':
-                    os.chmod(os.path.join(root, f), 0o555)
-                else:
-                    os.chmod(os.path.join(root, f), 0o444)
+                with open(os.path.join(root, f), 'rb') as file:
+                    fline = file.read(2)
+                    if fline[:2] == b'#!':
+                        os.chmod(os.path.join(root, f), 0o555)
+                    else:
+                        os.chmod(os.path.join(root, f), 0o444)
 
             for d in dirs:
                 os.chmod(os.path.join(root, d), 0o555)

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -300,9 +300,13 @@ class TestAccessPresubmission(TestMixin):
                 data={'upload_files':'', 'subdir':'notes',
                       'file_field':SimpleUploadedFile(f.name, f.read())})
         self.assertMessage(response, 25)
-        self.assertEqual(
-            open(os.path.join(project.file_root(), 'D_ITEMS.csv.gz'), 'rb').read(),
-            open(os.path.join(project.file_root(), 'notes/D_ITEMS.csv.gz'), 'rb').read())
+
+        with open(os.path.join(project.file_root(), 'D_ITEMS.csv.gz'), 'rb') as f:
+            f1 = f.read()
+        with open(os.path.join(project.file_root(), 'notes', 'D_ITEMS.csv.gz'), 'rb') as f:
+            f2 = f.read()
+        self.assertEqual(f1, f2)
+
         project.refresh_from_db()
         self.assertGreater(project.modified_datetime, timestamp)
 


### PR DESCRIPTION
While running tests in preparation for upgrading to Django 3, I noticed that files are opened but not closed in a couple of places, raising a ResourceWarning. To display these warnings, run:

```python -Wa manage.py test```

(the deprecation warnings are silenced by default. -Wa enables them).

Example warning:

```
...../projects/physionet-build/physionet-django/project/modelcomponents/activeproject.py:60: ResourceWarning: unclosed file <_io.BufferedReader name='...../projects/physionet-build/physionet-django/static/test/published-projects/mitbih/1.0.0/RECORDS'>
  with open(os.path.join(root, f), 'rb').read(2) as fline:
```

This pull request uses the `with open(path) as f:` syntax to fix the issue in two places:
1. In the `move_files_as_readonly` function.
2. In `project/test_views.py`