### PR TITLE
Correct is_expired and is_valid behaviour.

### DIFF
--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -1109,9 +1109,12 @@ class Training(models.Model):
                 return self.process_datetime + self.training_type.valid_duration >= timezone.now()
 
     def is_expired(self):
+        """checks if it has exceeded the valid period (process_time + duration)
+        if no valid duration, its not expired.
+        """
         if self.status == TrainingStatus.ACCEPTED:
             if not self.training_type.valid_duration:
-                return True
+                return False
             else:
                 return self.process_datetime + self.training_type.valid_duration < timezone.now()
 


### PR DESCRIPTION
Bug as raised here: https://github.com/MIT-LCP/physionet-build/issues/1596

There seems to be a bug in the way training reports are managed. The "is_valid" and "is_expired" flags for a Training object should be mutually exclusive, but it is possible for both flags to return True for a single training type.
If the valid duration does not exist, it should not be termed expired.