### PR TITLE
Allow forward slashes, `/`, in project titles

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -115,8 +115,9 @@ def validate_title(value):
     characters marked as letters in Unicode along side with the following
     special characters: ' , * ? : ( ) -
     """
-    if not re.fullmatch(r'[a-zA-Z0-9][\w\'*,?:( )-]+', value):
-        raise ValidationError("Enter a valid title. This value may contain only letters, numbers, spaces and [,-'*?:()]")
+    if not re.fullmatch(r'[a-zA-Z0-9][\w\'*,?:( )-/]+', value):
+        raise ValidationError("Enter a valid title. This value may contain only letters, numbers, spaces and "
+                              "[,-'*?:/()]")
 
 
 def validate_topic(value):


### PR DESCRIPTION
This updates the title validator to allow for forward slashes (`/`). This provides compatibility with previous PhysioNet challenge titles which use "PhysioNet/Computing" in the title.