### PR TITLE
If the signed data use agreement isn't found, raise a 404. fix #1632

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -861,7 +861,7 @@ def view_signed_agreement(request, id):
     View a printable agreement in the user profile.
     """
     user = request.user
-    signed = DUASignature.objects.get(user=user, id=id)
+    signed = get_object_or_404(DUASignature, user=user, id=id)
 
     return render(request, 'user/view_signed_agreement.html',
                   {'user': user, 'signed': signed})


### PR DESCRIPTION
As noted in https://github.com/MIT-LCP/physionet-build/issues/1632, if someone attempts to view a signed data use agreement that isn't available, the system raises a server error. e.g. http://localhost:8000/settings/agreements/2323234/ 

This pull request replaces the `DUASignature.objects.get` call with a call using the `get_object_or_404` shortcut. If the ID isn't found, we return a 404. e.g. http://localhost:8000/settings/agreements/232323432423432/ should now raise a 404.