### PR TITLE
Display reviewer details for training in the console

### DIFF
--- a/physionet-django/console/templates/console/rejected_training_table.html
+++ b/physionet-django/console/templates/console/rejected_training_table.html
@@ -7,8 +7,9 @@
                 <th>Email</th>
                 <th>Training Type</th>
                 <th>Identity Verified</th>
-                <th>Submitted on</th>
-                <th>Rejected on</th>
+                <th>Submitted</th>
+                <th>Rejected</th>
+                <th>Reviewer</th>
                 <th>View</th>
             </tr>
         </thead>
@@ -20,8 +21,9 @@
                     <td>{{ training.user.email }}</td>
                     <td>{{ training.training_type.name }}</td>
                     <td>{{ training.user.is_credentialed|yesno:"Yes,No" }}</td>
-                    <td>{{ training.application_datetime }}</td>
-                    <td>{{ training.process_datetime }}</td>
+                    <td>{{ training.application_datetime|date }}</td>
+                    <td>{{ training.process_datetime|date }}</td>
+                    <td>{{ training.reviewer.username }}</td>
                     <td><a href="{% url 'training_detail' training.id %}" class="btn btn-sm btn-primary" role="button">View</a></td>
                 </tr>
             {% endfor %}

--- a/physionet-django/console/templates/console/training_detail.html
+++ b/physionet-django/console/templates/console/training_detail.html
@@ -16,7 +16,10 @@
     {% if training.completion_report_url %}
       URL: <a href="{{ training.completion_report_url }}" target="_blank">{{ training.completion_report_url }}</a><br>
     {% endif %}
-    Submitted on: {{ training.application_datetime|date }}<br>
+      Submitted on: {{ training.application_datetime|date }}<br>
+    {% if training.reviewer %}
+      Reviewer: {{ training.reviewer.get_full_name }} ({{ training.reviewer.username }})<br>
+    {% endif %}
     {% if training.reviewer_comments %}
       Reviewer comments: {{ training.reviewer_comments }}
     {% endif %}

--- a/physionet-django/console/templates/console/training_detail.html
+++ b/physionet-django/console/templates/console/training_detail.html
@@ -10,19 +10,15 @@
     {{ training.training_type.name }} Training - {{ training.user.get_full_name }} {% include "user/training_badge.html" %}
   </div>
   <div class="card-body">
-    {% if training.completion_report %}
-      Document: <a href="{% url 'training_report' training.pk %}" target="_blank">Training report</a><br>
-    {% endif %}
-    {% if training.completion_report_url %}
-      URL: <a href="{{ training.completion_report_url }}" target="_blank">{{ training.completion_report_url }}</a><br>
-    {% endif %}
-      Submitted on: {{ training.application_datetime|date }}<br>
-    {% if training.reviewer %}
-      Reviewer: {{ training.reviewer.get_full_name }} ({{ training.reviewer.username }})<br>
-    {% endif %}
-    {% if training.reviewer_comments %}
-      Reviewer comments: {{ training.reviewer_comments }}
-    {% endif %}
+    Document: <a href="{% url 'training_report' training.pk %}" target="_blank">Training report</a><br>
+    URL: <a href="{{ training.completion_report_url }}" target="_blank">{{ training.completion_report_url|default:"No URL." }}</a><br>
+    <br>
+    Submitted on: {{ training.application_datetime|date }}<br>
+    Valid until: {{ training.valid_datetime|default:"End of the world." }}<br>
+    <br>
+    Reviewed on: {{ training.process_datetime|date }}<br>
+    Reviewer: {{ training.reviewer.get_full_name|default:"Unknown." }} ({{ training.reviewer.username|default:"" }})<br>
+    Reviewer comments: {{ training.reviewer_comments|default:"No comments." }}
   </div>
 </div>
 <br>

--- a/physionet-django/console/templates/console/valid_training_table.html
+++ b/physionet-django/console/templates/console/valid_training_table.html
@@ -8,7 +8,7 @@
                     <th>Email</th>
                     <th>Training Type</th>
                     <th>Identity Verified</th>
-                    <th>Valid until</th>
+                    <th>Reviewed</th>
                     <th>View</th>
                 </tr>
             </thead>
@@ -20,13 +20,7 @@
                         <td>{{ training.user.email }}</td>
                         <td>{{ training.training_type.name }}</td>
                         <td>{{ training.user.is_credentialed|yesno:"Yes,No" }}</td>
-                        <td>
-                        {% if training.valid_datetime %}
-                            {{ training.valid_datetime }}
-                        {% else %}
-                            End of the world
-                        {% endif %}
-                        </td>
+                        <td>{{ training.process_datetime|date }}</td>
                         <td><a href="{% url 'training_detail' training.id %}" class="btn btn-sm btn-primary" role="button">View</a></td>
                     </tr>
                 {% endfor %}

--- a/physionet-django/console/templates/console/valid_training_table.html
+++ b/physionet-django/console/templates/console/valid_training_table.html
@@ -9,6 +9,7 @@
                     <th>Training Type</th>
                     <th>Identity Verified</th>
                     <th>Reviewed</th>
+                    <th>Reviewer</th>
                     <th>View</th>
                 </tr>
             </thead>
@@ -21,6 +22,7 @@
                         <td>{{ training.training_type.name }}</td>
                         <td>{{ training.user.is_credentialed|yesno:"Yes,No" }}</td>
                         <td>{{ training.process_datetime|date }}</td>
+                        <td>{{ training.reviewer.username }}</td>
                         <td><a href="{% url 'training_detail' training.id %}" class="btn btn-sm btn-primary" role="button">View</a></td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
This is a minor change to display more information in the console about training reports. Specifically:

- On the "training detail" page for training reports (e.g. http://localhost:8000/console/training/view/1/) we currently display information like submission date, valid until, etc. This pull request adds the date of the review and the reviewer.
- On the approved/valid and rejected lists, the pull request adds the date of the review and the reviewer.