### PR TITLE
Fix security issue with direct GCP uploads

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2284,7 +2284,7 @@ def generate_signed_url(request, project_slug):
 
     queryset = ActiveProject.objects.all()
     if not request.user.is_admin:
-        queryset.filter(Q(authors__user=request.user) | Q(editor=request.user))
+        queryset = queryset.filter(Q(authors__user=request.user) | Q(editor=request.user))
 
     project = get_object_or_404(queryset, slug=project_slug)
 


### PR DESCRIPTION
`filter` does not work in place. The new queryset not being assigned means that the project will always be found and any user can change the content of any ActiveProject by generating a signed url.