### PR TITLE
Prompt for affiliation when accepting authorship invitation

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -42,6 +42,7 @@ from project.models import (
 )
 from project.projectfiles import ProjectFiles
 from user.models import User, TrainingType
+from user.validators import validate_affiliation
 
 INVITATION_CHOICES = (
     (1, 'Accept'),
@@ -931,6 +932,12 @@ class InvitationResponseForm(forms.ModelForm):
         fields = ('response',)
         widgets = {'response': forms.Select(choices=INVITATION_CHOICES)}
 
+    affiliation = forms.CharField(max_length=Affiliation.MAX_LENGTH,
+                                  validators=[validate_affiliation],
+                                  label=('Your affiliation (displayed '
+                                         'when the project is published)'),
+                                  required=False)
+
     def clean(self):
         """
         Invitation must be active, user must be invited
@@ -942,6 +949,9 @@ class InvitationResponseForm(forms.ModelForm):
         if self.instance.email not in self.user.get_emails():
             raise forms.ValidationError(
                   'You are not invited.')
+
+        if cleaned_data['response'] and not cleaned_data.get('affiliation'):
+            raise forms.ValidationError('You must specify your affiliation.')
 
         return cleaned_data
 

--- a/physionet-django/project/modelcomponents/authors.py
+++ b/physionet-django/project/modelcomponents/authors.py
@@ -50,7 +50,9 @@ class Affiliation(models.Model):
     """
     Affiliations belonging to an author
     """
-    name = models.CharField(max_length=202, validators=[validate_affiliation])
+    MAX_LENGTH = 202
+    name = models.CharField(max_length=MAX_LENGTH,
+                            validators=[validate_affiliation])
     author = models.ForeignKey('project.Author', related_name='affiliations',
         on_delete=models.CASCADE)
 

--- a/physionet-django/project/static/project/js/project_home.js
+++ b/physionet-django/project/static/project/js/project_home.js
@@ -1,0 +1,19 @@
+$('.author_invitation_response_form').each(function() {
+    var response_select = $(this).find('select[name$="-response"]');
+    var affiliation_label = $(this).find('label[for$="-affiliation"]');
+    var affiliation_input = $(this).find('input[name$="-affiliation"]');
+    function update_response() {
+        if (this.value === '0') { // decline invitation
+            affiliation_label.hide();
+            affiliation_input.hide();
+            affiliation_input.attr('required', false);
+        }
+        else {
+            affiliation_label.show();
+            affiliation_input.show();
+            affiliation_input.attr('required', true);
+        }
+    }
+    response_select.each(update_response);
+    response_select.change(update_response);
+});

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -10,6 +10,10 @@
 <link rel="stylesheet" type="text/css" href="{% static 'project/css/project-home.css' %}">
 {% endblock %}
 
+{% block local_js_bottom %}
+  <script src="{% static 'project/js/project_home.js' %}"></script>
+{% endblock %}
+
 {% block content %}
 <div class="container">
   {% include "message_snippet.html" %}
@@ -65,9 +69,11 @@
                   </button>
                 </div>
 
-                <div class="modal-body">
+                <div class="modal-body author_invitation_response_form">
                   <p>You have been invited to co-author "{{ invitation_response_form.instance.project }}" by {{ invitation_response_form.instance.inviter.get_full_name }}.</p>
                   {{ invitation_response_form }}
+                  {# Note: the affiliation input field will be shown or #}
+                  {# hidden by update_response() in project_home.js #}
                 </div>
 
                 <div class="modal-footer">

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -67,12 +67,7 @@
 
                 <div class="modal-body">
                   <p>You have been invited to co-author "{{ invitation_response_form.instance.project }}" by {{ invitation_response_form.instance.inviter.get_full_name }}.</p>
-                  {{ invitation_response_form }}<br>
-                  {% if user.profile.affiliation %}
-                    <p>Your current affiliation "{{user.profile.affiliation}}" will be added to the project. To edit your affiliation, or to add an additional affiliation, please visit the project author page.</p>
-                  {% else %}
-                    <p><font color='red'>After accepting, please add your affiliation to the project author page.</font></p>
-                  {% endif %}
+                  {{ invitation_response_form }}
                 </div>
 
                 <div class="modal-footer">

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -931,6 +931,7 @@ class TestInteraction(TestMixin):
             data = {
                 'form-TOTAL_FORMS': ['1'], 'form-MAX_NUM_FORMS': ['1000'],
                 'form-0-response': [str(inv_response)], 'form-MIN_NUM_FORMS': ['0'],
+                'form-0-affiliation': ['MIT' if inv_response else ''],
                 'form-INITIAL_FORMS': ['1'],
                 'form-0-id': [str(iid)], 'invitation_response': [str(iid)]
             }

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -159,23 +159,35 @@ def process_invitation_response(request, invitation_response_formset):
             # same user, project, and invitation type
             invitation = invitation_response_form.instance
             project = invitation.project
-            invitations = AuthorInvitation.objects.filter(is_active=True,
-                email__in=user.get_emails(), project=project)
+            invitations = AuthorInvitation.objects.filter(
+                is_active=True,
+                email__in=user.get_emails(),
+                project=project,
+            )
             affected_emails = [i.email for i in invitations]
-            invitations.update(response=invitation.response,
-                response_datetime=timezone.now(), is_active=False)
+            invitations.update(
+                response=invitation.response,
+                response_datetime=timezone.now(),
+                is_active=False,
+            )
             # Create a new Author object
             author_imported = False
             if invitation.response:
-                author = Author.objects.create(project=project, user=user,
+                author = Author.objects.create(
+                    project=project,
+                    user=user,
                     display_order=project.authors.count() + 1,
-                    corresponding_email=user.get_primary_email())
+                    corresponding_email=user.get_primary_email(),
+                )
                 author_imported = author.import_profile_info()
 
             notification.invitation_response_notify(invitation,
                                                     affected_emails)
-            messages.success(request,'The invitation has been {0}.'.format(
-                notification.RESPONSE_ACTIONS[invitation.response]))
+            messages.success(
+                request,
+                'The invitation has been {0}.'.format(
+                    notification.RESPONSE_ACTIONS[invitation.response])
+            )
             if not author_imported and invitation.response:
                 return True, project
             elif invitation.response:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -197,6 +197,11 @@ def process_invitation_response(request, invitation_response_formset):
                 return project
             else:
                 return None
+    else:
+        # form is not valid
+        messages.error(request,
+                       utility.get_form_errors(invitation_response_form))
+        return None
 
 
 @login_required

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -263,6 +263,9 @@ def project_home(request):
 
     invitation_response_formset = InvitationResponseFormSet(
         queryset=AuthorInvitation.get_user_invitations(user))
+    invitation_response_formset.form_kwargs['initial'] = {
+        'affiliation': user.profile.affiliation
+    }
 
     data_access_requests = DataAccessRequest.objects.filter(
         project__in=[p for p in published_projects if p.can_approve_requests(user)],

--- a/physionet-django/sso/tests/test_views.py
+++ b/physionet-django/sso/tests/test_views.py
@@ -6,7 +6,7 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import path, reverse
 from physionet.urls import urlpatterns
-from user.models import User
+from user.models import Profile, User
 
 authentication_backends = settings.AUTHENTICATION_BACKENDS + ['sso.auth.RemoteUserBackend']
 
@@ -27,8 +27,14 @@ class TestViews(TestCase):
         self.inactive_user = User.objects.create(
             username='ssoinactive', email='sso_inactive@mit.edu', sso_id='inactive_remote_id'
         )
+        Profile.objects.create(
+            user=self.inactive_user, first_names='sso', last_name='inactive'
+        )
         self.active_user = User.objects.create(
             username='ssoactive', email='sso_active@mit.edu', sso_id='active_remote_id', is_active=True
+        )
+        Profile.objects.create(
+            user=self.active_user, first_names='sso', last_name='active'
         )
 
     def tearDown(self):


### PR DESCRIPTION
All authors of a project have to provide their name and (one or more) affiliations.  Sometimes people forget to enter their affiliation or don't understand that it's required (remember, this person may not be the submitting author and may not know anything at all about PhysioNet or the platform.)

Putting explanatory text like "After accepting, please add your affiliation to the project author page" is better than nothing but not a great solution.

Here we try to make it simpler by ensuring that they *have* to enter an affiliation (or confirm the affiliation, if they previously set an affiliation in their user profile) as part of the same form where they accept the authorship invitation.
