### PR TITLE
Refactoring of GenerateSignedUrl(file upload process)

### DIFF
--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1216,4 +1216,3 @@ class TestGenerateSignedUrl(TestMixin):
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
 
-

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1214,5 +1214,3 @@ class TestGenerateSignedUrl(TestMixin):
         media_mock.assert_not_called()
         signed_url_mock.assert_not_called()
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
-
-

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2309,7 +2309,7 @@ def generate_signed_url(request, project_slug):
         return JsonResponse({'detail': 'The filename contains whitespaces.'}, status=400)
 
     queryset = ActiveProject.objects.all()
-    if not request.user.is_admin:
+    if not request.user.groups.filter(name='Admin').exists():
         queryset = queryset.filter(Q(authors__user=request.user) | Q(editor=request.user))
 
     project = get_object_or_404(queryset, slug=project_slug)


### PR DESCRIPTION
**Context:** Currently the file upload process allows any user who has access to admin console to upload the files. This is a security issue. We need to restrict the file upload process to only the users who have access to  either of the following roles:
1. Project Author
2. Project Editor
3. System Admin

My change will restrict the access to unauthorized users. i also added a test case that checks and verifies the access to the file upload process.


Few further concerns not addressed on this PR but something to think about (from the TRA)
1. Should we prevent the  authors/editor from uploading file if the project has been published?
2. Should we prevent the authors from uploading file after the project has been submitted for review?