### PR TITLE
Automated URL testing

### DIFF
--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -15,3 +15,6 @@ urlpatterns = [
     path('rest/published-stats-list/', views.published_stats_list,
         name='published_stats_list'),
 ]
+
+# Parameters for testing URLs (see physionet/test_urls.py)
+TEST_DEFAULTS = {}

--- a/physionet-django/notification/urls.py
+++ b/physionet-django/notification/urls.py
@@ -9,3 +9,9 @@ urlpatterns = [
     path('news/post/<int:news_id>', views.news_by_id, name='news_by_id'),
     path('feed.xml', views.news_rss, name='news_rss'),
 ]
+
+# Parameters for testing URLs (see physionet/test_urls.py)
+TEST_DEFAULTS = {
+    'year': '2018',
+    'news_id': '1',
+}

--- a/physionet-django/physionet/test_urls.py
+++ b/physionet-django/physionet/test_urls.py
@@ -1,0 +1,192 @@
+import os
+import textwrap
+import urllib.parse
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import URLPattern, URLResolver, get_resolver
+from django.utils.regex_helper import normalize
+
+from user.test_views import TestMixin
+
+
+class TestURLs(TestMixin):
+    """
+    Test all application-defined URL patterns.
+
+    This test case walks through the URL patterns that are registered
+    with Django, and tries to perform an ordinary GET request for each
+    pattern.
+
+    Since URL patterns can accept parameters in the URL, the values of
+    these parameters must be set by defining a variable TEST_DEFAULTS
+    in urls.py.
+
+    For example, if urls.py contains:
+
+        urlpatterns = [
+            path('projects/', views.project_home, name='project_home'),
+            path('projects/<project_slug>/', views.project_overview,
+                 name='project_overview'),
+            path('projects/<project_slug>/preview/', views.project_preview,
+                 name='project_preview'),
+        ]
+
+        TEST_DEFAULTS = {
+            'project_slug': 'asdfghjk',
+        }
+
+    then this class would attempt to test the URLs:
+
+        /projects/
+        /projects/asdfghjk/
+        /projects/asdfghjk/preview/
+
+    The values in TEST_DEFAULTS can be overridden for a particular URL
+    pattern by defining a variable TEST_CASES.  This also allows
+    testing the same URL pattern with varying arguments.  For example:
+
+        TEST_CASES = {
+            'project_preview': [
+                {'project_slug': 'one'},
+                {'project_slug': 'two'},
+            ],
+        }
+
+    would result in the following URLs being tested:
+
+        /projects/
+        /projects/asdfghjk/
+        /projects/one/preview/
+        /projects/two/preview/
+
+    Additional special parameters can also be set in TEST_DEFAULTS and
+    TEST_CASES:
+
+    - '_user_' may be set to a username in order to view the page as a
+      logged-in user.
+
+    - '_query_' may be set to a dictionary in order to pass query
+      parameters.
+
+    - '_skip_' may be set to a boolean, or a function returning a
+      boolean, in order to skip testing the given URL under some
+      conditions.
+    """
+    def setUp(self):
+        super().setUp()
+
+        # If this environment variable is set, we will store the
+        # rendered contents of each view in this directory.  For
+        # example, if PHYSIONET_TEST_HTML_DIR is '/tmp/example-html',
+        # then the contents of the URL '/about/' will be saved as
+        # '/tmp/example-html/about/index.html'.
+        self._dump_dir = os.environ.get('PHYSIONET_TEST_HTML_DIR', None)
+        if self._dump_dir is not None:
+            self._dump_dir = os.path.realpath(self._dump_dir)
+
+    def _find_test_cases(self, prefix, resolver):
+        """
+        Enumerate possible URLs from a URLResolver.
+
+        This function walks through the URL patterns defined by the
+        application and returns an iterable of test cases.
+
+        """
+        # Find the example parameters for the current urlconf module.
+        TEST_DEFAULTS = getattr(resolver.urlconf_module, 'TEST_DEFAULTS', None)
+        TEST_CASES = getattr(resolver.urlconf_module, 'TEST_CASES', {})
+
+        for url_pattern in resolver.url_patterns:
+            path = prefix + url_pattern.pattern.regex.pattern.lstrip('^')
+            if isinstance(url_pattern, URLResolver):
+                # include() path: recurse into the included module
+                yield from self._find_test_cases(path, url_pattern)
+
+            elif isinstance(url_pattern, URLPattern):
+                test_cases = TEST_CASES.get(url_pattern.name, {})
+                if TEST_DEFAULTS is None and not test_cases:
+                    continue
+
+                if isinstance(test_cases, dict):
+                    test_cases = [test_cases]
+
+                for pattern, _ in normalize(path):
+                    for args in test_cases:
+                        if TEST_DEFAULTS is not None:
+                            args = {**TEST_DEFAULTS, **args}
+                        yield (resolver.urlconf_module, url_pattern.name,
+                               pattern, args)
+
+    def test_urls(self):
+        resolver = get_resolver()
+        for mod, name, pattern, args in self._find_test_cases('/', resolver):
+            with self.subTest(pattern, **args):
+                try:
+                    url = pattern % args
+                except KeyError as exc:
+                    message = textwrap.dedent("""
+                        Missing {parameter!r} for {name} in {module}
+                        (URL: {pattern!r})
+
+                        Note: you probably need to add something like this in
+                        {source_file}:
+
+                            TEST_DEFAULTS = {{
+                                {parameter!r}: 'something',
+                                ...
+                            }}
+
+                        or else:
+
+                            TEST_CASES = {{
+                                {name!r}: {{
+                                    {parameter!r}: 'something',
+                                    ...
+                                }},
+                                ...
+                            }}
+                    """).lstrip('\n').format(
+                        name=name, parameter=exc.args[0], pattern=pattern,
+                        module=mod.__name__, source_file=mod.__file__)
+                    raise Exception(message) from None
+                self._handle_request(url, **args)
+
+    def _handle_request(self, url, _user_=None, _query_={}, _skip_=False,
+                        **kwargs):
+        if callable(_skip_):
+            _skip_ = _skip_()
+        if _skip_:
+            self.skipTest("skipped by TEST_CASES")
+
+        if _user_ is None:
+            self.client.logout()
+        else:
+            user = get_user_model().objects.get_by_natural_key(_user_)
+            self.client.force_login(user)
+
+        response = self.client.get(url, _query_)
+        self.assertGreaterEqual(response.status_code, 200)
+        self.assertLess(response.status_code, 400)
+
+        if self._dump_dir is not None:
+            path = self._output_filename(url, _query_, response)
+            path = os.path.join(self._dump_dir, path)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'wb') as f:
+                f.write(response.content)
+
+    def _output_filename(self, url, query, response):
+        path = url
+        if path.endswith('/'):
+            default_suffix = {
+                'application/javascript': '.js',
+                'application/json': '.json',
+                'text/html': '.html',
+                'text/plain': '.txt',
+            }
+            content_type = response.get('Content-Type').split(';')[0]
+            path += 'index' + default_suffix.get(content_type, '')
+        if query:
+            path += '?' + urllib.parse.urlencode(query)
+        return path.lstrip('/')

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -1,3 +1,5 @@
+import shutil
+
 import lightwave.views as lightwave_views
 import project.views as project_views
 from django.conf import settings
@@ -80,7 +82,9 @@ urlpatterns = [
 if ProjectFiles().is_lightwave_supported:
     urlpatterns.append(path('lightwave/', include('lightwave.urls')))
     # backward compatibility for LightWAVE
-    urlpatterns.append(path('cgi-bin/lightwave', lightwave_views.lightwave_server))
+    urlpatterns.append(path('cgi-bin/lightwave',
+                            lightwave_views.lightwave_server,
+                            name='lightwave_server_compat'))
 
 if settings.ENABLE_SSO:
     urlpatterns.append(path('', include('sso.urls')))
@@ -90,3 +94,16 @@ if settings.DEBUG:
 
     # debug toolbar
     urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))
+
+# Parameters for testing URLs (see physionet/test_urls.py)
+TEST_DEFAULTS = {
+    'dua_slug': 'physionet-credentialed-health-data-dua',
+    'event_slug': 'iLII4L9jSDFh',
+    'license_slug': 'open-data-commons-attribution-license-v10',
+    'static_url': 'publish',
+}
+TEST_CASES = {
+    'lightwave_server_compat': {
+        '_skip_': lambda: (shutil.which('sandboxed-lightwave') is None),
+    },
+}

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -2232,5 +2232,20 @@
     "expiration_datetime": null,
     "creator": null
   }
+},
+{
+  "model": "project.dataaccessrequest",
+  "pk": 1,
+  "fields": {
+    "request_datetime": "2022-01-31T12:00:00.000Z",
+    "requester": ["tompollard"],
+    "project": 4,
+    "data_use_title": "Exploration of data access requests",
+    "data_use_purpose": "<p>We propose to develop a model to distinguish between real research projects and dummy data that somebody invented for a test case</p>",
+    "status": 0,
+    "decision_datetime": null,
+    "responder": null,
+    "responder_comments": ""
+  }
 }
 ]

--- a/physionet-django/project/management/commands/test_accept_pending_requests.py
+++ b/physionet-django/project/management/commands/test_accept_pending_requests.py
@@ -27,9 +27,11 @@ class TestAcceptPendingRequests(TestMixin):
         get_req('rgmark', 1)
         get_req('aewj', 30)
 
-        self.assertEqual(DataAccessRequest.objects.count(), 2)
+        # there are two access requests created above, plus one
+        # predefined in demo-project.json
+        self.assertEqual(DataAccessRequest.objects.count(), 3)
         self.assertEqual(DataAccessRequest.objects.filter(
-            status=DataAccessRequest.PENDING_VALUE).count(), 2)
+            status=DataAccessRequest.PENDING_VALUE).count(), 3)
 
         accept_pending_requests.Command().handle()
 
@@ -40,4 +42,6 @@ class TestAcceptPendingRequests(TestMixin):
             requester=User.objects.get(username='aewj')).status,
                          DataAccessRequest.ACCEPT_REQUEST_VALUE)
 
-        self.assertEqual(len(mail.outbox), 1)
+        # one of the two access requests above should be approved,
+        # plus one from demo-project.json
+        self.assertEqual(len(mail.outbox), 2)

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -85,5 +85,37 @@ urlpatterns = [
     path('physiobank/database/wfdbcal', views.wfdbcal),
     re_path('^physiobank/database/(?P<project_slug>[\w\-]+)/$', views.redirect_project),
     re_path('^physiotools/(?P<project_slug>[\w\-]+)/$', views.redirect_project),
-    re_path('^challenge/(?P<year>\w+)/$', views.redirect_challenge_project),
+    re_path(r'^challenge/(?P<year>\w+)/$', views.redirect_challenge_project,
+            name='redirect_challenge_project'),
 ]
+
+# Parameters for testing URLs (see physionet/test_urls.py)
+_demo_open_access = {
+    'project_slug': 'demoecg',
+    'version': '10.5.24',
+}
+_demo_access_manager = {
+    'project_slug': 'demoselfmanaged',
+    'version': '1.0.0',
+    '_user_': 'george',
+}
+TEST_DEFAULTS = {
+    **_demo_open_access,
+}
+TEST_CASES = {
+    'anonymous_login': {'anonymous_url': ('pjSJgS45PvCw1y5z8pHOTEJYH4s6nj37'
+                                          'kMGQtJyOMC2RiuBdB0tIk9cx2NId8Thr')},
+    'published_files_panel': {'_query_': {'subdir': 'doc'}},
+    'published_project_subdir': {'subdir': 'doc'},
+    'serve_published_project_file': {'full_file_name': 'Makefile'},
+    'display_published_project_file': {'full_file_name': 'Makefile'},
+
+    'request_data_access': _demo_access_manager,
+    'data_access_request_status_detail': {**_demo_access_manager, 'pk': '1'},
+    'data_access_request_view': {**_demo_access_manager, 'pk': '1'},
+    'data_access_requests_overview': _demo_access_manager,
+    'manage_data_access_reviewers': _demo_access_manager,
+
+    # not implemented in demo
+    'redirect_challenge_project': {'year': '2001', '_skip_': True},
+}

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -20934,5 +20934,22 @@
         "is_active": true,
         "html_content": "<p>This is a sample CoC.</p>"
     }
+},
+{
+  "model": "user.event",
+  "pk": 1,
+  "fields": {
+    "title": "Introduction to Health Widgets",
+    "description": "What is a Health Widget? This course will teach you everything you need to know.",
+    "category": "Course",
+    "host": [
+      "rgmark"
+    ],
+    "added_datetime": "2022-10-24T19:38:27.795Z",
+    "start_date": "2022-10-24",
+    "end_date": "2022-12-20",
+    "slug": "iLII4L9jSDFh",
+    "allowed_domains": null
+  }
 }
 ]


### PR DESCRIPTION
This creates a framework for systematic testing of URL patterns.

What this means:

- The test suite will automatically load every URL defined in
  physionet/urls.py and check that it returns an HTTP status between
  200 and 399.

- When you, as a developer, define a new URL pattern in
  physionet/urls.py, you will need to define some suitable test
  arguments (which may mean that you'll need to add some suitable
  fixture data to demo-*.json.)

This currently applies to `physionet.urls`, `notification.urls`,
`search.urls`, and `export.urls`; eventually I intend to expand it to
all URLs in the site.

There are a few reasons for this, as explained in the commit message:

- ensuring that every view gets a bare minimum of testing

- ability to diff and grep the resulting html

- future use of vnu or other validators (which are not written in
  python and don't play well with the python unittest framework)

Every view *should be possible to test in this way.*  In many cases it
will require adding additional demo fixture data.  This generally
isn't difficult, we just have to work through the views one by one.
