### PR TITLE
Merge changes from lightwave 0.71

### DIFF
--- a/physionet-django/lightwave/static/lightwave/js/lightwave.js
+++ b/physionet-django/lightwave/static/lightwave/js/lightwave.js
@@ -1852,7 +1852,7 @@ function gorev() {
 
     t0_string = $('.t0_str').val();
     t_ticks = strtim(t0_string) - dt_ticks;
-    go_here(t_ticks);
+    go_here(Math.round(t_ticks / tickfreq) * tickfreq);
     prefetch(t_ticks - dt_ticks);
 }
 
@@ -1886,7 +1886,7 @@ function gofwd() {
 
     t0_string = $('.t0_str').val();
     t_ticks = strtim(t0_string) + dt_ticks;
-    go_here(t_ticks);
+    go_here(Math.round(t_ticks / tickfreq) * tickfreq);
     prefetch(t_ticks + Number(dt_ticks));
 }
 

--- a/physionet-django/lightwave/static/lightwave/js/lightwave.js
+++ b/physionet-django/lightwave/static/lightwave/js/lightwave.js
@@ -1239,8 +1239,6 @@ function show_plot() {
 
 	    s = trace.samp;
 	    tps = trace.tps;
-	    imin = (t0_ticks - trace.t0)/tps;
-	    imax = Math.min(s.length, dt_ticks/tps + imin);
 	    g = (-400*mag[sname]/(trace.scale*trace.gain));
 	    z = trace.zbase*g - y0;
 	    v = Math.round(g*s[imin] - z);
@@ -1249,10 +1247,8 @@ function show_plot() {
 	    if (sname === sigselected) { svs += lwb; }
 	    else { svs += lwn; }
 	    svs += '" d="';
-	    t = 0;
 	    tnext = t0_ticks;
 	    tf = Math.min(tf_ticks, rdt_ticks);
-	    x = 0;
 	    xstep = tscl/tickfreq;
 	    pv = false;
 	    while (tnext < tf) {
@@ -1274,10 +1270,12 @@ function show_plot() {
 			break;
 		    }
 		    s = trace.samp;
-		    imin = (tnext - trace.t0)/tps;
-		    imax = Math.min(s.length, (tf - tnext)/tps + imin);
 		}
+		imin = Math.max(Math.floor((tnext - trace.t0)/tps), 0);
+		imax = Math.min((tf - tnext)/tps + imin, s.length);
+		t = imin * tps + trace.t0 - t0_ticks;
 		for (i = imin; i < imax; i++) {
+		    x = t*xstep;
 		    if (s[i] !== -32768) {
 			v = Math.round(g*s[i] - z);
 			if (pv) { svs += ' '  + x + ',' + v; }
@@ -1286,7 +1284,6 @@ function show_plot() {
 		    }
 		    else { pv = false; }
 		    t += tps;
-		    x = t*xstep;
 		}
 		tnext = trace.tf;
 	    }

--- a/physionet-django/lightwave/static/lightwave/js/lightwave.js
+++ b/physionet-django/lightwave/static/lightwave/js/lightwave.js
@@ -1089,7 +1089,7 @@ function show_plot() {
 	    + '" d="M' + x0r + ',0 ';
 	uparrow = ' l-' + adx1 + ',' + ady1 + 'l' + adx2 + ',0 l-' + adx1
 	    + ',-' + ady1 +  'm' + griddx + ',-';
-	for (x = 0; x + x0r <= svgw; x += griddx) {
+	for (x = 0; x + x0r <= svgw + 0.01 * griddx; x += griddx) {
 	    if (x%tscl === x0q) { grd += 'l0,' + svgh + uparrow + svgh; }
 	    else { grd += 'l0,' + svgh + ' m' + griddx + ',-' + svgh; }
 	}
@@ -1106,7 +1106,7 @@ function show_plot() {
     if (ttick < t0_ticks) { ttick += tickint; }
 
     tst = '<g id="times">\n';
-    while (ttick <= tf_ticks) {
+    while (ttick <= tf_ticks + 0.1) {
 	xtick = Math.round((ttick - t0_ticks)*tscl/tickfreq);
 	tst += '<text x="' + xtick + '" y="' + svgts + '" font-size="' + svgtf
 	    + '" fill="red" style="text-anchor: middle;">'

--- a/physionet-django/lightwave/static/lightwave/js/lightwave.js
+++ b/physionet-django/lightwave/static/lightwave/js/lightwave.js
@@ -1,5 +1,5 @@
 // file: lightwave.js	G. Moody	18 November 2012
-//			Last revised:	  23 April 2019    version 0.68
+//			Last revised:	  15 June 2022     version 0.71
 // LightWAVE Javascript code
 //
 // Copyright (C) 2012-2013 George B. Moody
@@ -206,6 +206,21 @@ function find_trace(db, record, signame, t) {
 	}
     }
     return null;
+}
+
+// Find the earliest-starting trace that overlaps the given range
+function find_trace_in_range(db, record, signame, t0, tf) {
+    var i, trace = null;
+
+    for (i = 0; i < tpool.length; i++) {
+	if (tpool[i].name === signame &&
+	    tpool[i].t0 < tf && t0 < tpool[i].tf &&
+	    tpool[i].record === record && tpool[i].db === db) {
+	    trace = tpool[i];
+	    tf = trace.t0;
+	}
+    }
+    return trace;
 }
 
 // Replace the least-recently-used trace with the contents of s
@@ -1202,7 +1217,7 @@ function show_plot() {
 	y0 = y0s[is];
 	ytop = y0 - svgf;
 	sname = signals[is].name;
-	trace = find_trace(db, record, sname, t0_ticks);
+	trace = find_trace_in_range(db, record, sname, t0_ticks, tf_ticks);
 
 	svs += '<g id="sig;;' + html_escape(sname) + '">\n';
 	if (trace && s_visible[sname] === 1) {
@@ -1242,7 +1257,7 @@ function show_plot() {
 	    pv = false;
 	    while (tnext < tf) {
 		if (tnext > t0_ticks) {
-		    trace = find_trace(db, record, sname, tnext);
+		    trace = find_trace_in_range(db, record, sname, tnext, tf);
 		    if (trace === null) {
 			if (pending < 1) {
 			    read_signals(t0_ticks, true);
@@ -1256,7 +1271,7 @@ function show_plot() {
 			    autoplay_off();
 			    alert_server_error();
 			}
-			return;
+			break;
 		    }
 		    s = trace.samp;
 		    imin = (tnext - trace.t0)/tps;

--- a/physionet-django/lightwave/static/lightwave/js/lightwave.js
+++ b/physionet-django/lightwave/static/lightwave/js/lightwave.js
@@ -276,7 +276,7 @@ function set_trace(db, record, s) {
 function timstr(t) {
     var ss, mm, hh, tstring;
 
-    ss = Math.floor(t/tickfreq);
+    ss = Math.round(t/tickfreq);
     mm  = Math.floor(ss/60);    ss %= 60;
     hh  = Math.floor(mm/60);    mm %= 60;
     if (ss < 10) { ss = '0' + ss; }
@@ -288,15 +288,21 @@ function timstr(t) {
 
 // Convert argument (in samples) to a string in HH:MM:SS.mmm format
 function mstimstr(t) {
-    var mmm, tstring;
+    var mmm, ss, mm, hh, tstring;
 
-    mmm = Math.floor(1000*t/tickfreq) % 1000;
+    mmm = Math.round(1000*t/tickfreq);
+    ss  = Math.floor(mmm/1000); mmm %= 1000;
+    mm  = Math.floor(ss/60);    ss %= 60;
+    hh  = Math.floor(mm/60);    mm %= 60;
     if (mmm < 100) {
 	if (mmm < 10) { mmm = '.00' + mmm; }
 	else { mmm = '.0' + mmm; }
     }
     else { mmm = '.' + mmm; }
-    tstring = timstr(t) + mmm;
+    if (ss < 10) { ss = '0' + ss; }
+    if (mm < 10) { mm = '0' + mm; }
+    if (hh < 10) { hh = '0' + hh; }
+    tstring = hh + ':' +  mm + ':' + ss + mmm;
     return tstring;
 }
 

--- a/physionet-django/lightwave/templates/lightwave/home.html
+++ b/physionet-django/lightwave/templates/lightwave/home.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv='content-type' content='text/html; charset=utf-8'>
 <meta http-equiv="X-UA-Compatible" content="chrome=1">
-<title>LightWAVE 0.68</title>
+<title>LightWAVE 0.71</title>
 <!-- -{##}->{% include "lightwave/lw-head.html" %}<!-{##}- -->
 <link rel="stylesheet" href="{% static 'lightwave/css/jquery-ui.min.css' %}">
 <link rel="stylesheet" href="{% static 'lightwave/css/lightwave.css' %}">
@@ -349,7 +349,7 @@ signal window if selected below">&#x21b4;</button>
   </tr>
   <tr>
     <td align="left">Client: <span id="client">lightwave</span></td>
-    <td><span id="cversion">version 0.68</span></td>
+    <td><span id="cversion">version 0.71</span></td>
   </tr>
   <tr>
     <td align="left">Scribe:


### PR DESCRIPTION
Apply the client-side bug fixes from lightwave 0.71.

(Although the current dev branch claims to be lightwave 0.68, it had
already included the client-side bug fix from 0.69.  Version 0.70 was
a server-side-only change.)

The main change here is to fix the display of multi-frequency and
non-integer-frequency records.  An example of a record that is
currently displayed poorly can be found here:

https://github.com/MIT-LCP/wfdb-python/pull/372/commits/9b5df00cc13f3bf0feefb4d78ce7def92ab48410

(you'll also need to have wfdb 10.7.0 with libFLAC in order to see it...)
