### PR TITLE
[WIP] Add order field to reference objects

### DIFF
--- a/physionet-django/project/migrations/0066_migrate_references_to_use_order.py
+++ b/physionet-django/project/migrations/0066_migrate_references_to_use_order.py
@@ -1,0 +1,63 @@
+from django.db import migrations, models
+from project.models import PublishedProject, ActiveProject, ArchivedProject, LegacyProject
+
+
+def migrate_forward(apps, schema_editor):
+
+    for project in PublishedProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+    for project in ActiveProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+    for project in ArchivedProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+    for project in LegacyProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+
+def migrate_backward(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('project', '0065_editor_permissions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='publishedreference',
+            name='order',
+            field=models.PositiveIntegerField(null=True),
+        ),
+        migrations.AddField(
+            model_name='reference',
+            name='order',
+            field=models.PositiveIntegerField(null=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='publishedreference',
+            unique_together={('description', 'project', 'order')},
+        ),
+        migrations.AlterUniqueTogether(
+            name='reference',
+            unique_together={('description', 'content_type', 'order')},
+        ),
+        migrations.RunPython(migrate_forward, migrate_backward),
+    ]

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -532,9 +532,10 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                     published_project.set_version_order()
 
                 # Same content, different objects.
-                for reference in self.references.all().order_by('id'):
+                for reference in self.references.all().order_by('order'):
                     published_reference = PublishedReference.objects.create(
                         description=reference.description,
+                        order=reference.order,
                         project=published_project)
 
                 for publication in self.publications.all():

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -603,14 +603,16 @@ class Reference(models.Model):
 
 class PublishedReference(models.Model):
     """
+    Reference field for PublishedProject
     """
     description = models.CharField(max_length=1000)
     project = models.ForeignKey('project.PublishedProject',
         related_name='references', on_delete=models.CASCADE)
+    order = models.PositiveIntegerField(null=True)
 
     class Meta:
         default_permissions = ()
-        unique_together = (('description', 'project'))
+        unique_together = (('description', 'project', 'order'))
 
 
 class Contact(models.Model):

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -581,12 +581,13 @@ class Reference(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     project = GenericForeignKey('content_type', 'object_id')
+    order = models.PositiveIntegerField(null=True)
 
     description = models.CharField(max_length=1000)
 
     class Meta:
         default_permissions = ()
-        unique_together = (('description', 'content_type', 'object_id'),)
+        unique_together = (('description', 'content_type', 'order'),)
 
     def __str__(self):
         return self.description

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1175,7 +1175,7 @@ def project_preview(request, project_slug, subdir='', **kwargs):
     corresponding_author = authors.get(is_corresponding=True)
     corresponding_author.text_affiliations = ', '.join(a.name for a in corresponding_author.affiliations.all())
 
-    references = project.references.all().order_by('id')
+    references = project.references.all().order_by('order')
     publication = project.publications.all().first()
     topics = project.topics.all()
     parent_projects = project.parent_projects.all()
@@ -1792,7 +1792,7 @@ def published_project(request, project_slug, version, subdir=''):
     authors = project.authors.all().order_by('display_order')
     for a in authors:
         a.set_display_info()
-    references = project.references.all().order_by('id')
+    references = project.references.all().order_by('order')
     publication = project.publications.all().first()
     topics = project.topics.all()
     languages = project.programming_languages.all()


### PR DESCRIPTION
# Background

Project descriptions include a "References" section that lists relevant papers, websites, etc. An example of a references section for a demo project is shown below (screenshot from http://localhost:8000/content/demoecg/10.5.24/):

![Screen Shot 2022-06-02 at 14 04 47](https://user-images.githubusercontent.com/822601/171698671-02926733-a328-4946-9dc8-fcc2ad91618b.png)

# Problem

As discussed in https://github.com/MIT-LCP/physionet-build/issues/1557 and https://github.com/MIT-LCP/physionet-build/issues/1105, the way we manage these references is extremely buggy.  The problem is that there is no "order" field associated with the references. Instead the references are ordered by their primary key!

For both `ActiveProject` and `ArchivedProject`, the references are stored using the `Reference` class:

https://github.com/MIT-LCP/physionet-build/blob/1dc09c6ce67ad6d77c76a1ebe16a2dcdee65c883/physionet-django/project/modelcomponents/metadata.py#L575-L587

For `PublishedProject`, the references are copied to the `PublishedReference` class:

https://github.com/MIT-LCP/physionet-build/blob/1dc09c6ce67ad6d77c76a1ebe16a2dcdee65c883/physionet-django/project/modelcomponents/metadata.py#L601-L610

# Fixing the problem

This pull request:
- adds an `order` attribute to the `Reference` and `PublishedReference` classes.
- adds a migration that (a) adds the order field (2) migrates the order of existing references to the order field
- updates the view/templates to use the order field to display references.

What's needed before merging:
- We need to update the forms displayed in the following template so that newly created projects record `order` (instead of the ID): https://github.com/MIT-LCP/physionet-build/blob/dev/physionet-django/project/templates/project/project_content.html

The current formset is:

https://github.com/MIT-LCP/physionet-build/blob/1dc09c6ce67ad6d77c76a1ebe16a2dcdee65c883/physionet-django/project/forms.py#L658-L691

The formset is rendered by a generic "item_list" template:
https://github.com/MIT-LCP/physionet-build/blob/dev/physionet-django/project/templates/project/item_list.html
