### PR TITLE
Update patterns to match 32 character tokens. Ref #1641

### DIFF
--- a/physionet-django/sso/tests/test_views.py
+++ b/physionet-django/sso/tests/test_views.py
@@ -42,7 +42,7 @@ class TestViews(TestCase):
     def getActivationUrl(self):
         return re.findall(
             'http://localhost:8000/sso/activate/'
-            '(?P<uidb64>[0-9A-Za-z_-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
+            '(?P<uidb64>[0-9A-Za-z_-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[0].body,
         )[0]
 

--- a/physionet-django/sso/urls.py
+++ b/physionet-django/sso/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path('sso/login/', views.sso_login, name='sso_login'),
     path('sso/register/', views.sso_register, name='sso_register'),
     re_path(
-        '^sso/activate/(?P<uidb64>[0-9A-Za-z_-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        '^sso/activate/(?P<uidb64>[0-9A-Za-z_-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$',
         views.sso_activate_user,
         name='sso_activate_user',
     ),

--- a/physionet-django/user/test_integration.py
+++ b/physionet-django/user/test_integration.py
@@ -157,7 +157,7 @@ class TestPublic(TestCase):
         self.assertRedirects(response, reverse('reset_password_sent'))
 
         # Get the reset info from the email
-        uidb64, token = re.findall('reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
+        uidb64, token = re.findall('reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[0].body)[0]
 
         # Visit the reset url which redirects to the password set form
@@ -233,7 +233,7 @@ class TestCredentialing(TestMixin):
         response = self.client.post(reverse('register'),
             data={'email':'admin@upr.edu', 'username':'adminupr',
             'first_names': 'admin', 'last_name': 'upr'})
-        uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
+        uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[-1].body)[0]
 
         response = self.client.get(reverse('activate_user', args=(uidb64, token)))
@@ -271,7 +271,7 @@ class TestCredentialing(TestMixin):
             data={'email':'admin@upr.edu', 'username':'sneakyfriend',
             'first_names': 'admin', 'last_name': 'upr',
             'password1':'Very5trongt0t@11y', 'password2':'Very5trongt0t@11y'})
-        uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
+        uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[-1].body)[0]
 
         response = self.client.get(reverse('activate_user', args=(uidb64, token)))

--- a/physionet-django/user/test_integration.py
+++ b/physionet-django/user/test_integration.py
@@ -157,7 +157,9 @@ class TestPublic(TestCase):
         self.assertRedirects(response, reverse('reset_password_sent'))
 
         # Get the reset info from the email
-        uidb64, token = re.findall('reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
+        uidb64, token = re.findall(
+            r'reset/(?P<uidb64>[0-9A-Za-z_\-]+)/'
+            r'(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[0].body)[0]
 
         # Visit the reset url which redirects to the password set form
@@ -231,9 +233,12 @@ class TestCredentialing(TestMixin):
 
         # Register and activate a user with old credentialed account
         response = self.client.post(reverse('register'),
-            data={'email':'admin@upr.edu', 'username':'adminupr',
-            'first_names': 'admin', 'last_name': 'upr'})
-        uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
+                                    data={'email': 'admin@upr.edu', 'username': 'adminupr',
+                                          'first_names': 'admin', 'last_name': 'upr'})
+
+        uidb64, token = re.findall(
+            r'activate/(?P<uidb64>[0-9A-Za-z_\-]+)/'
+            r'(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[-1].body)[0]
 
         response = self.client.get(reverse('activate_user', args=(uidb64, token)))
@@ -269,9 +274,12 @@ class TestCredentialing(TestMixin):
             self.client.get(reverse('register'))
         response = self.client.post(reverse('register'),
             data={'email':'admin@upr.edu', 'username':'sneakyfriend',
-            'first_names': 'admin', 'last_name': 'upr',
-            'password1':'Very5trongt0t@11y', 'password2':'Very5trongt0t@11y'})
-        uidb64, token = re.findall('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
+                  'first_names': 'admin', 'last_name': 'upr',
+                  'password1': 'Very5trongt0t@11y', 'password2': 'Very5trongt0t@11y'})
+
+        uidb64, token = re.findall(
+            r'activate/(?P<uidb64>[0-9A-Za-z_\-]+)/'
+            r'(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[-1].body)[0]
 
         response = self.client.get(reverse('activate_user', args=(uidb64, token)))

--- a/physionet-django/user/test_views.py
+++ b/physionet-django/user/test_views.py
@@ -400,7 +400,7 @@ class TestPublic(TestMixin):
         self.assertFalse(User.objects.get(email='jackreacher@mit.edu').is_active)
 
         # Get the activation info from the sent email
-        uidb64, token = re.findall('http://localhost:8000/activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/',
+        uidb64, token = re.findall('http://localhost:8000/activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[0].body)[0]
         # Visit the activation link
         response = self.client.get(reverse('activate_user', args=(uidb64, token)))

--- a/physionet-django/user/test_views.py
+++ b/physionet-django/user/test_views.py
@@ -400,7 +400,9 @@ class TestPublic(TestMixin):
         self.assertFalse(User.objects.get(email='jackreacher@mit.edu').is_active)
 
         # Get the activation info from the sent email
-        uidb64, token = re.findall('http://localhost:8000/activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
+        uidb64, token = re.findall(
+            r'http://localhost:8000/activate/'
+            r'(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/',
             mail.outbox[0].body)[0]
         # Visit the activation link
         response = self.client.get(reverse('activate_user', args=(uidb64, token)))

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -52,7 +52,7 @@ if not settings.ENABLE_SSO:
         path('register/', views.register, name='register'),
         path('settings/password/', views.edit_password, name='edit_password'),
         path('settings/password/changed/', views.edit_password_complete, name='edit_password_complete'),
-        re_path(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        re_path(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$',
                 views.activate_user,
                 name='activate_user'),
         # Request password reset
@@ -62,7 +62,7 @@ if not settings.ENABLE_SSO:
         path('reset-password/sent/', views.reset_password_sent,
              name='reset_password_sent'),
         # Prompt user to enter new password and carry out password reset (if url is valid)
-        re_path(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        re_path(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$',
                 views.reset_password_confirm, name='reset_password_confirm'),
         # Password reset successfully carried out
         path('reset/complete/', views.reset_password_complete,


### PR DESCRIPTION
Django 3.1 introduces a change that increases the length of secure tokens from 20 characters to 32 characters (possibly a result of [switching the default hashing algorithm](https://docs.djangoproject.com/en/4.0/releases/3.1/#default-hashing-algorithm-settings)?)

This pull request updates several patterns to match the longer tokens, allowing us to move to Django 3.1+ (Ref #1641 and Ref #1095). 

Example of an old activation token: http://localhost:8000/activate/MjA5/430-670ed1288ec90a7de205/
Example of a new activation token: http://localhost:8000/activate/MjA4/b6kihw-6c2ec99e8061943db45eed9f64d67d12/

The update fixes the `django.urls.exceptions.NoReverseMatch` errors in #1641 like the one below:

```
======================================================================
ERROR: test_reset_password (user.test_integration.TestPublic)
Test the full reset password functionality
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/physionet-django/user/test_integration.py", line 156, in test_reset_password
    data={'email':'blah@blah.com'})
  File "/usr/local/lib/python3.7/site-packages/django/test/client.py", line 748, in post
    response = super().post(path, data=data, content_type=content_type, secure=secure, **extra)
  File "/usr/local/lib/python3.7/site-packages/django/test/client.py", line 405, in post
    secure=secure, **extra)
  File "/usr/local/lib/python3.7/site-packages/django/test/client.py", line 470, in generic
    return self.request(**r)
  File "/usr/local/lib/python3.7/site-packages/django/test/client.py", line 716, in request
    self.check_exception(response)
  File "/usr/local/lib/python3.7/site-packages/django/test/client.py", line 577, in check_exception
    raise exc_value
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/utils/decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/views.py", line 222, in dispatch
    return super().dispatch(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/generic/edit.py", line 142, in post
    return self.form_valid(form)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/views.py", line 235, in form_valid
    form.save(**opts)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/forms.py", line 325, in save
    user_email, html_email_template_name=html_email_template_name,
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/forms.py", line 266, in send_mail
    body = loader.render_to_string(email_template_name, context)
  File "/usr/local/lib/python3.7/site-packages/django/template/loader.py", line 62, in render_to_string
    return template.render(context, request)
  File "/usr/local/lib/python3.7/site-packages/django/template/backends/django.py", line 61, in render
    return self.template.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 170, in render
    return self._render(context)
  File "/usr/local/lib/python3.7/site-packages/django/test/utils.py", line 96, in instrumented_test_render
    return self.nodelist.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 938, in render
    bit = node.render_annotated(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 905, in render_annotated
    return self.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/defaulttags.py", line 39, in render
    output = self.nodelist.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 938, in render
    bit = node.render_annotated(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 905, in render_annotated
    return self.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/defaulttags.py", line 111, in render
    output = self.nodelist.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 938, in render
    bit = node.render_annotated(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 905, in render_annotated
    return self.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/loader_tags.py", line 53, in render
    result = self.nodelist.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 938, in render
    bit = node.render_annotated(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/base.py", line 905, in render_annotated
    return self.render(context)
  File "/usr/local/lib/python3.7/site-packages/django/template/defaulttags.py", line 446, in render
    url = reverse(view_name, args=args, kwargs=kwargs, current_app=current_app)
  File "/usr/local/lib/python3.7/site-packages/django/urls/base.py", line 87, in reverse
    return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
  File "/usr/local/lib/python3.7/site-packages/django/urls/resolvers.py", line [689](https://github.com/MIT-LCP/physionet-build/runs/7639731497?check_suite_focus=true#step:5:690), in _reverse_with_prefix
    raise NoReverseMatch(msg)
django.urls.exceptions.NoReverseMatch: Reverse for 'reset_password_confirm' with keyword arguments '{'uidb64': 'Mg', 'token': 'b9jexu-e8cbcd1a5be01b74b441ecab997147f2'}' not found. 1 pattern(s) tried: ['reset/(?P<uidb64>[0-9A-Za-z_\\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$']
```

## Example test for the fix:

- Upgrade your local version of Django to 3.1.14
- Try registering a new user at http://localhost:8000/register/
- On the current/old codebase, you should see a server error relating to the token pattern.
- On the updated codebase, registration should be successful (because the updated pattern is matching the longer token).