### PR TITLE
Updated gitattributes to enforce LF line endings for Docker  and *.sh…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.py    diff=python
+*.sh text eol=lf
+Dockerfile text eol=lf


### PR DESCRIPTION


Issue: Docker build fails on Windows due to CRLF line endings in shell scripts and Dockerfile. Looks like this can be fixed if we enforce LF line endings for *.sh and Dockerfile files.

This change should prevent the issue of the build failing on Windows due to the line endings being CRLF instead of LF as git will automatically convert the line endings to LF when the files are checked out.

I tested by manually changing the line endings and was able to build a docker image successfully