### PR TITLE
ugettext_lazy() and ugettext() are deprecated in Django 3

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -1,7 +1,7 @@
 import re
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 MAX_FILENAME_LENGTH = 60
 MAX_PROJECT_SLUG_LENGTH = 30

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -11,7 +11,7 @@ from django.db.models import F, Q
 from django.forms.widgets import FileInput
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext
 from user.models import (
     AssociatedEmail,
     CloudInformation,
@@ -107,11 +107,11 @@ class LoginForm(auth_forms.AuthenticationForm):
     remember = forms.BooleanField(label='Remember Me', required=False)
 
     error_messages = {
-        'invalid_login': ugettext_lazy(
+        'invalid_login': gettext(
             "Please enter a correct username/email and password. Note that the password "
             "field is case-sensitive."
         ),
-        'inactive': ugettext_lazy("This account has not been activated. Please check your "
+        'inactive': gettext("This account has not been activated. Please check your "
             "email for the activation link."),
     }
 

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -11,7 +11,7 @@ from django.db.models import F, Q
 from django.forms.widgets import FileInput
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy
 from user.models import (
     AssociatedEmail,
     CloudInformation,
@@ -107,11 +107,11 @@ class LoginForm(auth_forms.AuthenticationForm):
     remember = forms.BooleanField(label='Remember Me', required=False)
 
     error_messages = {
-        'invalid_login': gettext(
+        'invalid_login': gettext_lazy(
             "Please enter a correct username/email and password. Note that the password "
             "field is case-sensitive."
         ),
-        'inactive': gettext("This account has not been activated. Please check your "
+        'inactive': gettext_lazy("This account has not been activated. Please check your "
             "email for the activation link."),
     }
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -20,7 +20,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from project.validators import validate_version
 from project.modelcomponents.access import AccessPolicy

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -3,7 +3,7 @@ import re
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from zxcvbn import zxcvbn
 
 


### PR DESCRIPTION
ugettext_lazy() and ugettext() are automatic translation functions that are deprecated in Django 3 (https://django.readthedocs.io/en/stable/releases/3.0.html#deprecated-features-3-0). This pull request replaces them with gettext().