### PR TITLE
Swap Ethics and Release Notes

### DIFF
--- a/physionet-django/project/templates/project/challenge_content.html
+++ b/physionet-django/project/templates/project/challenge_content.html
@@ -18,15 +18,15 @@
 {{ project.usage_notes|safe }}
 <hr>
 
-{% if project.ethics_statement %}
-  <h2 id="ethics">Ethics</h2>
-    {{ project.ethics_statement|safe }}
-  <hr>
-{% endif %}
-
 {% if project.release_notes %}
   <h2 id="release-notes">Release Notes</h2>
     {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
+{% if project.ethics_statement %}
+  <h2 id="ethics">Ethics</h2>
+    {{ project.ethics_statement|safe }}
   <hr>
 {% endif %}
 

--- a/physionet-django/project/templates/project/challenge_content_preview.html
+++ b/physionet-django/project/templates/project/challenge_content_preview.html
@@ -30,11 +30,13 @@
 {% endif %}
 <hr>
 
+<h2 id="evaluation">Evaluation</h2>
 {% if project.usage_notes %}
-  <h2 id="evaluation">Evaluation</h2>
   {{ project.usage_notes|safe }}
-  <hr>
+{% else %}
+  <p style="color:red"><strong>* Required field missing</strong></p>
 {% endif %}
+<hr>
 
 {% if project.release_notes %}
   <h2 id="release-notes">Release Notes</h2>

--- a/physionet-django/project/templates/project/challenge_content_preview.html
+++ b/physionet-django/project/templates/project/challenge_content_preview.html
@@ -36,6 +36,12 @@
   <hr>
 {% endif %}
 
+{% if project.release_notes %}
+  <h2 id="release-notes">Release Notes</h2>
+  {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
 <h2 id="ethics">Ethics</h2>
 {% if project.ethics_statement %}
   {{ project.ethics_statement|safe }}
@@ -43,12 +49,6 @@
   <p style="color:red"><strong>* Required field missing</strong></p>
 {% endif %}
 <hr>
-
-{% if project.release_notes %}
-  <h2 id="release-notes">Release Notes</h2>
-  {{ project.release_notes|safe }}
-  <hr>
-{% endif %}
 
 {% if project.acknowledgements %}
   <h2 id="acknowledgements">Acknowledgements</h2>

--- a/physionet-django/project/templates/project/database_content.html
+++ b/physionet-django/project/templates/project/database_content.html
@@ -18,15 +18,15 @@
 {{ project.usage_notes|safe }}
 <hr>
 
-{% if project.ethics_statement %}
-  <h2 id="ethics">Ethics</h2>
-    {{ project.ethics_statement|safe }}
-  <hr>
-{% endif %}
-
 {% if project.release_notes %}
   <h2 id="release-notes">Release Notes</h2>
     {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
+{% if project.ethics_statement %}
+  <h2 id="ethics">Ethics</h2>
+    {{ project.ethics_statement|safe }}
   <hr>
 {% endif %}
 

--- a/physionet-django/project/templates/project/database_content_preview.html
+++ b/physionet-django/project/templates/project/database_content_preview.html
@@ -38,6 +38,12 @@
 {% endif %}
 <hr>
 
+{% if project.release_notes %}
+  <h2 id="release-notes">Release Notes</h2>
+  {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
 <h2 id="ethics">Ethics</h2>
 {% if project.ethics_statement %}
   {{ project.ethics_statement|safe }}
@@ -45,12 +51,6 @@
   <p style="color:red"><strong>* Required field missing</strong></p>
 {% endif %}
 <hr>
-
-{% if project.release_notes %}
-  <h2 id="release-notes">Release Notes</h2>
-  {{ project.release_notes|safe }}
-  <hr>
-{% endif %}
 
 {% if project.acknowledgements %}
   <h2 id="acknowledgements">Acknowledgements</h2>

--- a/physionet-django/project/templates/project/model_content.html
+++ b/physionet-django/project/templates/project/model_content.html
@@ -22,15 +22,15 @@
 {{ project.usage_notes|safe }}
 <hr>
 
-{% if project.ethics_statement %}
-  <h2 id="ethics">Ethics</h2>
-    {{ project.ethics_statement|safe }}
-  <hr>
-{% endif %}
-
 {% if project.release_notes %}
   <h2 id="release-notes">Release Notes</h2>
     {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
+{% if project.ethics_statement %}
+  <h2 id="ethics">Ethics</h2>
+    {{ project.ethics_statement|safe }}
   <hr>
 {% endif %}
 

--- a/physionet-django/project/templates/project/model_content_preview.html
+++ b/physionet-django/project/templates/project/model_content_preview.html
@@ -46,6 +46,12 @@
 {% endif %}
 <hr>
 
+{% if project.release_notes %}
+  <h2 id="release-notes">Release Notes</h2>
+  {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
 <h2 id="ethics">Ethics</h2>
 {% if project.ethics_statement %}
   {{ project.ethics_statement|safe }}
@@ -53,12 +59,6 @@
   <p style="color:red"><strong>* Required field missing</strong></p>
 {% endif %}
 <hr>
-
-{% if project.release_notes %}
-  <h2 id="release-notes">Release Notes</h2>
-  {{ project.release_notes|safe }}
-  <hr>
-{% endif %}
 
 {% if project.acknowledgements %}
   <h2 id="acknowledgements">Acknowledgements</h2>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -112,52 +112,88 @@
           Contents
         </button>
         <div class="dropdown-menu">
-          {% if project.resource_type.id == 0 %}
+          {% if project.resource_type.id == 0 %}{# 0: Database #}
             <a class="dropdown-item" href="#abstract">Abstract</a>
             <a class="dropdown-item" href="#background">Background</a>
             <a class="dropdown-item" href="#methods">Methods</a>
             <a class="dropdown-item" href="#description">Data Description</a>
             <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
-            <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            {% if project.release_notes %}
+              <a class="dropdown-item" href="#release-notes">Release Notes</a>
+            {% endif %}
+            {% if project.ethics_statement %}
+              <a class="dropdown-item" href="#ethics">Ethics</a>
+            {% endif %}
+            {% if project.acknowledgements %}
+              <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            {% endif %}
             <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-            <a class="dropdown-item" href="#references">References</a>
-            <a class="dropdown-item" href="#files">Files</a>
-          {% elif project.resource_type.id == 1 %}
+            {% if references %}
+              <a class="dropdown-item" href="#references">References</a>
+            {% endif %}
+          {% elif project.resource_type.id == 1 %}{# 1: Software #}
             <a class="dropdown-item" href="#abstract">Abstract</a>
             <a class="dropdown-item" href="#background">Background</a>
             <a class="dropdown-item" href="#description">Software Description</a>
             {% if project.methods %}
               <a class="dropdown-item" href="#implementation">Technical Implementation</a>
             {% endif %}
-            {% if project.installation %}
-              <a class="dropdown-item" href="#installation">Installation and Requirements</a>
-            {% endif %}
+            <a class="dropdown-item" href="#installation">Installation and Requirements</a>
             <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
-            {% if project.ethics_statement %}
-              <a class="dropdown-item" href="#ethics">Ethics</a>
-            {% endif %}
             {% if project.release_notes %}
               <a class="dropdown-item" href="#release-notes">Release Notes</a>
+            {% endif %}
+            {% if project.ethics_statement %}
+              <a class="dropdown-item" href="#ethics">Ethics</a>
             {% endif %}
             {% if project.acknowledgements %}
               <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
             {% endif %}
             <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-            <a class="dropdown-item" href="#references">References</a>
-            <a class="dropdown-item" href="#files">Files</a>
-          {% elif project.resource_type.id == 2 %}
+            {% if references %}
+              <a class="dropdown-item" href="#references">References</a>
+            {% endif %}
+          {% elif project.resource_type.id == 2 %}{# 2: Challenge #}
             <a class="dropdown-item" href="#abstract">Abstract</a>
             <a class="dropdown-item" href="#objective">Objective</a>
             <a class="dropdown-item" href="#participation">Participation</a>
             <a class="dropdown-item" href="#description">Data Description</a>
             <a class="dropdown-item" href="#evaluation">Evaluation</a>
-            <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            {% if project.release_notes %}
+              <a class="dropdown-item" href="#release-notes">Release Notes</a>
+            {% endif %}
+            {% if project.ethics_statement %}
+              <a class="dropdown-item" href="#ethics">Ethics</a>
+            {% endif %}
+            {% if project.acknowledgements %}
+              <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            {% endif %}
             <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
-            <a class="dropdown-item" href="#references">References</a>
-            <a class="dropdown-item" href="#files">Files</a>
-          {% else %}
-            <a class="dropdown-item" href="#files">Files</a>
+            {% if references %}
+              <a class="dropdown-item" href="#references">References</a>
+            {% endif %}
+          {% elif project.resource_type.id == 3 %}{# 3: Model #}
+            <a class="dropdown-item" href="#abstract">Abstract</a>
+            <a class="dropdown-item" href="#background">Background</a>
+            <a class="dropdown-item" href="#description">Model Description</a>
+            <a class="dropdown-item" href="#implementation">Technical Implementation</a>
+            <a class="dropdown-item" href="#installation">Installation and Requirements</a>
+            <a class="dropdown-item" href="#usage-notes">Usage Notes</a>
+            {% if project.release_notes %}
+              <a class="dropdown-item" href="#release-notes">Release Notes</a>
+            {% endif %}
+            {% if project.ethics_statement %}
+              <a class="dropdown-item" href="#ethics">Ethics</a>
+            {% endif %}
+            {% if project.acknowledgements %}
+              <a class="dropdown-item" href="#acknowledgements">Acknowledgements</a>
+            {% endif %}
+            <a class="dropdown-item" href="#conflicts-of-interest">Conflicts of Interest</a>
+            {% if references %}
+              <a class="dropdown-item" href="#references">References</a>
+            {% endif %}
           {% endif %}
+          <a class="dropdown-item" href="#files">Files</a>
         </div>
       </div>
       {% endif %}

--- a/physionet-django/project/templates/project/software_content.html
+++ b/physionet-django/project/templates/project/software_content.html
@@ -24,15 +24,15 @@
 {{ project.usage_notes|safe }}
 <hr>
 
-{% if project.ethics_statement %}
-  <h2 id="ethics">Ethics</h2>
-    {{ project.ethics_statement|safe }}
-  <hr>
-{% endif %}
-
 {% if project.release_notes %}
   <h2 id="release-notes">Release Notes</h2>
     {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
+{% if project.ethics_statement %}
+  <h2 id="ethics">Ethics</h2>
+    {{ project.ethics_statement|safe }}
   <hr>
 {% endif %}
 

--- a/physionet-django/project/templates/project/software_content_preview.html
+++ b/physionet-django/project/templates/project/software_content_preview.html
@@ -46,6 +46,12 @@
 {% endif %}
 <hr>
 
+{% if project.release_notes %}
+  <h2 id="release-notes">Release Notes</h2>
+  {{ project.release_notes|safe }}
+  <hr>
+{% endif %}
+
 <h2 id="ethics">Ethics</h2>
 {% if project.ethics_statement %}
   {{ project.ethics_statement|safe }}
@@ -53,12 +59,6 @@
   <p style="color:red"><strong>* Required field missing</strong></p>
 {% endif %}
 <hr>
-
-{% if project.release_notes %}
-  <h2 id="release-notes">Release Notes</h2>
-  {{ project.release_notes|safe }}
-  <hr>
-{% endif %}
 
 {% if project.acknowledgements %}
   <h2 id="acknowledgements">Acknowledgements</h2>


### PR DESCRIPTION
This is a stylistic change to swap the order of the "Ethics" and "Release Notes" sections in published projects.

My reasoning for doing this is:

1. "Usage Notes" (or "Evaluation") and "Release Notes" are both what I would consider technically heavy sections.  "Release Notes", if present, should provide a detailed technical explanation of what has changed, which pertains directly to "Usage Notes", and generally *doesn't* pertain to "Ethics" (or to "Acknowledgements" or "Conflicts of Interest").

2. "Ethics" is typically a very brief statement that looks strange when placed between two (potentially) long and detailed sections.

I like putting "Ethics" above "Acknowledgements" rather than below but that's mostly a gut feeling and I could be persuaded otherwise.

I've reviewed the projects that have been published since the "Ethics" section was added (from March 10 to May 16), and I don't think that reordering these sections has a substantial impact on the flow of the document.  I haven't reviewed the projects currently in the pipeline.
