### PR TITLE
set url dispatcher to match signed agreements on int only. fix #1633

### DIFF
--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -25,8 +25,7 @@ urlpatterns = [
     path('settings/training/', views.edit_training, name='edit_training'),
     path('settings/training/<int:training_id>/', views.edit_training_detail, name='edit_training_detail'),
     path('settings/agreements/', views.view_agreements, name='edit_agreements'),
-    path('settings/agreements/<id>/',
-        views.view_signed_agreement, name='view_signed_agreement'),
+    path('settings/agreements/<int:id>/', views.view_signed_agreement, name='view_signed_agreement'),
 
     # Current tokens are 20 characters long and consist of 0-9A-Za-z
     # Obsolete tokens are 34 characters long and also include a hyphen


### PR DESCRIPTION
As noted in https://github.com/MIT-LCP/physionet-build/issues/1633, the URL dispatcher for the agreements page raises an error if a string is added to the URL path.

e.g.  http://localhost:8000/settings/agreements/hello/ will raise an error ("`invalid literal for int() with base 10 error`"). This pull request sets the URL dispatcher to match integers only, preventing the server error (and instead raising a 404 not found).