### PR TITLE
update the max filename length to 100 characters

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -3,7 +3,7 @@ import re
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
-MAX_FILENAME_LENGTH = 60
+MAX_FILENAME_LENGTH = 100
 MAX_PROJECT_SLUG_LENGTH = 30
 
 _good_name_pattern = re.compile(r'\w+([\w\-\.]*\w+)?', re.ASCII)


### PR DESCRIPTION
This change updates the code base to change the file length name from 60 to 100 characters long. This is done in order to avoid having to ask the contributors to reorganize their files.