### PR TITLE
Fix DoesNotExist error when AssociatedEmail is removed.

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -226,12 +226,16 @@ def check_legacy_credentials(user, email):
 def remove_email(request, email_id):
     "Remove a non-primary email associated with a user"
     user = request.user
-    associated_email = AssociatedEmail.objects.get(id=email_id)
-    if associated_email.user == user and not associated_email.is_primary_email:
-        email = associated_email.email
-        associated_email.delete()
-        logger.info('Removed email {0} from user {1}'.format(email, user.id))
-        messages.success(request, 'Your email: {0} has been removed from your account.'.format(email))
+    try:
+        associated_email = AssociatedEmail.objects.get(id=email_id)
+        if associated_email.user == user and not associated_email.is_primary_email:
+            email = associated_email.email
+            associated_email.delete()
+            logger.info(f"Removed email {email} from user {user.id}")
+            messages.success(request, f"The email address ({email}) has been removed from your account.")
+    except AssociatedEmail.DoesNotExist:
+        messages.success(request, "The email address has been removed from your account.")
+
 
 def set_primary_email(request, primary_email_form):
     "Set the selected email as the primary email"


### PR DESCRIPTION
We frequently see the following error. This pull request:
- prevents the error by catching it in a try/except block
- switches to f-strings for readability
- tweaks the language slightly

```
Internal Server Error: /settings/emails/

DoesNotExist at /settings/emails/
AssociatedEmail matching query does not exist.

Request Method: POST
Request URL: https://physionet.org/settings/emails/

Traceback:

File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/core/handlers/exception.py" in inner
 34.             response = get_response(request)

File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/core/handlers/base.py" in _get_response
 115.                 response = self.process_exception_by_middleware(e, request)

File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/core/handlers/base.py" in _get_response
 113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
 21.                 return view_func(request, *args, **kwargs)

File "./user/views.py" in edit_emails
 318.             remove_email(request, email_id)

File "./user/views.py" in remove_email
 229.     associated_email = AssociatedEmail.objects.get(id=email_id)

File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/db/models/manager.py" in manager_method
 82.                 return getattr(self.get_queryset(), name)(*args, **kwargs)

File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/db/models/query.py" in get
 406.             raise self.model.DoesNotExist(

Exception Type: DoesNotExist at /settings/emails/
Exception Value: AssociatedEmail matching query does not exist.
Request information:
USER: XXX
```

The error is raised when a user attempts to remove an email address that has already been removed. To reproduce the error:

1. Go to http://localhost:8000/settings/emails/
2. Add a new email address (no need to activate it)
3. Click the red trash icon to delete the email.
4. Double click the "Remove Email" button in the following pop-up.

![Screen Shot 2022-05-28 at 17 04 06](https://user-images.githubusercontent.com/822601/170843340-e6037883-e688-484f-b6e3-8b938dc1af3d.png)