### PR TITLE
Update the is_editable_by_func to make sure only authorized user can edit the project

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -610,7 +610,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Whether the user can edit the project
         """
-        if user == self.submitting_author().user:
+        if self.authors.filter(is_submitting=True, user=user).exists():
             if self.author_editable():
                 return True
         elif user == self.editor:

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -611,11 +611,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         Whether the user can edit the project
         """
         if user == self.submitting_author().user:
-            if not self.author_editable():
-                return False
+            if self.author_editable():
+                return True
         elif user == self.editor:
-            if not self.copyeditable():
-                return False
-        else:
-            return False
-        return True
+            if self.copyeditable():
+                return True
+        return False

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -610,14 +610,12 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Whether the user can edit the project
         """
-        if not user.has_perm('project.change_activeproject'):
-            project_authors = [author.user for author in self.author_list()]
-            if user in project_authors:
-                if user != self.submitting_author().user or not self.author_editable():
-                    return False
-            elif user == self.editor:
-                if not self.copyeditable():
-                    return False
-            else:
+        if user == self.submitting_author().user:
+            if not self.author_editable():
                 return False
+        elif user == self.editor:
+            if not self.copyeditable():
+                return False
+        else:
+            return False
         return True


### PR DESCRIPTION


After discussion with Tom, it looks like only submitting author, editors should be able to edit the project(when the project is on correct submission status i.e is before submission and during revision for author; and copyedit stage for editor) The previous implementation was not correct, it let Admin make changes to project even when they were not assigned to project