### PR TITLE
Replace dropdown menus in credentialing review process with accept/reject buttons

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -784,6 +784,17 @@ class TrainingQuestionFormSet(forms.BaseModelFormSet):
                 )
 
 
+class CredentialReviewForm(forms.Form):
+    reviewer_comments = forms.CharField(widget=forms.Textarea(attrs={'rows': 5}), required=False)
+
+    def clean(self):
+        if self.errors:
+            return
+
+        if not self.cleaned_data['reviewer_comments']:
+            raise forms.ValidationError('If you reject, you must explain why.')
+
+
 class TrainingReviewForm(forms.Form):
     reviewer_comments = forms.CharField(widget=forms.Textarea(attrs={'rows': 5}), required=False)
 

--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -83,7 +83,7 @@
                 <th onclick="sortTable(2,'referencet')">Email <i class="fas fa-sort" id="icon_2_referencet"></i></th>
                 <th onclick="sortTable(3,'referencet')">Reference Email <i class="fas fa-sort" id="icon_3_referencet"></i></th>
                 <th class="table-elapsed" onclick="sortTable(4,'referencet')">Application <i class="fas fa-sort" id="icon_4_referencet"></i></th>
-                <th>Reset Application</th>
+                <th>Reset Review</th>
                 <th class="table-process">Process Application</th>
               </tr>
             </thead>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -73,7 +73,7 @@
             <form action="" method="post" class="form-signin">
               {% csrf_token %}
               {% include "form_snippet.html" with form=credential_review_form %}
-              <button class="btn btn-success btn-fixed" name="accept_id" type="submit">Accept</button>
+              <button class="btn btn-success btn-fixed" name="accept_id" type="submit">Accept ID</button>
               <button class="btn btn-primary btn-fixed" name="full_approve" type="submit">Full approve</button>
               <button class="btn btn-danger btn-fixed" name="reject" type="submit">Reject</button>
             </form>
@@ -189,7 +189,7 @@
             <form action="" method="post">
               {% csrf_token %}
               {% include "form_snippet.html" with form=credential_review_form %}
-              <button class="btn btn-success btn-fixed" name="accept_final" type="submit">Approve</button>
+              <button class="btn btn-success btn-fixed" name="accept_final" type="submit">Full approve</button>
               <button class="btn btn-danger btn-fixed" name="reject" type="submit">Reject</button>
             </form>
           </div>

--- a/physionet-django/console/templates/console/process_credential_application.html
+++ b/physionet-django/console/templates/console/process_credential_application.html
@@ -45,10 +45,10 @@
               <p>The reference has not been contacted.</p>
             {% endif %}
             {% if not application.reference_email|length < 1 %}
-            <form action="" method="post" class="form-signin">
+            <form action="" method="post">
               {% csrf_token %}
-              {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="contact_reference" submit_value=app_user.id submit_text="Contact Reference" %}
-              <button type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact Reference</button>
+              {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="contact_reference" submit_value=app_user.id submit_text="Send" %}
+              <button type="button" class="btn btn-primary btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact reference (again!)</button>
             </form>
             {% endif %}
             {# Reference already responded #}
@@ -72,14 +72,11 @@
             {# Personal #}
             <form action="" method="post" class="form-signin">
               {% csrf_token %}
-              {% include "form_snippet.html" with form=intermediate_credential_form %}
-              <button class="btn btn-primary btn-fixed" name="approve_personal" value="{{ app_user.id }}" type="submit">Submit response</button>
+              {% include "form_snippet.html" with form=credential_review_form %}
+              <button class="btn btn-success btn-fixed" name="accept_id" type="submit">Accept</button>
+              <button class="btn btn-primary btn-fixed" name="full_approve" type="submit">Full approve</button>
+              <button class="btn btn-danger btn-fixed" name="reject" type="submit">Reject</button>
             </form>
-            <br />
-            <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
-                {% csrf_token %}
-               <button class="btn btn-danger btn-fixed" name="immediate_accept" value="{{ app_user.id }}" type="submit">Full approve</button>
-          </form>
           </div>
         </div>
 
@@ -98,7 +95,7 @@
                 <ul>
                 <li>Independent researcher should not list an organization</li>
                 <li>Students should be listed as "student" or "postdoc"</li>
-                <li>MD's with a hospital as their organization should be "hospital researcher"</li>
+                <li>Medical doctors with a hospital as their organization should be "hospital researcher"</li>
               </ul>
               </li>
             </ul>
@@ -113,15 +110,21 @@
           </div>
           <div class="card-body">
             {# Reference #}
-            <form action="" method="post" class="form-signin">
+            <form action="" method="post">
               {% csrf_token %}
-              {% include "form_snippet.html" with form=intermediate_credential_form %}
-              <button class="btn btn-primary btn-fixed" name="approve_reference" value="{{ app_user.id }}" type="submit">Submit Response</button>
+              {% if application.reference_email|length > 1 %}
+                <button type="button" class="btn btn-success btn-fixed" data-toggle="modal" data-target="#contact-reference-modal">Contact reference</button>
+              {% else %}
+                <button type="button" class="btn btn-success btn-fixed" data-toggle="modal" data-target="#contact-reference-modal" disabled>Contact reference</button>
+              {% endif %}
+              <br /><br />
+              {% include "console/email_modal.html" with form=contact_cred_ref_form app_user=app_user modal_id="contact-reference-modal" modal_title="Email Reference" submit_name="accept_ref" submit_value=app_user.id submit_text="Send" %}
             </form>
-            <br />
-            <form action="" method="post" class="form-signin"  onsubmit="return confirm ('Are you sure? ')">
+            <form action="" method="post">
               {% csrf_token %}
-              <button class="btn btn-primary btn-danger" name="skip_reference" value="{{ app_user.id }}" type="submit">Skip Reference Check</button>
+              {% include "form_snippet.html" with form=credential_review_form %}
+              <button class="btn btn-primary btn-fixed" name="skip_ref" type="submit">Skip reference</button>
+              <button class="btn btn-danger btn-danger" name="reject" type="submit">Reject</button>
             </form>
           </div>
         </div>
@@ -156,7 +159,7 @@
           </div>
           <div class="card-body">
             {# Response #}
-            <form action="" method="post" class="form-signin">
+            <form action="" method="post">
               {% csrf_token %}
               {% include "form_snippet.html" with form=intermediate_credential_form %}
               <button class="btn btn-primary btn-fixed" name="approve_response" value="{{app_user.id}}" type="submit">Submit Response</button>
@@ -183,10 +186,11 @@
             Process Application
           </div>
           <div class="card-body">
-            <form action="" method="post" class="form-signin">
+            <form action="" method="post">
               {% csrf_token %}
-              {% include "form_snippet.html" with form=process_credential_form %}
-              <button class="btn btn-primary btn-lg" name="process_application" value="{{app_user.id}}" type="submit">Submit Response</button>
+              {% include "form_snippet.html" with form=credential_review_form %}
+              <button class="btn btn-success btn-fixed" name="accept_final" type="submit">Approve</button>
+              <button class="btn btn-danger btn-fixed" name="reject" type="submit">Reject</button>
             </form>
           </div>
         </div>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -354,15 +354,18 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
     # Metadata forms and formsets
     ReferenceFormSet = generic_inlineformset_factory(Reference,
                                                      fields=('description',), extra=0,
-                                                     max_num=project_forms.ReferenceFormSet.max_forms, can_delete=False,
+                                                     max_num=project_forms.ReferenceFormSet.max_forms,
+                                                     can_delete=False,
                                                      formset=project_forms.ReferenceFormSet, validate_max=True)
     TopicFormSet = generic_inlineformset_factory(Topic,
                                                  fields=('description',), extra=0,
-                                                 max_num=project_forms.TopicFormSet.max_forms, can_delete=False,
+                                                 max_num=project_forms.TopicFormSet.max_forms,
+                                                 can_delete=False,
                                                  formset=project_forms.TopicFormSet, validate_max=True)
     PublicationFormSet = generic_inlineformset_factory(Publication,
                                                        fields=('citation', 'url'), extra=0,
-                                                       max_num=project_forms.PublicationFormSet.max_forms, can_delete=False,
+                                                       max_num=project_forms.PublicationFormSet.max_forms,
+                                                       can_delete=False,
                                                        formset=project_forms.PublicationFormSet, validate_max=True)
 
     description_form = project_forms.ContentForm(
@@ -666,7 +669,8 @@ def process_storage_response(request, storage_response_formset):
 
                 notification.storage_response_notify(storage_request)
                 messages.success(request,
-                                 'The storage request has been {}'.format(notification.RESPONSE_ACTIONS[storage_request.response]))
+                                 (f"The storage request has been "
+                                  f"{notification.RESPONSE_ACTIONS[storage_request.response]}"))
 
 
 @permission_required('project.change_storagerequest', raise_exception=True)
@@ -1376,17 +1380,23 @@ def credential_applications(request, status):
                                'u_applications': unsuccessful_apps,
                                'p_applications': pending_apps})
 
-    legacy_apps = LegacyCredential.objects.filter(migrated=True,
-                                                  migrated_user__is_credentialed=True).order_by('-migration_date').select_related('migrated_user__profile')
+    legacy_apps = (LegacyCredential.objects.filter(migrated=True,
+                                                   migrated_user__is_credentialed=True)
+                   .order_by('-migration_date')
+                   .select_related('migrated_user__profile'))
 
-    successful_apps = CredentialApplication.objects.filter(status=2
-                                                           ).order_by('-decision_datetime').select_related('user__profile', 'responder__profile')
+    successful_apps = (CredentialApplication.objects.filter(status=2
+                                                            ).
+                       order_by('-decision_datetime')
+                       .select_related('user__profile', 'responder__profile'))
 
     unsuccessful_apps = CredentialApplication.objects.filter(
         status__in=[1, 3, 4]).order_by('-decision_datetime').select_related('user__profile', 'responder')
 
-    pending_apps = CredentialApplication.objects.filter(status=0
-                                                        ).order_by('-application_datetime').select_related('user__profile', 'credential_review')
+    pending_apps = (CredentialApplication.objects.filter(status=0
+                                                         )
+                    .order_by('-application_datetime')
+                    .select_related('user__profile', 'credential_review'))
 
     # Merge legacy applications and new applications
     all_successful_apps = list(chain(successful_apps, legacy_apps))
@@ -1412,12 +1422,13 @@ def search_credential_applications(request):
     if request.POST:
         search_field = request.POST['search']
 
-        legacy_apps = LegacyCredential.objects.filter(Q(migrated=True) &
-                                                      Q(migrated_user__is_credentialed=True)
-                                                      & (Q(migrated_user__username__icontains=search_field) |
-                                                         Q(migrated_user__profile__first_names__icontains=search_field)
-                                                         | Q(migrated_user__profile__last_name__icontains=search_field)
-                                                         | Q(migrated_user__email__icontains=search_field))).order_by('-migration_date')
+        legacy_apps = (LegacyCredential.objects.filter(
+            Q(migrated=True)
+            & Q(migrated_user__is_credentialed=True)
+            & (Q(migrated_user__username__icontains=search_field)
+               | Q(migrated_user__profile__first_names__icontains=search_field)
+               | Q(migrated_user__profile__last_name__icontains=search_field)
+               | Q(migrated_user__email__icontains=search_field))).order_by('-migration_date'))
 
         successful_apps = CredentialApplication.objects.filter(
             Q(status=2) & (Q(user__username__icontains=search_field) |
@@ -1755,7 +1766,9 @@ def add_featured(request):
         form = forms.FeaturedForm()
 
     return render(request, 'console/add_featured.html', {'title': title,
-                                                         'projects': projects, 'form': form, 'valid_search': valid_search,
+                                                         'projects': projects,
+                                                         'form': form,
+                                                         'valid_search': valid_search,
                                                          'featured_content_nav': True})
 
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1189,8 +1189,10 @@ def process_credential_application(request, application_slug):
                 application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
                 application.save()
             application.update_review_status(20)
-            page_title = title_dict[application.credential_review.status]
             messages.success(request, 'The ID was approved.')
+            page_title = title_dict[application.credential_review.status]
+            # reset form
+            credential_review_form = forms.CredentialReviewForm()
         elif 'full_approve' in request.POST:
             credential_review_form = forms.CredentialReviewForm(data=request.POST)
             if credential_review_form.is_valid():
@@ -1202,10 +1204,6 @@ def process_credential_application(request, application_slug):
             return redirect(credential_processing)
         # PROCESS REFERENCE CHECK STAGE
         elif 'accept_ref' in request.POST:
-            credential_review_form = forms.CredentialReviewForm(data=request.POST)
-            if credential_review_form.is_valid():
-                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
-                application.save()
             contact_cred_ref_form = forms.ContactCredentialRefForm(data=request.POST)
             if contact_cred_ref_form.is_valid():
                 application.update_review_status(30)
@@ -1217,6 +1215,8 @@ def process_credential_application(request, application_slug):
                                                subject=subject, body=body)
                 messages.success(request, 'The reference was contacted.')
                 page_title = title_dict[application.credential_review.status]
+                # reset form
+                contact_cred_ref_form = forms.ContactCredentialRefForm(initial=ref_email)
         elif 'skip_ref' in request.POST:
             credential_review_form = forms.CredentialReviewForm(data=request.POST)
             if credential_review_form.is_valid():
@@ -1225,6 +1225,8 @@ def process_credential_application(request, application_slug):
             application.update_review_status(40)
             messages.success(request, 'The reference was skipped.')
             page_title = title_dict[application.credential_review.status]
+            # reset form
+            credential_review_form = forms.CredentialReviewForm()
         # CONTACT REFERENCE AGAIN
         elif 'contact_reference' in request.POST:
             contact_cred_ref_form = forms.ContactCredentialRefForm(

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -170,7 +170,7 @@ def submitted_projects(request):
                 pid = request.POST.get('send_approval_reminder', '')
                 project = ActiveProject.objects.get(id=pid)
                 notification.copyedit_complete_notify(request, project,
-                    project.copyedit_logs.last(), reminder=True)
+                                                      project.copyedit_logs.last(), reminder=True)
                 project.latest_reminder = timezone.now()
                 project.save()
                 messages.success(request, 'The reminder email has been sent.')
@@ -178,22 +178,22 @@ def submitted_projects(request):
                 pid = request.POST.get('send_revision_reminder', '')
                 project = ActiveProject.objects.get(id=pid)
                 notification.edit_decision_notify(request, project,
-                    project.edit_logs.last(), reminder=True)
+                                                  project.edit_logs.last(), reminder=True)
                 project.latest_reminder = timezone.now()
                 project.save()
                 messages.success(request, 'The reminder email has been sent.')
         except (ValueError, ActiveProject.DoesNotExist):
             pass
     return render(request, 'console/submitted_projects.html',
-        {'assign_editor_form': assign_editor_form,
-         'assignment_projects': assignment_projects,
-         'decision_projects': decision_projects,
-         'revision_projects': revision_projects,
-         'copyedit_projects': copyedit_projects,
-         'approval_projects': approval_projects,
-         'publish_projects': publish_projects,
-         'submitted_projects_nav': True,
-         'yesterday': yesterday})
+                  {'assign_editor_form': assign_editor_form,
+                   'assignment_projects': assignment_projects,
+                   'decision_projects': decision_projects,
+                   'revision_projects': revision_projects,
+                   'copyedit_projects': copyedit_projects,
+                   'approval_projects': approval_projects,
+                   'publish_projects': publish_projects,
+                   'submitted_projects_nav': True,
+                   'yesterday': yesterday})
 
 
 @permission_required('project.change_activeproject', raise_exception=True)
@@ -223,19 +223,19 @@ def editor_home(request):
             pid = request.POST.get('send_reminder', '')
             project = ActiveProject.objects.get(id=pid)
             notification.edit_decision_notify(request, project,
-                project.edit_logs.last(), reminder=True)
+                                              project.edit_logs.last(), reminder=True)
             project.latest_reminder = timezone.now()
             project.save()
             messages.success(request, 'The reminder email has been sent.')
         except (ValueError, ActiveProject.DoesNotExist):
             pass
     return render(request, 'console/editor_home.html',
-        {'decision_projects': decision_projects,
-         'revision_projects': revision_projects,
-         'copyedit_projects': copyedit_projects,
-         'approval_projects': approval_projects,
-         'publish_projects': publish_projects,
-         'yesterday': yesterday, 'editor_home': True})
+                  {'decision_projects': decision_projects,
+                   'revision_projects': revision_projects,
+                   'copyedit_projects': copyedit_projects,
+                   'approval_projects': approval_projects,
+                   'publish_projects': publish_projects,
+                   'yesterday': yesterday, 'editor_home': True})
 
 
 def submission_info_redirect(request, project_slug):
@@ -271,19 +271,19 @@ def submission_info(request, project_slug):
         messages.success(request, 'The editor has been reassigned')
         LOGGER.info("The editor for the project {0} has been reassigned from "
                     "{1} to {2}".format(project, user,
-                        reassign_editor_form.cleaned_data['editor']))
+                                        reassign_editor_form.cleaned_data['editor']))
 
     url_prefix = notification.get_url_prefix(request)
     bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     return render(request, 'console/submission_info.html',
-        {'project': project, 'authors': authors,
-         'author_emails': author_emails, 'storage_info': storage_info,
-         'edit_logs': edit_logs, 'copyedit_logs': copyedit_logs,
-         'latest_version': latest_version, 'passphrase': passphrase,
-         'anonymous_url': anonymous_url, 'url_prefix': url_prefix,
-         'bulk_url_prefix': bulk_url_prefix,
-         'reassign_editor_form': reassign_editor_form,
-         'project_info_nav': True})
+                  {'project': project, 'authors': authors,
+                   'author_emails': author_emails, 'storage_info': storage_info,
+                   'edit_logs': edit_logs, 'copyedit_logs': copyedit_logs,
+                   'latest_version': latest_version, 'passphrase': passphrase,
+                   'anonymous_url': anonymous_url, 'url_prefix': url_prefix,
+                   'bulk_url_prefix': bulk_url_prefix,
+                   'reassign_editor_form': reassign_editor_form,
+                   'project_info_nav': True})
 
 
 @handling_editor
@@ -319,8 +319,8 @@ def edit_submission(request, project_slug, *args, **kwargs):
             # Notify the authors
             notification.edit_decision_notify(request, project, edit_log)
             return render(request, 'console/edit_complete.html',
-                {'decision': edit_log.decision, 'editor_home': True,
-                 'project': project, 'edit_log': edit_log})
+                          {'decision': edit_log.decision, 'editor_home': True,
+                           'project': project, 'edit_log': edit_log})
         messages.error(request, 'Invalid response. See form below.')
     else:
         edit_submission_form = forms.EditSubmissionForm(
@@ -331,12 +331,12 @@ def edit_submission(request, project_slug, *args, **kwargs):
     bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
 
     return render(request, 'console/edit_submission.html',
-        {'project': project, 'edit_submission_form': edit_submission_form,
-         'authors': authors, 'author_emails': author_emails,
-         'storage_info': storage_info, 'edit_logs': edit_logs,
-         'latest_version': latest_version, 'url_prefix': url_prefix,
-         'bulk_url_prefix': bulk_url_prefix,
-         'editor_home': True, 'reassign_editor_form': reassign_editor_form})
+                  {'project': project, 'edit_submission_form': edit_submission_form,
+                   'authors': authors, 'author_emails': author_emails,
+                   'storage_info': storage_info, 'edit_logs': edit_logs,
+                   'latest_version': latest_version, 'url_prefix': url_prefix,
+                   'bulk_url_prefix': bulk_url_prefix,
+                   'editor_home': True, 'reassign_editor_form': reassign_editor_form})
 
 
 @handling_editor
@@ -353,17 +353,17 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
 
     # Metadata forms and formsets
     ReferenceFormSet = generic_inlineformset_factory(Reference,
-        fields=('description',), extra=0,
-        max_num=project_forms.ReferenceFormSet.max_forms, can_delete=False,
-        formset=project_forms.ReferenceFormSet, validate_max=True)
+                                                     fields=('description',), extra=0,
+                                                     max_num=project_forms.ReferenceFormSet.max_forms, can_delete=False,
+                                                     formset=project_forms.ReferenceFormSet, validate_max=True)
     TopicFormSet = generic_inlineformset_factory(Topic,
-        fields=('description',), extra=0,
-        max_num=project_forms.TopicFormSet.max_forms, can_delete=False,
-        formset=project_forms.TopicFormSet, validate_max=True)
+                                                 fields=('description',), extra=0,
+                                                 max_num=project_forms.TopicFormSet.max_forms, can_delete=False,
+                                                 formset=project_forms.TopicFormSet, validate_max=True)
     PublicationFormSet = generic_inlineformset_factory(Publication,
-        fields=('citation', 'url'), extra=0,
-        max_num=project_forms.PublicationFormSet.max_forms, can_delete=False,
-        formset=project_forms.PublicationFormSet, validate_max=True)
+                                                       fields=('citation', 'url'), extra=0,
+                                                       max_num=project_forms.PublicationFormSet.max_forms, can_delete=False,
+                                                       formset=project_forms.PublicationFormSet, validate_max=True)
 
     description_form = project_forms.ContentForm(
         resource_type=project.resource_type.id, instance=project)
@@ -376,7 +376,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         access_form = project_forms.AccessMetadataForm(instance=project)
 
     discovery_form = project_forms.DiscoveryForm(resource_type=project.resource_type.id,
-        instance=project)
+                                                 instance=project)
     description_form_saved = False
     reference_formset = ReferenceFormSet(instance=project)
     publication_formset = PublicationFormSet(instance=project)
@@ -391,14 +391,14 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
                 instance=project)
             ethics_form = project_forms.EthicsForm(data=request.POST, instance=project)
             access_form = project_forms.AccessMetadataForm(data=request.POST,
-                instance=project)
+                                                           instance=project)
             discovery_form = project_forms.DiscoveryForm(
                 resource_type=project.resource_type, data=request.POST,
                 instance=project)
             reference_formset = ReferenceFormSet(data=request.POST,
-                instance=project)
-            publication_formset = PublicationFormSet(request.POST,
                                                  instance=project)
+            publication_formset = PublicationFormSet(request.POST,
+                                                     instance=project)
             topic_formset = TopicFormSet(request.POST, instance=project)
             if (
                 description_form.is_valid()
@@ -417,7 +417,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
                 publication_formset.save()
                 topic_formset.save()
                 messages.success(request,
-                    'The project metadata has been updated.')
+                                 'The project metadata has been updated.')
                 description_form_saved = True
                 # Reload formsets
                 reference_formset = ReferenceFormSet(instance=project)
@@ -425,17 +425,17 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
                 topic_formset = TopicFormSet(instance=project)
             else:
                 messages.error(request,
-                    'Invalid submission. See errors below.')
+                               'Invalid submission. See errors below.')
         elif 'complete_copyedit' in request.POST:
             copyedit_form = forms.CopyeditForm(request.POST,
-                instance=copyedit_log)
+                                               instance=copyedit_log)
             if copyedit_form.is_valid():
                 copyedit_log = copyedit_form.save()
                 notification.copyedit_complete_notify(request, project,
-                    copyedit_log)
+                                                      copyedit_log)
                 return render(request, 'console/copyedit_complete.html',
-                    {'project': project, 'copyedit_log': copyedit_log,
-                     'editor_home': True})
+                              {'project': project, 'copyedit_log': copyedit_log,
+                               'editor_home': True})
             else:
                 messages.error(request, 'Invalid submission. See errors below.')
         else:
@@ -539,10 +539,10 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
             project.reopen_copyedit()
             notification.reopen_copyedit_notify(request, project)
             return render(request, 'console/reopen_copyedit_complete.html',
-                {'project':project})
+                          {'project': project})
         elif 'send_reminder' in request.POST:
             notification.copyedit_complete_notify(request, project,
-                project.copyedit_logs.last(), reminder=True)
+                                                  project.copyedit_logs.last(), reminder=True)
             messages.success(request, 'The reminder email has been sent.')
             project.latest_reminder = timezone.now()
             project.save()
@@ -552,13 +552,13 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
     yesterday = timezone.now() + timezone.timedelta(days=-1)
 
     return render(request, 'console/awaiting_authors.html',
-        {'project': project, 'authors': authors, 'author_emails': author_emails,
-         'storage_info': storage_info, 'edit_logs': edit_logs,
-         'copyedit_logs': copyedit_logs, 'latest_version': latest_version,
-         'outstanding_emails': outstanding_emails, 'url_prefix': url_prefix,
-         'bulk_url_prefix': bulk_url_prefix,
-         'yesterday': yesterday, 'editor_home': True,
-         'reassign_editor_form': reassign_editor_form})
+                  {'project': project, 'authors': authors, 'author_emails': author_emails,
+                   'storage_info': storage_info, 'edit_logs': edit_logs,
+                   'copyedit_logs': copyedit_logs, 'latest_version': latest_version,
+                   'outstanding_emails': outstanding_emails, 'url_prefix': url_prefix,
+                   'bulk_url_prefix': bulk_url_prefix,
+                   'yesterday': yesterday, 'editor_home': True,
+                   'reassign_editor_form': reassign_editor_form})
 
 
 @handling_editor
@@ -576,7 +576,7 @@ def publish_slug_available(request, project_slug, *args, **kwargs):
     else:
         result = not exists_project_slug(desired_slug)
 
-    return JsonResponse({'available':result})
+    return JsonResponse({'available': result})
 
 
 @handling_editor
@@ -601,7 +601,7 @@ def publish_submission(request, project_slug, *args, **kwargs):
             else:
                 slug = publish_form.cleaned_data['slug']
             published_project = project.publish(slug=slug,
-                make_zip=int(publish_form.cleaned_data['make_zip']))
+                                                make_zip=int(publish_form.cleaned_data['make_zip']))
 
             notification.publish_notify(request, published_project)
 
@@ -632,13 +632,13 @@ def publish_submission(request, project_slug, *args, **kwargs):
     publish_form = forms.PublishForm(project=project)
 
     return render(request, 'console/publish_submission.html',
-        {'project': project, 'publishable': publishable, 'authors': authors,
-         'author_emails': author_emails, 'storage_info': storage_info,
-         'edit_logs': edit_logs, 'copyedit_logs': copyedit_logs,
-         'latest_version': latest_version, 'publish_form': publish_form,
-         'max_slug_length': MAX_PROJECT_SLUG_LENGTH, 'url_prefix': url_prefix,
-         'bulk_url_prefix': bulk_url_prefix,
-         'reassign_editor_form': reassign_editor_form, 'editor_home': True})
+                  {'project': project, 'publishable': publishable, 'authors': authors,
+                   'author_emails': author_emails, 'storage_info': storage_info,
+                   'edit_logs': edit_logs, 'copyedit_logs': copyedit_logs,
+                   'latest_version': latest_version, 'publish_form': publish_form,
+                   'max_slug_length': MAX_PROJECT_SLUG_LENGTH, 'url_prefix': url_prefix,
+                   'bulk_url_prefix': bulk_url_prefix,
+                   'reassign_editor_form': reassign_editor_form, 'editor_home': True})
 
 
 @permission_required('project.change_storagerequest', raise_exception=True)
@@ -666,7 +666,7 @@ def process_storage_response(request, storage_response_formset):
 
                 notification.storage_response_notify(storage_request)
                 messages.success(request,
-                    'The storage request has been {}'.format(notification.RESPONSE_ACTIONS[storage_request.response]))
+                                 'The storage request has been {}'.format(notification.RESPONSE_ACTIONS[storage_request.response]))
 
 
 @permission_required('project.change_storagerequest', raise_exception=True)
@@ -675,21 +675,21 @@ def storage_requests(request):
     Page for listing and responding to project storage requests
     """
     StorageResponseFormSet = modelformset_factory(StorageRequest,
-        fields=('response', 'response_message'),
-        widgets={'response':Select(choices=forms.RESPONSE_CHOICES),
-                 'response_message':Textarea()}, extra=0)
+                                                  fields=('response', 'response_message'),
+                                                  widgets={'response': Select(choices=forms.RESPONSE_CHOICES),
+                                                           'response_message': Textarea()}, extra=0)
 
     if request.method == 'POST':
         storage_response_formset = StorageResponseFormSet(request.POST,
-            queryset=StorageRequest.objects.filter(is_active=True))
+                                                          queryset=StorageRequest.objects.filter(is_active=True))
         process_storage_response(request, storage_response_formset)
 
     storage_response_formset = StorageResponseFormSet(
         queryset=StorageRequest.objects.filter(is_active=True))
 
     return render(request, 'console/storage_requests.html',
-        {'storage_response_formset': storage_response_formset,
-         'storage_requests_nav': True})
+                  {'storage_response_formset': storage_response_formset,
+                   'storage_requests_nav': True})
 
 
 @permission_required('project.change_activeproject', raise_exception=True)
@@ -702,7 +702,7 @@ def unsubmitted_projects(request):
     projects = paginate(request, projects, 50)
 
     return render(request, 'console/unsubmitted_projects.html',
-        {'projects': projects, 'unsubmitted_projects_nav': True})
+                  {'projects': projects, 'unsubmitted_projects_nav': True})
 
 
 @permission_required('project.change_publishedproject', raise_exception=True)
@@ -713,7 +713,7 @@ def published_projects(request):
     projects = PublishedProject.objects.all().order_by('-publish_datetime')
     projects = paginate(request, projects, 50)
     return render(request, 'console/published_projects.html',
-        {'projects': projects, 'published_projects_nav': True})
+                  {'projects': projects, 'published_projects_nav': True})
 
 
 @associated_task(PublishedProject, 'pid', read_only=True)
@@ -953,7 +953,7 @@ def gcp_bucket_management(request, project, user):
             messages.success(request, "The GCP bucket for project {0} was \
                 successfully created.".format(project))
         GCP.objects.create(project=project, bucket_name=bucket_name,
-            managed_by=user, is_private=is_private, access_group=group)
+                           managed_by=user, is_private=is_private, access_group=group)
         if is_private:
             granted = utility.add_email_bucket_access(project, group, True)
             DataAccess.objects.create(project=project, platform=3, location=group)
@@ -977,7 +977,7 @@ def rejected_submissions(request):
     projects = ArchivedProject.objects.filter(archive_reason=3).order_by('archive_datetime')
     projects = paginate(request, projects, 50)
     return render(request, 'console/rejected_submissions.html',
-        {'projects': projects, 'rejected_projects_nav': True})
+                  {'projects': projects, 'rejected_projects_nav': True})
 
 
 @permission_required('user.view_user', raise_exception=True)
@@ -1020,7 +1020,6 @@ def user_management(request, username):
     training['Expired'] = _training.get_expired()
     training['Rejected'] = _training.get_rejected()
 
-
     emails = {}
     emails['primary'] = AssociatedEmail.objects.filter(user=user,
                                                        is_primary_email=True,
@@ -1033,9 +1032,9 @@ def user_management(request, username):
 
     projects = {}
     projects['Unsubmitted'] = ActiveProject.objects.filter(authors__user=user,
-                                submission_status=0).order_by('-creation_datetime')
+                                                           submission_status=0).order_by('-creation_datetime')
     projects['Submitted'] = ActiveProject.objects.filter(authors__user=user,
-                                submission_status__gt=0).order_by('-submission_datetime')
+                                                         submission_status__gt=0).order_by('-submission_datetime')
     projects['Archived'] = ArchivedProject.objects.filter(authors__user=user).order_by('-archive_datetime')
     projects['Published'] = PublishedProject.objects.filter(authors__user=user).order_by('-publish_datetime')
 
@@ -1061,9 +1060,9 @@ def users_search(request, group):
     if request.method == 'POST':
         search_field = request.POST['search']
 
-        users = User.objects.filter(Q(username__icontains=search_field) |
-            Q(profile__first_names__icontains=search_field) |
-            Q(email__icontains=search_field))
+        users = User.objects.filter(Q(username__icontains=search_field)
+                                    | Q(profile__first_names__icontains=search_field)
+                                    | Q(email__icontains=search_field))
 
         if 'inactive' in group:
             users = users.filter(is_active=False)
@@ -1075,8 +1074,8 @@ def users_search(request, group):
         if len(search_field) == 0:
             users = paginate(request, users, 50)
 
-        return render(request, 'console/users_list.html', {'users':users,
-            'group': group})
+        return render(request, 'console/users_list.html', {'users': users,
+                                                           'group': group})
 
     raise Http404()
 
@@ -1091,10 +1090,10 @@ def known_references_search(request):
         search_field = request.POST['search']
 
         applications = CredentialApplication.objects.filter(
-            Q(reference_email__icontains=search_field) |
-            Q(reference_name__icontains=search_field) |
-            Q(user__profile__last_name__icontains=search_field) |
-            Q(user__profile__first_names__icontains=search_field))
+            Q(reference_email__icontains=search_field)
+            | Q(reference_name__icontains=search_field)
+            | Q(user__profile__last_name__icontains=search_field)
+            | Q(user__profile__first_names__icontains=search_field))
 
         all_known_ref = applications.exclude(
             reference_contact_datetime__isnull=True).order_by(
@@ -1133,7 +1132,7 @@ def process_credential_application(request, application_slug):
     """
     try:
         application = CredentialApplication.objects.get(slug=application_slug,
-            status=0)
+                                                        status=0)
         # create the review object if it does not exist
         CredentialReview.objects.get_or_create(application=application)
     except CredentialApplication.DoesNotExist:
@@ -1150,16 +1149,15 @@ def process_credential_application(request, application_slug):
     training['Expired'] = _training.get_expired()
     training['Rejected'] = _training.get_rejected()
 
-    process_credential_form = forms.ProcessCredentialReviewForm(responder=request.user,
-        instance=application)
-
     ref_email = notification.contact_reference(request, application,
-                                               send=False,  wordwrap=False)
+                                               send=False, wordwrap=False)
     contact_cred_ref_form = forms.ContactCredentialRefForm(initial=ref_email)
 
     page_title = None
     title_dict = {a: k for a, k in CredentialReview.REVIEW_STATUS_LABELS}
     page_title = title_dict[application.credential_review.status]
+
+    credential_review_form = forms.CredentialReviewForm()
 
     if application.credential_review.status == 10:
         intermediate_credential_form = forms.PersonalCredentialForm(responder=request.user, instance=application)
@@ -1171,51 +1169,59 @@ def process_credential_application(request, application_slug):
         intermediate_credential_form = forms.ProcessCredentialReviewForm(responder=request.user, instance=application)
 
     if request.method == 'POST':
-        if 'approve_personal' in request.POST:
-            intermediate_credential_form = forms.PersonalCredentialForm(
-                responder=request.user, data=request.POST, instance=application)
-            if intermediate_credential_form.is_valid():
-                intermediate_credential_form.save()
-                if intermediate_credential_form.cleaned_data['decision'] == '0':
-                    notification.process_credential_complete(request,
-                                                             application)
-                    return render(request, 'console/process_credential_complete.html',
-                        {'application':application})
-                page_title = title_dict[application.credential_review.status]
-                intermediate_credential_form = forms.ReferenceCredentialForm(
-                    responder=request.user, instance=application)
-            else:
-                messages.error(request, 'Invalid review. See form below.')
-        elif 'approve_reference' in request.POST:
-            intermediate_credential_form = forms.ReferenceCredentialForm(
-                responder=request.user, data=request.POST, instance=application)
-            if intermediate_credential_form.is_valid():
-                intermediate_credential_form.save()
-                if intermediate_credential_form.cleaned_data['decision'] == '0':
-                    notification.process_credential_complete(request,
-                                                             application)
-                    return render(request, 'console/process_credential_complete.html',
-                        {'application':application})
-                page_title = title_dict[application.credential_review.status]
-                intermediate_credential_form = forms.ResponseCredentialForm(
-                    responder=request.user, instance=application)
-            else:
-                messages.error(request, 'Invalid review. See form below.')
-        elif 'approve_response' in request.POST:
-            intermediate_credential_form = forms.ResponseCredentialForm(
-                responder=request.user, data=request.POST, instance=application)
-            if intermediate_credential_form.is_valid():
-                intermediate_credential_form.save()
-                if intermediate_credential_form.cleaned_data['decision'] == '0':
-                    notification.process_credential_complete(request,
-                                                             application)
-                    return render(request, 'console/process_credential_complete.html',
-                        {'application':application})
-                page_title = title_dict[application.credential_review.status]
-                intermediate_credential_form = forms.ProcessCredentialReviewForm(
-                    responder=request.user, instance=application)
-            else:
-                messages.error(request, 'Invalid review. See form below.')
+        if 'reject' in request.POST:
+            credential_review_form = forms.CredentialReviewForm(data=request.POST)
+            if credential_review_form.is_valid():
+                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
+                application.save()
+                application.reject(request.user)
+                notification.process_credential_complete(request, application)
+                messages.success(request, 'The application was not approved.')
+                return redirect(credential_processing)
+        # PROCESS ID STAGE
+        elif 'accept_id' in request.POST:
+            credential_review_form = forms.CredentialReviewForm(data=request.POST)
+            if credential_review_form.is_valid():
+                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
+                application.save()
+            application.update_review_status(20)
+            messages.success(request, 'The ID was approved.')
+            return redirect(credential_processing)
+        elif 'full_approve' in request.POST:
+            credential_review_form = forms.CredentialReviewForm(data=request.POST)
+            if credential_review_form.is_valid():
+                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
+                application.save()
+            application.accept(responder=request.user)
+            messages.success(request, 'The application has been accepted')
+            notification.process_credential_complete(request, application)
+            return redirect(credential_processing)
+        # PROCESS REFERENCE CHECK STAGE
+        elif 'accept_ref' in request.POST:
+            credential_review_form = forms.CredentialReviewForm(data=request.POST)
+            if credential_review_form.is_valid():
+                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
+                application.save()
+            contact_cred_ref_form = forms.ContactCredentialRefForm(data=request.POST)
+            if contact_cred_ref_form.is_valid():
+                application.update_review_status(30)
+                application.reference_contact_datetime = timezone.now()
+                application.save()
+                subject = contact_cred_ref_form.cleaned_data['subject']
+                body = contact_cred_ref_form.cleaned_data['body']
+                notification.contact_reference(request, application,
+                                               subject=subject, body=body)
+                messages.success(request, 'The reference was contacted.')
+                return redirect(credential_processing)
+        elif 'skip_ref' in request.POST:
+            credential_review_form = forms.CredentialReviewForm(data=request.POST)
+            if credential_review_form.is_valid():
+                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
+                application.save()
+            application.update_review_status(40)
+            messages.success(request, 'The reference was skipped.')
+            return redirect(credential_processing)
+        # CONTACT REFERENCE AGAIN
         elif 'contact_reference' in request.POST:
             contact_cred_ref_form = forms.ContactCredentialRefForm(
                 data=request.POST)
@@ -1226,32 +1232,40 @@ def process_credential_application(request, application_slug):
                 body = contact_cred_ref_form.cleaned_data['body']
                 notification.contact_reference(request, application,
                                                subject=subject, body=body)
-                messages.success(request, 'The reference has been contacted.')
-        elif 'skip_reference' in request.POST:
-            application.update_review_status(40)
-            application.save()
-        elif 'process_application' in request.POST:
-            process_credential_form = forms.ProcessCredentialReviewForm(
+                messages.success(request, 'The reference was contacted.')
+        # APPROVE THE RESPONSE FROM THE REFERENCE
+        elif 'approve_response' in request.POST:
+            intermediate_credential_form = forms.ResponseCredentialForm(
                 responder=request.user, data=request.POST, instance=application)
-            if process_credential_form.is_valid():
-                application = process_credential_form.save()
-                notification.process_credential_complete(request, application)
-                return render(request, 'console/process_credential_complete.html',
-                    {'application':application})
+            if intermediate_credential_form.is_valid():
+                intermediate_credential_form.save()
+                if intermediate_credential_form.cleaned_data['decision'] == '0':
+                    notification.process_credential_complete(request,
+                                                             application)
+                    return render(request, 'console/process_credential_complete.html',
+                                  {'application': application})
+                page_title = title_dict[application.credential_review.status]
+                intermediate_credential_form = forms.ProcessCredentialReviewForm(
+                    responder=request.user, instance=application)
             else:
-                messages.error(request, 'Invalid submission. See form below.')
-        elif 'immediate_accept' in request.POST:
+                messages.error(request, 'Invalid review. See form below.')
+        # FINAL APPROVAL
+        elif 'accept_final' in request.POST:
+            credential_review_form = forms.CredentialReviewForm(data=request.POST)
+            if credential_review_form.is_valid():
+                application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
+                application.save()
             application.accept(responder=request.user)
-            messages.success(request, 'The application has been accepted')
             notification.process_credential_complete(request, application)
+            messages.success(request, 'The application was accepted')
             return redirect(credential_processing)
     return render(request, 'console/process_credential_application.html',
-        {'application': application, 'app_user': application.user,
-         'intermediate_credential_form': intermediate_credential_form,
-         'process_credential_form': process_credential_form,
-         'processing_credentials_nav': True, 'page_title': page_title,
-         'contact_cred_ref_form': contact_cred_ref_form,
-         'training_list': training})
+                  {'application': application, 'app_user': application.user,
+                   'intermediate_credential_form': intermediate_credential_form,
+                   'credential_review_form': credential_review_form,
+                   'processing_credentials_nav': True, 'page_title': page_title,
+                   'contact_cred_ref_form': contact_cred_ref_form,
+                   'training_list': training})
 
 
 @permission_required('user.change_credentialapplication', raise_exception=True)
@@ -1348,31 +1362,31 @@ def credential_applications(request, status):
                 pending_apps) = search_credential_applications(request)
             if status == 'successful':
                 return render(request, 'console/credential_successful_user_list.html',
-                    {'applications': all_successful_apps,
-                     'u_applications': unsuccessful_apps,
-                     'p_applications': pending_apps})
+                              {'applications': all_successful_apps,
+                               'u_applications': unsuccessful_apps,
+                               'p_applications': pending_apps})
             elif status == 'unsuccessful':
                 return render(request, 'console/credential_unsuccessful_user_list.html',
-                    {'applications': all_successful_apps,
-                     'u_applications': unsuccessful_apps,
-                     'p_applications': pending_apps})
+                              {'applications': all_successful_apps,
+                               'u_applications': unsuccessful_apps,
+                               'p_applications': pending_apps})
             elif status == 'pending':
                 return render(request, 'console/credential_pending_user_list.html',
-                    {'applications': all_successful_apps,
-                     'u_applications': unsuccessful_apps,
-                     'p_applications': pending_apps})
+                              {'applications': all_successful_apps,
+                               'u_applications': unsuccessful_apps,
+                               'p_applications': pending_apps})
 
     legacy_apps = LegacyCredential.objects.filter(migrated=True,
-        migrated_user__is_credentialed=True).order_by('-migration_date').select_related('migrated_user__profile')
+                                                  migrated_user__is_credentialed=True).order_by('-migration_date').select_related('migrated_user__profile')
 
     successful_apps = CredentialApplication.objects.filter(status=2
-        ).order_by('-decision_datetime').select_related('user__profile', 'responder__profile')
+                                                           ).order_by('-decision_datetime').select_related('user__profile', 'responder__profile')
 
     unsuccessful_apps = CredentialApplication.objects.filter(
         status__in=[1, 3, 4]).order_by('-decision_datetime').select_related('user__profile', 'responder')
 
     pending_apps = CredentialApplication.objects.filter(status=0
-        ).order_by('-application_datetime').select_related('user__profile', 'credential_review')
+                                                        ).order_by('-application_datetime').select_related('user__profile', 'credential_review')
 
     # Merge legacy applications and new applications
     all_successful_apps = list(chain(successful_apps, legacy_apps))
@@ -1382,9 +1396,9 @@ def credential_applications(request, status):
     pending_apps = paginate(request, pending_apps, 50)
 
     return render(request, 'console/credential_applications.html',
-        {'applications': all_successful_apps, 'past_credentials_nav': True,
-         'u_applications': unsuccessful_apps,
-         'p_applications': pending_apps})
+                  {'applications': all_successful_apps, 'past_credentials_nav': True,
+                   'u_applications': unsuccessful_apps,
+                   'p_applications': pending_apps})
 
 
 @permission_required('user.change_credentialapplication', raise_exception=True)
@@ -1399,29 +1413,29 @@ def search_credential_applications(request):
         search_field = request.POST['search']
 
         legacy_apps = LegacyCredential.objects.filter(Q(migrated=True) &
-            Q(migrated_user__is_credentialed=True) &
-            (Q(migrated_user__username__icontains=search_field) |
-            Q(migrated_user__profile__first_names__icontains=search_field) |
-            Q(migrated_user__profile__last_name__icontains=search_field) |
-            Q(migrated_user__email__icontains=search_field))).order_by('-migration_date')
+                                                      Q(migrated_user__is_credentialed=True)
+                                                      & (Q(migrated_user__username__icontains=search_field) |
+                                                         Q(migrated_user__profile__first_names__icontains=search_field)
+                                                         | Q(migrated_user__profile__last_name__icontains=search_field)
+                                                         | Q(migrated_user__email__icontains=search_field))).order_by('-migration_date')
 
         successful_apps = CredentialApplication.objects.filter(
             Q(status=2) & (Q(user__username__icontains=search_field) |
-            Q(user__profile__first_names__icontains=search_field) |
-            Q(user__profile__last_name__icontains=search_field) |
-            Q(user__email__icontains=search_field))).order_by('-application_datetime')
+                           Q(user__profile__first_names__icontains=search_field)
+                           | Q(user__profile__last_name__icontains=search_field)
+                           | Q(user__email__icontains=search_field))).order_by('-application_datetime')
 
         unsuccessful_apps = CredentialApplication.objects.filter(
             Q(status__in=[1, 3]) & (Q(user__username__icontains=search_field) |
-            Q(user__profile__first_names__icontains=search_field) |
-            Q(user__profile__last_name__icontains=search_field) |
-            Q(user__email__icontains=search_field))).order_by('-application_datetime')
+                                    Q(user__profile__first_names__icontains=search_field)
+                                    | Q(user__profile__last_name__icontains=search_field)
+                                    | Q(user__email__icontains=search_field))).order_by('-application_datetime')
 
         pending_apps = CredentialApplication.objects.filter(
             Q(status=0) & (Q(user__username__icontains=search_field) |
-            Q(user__profile__first_names__icontains=search_field) |
-            Q(user__profile__last_name__icontains=search_field) |
-            Q(user__email__icontains=search_field))).order_by('-application_datetime')
+                           Q(user__profile__first_names__icontains=search_field)
+                           | Q(user__profile__last_name__icontains=search_field)
+                           | Q(user__email__icontains=search_field))).order_by('-application_datetime')
 
         # Merge legacy applications with new applications
         all_successful_apps = list(chain(successful_apps, legacy_apps))
@@ -1605,7 +1619,7 @@ def news_console(request):
     news_items = News.objects.all().order_by('-publish_datetime')
     news_items = paginate(request, news_items, 50)
     return render(request, 'console/news_console.html',
-        {'news_items': news_items, 'news_nav': True})
+                  {'news_items': news_items, 'news_nav': True})
 
 
 @permission_required('notification.change_news', raise_exception=True)
@@ -1621,7 +1635,7 @@ def news_add(request):
         form = forms.NewsForm()
 
     return render(request, 'console/news_add.html', {'form': form,
-        'news_nav': True})
+                                                     'news_nav': True})
 
 
 @permission_required('notification.change_news', raise_exception=True)
@@ -1634,7 +1648,7 @@ def news_search(request):
         search = request.POST['search']
         news_items = News.objects.filter(title__icontains=search).order_by('-publish_datetime')
 
-        return render(request, 'console/news_list.html', {'news_items':news_items})
+        return render(request, 'console/news_list.html', {'news_items': news_items})
 
     raise Http404()
 
@@ -1661,7 +1675,7 @@ def news_edit(request, news_id):
         form = forms.NewsForm(instance=news)
 
     response = render(request, 'console/news_edit.html', {'news': news,
-        'form': form, 'news_nav': True})
+                                                          'form': form, 'news_nav': True})
     if saved:
         set_saved_fields_cookie(form, request.path, response)
     return response
@@ -1676,7 +1690,7 @@ def featured_content(request):
     if 'add' in request.POST:
         featured = PublishedProject.objects.filter(featured__isnull=False)
         mx = max(featured.values_list('featured', flat=True), default=1)
-        project = PublishedProject.objects.filter(id=request.POST['id']).update(featured=mx+1)
+        project = PublishedProject.objects.filter(id=request.POST['id']).update(featured=mx + 1)
     elif 'remove' in request.POST:
         project = PublishedProject.objects.filter(id=request.POST['id']).update(featured=None)
     elif 'up' in request.POST:
@@ -1689,8 +1703,8 @@ def featured_content(request):
         move.save()
 
         # Swap positions
-        PublishedProject.objects.filter(featured=idx-1).update(featured=idx)
-        move.featured = idx-1
+        PublishedProject.objects.filter(featured=idx - 1).update(featured=idx)
+        move.featured = idx - 1
         move.save()
     elif 'down' in request.POST:
         # Get project to be moved
@@ -1702,7 +1716,7 @@ def featured_content(request):
         move.save()
 
         # Swap positions
-        PublishedProject.objects.filter(featured=idx+1).update(featured=idx)
+        PublishedProject.objects.filter(featured=idx + 1).update(featured=idx)
         move.featured = idx + 1
         move.save()
 
@@ -1711,7 +1725,7 @@ def featured_content(request):
     ).order_by('featured')
 
     return render(request, 'console/featured_content.html',
-        {'featured_content': featured_content, 'featured_content_nav': True})
+                  {'featured_content': featured_content, 'featured_content_nav': True})
 
 
 @permission_required('project.can_edit_featured_content', raise_exception=True)
@@ -1734,15 +1748,15 @@ def add_featured(request):
             wb = r'\y'
 
         projects = PublishedProject.objects.filter(
-            title__iregex=r'{0}{1}{0}'.format(wb,title),
+            title__iregex=r'{0}{1}{0}'.format(wb, title),
             featured__isnull=True
         )
     else:
         form = forms.FeaturedForm()
 
     return render(request, 'console/add_featured.html', {'title': title,
-        'projects': projects, 'form': form, 'valid_search': valid_search,
-        'featured_content_nav': True})
+                                                         'projects': projects, 'form': form, 'valid_search': valid_search,
+                                                         'featured_content_nav': True})
 
 
 @permission_required('project.can_view_project_guidelines', raise_exception=True)
@@ -1751,7 +1765,7 @@ def guidelines_review(request):
     Guidelines for reviewers.
     """
     return render(request, 'console/guidelines_review.html',
-        {'guidelines_review_nav': True})
+                  {'guidelines_review_nav': True})
 
 
 @permission_required('project.can_view_stats', raise_exception=True)
@@ -1770,7 +1784,7 @@ def editorial_stats(request):
         stats[y] = [years.count(y)]
 
     # Submission to editor assigned
-    sub_ed = projects.annotate(tm=Cast(F('editor_assignment_datetime')-F('submission_datetime'),
+    sub_ed = projects.annotate(tm=Cast(F('editor_assignment_datetime') - F('submission_datetime'),
                                DurationField())).values_list('tm', flat=True)
 
     for y in stats:
@@ -1782,7 +1796,7 @@ def editorial_stats(request):
             stats[y].append(None)
 
     # Submission to publication
-    sub_pub = projects.annotate(tm=Cast(F('publish_datetime')-F('submission_datetime'),
+    sub_pub = projects.annotate(tm=Cast(F('publish_datetime') - F('submission_datetime'),
                                 DurationField())).values_list('tm', flat=True)
 
     for y in stats:
@@ -1821,8 +1835,8 @@ def credentialing_stats(request):
         stats[y]['approved'] = round((100 * a) / (a + r))
 
     # Time taken to contact the reference
-    time_to_ref = apps.annotate(tm=Cast(F('reference_contact_datetime') -
-                                F('application_datetime'),
+    time_to_ref = apps.annotate(tm=Cast(F('reference_contact_datetime')
+                                - F('application_datetime'),
                                 DurationField())).values_list('tm', flat=True)
     for y in stats:
         durations = time_to_ref.filter(application_datetime__year=y)
@@ -1833,8 +1847,8 @@ def credentialing_stats(request):
             stats[y]['time_to_ref'] = None
 
     # Time taken for the reference to respond
-    time_to_reply = apps.annotate(tm=Cast(F('reference_response_datetime') -
-                                  F('reference_contact_datetime'),
+    time_to_reply = apps.annotate(tm=Cast(F('reference_response_datetime')
+                                  - F('reference_contact_datetime'),
                                   DurationField())).values_list('tm', flat=True)
     for y in stats:
         durations = time_to_reply.filter(application_datetime__year=y)
@@ -1845,8 +1859,8 @@ def credentialing_stats(request):
             stats[y]['time_to_reply'] = None
 
     # Time taken to process the application
-    time_to_decision = apps.annotate(tm=Cast(F('decision_datetime') -
-                                     F('application_datetime'),
+    time_to_decision = apps.annotate(tm=Cast(F('decision_datetime')
+                                     - F('application_datetime'),
                                      DurationField())).values_list('tm', flat=True)
     for y in stats:
         durations = time_to_decision.filter(application_datetime__year=y)
@@ -1949,25 +1963,24 @@ def download_credentialed_users(request):
         else:
             if application:
                 dua_info_csv.append([person.user.profile.first_names,
-                    person.user.profile.last_name, person.user.email,
-                    application.organization_name, application.country,
-                    mimic_signature_date, eicu_signature_date,
-                    application.research_summary])
+                                     person.user.profile.last_name, person.user.email,
+                                     application.organization_name, application.country,
+                                     mimic_signature_date, eicu_signature_date,
+                                     application.research_summary])
                 added.append(person.user.id)
             else:
                 legacy = LegacyCredential.objects.filter(migrated_user_id=person.user.id)
                 if legacy:
                     legacy = legacy.get()
                     dua_info_csv.append([person.user.profile.first_names,
-                        person.user.profile.last_name, person.user.email,
-                        'Legacy User', legacy.country,
-                        legacy.mimic_approval_date, legacy.eicu_approval_date,
-                        legacy.info])
+                                         person.user.profile.last_name, person.user.email,
+                                         'Legacy User', legacy.country,
+                                         legacy.mimic_approval_date, legacy.eicu_approval_date,
+                                         legacy.info])
                     added.append(person.user.id)
                 else:
                     LOGGER.info("Failed locating information of user {}".format(
                         person.user.id))
-
 
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="credentialed_users.csv"'

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1189,8 +1189,8 @@ def process_credential_application(request, application_slug):
                 application.responder_comments = credential_review_form.cleaned_data['reviewer_comments']
                 application.save()
             application.update_review_status(20)
+            page_title = title_dict[application.credential_review.status]
             messages.success(request, 'The ID was approved.')
-            return redirect(credential_processing)
         elif 'full_approve' in request.POST:
             credential_review_form = forms.CredentialReviewForm(data=request.POST)
             if credential_review_form.is_valid():
@@ -1216,7 +1216,7 @@ def process_credential_application(request, application_slug):
                 notification.contact_reference(request, application,
                                                subject=subject, body=body)
                 messages.success(request, 'The reference was contacted.')
-                return redirect(credential_processing)
+                page_title = title_dict[application.credential_review.status]
         elif 'skip_ref' in request.POST:
             credential_review_form = forms.CredentialReviewForm(data=request.POST)
             if credential_review_form.is_valid():
@@ -1224,7 +1224,7 @@ def process_credential_application(request, application_slug):
                 application.save()
             application.update_review_status(40)
             messages.success(request, 'The reference was skipped.')
-            return redirect(credential_processing)
+            page_title = title_dict[application.credential_review.status]
         # CONTACT REFERENCE AGAIN
         elif 'contact_reference' in request.POST:
             contact_cred_ref_form = forms.ContactCredentialRefForm(


### PR DESCRIPTION
We are in the process of implementing several changes to the credentialing workflow with the goal of improving usability and reducing the number of button clicks (e.g. https://github.com/MIT-LCP/physionet-build/pull/1570). 

The workflow can be found at: http://127.0.0.1:8000/console/credential_processing/. This change replaces the dropdown accept/reject menus with separate accept and reject buttons.

e.g. http://127.0.0.1:8000/console/credential-applications/5U5sjoUd3b0QmHMGZm5C/process/? displays the following buttons: 

![Screen Shot 2022-05-10 at 17 18 22](https://user-images.githubusercontent.com/822601/167724064-532e3635-4fc9-4f6b-a767-f2c5d97063b8.png)

A few notes on the changes:
- Please forgive the (auto applied) formatting changes in [physionet-django/console/views.py](https://github.com/MIT-LCP/physionet-build/compare/tp/cred_radio_1?expand=1#diff-f6a42ec9e0dd1026ae0ec1016b6549d4bc69526a31f5dcfb9ea14eff72dcf9d7). I'd really prefer to avoid having to spend time cleaning this up. If the changes result in conflicts with existing PRs, I will deal with those conflicts.
- I have not updated the buttons on the "Contact Reference" stage of the workflow. I plan to modify this stage in a later pull request so have left it unchanged for now.
- The use of `intermediate_credential_form` is pretty confusing and it can also be removed after I have implemented the change discussed above.

@kepaik this is the change we discussed. Please could you do some testing on your local machine? Let me know if you need help setting this up.
