### PR TITLE
Changing column name on Training list 

### DIFF
--- a/physionet-django/console/templates/console/expired_training_table.html
+++ b/physionet-django/console/templates/console/expired_training_table.html
@@ -6,7 +6,7 @@
                 <th>Full Name</th>
                 <th>Email</th>
                 <th>Training Type</th>
-                <th>Credentialed</th>
+                <th>Identity Verified</th>
                 <th>Valid until</th>
                 <th>View</th>
             </tr>

--- a/physionet-django/console/templates/console/rejected_training_table.html
+++ b/physionet-django/console/templates/console/rejected_training_table.html
@@ -6,7 +6,7 @@
                 <th>Full Name</th>
                 <th>Email</th>
                 <th>Training Type</th>
-                <th>Credentialed</th>
+                <th>Identity Verified</th>
                 <th>Submitted on</th>
                 <th>Rejected on</th>
                 <th>View</th>

--- a/physionet-django/console/templates/console/review_training_table.html
+++ b/physionet-django/console/templates/console/review_training_table.html
@@ -6,7 +6,7 @@
                 <th>Full Name</th>
                 <th>Email</th>
                 <th>Training Type</th>
-                <th>Credentialed</th>
+                <th>Identity Verified</th>
                 <th>Submitted on</th>
                 <th>Process Training</th>
             </tr>

--- a/physionet-django/console/templates/console/valid_training_table.html
+++ b/physionet-django/console/templates/console/valid_training_table.html
@@ -7,7 +7,7 @@
                     <th>Full Name</th>
                     <th>Email</th>
                     <th>Training Type</th>
-                    <th>Credentialed</th>
+                    <th>Identity Verified</th>
                     <th>Valid until</th>
                     <th>View</th>
                 </tr>


### PR DESCRIPTION
Changing column name on Training list (from "Credentialed" to "Identity Verified"). It's related to the #1690 issue.