### PR TITLE
Credential email

### DIFF
--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -16,7 +16,7 @@
 
   <p>Please use the form below to apply for {{ SITE_NAME }} credentialing. In order to apply:</p>
   <ul>
-    <li>If you have an institutional/academic please add it in your settings (<a href="{% url 'edit_emails' %}">Emails settings</a>).</li>
+    <li>If you have an institutional/academic email address please add it in your settings (<a href="{% url 'edit_emails' %}">Emails settings</a>).</li>
     <li>If you have an ORCID iD please link to it in your settings (<a href="{% url 'edit_orcid' %}">ORCID settings</a>) as this may help us expedite your application by making it easier to verify your identity.</li>
   </ul>
 

--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -16,6 +16,7 @@
 
   <p>Please use the form below to apply for {{ SITE_NAME }} credentialing. In order to apply:</p>
   <ul>
+    <li>If you have an institutional/academic please add it in your settings (<a href="{% url 'edit_emails' %}">Emails settings</a>).</li>
     <li>If you have an ORCID iD please link to it in your settings (<a href="{% url 'edit_orcid' %}">ORCID settings</a>) as this may help us expedite your application by making it easier to verify your identity.</li>
   </ul>
 

--- a/physionet-django/user/templates/user/credential_application.html
+++ b/physionet-django/user/templates/user/credential_application.html
@@ -16,8 +16,8 @@
 
   <p>Please use the form below to apply for {{ SITE_NAME }} credentialing. In order to apply:</p>
   <ul>
-    <li>If you have an institutional/academic email address please add it in your settings (<a href="{% url 'edit_emails' %}">Emails settings</a>).</li>
-    <li>If you have an ORCID iD please link to it in your settings (<a href="{% url 'edit_orcid' %}">ORCID settings</a>) as this may help us expedite your application by making it easier to verify your identity.</li>
+    <li>If you have an institutional/academic email address, please add it in your settings (<a href="{% url 'edit_emails' %}">Emails settings</a>).</li>
+    <li>If you have an ORCID iD, please link to it in your settings (<a href="{% url 'edit_orcid' %}">ORCID settings</a>) as this may help us expedite your application by making it easier to verify your identity.</li>
   </ul>
 
   <h2>Recommendations for a timely review</h2>

--- a/physionet-django/user/templates/user/edit_emails.html
+++ b/physionet-django/user/templates/user/edit_emails.html
@@ -62,7 +62,7 @@
 
 <br>
 <h4>Primary Email</h4>
-<p>Please use an institutional/academic email address. This will be used for authentication, and email notifications.</p>
+<p>The email address used for authentication, and email notifications. We recommend using an institutional/academic email address where possible.</p>
 <form action="{% url 'edit_emails' %}" method="post" class="form-signin row no-pd">
   {% csrf_token %}
   <div class='col-md-9'>

--- a/physionet-django/user/templates/user/edit_emails.html
+++ b/physionet-django/user/templates/user/edit_emails.html
@@ -62,7 +62,7 @@
 
 <br>
 <h4>Primary Email</h4>
-<p>The email address used for authentication, and email notifications.</p>
+<p>Please use an institutional/academic email address. This will be used for authentication, and email notifications.</p>
 <form action="{% url 'edit_emails' %}" method="post" class="form-signin row no-pd">
   {% csrf_token %}
   <div class='col-md-9'>


### PR DESCRIPTION
I wanted to make changes to the code base. This pull request makes two changes to be used on the credentialing pages:

- changing the "Edit Emails" page to prompt users to use an institutional/academic if applicable in the Primary Email section.
- changing the "Application for Credentialed Access" section to prompt users to add an institutional/academic email.