### PR TITLE
Fix: Record the time when Orcids are linked

### DIFF
--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -9772,7 +9772,8 @@
     "refresh_token": "",
     "token_type": "",
     "token_scope": "",
-    "token_expiration": "0E-40"
+    "token_expiration": "0E-40",
+    "datetime_added": "2021-04-10T15:51:15.446Z"
   }
 },
 {

--- a/physionet-django/user/migrations/0044_orcid_datetime_added.py
+++ b/physionet-django/user/migrations/0044_orcid_datetime_added.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+from django.utils.timezone import make_aware
+from datetime import datetime, timedelta
+
+
+def migrate_forward(apps, schema_editor):
+    orcid_model = apps.get_model('user', 'Orcid')
+    for row in orcid_model.objects.all():
+        row.datetime_added = make_aware(datetime.fromtimestamp(row.token_expiration)) - timedelta(days=20 * 365.2422)
+        row.save()
+
+
+def migrate_backward(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user', '0043_auto_20220406_1229'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='orcid',
+            name='datetime_added',
+            field=models.DateTimeField(auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.RunPython(migrate_forward, migrate_backward),
+    ]

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -2,6 +2,7 @@ import logging
 import os
 import uuid
 from datetime import timedelta
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
@@ -657,6 +658,7 @@ class Orcid(models.Model):
     token_type = models.CharField(max_length=50, default='', blank=True)
     token_scope = models.CharField(max_length=50, default='', blank=True)
     token_expiration = models.DecimalField(max_digits=50, decimal_places=40, default=0)
+    datetime_added = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         default_permissions = ()

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -2,7 +2,6 @@ import logging
 import os
 import uuid
 from datetime import timedelta
-from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/1467, we would like to record the time when users add an Orcid to their profile.

https://github.com/MIT-LCP/physionet-build/pull/1594 added a new field to capture the datettime. This approach worked fine on dev and staging servers, but errored on production.

```
remote:     value = timezone.make_aware(value, default_timezone)
remote:   File "/home/physionet/python-env/physionet/lib/python3.9/site-packages/django/utils/timezone.py", line 270, in make_aware
remote:     return timezone.localize(value, is_dst=is_dst)
remote:   File "/home/physionet/python-env/physionet/lib/python3.9/site-packages/pytz/tzinfo.py", line 327, in localize
remote:     raise NonExistentTimeError(dt)
remote: pytz.exceptions.NonExistentTimeError: 2021-03-14 02:37:39.400000
```

The fix for this error is to make sure that datetimes are accompanied by a timezone. The easiest way to manage this is to use Django's timeaware function. 