### PR TITLE
Fix the access requirement list in the published project template

### DIFF
--- a/physionet-django/project/templates/project/published_project_unauthorized.html
+++ b/physionet-django/project/templates/project/published_project_unauthorized.html
@@ -2,7 +2,7 @@
   This is a restricted-access resource. To access the files, you must fulfill all of the following requirements:
   <ul>
     {% if project.access_policy == AccessPolicy.RESTRICTED %}
-      {% if not has_required_trainings %}
+      {% if requires_training and not has_required_training %}
         <li>finish required <a href="{% url 'edit_training' %}">training</a></li>
       {% endif %}
       {% if not has_signed_dua %}
@@ -14,8 +14,14 @@
       {% if not user.is_credentialed %}
         <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
       {% endif %}
-      {% if not has_required_trainings %}
-        <li>finish required <a href="{% url 'edit_training' %}">training</a></li>
+      {% if requires_training and not has_required_training %}
+        <li>complete required training:</li>
+        <ul>
+          {% for required_training in project.required_trainings.all %}
+            <li><a href="{% url 'published_project_required_trainings' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
+          {% endfor %}
+          You may submit your training <a href="{% url 'edit_training' %}">here</a>.
+        </ul>
       {% endif %}
       {% if not has_signed_dua %}
         <li>
@@ -26,7 +32,7 @@
       {% if not user.is_credentialed %}
         <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
       {% endif %}
-      {% if not has_required_trainings %}
+      {% if requires_training and not has_required_training %}
         <li>complete required training:</li>
         <ul>
           {% for required_training in project.required_trainings.all %}

--- a/physionet-django/project/templates/project/published_project_unauthorized.html
+++ b/physionet-django/project/templates/project/published_project_unauthorized.html
@@ -1,7 +1,16 @@
 <div class="alert alert-danger col-md-8" role="alert">
   This is a restricted-access resource. To access the files, you must fulfill all of the following requirements:
   <ul>
-    {% if project.access_policy == AccessPolicy.CREDENTIALED or project.access_policy == AccessPolicy.RESTRICTED %}
+    {% if project.access_policy == AccessPolicy.RESTRICTED %}
+      {% if not has_required_trainings %}
+        <li>finish required <a href="{% url 'edit_training' %}">training</a></li>
+      {% endif %}
+      {% if not has_signed_dua %}
+        <li>
+          <a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project
+        </li>
+      {% endif %}
+    {% elif project.access_policy == AccessPolicy.CREDENTIALED %}
       {% if not user.is_credentialed %}
         <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
       {% endif %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1796,7 +1796,13 @@ def published_project(request, project_slug, version, subdir=''):
         requester=user,
         status=DataAccessRequest.ACCEPT_REQUEST_VALUE
     ).exists()
-    has_required_trainings = (
+
+    if project.required_trainings.exists():
+        requires_training = True
+    else:
+        requires_training = False
+
+    has_required_training = (
         False
         if not user.is_authenticated
         else Training.objects.get_valid().filter(training_type__in=project.required_trainings.all(), user=user).count()
@@ -1816,7 +1822,8 @@ def published_project(request, project_slug, version, subdir=''):
         'has_access': has_access,
         'has_signed_dua': has_signed_dua,
         'has_accepted_access_request': has_accepted_access_request,
-        'has_required_trainings': has_required_trainings,
+        'requires_training': requires_training,
+        'has_required_training': has_required_training,
         'current_site': current_site,
         'bulk_url_prefix': bulk_url_prefix,
         'citations': citations,


### PR DESCRIPTION
When someone attempts to view a protected project (restricted, credentialed, contributor review), they see a list of access requirements in the "Files" section of the project. 

These requirements are defined in the following template:
https://github.com/MIT-LCP/physionet-build/blob/dev/physionet-django/project/templates/project/published_project_unauthorized.html

Currently the template (and the associated view) has some bad logic, that means incorrect information is displayed to users. e.g.
- If the user is not logged in, they will always see a note saying that training is required (regardless of whether or not the project actually requires training).
- if the project is `AccessPolicy.RESTRICTED`, the user will see a note saying that credentialing is required (even though credentialing is not required).

This pull request is a quick fix for these bugs.