### PR TITLE
JSON export of AWS user accounts

### DIFF
--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -78,6 +78,8 @@ urlpatterns = [
     path('training/process/<int:pk>/', views.training_process, name='training_process'),
     path('users/search/<group>/', views.users_search, name='users_list_search'),
     path('users/<group>/', views.users, name='users'),
+    path('users/aws-access-list.json', views.users_aws_access_list_json,
+         name='users_aws_access_list_json'),
     path('user/manage/<username>/', views.user_management,
         name='user_management'),
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1093,21 +1093,27 @@ def users_aws_access_list_json(request):
     This is a temporary kludge to support an upcoming event (November
     2022).  Don't rely on this function; it will go away.
     """
+    projects_datathon = [
+        "mimiciv-0.3",
+        "mimiciv-0.4",
+        "mimiciv-1.0",
+        "mimiciv-2.0"
+    ]
     published_projects = PublishedProject.objects.all()
-    users_with_awsid = User.objects.filter(
-        cloud_information__aws_id__isnull=False
-    )
+    users_with_awsid = User.objects.filter(cloud_information__aws_id__isnull=False)
     datasets = {}
     datasets['datasets'] = []
 
     for project in published_projects:
         dataset = {}
-        dataset['name'] = project.slug + "-" + project.version
-        dataset['accounts'] = []
-        for user in users_with_awsid:
-            if project.has_access(user):
-                dataset['accounts'].append(user.cloud_information.aws_id)
-        datasets['datasets'].append(dataset)
+        project_name = project.slug + "-" + project.version
+        if project_name in projects_datathon:
+            dataset['name'] = project_name
+            dataset['accounts'] = []
+            for user in users_with_awsid:
+                if project.has_access(user):
+                    dataset['accounts'].append(user.cloud_information.aws_id)
+            datasets['datasets'].append(dataset)
 
     return JsonResponse(datasets)
 


### PR DESCRIPTION

This provides a JSON file of AWS user accounts that can be downloaded by administrators.

The data export code was provided by Chrystinne - I've just taken this code and turned it into a view.

One issue is that this will duplicate the list of users many times over, as there are hundreds of published projects to which *every* user has access.  Instead, you probably only want to include *restricted/credentialed* projects, and more specifically you probably only want to include projects that are *currently mirrored on AWS*.
