### PR TITLE
Removes hardcoded frontpage buttons. Fixes #1720.

### DIFF
--- a/physionet-django/physionet/fixtures/demo-physionet.json
+++ b/physionet-django/physionet/fixtures/demo-physionet.json
@@ -143,9 +143,36 @@
   "model": "physionet.frontpagebutton",
   "pk": 1,
   "fields": {
-    "label": "About",
-    "url": "/about/",
+    "label": "Data",
+    "url": "/about/database/",
     "order": 1
+  }
+},
+{
+  "model": "physionet.frontpagebutton",
+  "pk": 2,
+  "fields": {
+    "label": "Software",
+    "url": "/about/software/",
+    "order": 2
+  }
+},
+{
+  "model": "physionet.frontpagebutton",
+  "pk": 3,
+  "fields": {
+    "label": "Challenges",
+    "url": "/about/challenge/",
+    "order": 3
+  }
+},
+{
+  "model": "physionet.frontpagebutton",
+  "pk": 4,
+  "fields": {
+    "label": "Tutorials",
+    "url": "/about/tutorial/",
+    "order": 4
   }
 }
 ]

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -38,14 +38,9 @@
       </p>
       <br>
       <div>
-        <a href="{% url 'database_overview' %}">Data</a>
-        <a href="{% url 'software_overview' %}">Software</a>
-        <a href="{% url 'challenge_overview' %}">Challenges</a>
-        <a href="{% url 'tutorial_overview' %}">Tutorials</a>
         {% for button in front_page_buttons %}
             <a href="{{ button.url }}">{{ button.label|title }}</a>
         {% endfor %}
-        <!-- <a href="">News</a> -->
       </div>
     </div>
     <a href="#latest">


### PR DESCRIPTION
Currently there are several hardcoded frontpage buttons:

![Screen Shot 2022-11-30 at 11 06 14 AM](https://user-images.githubusercontent.com/822601/204848520-920db9b8-5147-47f5-adc1-5a2feec43f25.png)

These hardcoded buttons are unnecessary, now that the buttons are handled dynamically (thanks to https://github.com/MIT-LCP/physionet-build/pull/1706). 

This pull request addresses #1720 by:
- Removing the hardcoded buttons
- Adding the current buttons (data, software, challenges, tutorials) to the fixtures.