### PR TITLE
Add TICKET_SYSTEM_URL variable to config and display in template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ ADMINS_MAIL=technical@dev.physionet.org
 #SYSTEM_MAINTENANCE_NO_UPLOAD=1
 #SYSTEM_MAINTENANCE_MESSAGE='PhysioNet is undergoing maintenance, and projects cannot be edited. The site will be back online at 16:00 GMT.'
 
+# Ticket system for user support
+# TICKET_SYSTEM_URL=
+
 # Credentialing
 PAUSE_CREDENTIALING=0
 PAUSE_CREDENTIALING_MESSAGE='PhysioNet will not be taking new applications for credentialed access until 4 January 2021. We apologize for the inconvenience.'

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -518,6 +518,9 @@ COPY_FILES_TO_NEW_VERSION = config('COPY_FILES_TO_NEW_VERSION', cast=bool, defau
 
 LOG_TIMEDELTA = config('LOG_TIMEDELTA', cast=int, default='10')
 
+# Ticket system for user support
+TICKET_SYSTEM_URL = config('TICKET_SYSTEM_URL', default=None)
+
 #  Platform wide citation config
 PLATFORM_WIDE_CITATION = {
     'APA': config('PLATFORM_WIDE_CITATION_APA', default=None),

--- a/physionet-django/user/templates/user/edit_credentialing.html
+++ b/physionet-django/user/templates/user/edit_credentialing.html
@@ -15,6 +15,10 @@
 <p>To access certain datasets, we require your account to be "credentialed". This means that you must formally submit your personal details for review, so that we can confirm your identity.</p>
 <p>Certain datasets also require you to complete <a href="{% url 'edit_training' %} ">training</a> and/or to sign a Data Use Agreement. You can find specific requirements in the "Files" section of the project description.</p>
 
+{% if ticket_system_url %}
+  <p>To raise a support request, please <a href="{{ ticket_system_url }}">click here</a>.</p>
+{% endif %}
+
 <div class="alert alert-warning">
 {% if user.is_credentialed %}
   <p><i class="fas fa-check" style="color:green"></i> Your account was successfully credentialed on {{ user.credential_datetime }}</p>

--- a/physionet-django/user/templates/user/edit_training.html
+++ b/physionet-django/user/templates/user/edit_training.html
@@ -6,7 +6,7 @@
 <h1>Training</h1>
   <hr>
     <p>To gain access to certain datasets on {{ SITE_NAME }}, you are required to demonstrate that you have completed relevant training. You can find specific training requirements in the "Files" section of the project description.</p>
-  
+
     {% for status, group in training_by_status.items %}
       {% if not status == 'under review' %}
         <div class="mb-3">
@@ -50,7 +50,11 @@
     {% endif %}
   {% endfor %}
 
-  <p>Please use the form below to submit a new completion report. For CITI training, please refer to our <a href="{% url "citi_course" %}" target="_blank">step-by-step instructions</a>. </p>
+  <p>Please use the form below to submit a new completion report. 
+    For CITI training, please refer to our <a href="{% url "citi_course" %}" target="_blank">step-by-step instructions</a>. 
+  {% if ticket_system_url %}To raise a support request, please <a href="{{ ticket_system_url }}">click here</a>.
+  {% endif %}</p>
+
   <form action="{% url "edit_training" %}" method="post" enctype="multipart/form-data" id="training">
       {% include "descriptive_inline_form_snippet.html" with form=training_form %}
       <button type="button" class="btn btn-primary btn-rsp" data-toggle="modal" data-target="#submit-training">Submit Training</button>

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -649,7 +649,7 @@ def user_credential_applications(request):
 @login_required
 def credential_application(request):
     """
-    Page to apply for credentially
+    Page to apply for credentialing
     """
     user = request.user
     if user.is_credentialed or CredentialApplication.objects.filter(
@@ -704,6 +704,14 @@ def credential_application(request):
 
 @login_required
 def edit_training(request):
+    """
+    Training settings page.
+    """
+    if settings.TICKET_SYSTEM_URL:
+        ticket_system_url = settings.TICKET_SYSTEM_URL
+    else:
+        ticket_system_url = None
+
     if request.method == 'POST':
         training_form = forms.TrainingForm(
             user=request.user, data=request.POST, files=request.FILES, training_type=request.POST.get('training_type')
@@ -734,7 +742,9 @@ def edit_training(request):
     return render(
         request,
         'user/edit_training.html',
-        {'training_form': training_form, 'training_by_status': training_by_status}
+        {'training_form': training_form,
+         'training_by_status': training_by_status,
+         'ticket_system_url': ticket_system_url},
     )
 
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -611,6 +611,11 @@ def edit_credentialing(request):
         pause_applications = False
         pause_message = None
 
+    if settings.TICKET_SYSTEM_URL:
+        ticket_system_url = settings.TICKET_SYSTEM_URL
+    else:
+        ticket_system_url = None
+
     applications = CredentialApplication.objects.filter(user=request.user)
     current_application = applications.filter(status=0).first()
 
@@ -625,7 +630,8 @@ def edit_credentialing(request):
         'applications': applications,
         'pause_applications': pause_applications,
         'pause_message': pause_message,
-        'current_application': current_application})
+        'current_application': current_application,
+        'ticket_system_url': ticket_system_url})
 
 
 @login_required


### PR DESCRIPTION
Currently we are dealing with support requests by email, which is becoming overwhelming. This pull request adds a `TICKET_SYSTEM_URL` to the config file. 

If `TICKET_SYSTEM_URL` is set, the following statement is added to the "edit training" and "edit credentialing" pages, where users submit their training and credentialing applications:

> To raise a support request, please [click here](url).

I'm sure we'll want to tweak the language etc later, but this is a start. 