### PR TITLE
Prevent upload of CITI training certificates. Ref #1610 and #1600

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -779,6 +779,17 @@ class TrainingForm(forms.ModelForm):
         if data['training_type'] not in available_training_types:
             raise forms.ValidationError('You have already submitted a training of this type.')
 
+        # Check for a recognized CITI verification link.
+        # TODO: This is a hack and it should be replaced with something generalisable.
+        if data['training_type'].name == 'CITI Data or Specimens Only Research':
+            try:
+                reportfile = data['completion_report']
+                self.report_url = find_training_report_url(reportfile)
+            except TrainingCertificateError:
+                raise forms.ValidationError(
+                    'Please upload the "Completion Report" file, '
+                    'not the "Completion Certificate".')
+
     def save(self):
         training = super().save(commit=False)
 


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/1600, in the past we would automatically prevent users from uploading CITI Certificates instead of CITI reports.

Commit https://github.com/MIT-LCP/physionet-build/commit/dcafd1c1ab9947b569fdce5ab0a39b843d6d8c39 removed this automatic check. As a result, we now find that a large proportion of users submit certificates instead of reports.

This pull request adds back the validation step that prevented users from uploading CITI certificates.

```python
        # Check for a recognized CITI verification link.
        try:
            reportfile = data['training_completion_report']
            self.report_url = find_training_report_url(reportfile)
        except TrainingCertificateError:
            raise forms.ValidationError(
                'Please upload the "Completion Report" file, '
                'not the "Completion Certificate".')
```

As we would like this step to apply to CITI training only, I have wrapped the validation chunk in a (hacky) if statement. It would be good to come up with a more elegant approach in future:

```
if data['training_type'].name == 'CITI Data or Specimens Only Research':
```

## Testing

To test this change:
- Login as an existing user
- Go to http://127.0.0.1:8000/settings/training/, upload a CITI certificate, click submit (expected result is validation error)
- Now try uploading a completion report instead.
