### PR TITLE
Loosen requirement in poetry to cffi ^1.15.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -682,7 +682,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "23989efd8e4ad098c0010cd55e6e6e1b6ec24de91a9d63ac33fb42ebd59c6ec0"
+content-hash = "61275f135744ec23d2bf2a164c74bd92221fdc7000d48c2e88cc92c3761824b6"
 
 [metadata.files]
 bleach = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ python-json-logger = "^2.0.2"
 django-storages = { version = "^1.11.1", extras = ["google"] }
 "pdfminer.six" = "^20211012"
 requests = "2.27.1"
-cffi = "1.15.1"
+cffi = "^1.15.1"
 
 [tool.poetry.dev-dependencies]
 coverage = "^4.4.2"


### PR DESCRIPTION
I'd previously fixed the version of cffi to 1.15.1 in the poetry lock file. This pull request loosens the requirement to ^1.15.1 to avoid dependency issues when making updates in future.