### PR TITLE
Create date_added field for the `Orcid` user model

### DIFF
--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -9772,7 +9772,8 @@
     "refresh_token": "",
     "token_type": "",
     "token_scope": "",
-    "token_expiration": "0E-40"
+    "token_expiration": "0E-40",
+    "datetime_added": "2021-04-10T15:51:15.446Z"
   }
 },
 {

--- a/physionet-django/user/migrations/0044_orcid_datetime_added.py
+++ b/physionet-django/user/migrations/0044_orcid_datetime_added.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+import django.utils.timezone
+from datetime import datetime, timedelta
+
+
+def migrate_forward(apps, schema_editor):
+    orcid_model = apps.get_model('user', 'Orcid')
+    for row in orcid_model.objects.all():
+        row.datetime_added = datetime.fromtimestamp(row.token_expiration) - timedelta(days=20*365.2422)
+        row.save()
+
+
+def migrate_backward(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user', '0043_auto_20220406_1229'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='orcid',
+            name='datetime_added',
+            field=models.DateTimeField(auto_now_add=True, default=django.utils.timezone.now),
+            preserve_default=False,
+        ),
+        migrations.RunPython(migrate_forward, migrate_backward),
+    ]

--- a/physionet-django/user/migrations/0044_orcid_datetime_added.py
+++ b/physionet-django/user/migrations/0044_orcid_datetime_added.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 def migrate_forward(apps, schema_editor):
     orcid_model = apps.get_model('user', 'Orcid')
     for row in orcid_model.objects.all():
-        row.datetime_added = datetime.fromtimestamp(row.token_expiration) - timedelta(days = 20 * 365.2422)
+        row.datetime_added = datetime.fromtimestamp(row.token_expiration) - timedelta(days=20 * 365.2422)
         row.save()
 
 

--- a/physionet-django/user/migrations/0044_orcid_datetime_added.py
+++ b/physionet-django/user/migrations/0044_orcid_datetime_added.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 def migrate_forward(apps, schema_editor):
     orcid_model = apps.get_model('user', 'Orcid')
     for row in orcid_model.objects.all():
-        row.datetime_added = datetime.fromtimestamp(row.token_expiration) - timedelta(days=20*365.2422)
+        row.datetime_added = datetime.fromtimestamp(row.token_expiration) - timedelta(days = 20 * 365.2422)
         row.save()
 
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -2,6 +2,7 @@ import logging
 import os
 import uuid
 from datetime import timedelta
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
@@ -657,6 +658,7 @@ class Orcid(models.Model):
     token_type = models.CharField(max_length=50, default='', blank=True)
     token_scope = models.CharField(max_length=50, default='', blank=True)
     token_expiration = models.DecimalField(max_digits=50, decimal_places=40, default=0)
+    datetime_added = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         default_permissions = ()


### PR DESCRIPTION
This adds a derived `date_added` field to the `Orcid` model in the user app. The `date_added` is derived from the `token_expiration` for consistency with the objects that are already in the database. The token expires after 20 years so it can be used to calculate the date the object was created, taken as 20 years prior to expiration. 

Even though it would be more accurate, I did not use `relativedelta` from the `python-dateutil` package to generate the 20 year offset because it is not already installed in our docker environment (but it is in requirements.txt) and doesn't seem necessary for this application. Instead I used `timedelta(days=20*365.2422)` which isn't aware of when it is a leap year but should be sufficient for the `date_added` field. 

I have tested this PR on my local machine but not on staging. I have done the following locally:

- confirmed that old `Orcid` records in the database which don't have a `date_added` field are properly populated with `date_added` once the migration is run
- confirmed that new `Orcid` records generated by connecting to the ORCID API continue to work as expected and generate the correct `date_added` field, as derived from the `token_expiration`. 
- confirmed that I can roll back to a prior migration (i.e. from 0044 to 0043). In `migrate_backward` I simply use `pass` as @tompollard didn't think it was necessary to do a `.delete` of the `date_added` field in this case.