### PR TITLE
force_text() is deprecated in Django 3. replace with force_str()

### DIFF
--- a/physionet-django/sso/views.py
+++ b/physionet-django/sso/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
 from django.shortcuts import redirect, render
 from django.utils import timezone
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from notification.utility import notify_account_registration
 from physionet.middleware.maintenance import disallow_during_maintenance
@@ -81,7 +81,7 @@ def sso_register(request):
 
         if form.is_valid():
             user = form.save()
-            uidb64 = force_text(urlsafe_base64_encode(force_bytes(user.pk)))
+            uidb64 = force_str(urlsafe_base64_encode(force_bytes(user.pk)))
             token = default_token_generator.make_token(user)
             notify_account_registration(request, user, uidb64, token, sso=True)
             return render(request, 'user/register_done.html', {'email': user.email, 'sso': True})
@@ -107,7 +107,7 @@ def sso_activate_user(request, uidb64, token):
     context = {'title': 'Invalid Activation Link', 'isvalid': False}
 
     try:
-        uid = force_text(urlsafe_base64_decode(uidb64))
+        uid = force_str(urlsafe_base64_decode(uidb64))
         remote_sso_id = request.META.get(settings.SSO_REMOTE_USER_HEADER)
         user = User.objects.get(pk=uid, sso_id=remote_sso_id)
     except (TypeError, ValueError, OverflowError, User.DoesNotExist):

--- a/physionet-django/user/management/commands/sendnewemailtokens.py
+++ b/physionet-django/user/management/commands/sendnewemailtokens.py
@@ -46,7 +46,7 @@ from django.core.management.base import BaseCommand
 from django.template import loader
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_encode
 
 from user.models import AssociatedEmail
@@ -95,7 +95,7 @@ class Command(BaseCommand):
 
             # Send an updated email (this mimics user.views.add_email)
 
-            uidb64 = force_text(urlsafe_base64_encode(force_bytes(associated_email.pk)))
+            uidb64 = force_str(urlsafe_base64_encode(force_bytes(associated_email.pk)))
             subject = "PhysioNet Email Verification (CORRECTION)"
             context = {
                 'name': user.get_full_name(),

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -22,7 +22,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.decorators import method_decorator
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.views.decorators.debug import sensitive_post_parameters
 from notification.utility import (
@@ -150,7 +150,7 @@ def activate_user(request, uidb64, token):
     context = {'title': 'Invalid Activation Link', 'isvalid': False}
 
     try:
-        uid = force_text(urlsafe_base64_decode(uidb64))
+        uid = force_str(urlsafe_base64_decode(uidb64))
         user = User.objects.get(pk=uid)
     except (TypeError, ValueError, OverflowError, User.DoesNotExist):
         user = None
@@ -281,7 +281,7 @@ def add_email(request, add_email_form):
             verification_token=token)
 
         # Send an email to the newly added email with a verification link
-        uidb64 = force_text(urlsafe_base64_encode(force_bytes(associated_email.pk)))
+        uidb64 = force_str(urlsafe_base64_encode(force_bytes(associated_email.pk)))
         subject = f"{settings.SITE_NAME} Email Verification"
         context = {
             'name': user.get_full_name(),
@@ -516,7 +516,7 @@ def register(request):
                     raise
                 user = User.objects.get(username=form.data['username'])
             else:
-                uidb64 = force_text(urlsafe_base64_encode(force_bytes(
+                uidb64 = force_str(urlsafe_base64_encode(force_bytes(
                     user.pk)))
                 token = default_token_generator.make_token(user)
                 notify_account_registration(request, user, uidb64, token)
@@ -548,7 +548,7 @@ def verify_email(request, uidb64, token):
     """
     user = request.user
     try:
-        uid = force_text(urlsafe_base64_decode(uidb64))
+        uid = force_str(urlsafe_base64_decode(uidb64))
         associated_email = AssociatedEmail.objects.get(pk=uid)
     except (TypeError, ValueError, OverflowError, AssociatedEmail.DoesNotExist):
         associated_email = None


### PR DESCRIPTION
In Django 3, force_text() has been deprecated in favor of force_str(). force_text() is an alias of force_str(). https://django.fun/docs/django/en/4.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text

This pull request changes all instances of force_text() to force_str()