### PR TITLE
Updates allowed domains in views.

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -284,7 +284,7 @@ def event_add_participant(request, event_slug):
     if event.allowed_domains:
         domains = event.allowed_domains.split(',')
         emails = user.get_emails()
-        domain_match = [domain for domain in domains if any('@'+ domain.strip() in email for email in emails)]
+        domain_match = [domain for domain in domains if any('@' + domain.strip() in email for email in emails)]
         if not domain_match:
             messages.error(request, f"To register for the event, your account must be linked with "
                                     f"an email address from the following domains: {domains}. "

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -284,7 +284,7 @@ def event_add_participant(request, event_slug):
     if event.allowed_domains:
         domains = event.allowed_domains.split(',')
         emails = user.get_emails()
-        domain_match = [domain for domain in domains if any(domain.strip() in email for email in emails)]
+        domain_match = [domain for domain in domains if any('@'+ domain.strip() in email for email in emails)]
         if not domain_match:
             messages.error(request, f"To register for the event, your account must be linked with "
                                     f"an email address from the following domains: {domains}. "


### PR DESCRIPTION
This pull request verifies domain additions in a more secure way. For example, if the allowed domains from the instructors includes "mit.edu" an "@" is enforced before the email domain when matching the email address with the allowed domains to avoid users with fake emails such as "mit.edu@wobble.com"  to register for the event.