### PR TITLE
the user attribute is named 'requester' on the DataAccessRequest object. fix #1590

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2095,9 +2095,12 @@ def data_access_request_view(request, project_slug, version, pk):
 
     legacy_credentialing_data = None
     if credentialing_data is None:
-        legacy_credentialing_data = LegacyCredential.objects.filter(
-            migrated_user_id=access_request.user
-        ).order_by("-mimic_approval_date").first()
+        try:
+            legacy_credentialing_data = LegacyCredential.objects.filter(
+                migrated_user_id=access_request.requester
+            ).order_by("-mimic_approval_date").first()
+        except LegacyCredential.DoesNotExist:
+            pass
 
     other_access_requests = DataAccessRequest.objects.exclude(pk=pk).filter(
         requester=access_request.requester, project=project


### PR DESCRIPTION
This pull request fixes #1590. Currently the following chunk of code is referencing `user` on a `DataAccessRequest` object. 

https://github.com/MIT-LCP/physionet-build/blob/26182475ab095f3c9e937ba2dffebd1ce3165d12/physionet-django/project/views.py#L2096-L2100

There is no `user`. The correct attribute is `requester` (might need to scroll down in the code block below):

https://github.com/MIT-LCP/physionet-build/blob/141d2a9262e6b9191e3bf81f3ccee9485c43e9cf/physionet-django/project/modelcomponents/access.py#L46-L71

I've wrapped the query in a try/except block just to make this a little more robust. The template catches `legacy_credentialing_data = None` in the chunk below:

```
                    {% else %}
                        {#  should not happen #}
                        No credentialing information found for this user.
                    {% endif %}
```