### PR TITLE
Login ux upgrade

### DIFF
--- a/physionet-django/physionet/fixtures/login-instruction-static-page.json
+++ b/physionet-django/physionet/fixtures/login-instruction-static-page.json
@@ -4,7 +4,7 @@
     "pk": 3,
     "fields": {
       "title": "Login Instructions",
-      "url": "/login/"
+      "url": "/about/login/"
     }
   }
 ]

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -79,7 +79,7 @@ class SSOLoginView(auth_views.LoginView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         try:
-            login_static_page = StaticPage.objects.get(url='/login/')
+            login_static_page = StaticPage.objects.get(url='/about/login/')
             instruction_sections = Section.objects.filter(static_page=login_static_page)
         except StaticPage.DoesNotExist:
             instruction_sections = []


### PR DESCRIPTION
Fixed Login Instructions under the "Login" tab on Login page

**Context**
Around 1 months ago  looks like Harry added dynamic page feature and made it so that all the static page begin with this format `/about/static-page-url`. This seems to have broken the Login instruction static page and it was no longer appearing under the SSO login page.[I found this when working on a task to add an editable Login Instructions under the SSO Login Container]

**Changes**

- I only fixed the URL to login static page and We already seem to have the  rest if the feature that's let's us add login instructions under the Login Section for SSO login. A fixture `login-instruction-static-page.json` already exists which automatically creates a static page called Login instructions.
-  To add login instructions, Admin can login to admin console and add the instruction content on the Static page called Login instructions. The content will be displayed on the login page.

