### PR TITLE
Tp/ref order 1

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -690,15 +690,6 @@ class ReferenceFormSet(BaseGenericInlineFormSet):
                     raise forms.ValidationError('References must be unique.')
                 descriptions.append(description)
 
-        # orders = []
-        # for form in self.forms:
-        #     # This is to allow empty unsaved form
-        #     if 'order' in form.cleaned_data:
-        #         order = form.cleaned_data['order']
-        #         if order in orders:
-        #             raise forms.ValidationError('Order must be unique.')
-        #         orders.append(orders)
-
 
 class PublicationFormSet(BaseGenericInlineFormSet):
     """

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -690,6 +690,15 @@ class ReferenceFormSet(BaseGenericInlineFormSet):
                     raise forms.ValidationError('References must be unique.')
                 descriptions.append(description)
 
+        # orders = []
+        # for form in self.forms:
+        #     # This is to allow empty unsaved form
+        #     if 'order' in form.cleaned_data:
+        #         order = form.cleaned_data['order']
+        #         if order in orders:
+        #             raise forms.ValidationError('Order must be unique.')
+        #         orders.append(orders)
+
 
 class PublicationFormSet(BaseGenericInlineFormSet):
     """

--- a/physionet-django/project/migrations/0064_auto_20220602_1151.py
+++ b/physionet-django/project/migrations/0064_auto_20220602_1151.py
@@ -1,0 +1,63 @@
+from django.db import migrations, models
+from project.models import PublishedProject, ActiveProject, ArchivedProject, LegacyProject
+
+
+def migrate_forward(apps, schema_editor):
+
+    for project in PublishedProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+    for project in ActiveProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+    for project in ArchivedProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+    for project in LegacyProject.objects.all():
+        refs = project.references.all().order_by('id')
+        for n, ref in enumerate(refs):
+            ref.order = n + 1
+            ref.save()
+
+
+def migrate_backward(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('project', '0063_auto_20220528_2248'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='publishedreference',
+            name='order',
+            field=models.PositiveIntegerField(null=True),
+        ),
+        migrations.AddField(
+            model_name='reference',
+            name='order',
+            field=models.PositiveIntegerField(null=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='publishedreference',
+            unique_together={('description', 'project', 'order')},
+        ),
+        migrations.AlterUniqueTogether(
+            name='reference',
+            unique_together={('description', 'content_type', 'order')},
+        ),
+        migrations.RunPython(migrate_forward, migrate_backward),
+    ]

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -522,9 +522,10 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                     published_project.set_version_order()
 
                 # Same content, different objects.
-                for reference in self.references.all().order_by('id'):
+                for reference in self.references.all().order_by('order'):
                     published_reference = PublishedReference.objects.create(
                         description=reference.description,
+                        order=reference.order,
                         project=published_project)
 
                 for publication in self.publications.all():

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -579,12 +579,13 @@ class Reference(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     project = GenericForeignKey('content_type', 'object_id')
+    order = models.PositiveIntegerField(null=True)
 
     description = models.CharField(max_length=1000)
 
     class Meta:
         default_permissions = ()
-        unique_together = (('description', 'content_type', 'object_id'),)
+        unique_together = (('description', 'content_type', 'order'),)
 
     def __str__(self):
         return self.description

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -601,14 +601,16 @@ class Reference(models.Model):
 
 class PublishedReference(models.Model):
     """
+    Reference field for PublishedProject
     """
     description = models.CharField(max_length=1000)
     project = models.ForeignKey('project.PublishedProject',
         related_name='references', on_delete=models.CASCADE)
+    order = models.PositiveIntegerField(null=True)
 
     class Meta:
         default_permissions = ()
-        unique_together = (('description', 'project'))
+        unique_together = (('description', 'project', 'order'))
 
 
 class Contact(models.Model):

--- a/physionet-django/project/templates/project/item_list.html
+++ b/physionet-django/project/templates/project/item_list.html
@@ -18,7 +18,7 @@
     {# This {{ item }}-%d id is identifying the form number on the page #}
     <div class="form-group row {{ item }}-body" id="{{ item }}-{{ forloop.counter }}">
       <div class="col-md-1"></div>
-      <div class="col-md-1 {{ item }}-number">{{ forloop.counter }}.</div>
+      <div class="col-md-1 {{ item }}-number">-></div>
       <div class="col-md-9 {{ item }}-form">
         {# id value is blank for forms without saved instances #}
         {# We want to display labels only for multi-attribute fields #}

--- a/physionet-django/project/templates/project/project_content.html
+++ b/physionet-django/project/templates/project/project_content.html
@@ -17,7 +17,7 @@
 <p>Please adhere to the standards specified in the helpstrings. Required fields are indicated by a <a style="color:red">*</a>.</p>
 <hr>
 
-<form action="{% url 'project_content' project.slug %}" onsubmit="return validateItems('reference-list', 'description', 'References')" method="post" class="no-pd">
+<form action="{% url 'project_content' project.slug %}" onsubmit="return validateItems('reference-list', 'description', 'References') && validateItems('reference-list', 'order', 'References')" method="post" class="no-pd">
   {% if not project.author_editable %}
     <div class="alert alert-form alert-warning alert-dismissible">
       <strong>The project cannot be edited right now.</strong>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1150,7 +1150,7 @@ def project_preview(request, project_slug, subdir='', **kwargs):
     corresponding_author = authors.get(is_corresponding=True)
     corresponding_author.text_affiliations = ', '.join(a.name for a in corresponding_author.affiliations.all())
 
-    references = project.references.all().order_by('id')
+    references = project.references.all().order_by('order')
     publication = project.publications.all().first()
     topics = project.topics.all()
     parent_projects = project.parent_projects.all()
@@ -1767,7 +1767,7 @@ def published_project(request, project_slug, version, subdir=''):
     authors = project.authors.all().order_by('display_order')
     for a in authors:
         a.set_display_info()
-    references = project.references.all().order_by('id')
+    references = project.references.all().order_by('order')
     publication = project.publications.all().first()
     topics = project.topics.all()
     languages = project.programming_languages.all()

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -613,7 +613,7 @@ def edit_content_item(request, project_slug):
                        'topic':forms.TopicFormSet}
 
     # The fields of each formset
-    content_item_fields = {'reference': ('description',),
+    content_item_fields = {'reference': ('description','order'),
                             'publication': ('citation', 'url'),
                             'topic': ('description',)}
 
@@ -666,7 +666,7 @@ def project_content(request, project_slug, **kwargs):
 
     # There are several forms for different types of content
     ReferenceFormSet = generic_inlineformset_factory(Reference,
-        fields=('description',), extra=0,
+        fields=('description','order',), extra=0,
         max_num=forms.ReferenceFormSet.max_forms, can_delete=False,
         formset=forms.ReferenceFormSet, validate_max=True)
 


### PR DESCRIPTION
Updates on the References Issue - Basic Working Version with duplicate order validation. Adding the order field and an additional validation check makes sure that INTEGRITY Error can't be replicated. 

This merge will update the MIT-LCP branch with the most basic working version. This version will show an extra field of order in the references part of the content. The reference order is tracked and used later on to sort the references for listing. 

