### PR TITLE
Add Past Events section to the Events home page

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from os import path
 from re import fullmatch
 from urllib.parse import urljoin
+from datetime import datetime
 
 import notification.utility as notification
 from django.contrib import messages
@@ -237,8 +238,9 @@ def event_home(request):
     is_instructor = user.has_perm('user.add_event')
 
     # sqlite doesn't support the distinct() method
-    events = set(Event.objects.filter(Q(host=user) | Q(participants__user=user)))
-
+    events_previous = Event.objects.filter(Q(host=user) | Q(participants__user=user))
+    events = set(events_previous.filter(end_date__gte=datetime.now()))
+    past_events = set(events_previous.filter(end_date__lt=datetime.now()))
     event_form = AddEventForm(user=user)
 
     url_prefix = notification.get_url_prefix(request)
@@ -251,6 +253,7 @@ def event_home(request):
 
     return render(request, 'event_home.html',
                   {'events': events,
+                   'past_events': past_events,
                    'event_form': event_form,
                    'url_prefix': url_prefix,
                    'is_instructor': is_instructor

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -271,7 +271,7 @@ def event_add_participant(request, event_slug):
 
     if event.end_date < datetime.now().date():
         messages.error(request, "This event has now finished")
-        return redirect(event_home)    
+        return redirect(event_home)
 
     if event.participants.filter(user=user).exists():
         messages.success(request, "You are already enrolled")

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -238,9 +238,9 @@ def event_home(request):
     is_instructor = user.has_perm('user.add_event')
 
     # sqlite doesn't support the distinct() method
-    events_previous = Event.objects.filter(Q(host=user) | Q(participants__user=user))
-    events = set(events_previous.filter(end_date__gte=datetime.now()))
-    past_events = set(events_previous.filter(end_date__lt=datetime.now()))
+    events_all = Event.objects.filter(Q(host=user) | Q(participants__user=user))
+    events_active = set(events_all.filter(end_date__gte=datetime.now()))
+    events_past = set(events_all.filter(end_date__lt=datetime.now()))
     event_form = AddEventForm(user=user)
 
     url_prefix = notification.get_url_prefix(request)
@@ -252,8 +252,8 @@ def event_home(request):
             return redirect(event_home)
 
     return render(request, 'event_home.html',
-                  {'events': events,
-                   'past_events': past_events,
+                  {'events_active': events_active,
+                   'events_past': events_past,
                    'event_form': event_form,
                    'url_prefix': url_prefix,
                    'is_instructor': is_instructor

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -269,6 +269,10 @@ def event_add_participant(request, event_slug):
 
     event = get_object_or_404(Event, slug=event_slug)
 
+    if event.end_date < datetime.now().date():
+        messages.error(request, "This event has now finished")
+        return redirect(event_home)    
+
     if event.participants.filter(user=user).exists():
         messages.success(request, "You are already enrolled")
         return redirect(event_home)

--- a/physionet-django/templates/event_entries.html
+++ b/physionet-django/templates/event_entries.html
@@ -1,0 +1,22 @@
+<div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Full name</th>
+          <th>Email</th>
+          <th>Credentialed</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for participant in event.participants.all %}
+          <tr>
+            <td>{{ participant.user.username }}</td>
+            <td>{{ participant.user.get_full_name }}</td>
+            <td>{{ participant.user.email }}</td>
+            <td>{{ participant.user.is_credentialed }}</td>  
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div> 

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -52,8 +52,7 @@
     </div>
     
     <ul class="list-group list-group-flush">
-      {% if events_active %}
-        {% for event in events_active %}
+      {% for event in events_active %}
           <li class="list-group-item">
             <h3>{{ event.title }}</h3>
             <p class="list-group-item-text text-muted">
@@ -66,12 +65,11 @@
               <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
             {% endif %}
           </li>
-        {% endfor %}
-      {% else %}
+      {% empty %}
         <div class="card-body text-center">
           <p class="card-text">No events to show</p>
         </div>
-      {% endif %}
+      {% endfor %}
     </ul>
   </div>
   <br>
@@ -123,8 +121,7 @@
     </div>
     
     <ul class="list-group list-group-flush">
-      {% if events_past %}
-        {% for event in events_past %}
+      {% for event in events_past %}
           <li class="list-group-item">
             <h3>{{ event.title }}</h3>
             <p class="list-group-item-text text-muted">
@@ -136,12 +133,11 @@
               <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
             {% endif %}
           </li>
-        {% endfor %}
-      {% else %}
+      {% empty %}
         <div class="card-body text-center">
           <p class="card-text">No events to show</p>
         </div>
-      {% endif %}
+      {% endfor %}
     </ul>
   </div>
   <br>

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -52,8 +52,8 @@
     </div>
     
     <ul class="list-group list-group-flush">
-      {% if events %}
-        {% for event in events %}
+      {% if events_active %}
+        {% for event in events_active %}
           <li class="list-group-item">
             <h3>{{ event.title }}</h3>
             <p class="list-group-item-text text-muted">
@@ -75,8 +75,8 @@
     </ul>
   </div>
   <br>
-  {% if events %}
-    {% for event in events %}
+  {% if events_active %}
+    {% for event in events_active %}
       <div class="modal fade" id="add-participant-modal-{{ event.id }}" tabindex="-1" role="dialog" aria-labelledby="add-participant-modal" aria-hidden="true">
         <div class="modal-dialog modal-lg"  role="document">
           <div class="modal-content">
@@ -123,8 +123,8 @@
     </div>
     
     <ul class="list-group list-group-flush">
-      {% if events %}
-        {% for event in past_events %}
+      {% if events_past %}
+        {% for event in events_past %}
           <li class="list-group-item">
             <h3>{{ event.title }}</h3>
             <p class="list-group-item-text text-muted">
@@ -145,8 +145,8 @@
     </ul>
   </div>
   <br>
-  {% if events %}
-    {% for event in past_events %}
+  {% if events_past %}
+    {% for event in events_past %}
       <div class="modal fade" id="add-participant-modal-{{ event.id }}" tabindex="-1" role="dialog" aria-labelledby="add-participant-modal" aria-hidden="true">
         <div class="modal-dialog modal-lg"  role="document">
           <div class="modal-content">

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -84,29 +84,7 @@
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>
-
-              <div class="table-responsive">
-                <table class="table table-bordered">
-                  <thead>
-                    <tr>
-                      <th>Username</th>
-                      <th>Full name</th>
-                      <th>Email</th>
-                      <th>Credentialed</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for participant in event.participants.all %}
-                      <tr>
-                        <td>{{ participant.user.username }}</td>
-                        <td>{{ participant.user.get_full_name }}</td>
-                        <td>{{ participant.user.email }}</td>
-                        <td>{{ participant.user.is_credentialed }}</td>  
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </div>      
+              {% include 'event_entries.html' %}
             </div>
           </div>
         </div>
@@ -152,29 +130,7 @@
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>
-
-              <div class="table-responsive">
-                <table class="table table-bordered">
-                  <thead>
-                    <tr>
-                      <th>Username</th>
-                      <th>Full name</th>
-                      <th>Email</th>
-                      <th>Credentialed</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for participant in event.participants.all %}
-                      <tr>
-                        <td>{{ participant.user.username }}</td>
-                        <td>{{ participant.user.get_full_name }}</td>
-                        <td>{{ participant.user.email }}</td>
-                        <td>{{ participant.user.is_credentialed }}</td>  
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </div>      
+              {% include 'event_entries.html' %}
             </div>
           </div>
         </div>

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -115,6 +115,79 @@
         </div>
     {% endfor %}
   {% endif %}
+
+<!-- Past events -->
+
+  <div class="card" >
+    <div class="card-header">
+      <h2>Past Events</h2>
+      <p class="card-text">Events hosted in the past</p>
+    </div>
+    
+    <ul class="list-group list-group-flush">
+      {% if events %}
+        {% for event in past_events %}
+          <li class="list-group-item">
+            <h3>{{ event.title }}</h3>
+            <p class="list-group-item-text text-muted">
+            <strong>Host: {{ event.host.get_full_name }} </strong><br>
+            <small>Created: {{ event.added_datetime|date }}. Number of participants: {{ event.participants.all|length }} </small><br>
+            <small>Start Date: {{ event.start_date }}. End Date: {{ event.end_date }}.</small><br>
+            {% if event.host == user %}
+              <small>Share the class code: {{ url_prefix }}{% url 'event_add_participant' event.slug %} </small><br>
+              </p>
+              <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
+            {% endif %}
+          </li>
+        {% endfor %}
+      {% else %}
+        <div class="card-body text-center">
+          <p class="card-text">No events to show</p>
+        </div>
+      {% endif %}
+    </ul>
+  </div>
+  <br>
+  {% if events %}
+    {% for event in past_events %}
+      <div class="modal fade" id="add-participant-modal-{{ event.id }}" tabindex="-1" role="dialog" aria-labelledby="add-participant-modal" aria-hidden="true">
+        <div class="modal-dialog modal-lg"  role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Participants</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+
+              <div class="table-responsive">
+                <table class="table table-bordered">
+                  <thead>
+                    <tr>
+                      <th>Username</th>
+                      <th>Full name</th>
+                      <th>Email</th>
+                      <th>Credentialed</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for participant in event.participants.all %}
+                      <tr>
+                        <td>{{ participant.user.username }}</td>
+                        <td>{{ participant.user.get_full_name }}</td>
+                        <td>{{ participant.user.email }}</td>
+                        <td>{{ participant.user.is_credentialed }}</td>  
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>      
+            </div>
+          </div>
+        </div>
+    {% endfor %}
+  {% endif %}
+
   </div>
 
 {% endblock %}

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -134,7 +134,6 @@
             <small>Created: {{ event.added_datetime|date }}. Number of participants: {{ event.participants.all|length }} </small><br>
             <small>Start Date: {{ event.start_date }}. End Date: {{ event.end_date }}.</small><br>
             {% if event.host == user %}
-              <small>Share the class code: {{ url_prefix }}{% url 'event_add_participant' event.slug %} </small><br>
               </p>
               <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
             {% endif %}

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -186,7 +186,5 @@
         </div>
     {% endfor %}
   {% endif %}
-
   </div>
-
 {% endblock %}

--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -49,7 +49,6 @@
   <div class="card" >
     <div class="card-header">
       <h2>Active Events</h2>
-      <p class="card-text">Events to be hosted</p>
     </div>
     
     <ul class="list-group list-group-flush">
@@ -121,7 +120,6 @@
   <div class="card" >
     <div class="card-header">
       <h2>Past Events</h2>
-      <p class="card-text">Events hosted in the past</p>
     </div>
     
     <ul class="list-group list-group-flush">


### PR DESCRIPTION
It solves issue #1664:

- Add a "Past events" section to the events home page to display projects where the End Date of the event is in the past;

- Hide the sign-up link for past events to prevent new users from signing up;

- Display the message 'This event has now finished' if someone clicks a link for a past event.

![image](https://user-images.githubusercontent.com/4949149/191122492-4cb52c38-9624-4fc2-ac13-f8b22ce21176.png)
