### PR TITLE
Adds a column that aggregates credentialing applications by event to the event list page.

### DIFF
--- a/physionet-django/console/templates/console/event.html
+++ b/physionet-django/console/templates/console/event.html
@@ -26,6 +26,7 @@
                   <th>Created</th>
                   <th>Started</th>
                   <th>Ended</th>
+                  <th>Credentialing</th>
                 </tr>
               </thead>
               <tbody>
@@ -37,6 +38,7 @@
                     <td>{{ event.added_datetime|date }}</td>
                     <td>{{ event.start_date }}</td>
                     <td>{{ event.end_date }}</td>
+                    <td><a href = "{% url 'credential_processing' %}?event={{ event.slug }}">View list</a></td>
                 </tr>
               {% endfor %}
               </tbody>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1281,7 +1281,11 @@ def credential_processing(request):
     Process applications for credentialed access.
     """
     applications = CredentialApplication.objects.filter(status=0).select_related('user__profile')
-
+    if 'event' in request.GET:
+        slug = request.GET['event']
+        event = Event.objects.get(slug=slug)
+        users = User.objects.filter(eventparticipant__event=event)
+        applications = applications.filter(user__in=users)
     # Awaiting initial review
     initial_1 = Q(credential_review__isnull=True)
     initial_2 = Q(credential_review__status=10)
@@ -2661,6 +2665,7 @@ def event(request):
     """
     events = Event.objects.all()
     events = paginate(request, events, 50)
+
     return render(request, 'console/event.html',
                   {'events': events,
                    'events_nav': True


### PR DESCRIPTION
This pull request, adds a column that adds a link that lists all outstanding credentialing applications to the event_list page. This is useful for admin to narrow down the participants to process that are relevant to a particular event.

- The next step could include adding a training column to view all outstanding training applications to the event_list page. 
- It also might be useful to add a flag to represent the number of users in a class, that are trained/credentialed to skip credentialing/training for courses that  already satisfy the credentialing/training requirement. 
- Right now after processing a credentialing application, the process is referred back to full list of users, a simple workflow could be devised to redirect admin to students in a batch, or back to the event_list if user's already satisfy the training/credentialing requirement.