### PR TITLE
Catch PDFSyntaxError if training report is missing or an unrecognised format. Fixes #1608

### DIFF
--- a/physionet-django/console/services.py
+++ b/physionet-django/console/services.py
@@ -4,6 +4,7 @@ import re
 from typing import Optional
 
 from pdfminer.high_level import extract_text
+from pdfminer.pdfparser import PDFSyntaxError
 from django.conf import settings
 
 from user.models import Training
@@ -26,7 +27,11 @@ def _get_regex_value_from_text(text: str, regex: str) -> Optional[str]:
 
 
 def _parse_pdf_to_string(training_path: str) -> str:
-    text = extract_text(training_path)
+    try:
+        text = extract_text(training_path)
+    except PDFSyntaxError:
+        text = ''
+        logging.error(f'Failed to extract text from {training_path}')
     return ' '.join(text.split())
 
 


### PR DESCRIPTION
We attempt to parse training reports to extract text using a PDF parser. If someone submits a training report that is not a PDF, the system currently raises an error (see: https://github.com/MIT-LCP/physionet-build/issues/1608). This pull request catches the PDFSyntaxError in these cases, and instead returns an empty string.