### PR TITLE
/settings/training/ 'completion_report'

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -785,7 +785,7 @@ class TrainingForm(forms.ModelForm):
             try:
                 reportfile = data['completion_report']
                 self.report_url = find_training_report_url(reportfile)
-            except TrainingCertificateError:
+            except (TrainingCertificateError, KeyError):
                 raise forms.ValidationError(
                     'Please upload the "Completion Report" file, '
                     'not the "Completion Certificate".')


### PR DESCRIPTION
We are currently seeing a fair amount of "KeyError at /settings/training/ 'completion_report'" errors, which I think are a result of people submitting the training form at: http://localhost:8000/settings/training/ without including a copy of their report (presumably because they somehow click submit before the report has had time to upload).

This pull request catches the server errors that are being raised in this case and prompts the user to upload their completion report.