### PR TITLE
If contributor-managed projects are not approved, the reason should be included in the email to the applicant

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_user_data_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_user_data_access_request.html
@@ -1,10 +1,13 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ data_access_request.requester.get_full_name }},
 
 We are writing in response to your request for access to the project "{{ data_access_request.project }}". 
 
-{% if data_access_request.is_accepted %}We are pleased to say that the project owners have approved{%else%}We are sorry to say that the project owners did not approve{% endif %} the request.
+{% if data_access_request.is_accepted %}We are pleased to say that the project owners have approved the request.{%else%}We are sorry to say that the project owners did not approve the request. The following reason was given: 
+{{ data_access_request.responder_comments|striptags }}{% endif %}
 
 For more details, please follow the link below:
 {{ request_protocol}}://{{ request_host}}{% url 'data_access_request_status' data_access_request.project.slug data_access_request.project.version %}
 
 {{ signature }}
+{% endfilter %}{% endautoescape %}


### PR DESCRIPTION
When the manager of a contributor-managed projects denies a request for access, they are required to provide a reason for denying the request. This reason should be sent to the applicant so that they know why their request was denied. Currently the email that we send to the applicant does _not_ include the reason:

```
Dear Admin Bot,

We are writing in response to your request for access to the project "Self Managed Access Database Demo v1.0.0". 

We are sorry to say that the project owners did not approve the request.

For more details, please follow the link below:
http://localhost:8000/request-access-status/demoselfmanaged/1.0.0/

Regards, ...
```

This pull request updates the email template so that it includes the reason. An example of the new email is below:

```
Dear Admin Bot,

We are writing in response to your request for access to the project
"Self Managed Access Database Demo v1.0.0". 

We are sorry to say that the project owners did not approve the
request. The following reason was given: 

The application did not explain the project.

For more details, please follow the link below:
http://localhost:8000/request-access-status/demoselfmanaged/1.0.0/

Regards, ...
```
