### PR TITLE
Updates reference column names on credentialing page.

### DIFF
--- a/physionet-django/console/templates/console/credential_processing.html
+++ b/physionet-django/console/templates/console/credential_processing.html
@@ -22,7 +22,7 @@
         <a class="nav-link" id="reference-tab" data-toggle="tab" href="#reference" role="tab" aria-controls="reference" aria-selected="false">Reference Check {{ reference_applications|task_count_badge|safe }}</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="response-tab" data-toggle="tab" href="#response" role="tab" aria-controls="response" aria-selected="false">Reference Response {{ response_applications|task_count_badge|safe }}</a>
+        <a class="nav-link" id="response-tab" data-toggle="tab" href="#response" role="tab" aria-controls="response" aria-selected="false">Awaiting Reference Response {{ response_applications|task_count_badge|safe }}</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" id="final-tab" data-toggle="tab" href="#final" role="tab" aria-controls="final" aria-selected="false">Final Review {{ final_applications|task_count_badge|safe }}</a>
@@ -117,7 +117,7 @@
           <p><i class="fas fa-check" style="color:green"></i> No applications to show.</p>
         {% endif %}
       </div>
-      {# Reference response #}
+      {# Awaiting Reference response #}
       <div class="tab-pane fade" id="response" role="tabpanel" aria-labelledby="response-tab">
         {% if response_applications %}
         <div class="table-responsive">


### PR DESCRIPTION
This pull request renames the column headers in the tabs on the credentialing page. 
The `Reference Response` is changed to `Awaiting Reference Response` and the `Final Review` is changed to `Final Reference Review` to assist admin in understanding the meaning of each tab.