### PR TITLE
Bump credentialing application to final review stage if positive reference response is received

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -642,9 +642,11 @@ class CredentialReferenceForm(forms.ModelForm):
         """
         application = super().save(commit=False)
 
-        # Deny
+        # Deny (1) or approve (2)
         if self.cleaned_data['reference_response'] == 1:
             application.status = 1
+        elif self.cleaned_data['reference_response'] == 2:
+            application.update_review_status(40)
 
         application.reference_response_datetime = timezone.now()
         application.reference_response_text = self.cleaned_data['reference_response_text']

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -771,9 +771,6 @@ def credential_reference(request, application_slug):
     """
     Page for a reference to verify or reject a credential application
     """
-    # application = CredentialApplication.objects.filter(
-    #     slug=application_slug, reference_contact_datetime__isnull=False,
-    #     reference_response_datetime=None)
     application = CredentialApplication.objects.filter(
         slug=application_slug, reference_response_datetime=None)
 


### PR DESCRIPTION
This is a minor improvement to the credentialing workflow (http://localhost:8000/console/credential-applications/) to reduce number of clicks required to process an application.

Currently, when a positive response is received from a reference, the reviewer needs to click a button to move the application to the "Final review" stage. 

This change automatically moves the application to the "Final review" stage when a positive response from the reviewer is received. Note that applications are already automatically bounced if the reviewer response is negative.