### PR TITLE
Remove hardcoded tutorial content

### DIFF
--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -464,9 +464,9 @@ class TestStaticPage(TestMixin):
         super().setUp()
         self.client.login(username='admin', password='Tester11!')
         self.page_1 = StaticPage.objects.create(
-            title="Testing Page 1", url="/about/page/testing/", nav_bar=True, nav_order=3)
+            title="Testing Page 1", url="/about/page/testing/", nav_bar=True, nav_order=10)
         self.page_2 = StaticPage.objects.create(
-            title="Testing Page 2", url="/about/page/testing/2/", nav_bar=True, nav_order=4)
+            title="Testing Page 2", url="/about/page/testing/2/", nav_bar=True, nav_order=11)
 
     def test_static_page_add_get(self):
         """test the get verb"""

--- a/physionet-django/physionet/fixtures/demo-physionet.json
+++ b/physionet-django/physionet/fixtures/demo-physionet.json
@@ -20,6 +20,16 @@
   }
 },
 {
+  "model": "physionet.staticpage",
+  "pk": 3,
+  "fields": {
+    "title": "Tutorials",
+    "url": "/about/tutorial/",
+    "nav_bar": false,
+    "nav_order": 3
+  }
+},
+{
   "model": "physionet.section",
   "pk": 1,
   "fields": {
@@ -137,6 +147,16 @@
     "title": "Contact us",
     "content": "<p>PhysioNet is maintained by researchers and engineers at the MIT Laboratory for Computational Physiology. \n     To reach us, email <a href=\"mailto:contact@physionet.org\">contact@physionet.org</a>.</p>",
     "order": 6
+  }
+},
+{
+  "model": "physionet.section",
+  "pk": 13,
+  "fields": {
+    "static_page": 3,
+    "title": "Tutorials",
+    "content": "<p>Our tutorials are intended to provide hands-on introductions to the data and software hosted here.</p>",
+    "order": 1
   }
 },
 {

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -58,8 +58,6 @@ urlpatterns = [
         name='software_overview'),
     path('about/challenge/', views.challenge_overview,
         name='challenge_overview'),
-    path('about/tutorial/', views.tutorial_overview,
-        name='tutorial_overview'),
 
     # detailed pages related to the challenges overview
     path('about/challenge/moody-challenge-overview', views.moody_challenge_overview,

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -225,13 +225,6 @@ def static_view(request, static_url=None):
     return render(request, 'about/static_template.html', params)
 
 
-def tutorial_overview(request):
-    """
-    Temporary content overview
-    """
-    return render(request, 'about/tutorial_index.html')
-
-
 @login_required
 def event_home(request):
     """

--- a/physionet-django/templates/about/about_physionet.html
+++ b/physionet-django/templates/about/about_physionet.html
@@ -23,11 +23,8 @@
         physiologically significant events using both classical techniques and novel methods based on statistical physics and nonlinear dynamics, interactive display and characterization of signals, creation of new databases, simulation of physiologic and other signals, quantitative evaluation and comparison of analysis methods, and analysis of nonequilibrium and nonstationary processes.</p>
       </li>
       <li>
-        <p>A  <a href="{% url 'tutorial_overview' %}">collection of popular tutorials and educational materials</a>,  offering expert guidance in approaches for exploring and analysing health data
-          and physiologic signals. A unifying theme for these resources
-          is a focus on the extraction of “hidden” information from biomedical data,
-          providing information that may have diagnostic or prognostic value in medicine,
-          or explanatory or predictive power in basic research.</p>
+        <p>A collection of popular tutorials and educational materials, offering expert guidance in approaches for exploring and analysing health data
+          and physiologic signals.</p>
       </li>
     </ul>
     <p>


### PR DESCRIPTION
Currently the information displayed at http://localhost:8000/about/tutorial/ is hardcoded. We have a hardcoded URL, a hardcoded view, and a hardcoded template. All of these are unnecessary now that static page content is managed via the database.

This pull request removes the hardcoded tutorial content and adds a fixture with a (sparsely populated!) demo tutorial page. 
Benefits of this change are: (1) improved flexibility for editing tutorial content and (2) generalizability to non-PhysioNet repos.

When the changes are pushed to our live server, we will need to manually recreate the tutorials page using the static page tool in the admin console.