### PR TITLE
Order training details by review date

### DIFF
--- a/physionet-django/console/templates/console/access_request.html
+++ b/physionet-django/console/templates/console/access_request.html
@@ -17,7 +17,7 @@
   <div class="card-body" >
     <strong>Data Use Title:</strong> {{ access_request.data_use_title }} <br>
     <strong>Requester:</strong> {{ access_request.requester.get_full_name }} <br>
-    <strong>Submitted on:</strong> {{ access_request.request_datetime }} <br>
+    <strong>Submitted:</strong> {{ access_request.request_datetime|date }} <br>
     <strong>Status:</strong> {{ access_request.status_text }} <br>
     <strong>Data Use Purpose:</strong> {{ access_request.data_use_purpose|safe }}
     {% if access_request.responder_comments %}

--- a/physionet-django/console/templates/console/review_training_table.html
+++ b/physionet-django/console/templates/console/review_training_table.html
@@ -7,7 +7,7 @@
                 <th>Email</th>
                 <th>Training Type</th>
                 <th>Identity Verified</th>
-                <th>Submitted on</th>
+                <th>Submitted</th>
                 <th>Process Training</th>
             </tr>
         </thead>
@@ -19,7 +19,7 @@
                     <td>{{ training.user.email }}</td>
                     <td>{{ training.training_type.name }}</td>
                     <td>{{ training.user.is_credentialed|yesno:"Yes,No" }}</td>
-                    <td>{{ training.application_datetime }}</td>
+                    <td>{{ training.application_datetime|date }}</td>
                     <td><a href="{% url 'training_process' training.id %}" class="btn btn-sm btn-primary" role="button">Process</a></td>
                 </tr>
             {% endfor %}

--- a/physionet-django/console/templates/console/training_detail.html
+++ b/physionet-django/console/templates/console/training_detail.html
@@ -10,15 +10,24 @@
     {{ training.training_type.name }} Training - {{ training.user.get_full_name }} {% include "user/training_badge.html" %}
   </div>
   <div class="card-body">
-    Document: <a href="{% url 'training_report' training.pk %}" target="_blank">Training report</a><br>
-    URL: <a href="{{ training.completion_report_url }}" target="_blank">{{ training.completion_report_url|default:"No URL." }}</a><br>
+    <h5 class="card-title">Document details</h5>
+    Report: <a href="{% url 'training_report' training.pk %}" target="_blank">Training report</a><br>
+    Link: {% if training.completion_report_url %}
+           <a href="{{ training.completion_report_url }}" target="_blank">{{ training.completion_report_url }}</a>
+         {% else %} No URL available.
+         {% endif %}<br>
     <br>
-    Submitted on: {{ training.application_datetime|date }}<br>
-    Valid until: {{ training.valid_datetime|default:"End of the world." }}<br>
+    <h5 class="card-title">Dates</h5>
+    Submitted: {{ training.application_datetime|date }}<br>
+    Expires: {{ training.valid_datetime|default:"End of the world." }}<br>
     <br>
-    Reviewed on: {{ training.process_datetime|date }}<br>
-    Reviewer: {{ training.reviewer.get_full_name|default:"Unknown." }} ({{ training.reviewer.username|default:"" }})<br>
-    Reviewer comments: {{ training.reviewer_comments|default:"No comments." }}
+    <h5 class="card-title">Reviewer</h5>
+    Reviewed: {{ training.process_datetime|date }}<br>
+    Reviewer: {% if training.reviewer %}
+                {{ training.reviewer.get_full_name }} ({{ training.reviewer.username|default:"" }})
+              {% else %} Reviewer not recorded.
+              {% endif %}<br>
+    Comments: {{ training.reviewer_comments|default:"No comments." }}
   </div>
 </div>
 <br>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1535,9 +1535,9 @@ def training_list(request, status):
 
     training_by_status = {
         'review': review_training,
-        'valid': valid_training,
+        'valid': valid_training.order_by('-process_datetime'),
         'expired': expired_training,
-        'rejected': rejected_training,
+        'rejected': rejected_training.order_by('-process_datetime'),
     }
 
     display_training = training_by_status[status]

--- a/physionet-django/project/templates/project/data_access_request_status.html
+++ b/physionet-django/project/templates/project/data_access_request_status.html
@@ -12,7 +12,7 @@
                 <thead>
                 <tr>
                     <th>Data Use Title</th>
-                    <th>Submitted on</th>
+                    <th>Submitted</th>
                     <th>Status</th>
                     <th>Actions</th>
                 </tr>
@@ -21,7 +21,7 @@
                 {% for access_request in access_requests %}
                     <tr>
                         <td>{{ access_request.data_use_title }}</td>
-                        <td>{{ access_request.request_datetime }}</td>
+                        <td>{{ access_request.request_datetime|date }}</td>
                         <td>
                             {{ access_request.status_text }}{% if access_request.is_accepted %}, valid {% if access_request.valid_until %}until {{ access_request.valid_until }}{% else %}forever {% endif %}{% endif %}
                         </td>

--- a/physionet-django/user/templates/user/edit_training_detail.html
+++ b/physionet-django/user/templates/user/edit_training_detail.html
@@ -13,7 +13,7 @@
     {% if training.completion_report_url %}
       URL: <a href="{{ training.completion_report_url }}" target="_blank">{{ training.completion_report_url }}</a><br>
     {% endif %}
-    Submitted on: {{ training.application_datetime|date }}<br>
+    Submitted: {{ training.application_datetime|date }}<br>
   {% if training.is_review %}
     <hr>
     <form action="{% url 'edit_training_detail' training.pk %}" method="post">


### PR DESCRIPTION
This is a minor change to follow https://github.com/MIT-LCP/physionet-build/pull/1699. Currently the training reports are displayed in the console at http://localhost:8000/console/training/review/ in a random-ish order. This pull request:

- Displays all approved and rejected training reports in the order in which they were reviewed (newest to oldest).
- Makes some minor style changes to the training detail page at (e.g.) http://localhost:8000/console/training/view/3/