### PR TITLE
Updated the File Upload View to make it consistent with the file upload process in UI + minor bug fix

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -605,3 +605,20 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         ProjectFiles().publish_complete(self, published_project)
 
         return published_project
+
+
+    def is_editable_by(self, user):
+        """
+        Whether the user can edit the project
+        """
+        if not user.has_perm('project.change_activeproject'):
+            project_authors = [author.user for author in self.author_list()]
+            if user in project_authors:
+                if user != self.submitting_author().user or not self.author_editable():
+                    return False
+            elif user == self.editor:
+                if not self.copyeditable():
+                    return False
+            else:
+                return False
+        return True

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -606,7 +606,6 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
 
         return published_project
 
-
     def is_editable_by(self, user):
         """
         Whether the user can edit the project

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1228,8 +1228,8 @@ class TestGenerateSignedUrl(TestMixin):
                         }
                         ),
                 self.valid_data,
-                format='json'
-                )
+                format='json')
+
             self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
         # awaiting editor decision

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1219,12 +1219,12 @@ class TestGenerateSignedUrl(TestMixin):
         self.client.login(**self.user_credentials)
 
         # Non-submitting author
-        self.client.login(username='aewj@mit.edu', password='Tester11!')
+        self.client.login(username='george@mit.edu', password='Tester11!')
         with self.subTest('Non Submitting author can not upload files.'):
             response = self.client.post(
                 reverse('generate_signed_url',
                         kwargs={
-                            "project_slug": ActiveProject.objects.get(title='MIMIC-III Clinical Database').slug
+                            "project_slug": ActiveProject.objects.get(title='Demo software project').slug
                         }
                         ),
                 self.valid_data,

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1213,7 +1213,7 @@ class TestGenerateSignedUrl(TestMixin):
 
         media_mock.assert_not_called()
         signed_url_mock.assert_not_called()
-        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
     def test_invalid_access(self):
         self.client.login(**self.user_credentials)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2313,11 +2313,12 @@ def generate_signed_url(request, project_slug):
 
     if not request.user.has_perm('project.change_activeproject'):
         project_authors = [author.user for author in project.author_list()]
-        if request.user in project_authors and (request.user != project.submitting_author()
-                                                or not project.author_editable()):
-            return JsonResponse({'detail': 'Author cannot edit the project right now.'}, status=403)
-        elif request.user == project.editor and not project.copyeditable():
-            return JsonResponse({'detail': 'Editor cannot edit the project right now.'}, status=403)
+        if request.user in project_authors:
+            if request.user != project.submitting_author().user or not project.author_editable():
+                return JsonResponse({'detail': 'Author cannot edit the project right now.'}, status=403)
+        elif request.user == project.editor:
+            if not project.copyeditable():
+                return JsonResponse({'detail': 'Editor cannot edit the project right now.'}, status=403)
         else:
             return JsonResponse({'detail': 'User is not authorized to edit the project.'}, status=403)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2313,8 +2313,7 @@ def generate_signed_url(request, project_slug):
 
     if not request.user.groups.filter(name='Admin').exists():
         # submitting authors can only upload files when the project is in the 0:'Not submitted'
-        # or 30:'Revisions requested'
-        # status
+        # or 30:'Revisions requested' status
         author_acceptable_statuses = (0, 30,)
 
         # editors can only upload files when the project is in the 40:'Submission accepted; awaiting editor copyedits'

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2310,7 +2310,8 @@ def generate_signed_url(request, project_slug):
 
     queryset = ActiveProject.objects.all()
     if not request.user.groups.filter(name='Admin').exists():
-        queryset = queryset.filter(Q(authors__user=request.user) | Q(editor=request.user)).distinct()
+        queryset = queryset.filter(Q(authors__user=request.user) |
+                                   Q(editor=request.user)).distinct('slug').order_by('slug')
 
     project = get_object_or_404(queryset, slug=project_slug)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2310,9 +2310,23 @@ def generate_signed_url(request, project_slug):
 
     queryset = ActiveProject.objects.all()
     if not request.user.groups.filter(name='Admin').exists():
-        queryset = queryset.filter(Q(authors__user=request.user) | Q(editor=request.user))
+        queryset = queryset.filter(Q(authors__user=request.user) | Q(editor=request.user)).distinct()
 
     project = get_object_or_404(queryset, slug=project_slug)
+
+    # submitting authors can only upload files when the project is in the 0:'Not submitted' or 30:'Revisions requested'
+    # status
+    author_acceptable_statuses = [0, 30]
+    if [i.user for i in project.authors.all()] and \
+        (request.user != project.authors.filter(is_submitting=True).first().user or
+        project.submission_status not in author_acceptable_statuses):
+        return JsonResponse({'detail': 'Author cannot edit the project right now.'}, status=403)
+
+    # editors can only upload files when the project is in the 40:'Submission accepted; awaiting editor copyedits'
+    # status
+    editor_acceptable_statuses = [40]
+    if request.user == project.editor and project.submission_status not in editor_acceptable_statuses:
+        return JsonResponse({'detail': 'Editor cannot edit the project right now.'}, status=403)
 
     if size > project.get_storage_info().remaining:
         return JsonResponse({'detail': 'The file size cannot be greater than the remaining space.'}, status=400)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2311,16 +2311,8 @@ def generate_signed_url(request, project_slug):
     queryset = ActiveProject.objects.all()
     project = get_object_or_404(queryset, slug=project_slug)
 
-    if not request.user.has_perm('project.change_activeproject'):
-        project_authors = [author.user for author in project.author_list()]
-        if request.user in project_authors:
-            if request.user != project.submitting_author().user or not project.author_editable():
-                return JsonResponse({'detail': 'Author cannot edit the project right now.'}, status=403)
-        elif request.user == project.editor:
-            if not project.copyeditable():
-                return JsonResponse({'detail': 'Editor cannot edit the project right now.'}, status=403)
-        else:
-            return JsonResponse({'detail': 'User is not authorized to edit the project.'}, status=403)
+    if not project.is_editable_by(request.user):
+        return JsonResponse({'detail': 'User is not authorized to edit the project at this moment.'}, status=403)
 
     if size > project.get_storage_info().remaining:
         return JsonResponse({'detail': 'The file size cannot be greater than the remaining space.'}, status=400)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2317,9 +2317,9 @@ def generate_signed_url(request, project_slug):
     # submitting authors can only upload files when the project is in the 0:'Not submitted' or 30:'Revisions requested'
     # status
     author_acceptable_statuses = [0, 30]
-    if [i.user for i in project.authors.all()] and \
-        (request.user != project.authors.filter(is_submitting=True).first().user or
-        project.submission_status not in author_acceptable_statuses):
+    project_authors = [author.user for author in project.authors.all()]
+    if project_authors and (request.user != project.authors.filter(is_submitting=True).first().user
+                            or project.submission_status not in author_acceptable_statuses):
         return JsonResponse({'detail': 'Author cannot edit the project right now.'}, status=403)
 
     # editors can only upload files when the project is in the 40:'Submission accepted; awaiting editor copyedits'

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2310,8 +2310,9 @@ def generate_signed_url(request, project_slug):
 
     queryset = ActiveProject.objects.all()
     if not request.user.groups.filter(name='Admin').exists():
-        queryset = queryset.filter(Q(authors__user=request.user) |
-                                   Q(editor=request.user)).distinct('slug').order_by('slug')
+        queryset = queryset.filter(
+            Q(authors__user=request.user) | Q(editor=request.user)
+        ).distinct('slug').order_by('slug')
 
     project = get_object_or_404(queryset, slug=project_slug)
 


### PR DESCRIPTION

**Context1:** This is a follow up to pr #1721. Currently, the file upload view doesnot check the project submission status and allows the user to upload the file even if the project is not in the submission phase where upload is permitted. The change aims to increase the security of view in case a user with access to the platform tries to maliciously upload a file to the project.

**Explanation:**
On the UI, Authors can only upload files if the project is not submitted or in revision state. and Editors can only upload files if the project is accepted.

But this is not the case with the file upload view. Before this change a malicious user can bypass the UI and upload files by sending the request directly.(See TRA report for more details)

**Context 2(minor bug):** It seems sometime, django filters with return duplicate objects when we have or filter, Q and one to many relation This causes the file upload view to throw a `MultipleObjectsReturned` exception on the get_object_or_404 call.So adding a distinct() call to the queryset fixes the issue. Here is a related issue on stackoverflow: https://stackoverflow.com/questions/34468505/why-is-django-queryset-with-q-expression-returning-duplicate-values

To replicate the bug, please call the generate_signed_url view for project ` Demo software project` by user `tpollard@mit.edu`
In Summary(context2): `get_object_or_404(queryset, slug=project_slug)` throws `MultipleObjectsReturned` error because the output of `queryset.filter(Q(authors__user=request.user) | Q(editor=request.user))` had duplicate projects

Note: Although it would have been a good idea to open 2 PR's, i did both changes in single PR because on of the test case(test_invalid_access) i added will fail with out the bug fix