### PR TITLE
Remove unneeded packages from install-pn-test-server

### DIFF
--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -54,9 +54,7 @@ apt-get install -y \
         `# Development and administration tools` \
         git sudo psmisc \
         `# SMTP and IMAP servers, for testing email` \
-        postfix postfix-pcre dovecot-imapd \
-        `# Cryptography related packages` \
-        rustc libssl-dev
+        postfix postfix-pcre dovecot-imapd
 
 ################################################################
 


### PR DESCRIPTION

rustc and libssl-dev were needed to install the cryptography package on Debian 10.  They are not needed now, so remove them.
