### PR TITLE
Add reviewer section to the "process training page" in the console

### DIFF
--- a/physionet-django/console/templates/console/training_process.html
+++ b/physionet-django/console/templates/console/training_process.html
@@ -84,6 +84,22 @@
                   </form>
             </div>
         </div>
+
+        <div class="card mb-4">
+            <div class="card-header">
+                Guidelines
+            </div>
+            <div class="card-body">
+                <ul>
+                    <li>Does the name on the certificate match the name of the user?</li>
+                    <li>Is the correct document attached (e.g. report, not certificate)?</li>
+                    <li>Is the training up to date?</li>
+                    <li>Are the required models complete?</li>
+                    <li>Has the HIPAA module been completed?</li>
+                </ul>
+            </div>
+        </div>
+
   </div>
 </div>
 


### PR DESCRIPTION
Currently we display multiple radio buttons on the page used to review training reports (e.g. at http://127.0.0.1:8000/console/training/process/2/). An example of these buttons is below:

<img width="491" alt="Screen Shot 2022-05-07 at 13 31 37" src="https://user-images.githubusercontent.com/822601/167265353-e7ef4890-4b57-4de4-9d06-161ee53fdb82.png">

To reduce the number of clicks required when processing, we would like to remove most or all of these buttons (which done by removing questions from the database).

In preparation for removing the questions, this pull request adds a "Guidelines" section underneath the form used to accept/reject applications to remind the reviewer of our review requirements.

<img width="492" alt="Screen Shot 2022-05-07 at 13 29 15" src="https://user-images.githubusercontent.com/822601/167265349-308f417a-6c51-45fa-9244-aad189921ff0.png">



