### PR TITLE
Minor changes to the wording on the credentialing pages 

### DIFF
--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -44,7 +44,7 @@
                 <th onclick="sortTable(2,'personalt')">Email <i class="fas fa-sort" id="icon_2_personalt"></i></th>
                 <th onclick="sortTable(3,'personalt')">Reference Email <i class="fas fa-sort" id="icon_3_personalt"></i></th>
                 <th class="table-elapsed" onclick="sortTable(4,'personalt')">Application <i class="fas fa-sort" id="icon_4_personalt"></i></th>
-                <th class="table-process">Process Application</th>
+                <th class="table-process">Process </th>
               </tr>
             </thead>
             <tbody>  

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -16,7 +16,7 @@
   <div class="col-sm-5">
     <div class="card mb-4">
       <div class="card-header">
-        Application information
+        Application Information
       </div>
       <div class="card-body">
         <div class='mb-2'>


### PR DESCRIPTION
I wanted to make some minor changes to the code base. This pull request makes two small changes to the languages used on the credentialing pages:

- changing the "Application information" to title case for consistency with the other headers.
- changing the "Process application" to "Process" in the table header to reduce the width of the column.