### PR TITLE
Adds edit events functionality on events home page for active events.

### DIFF
--- a/physionet-django/templates/event_home.html
+++ b/physionet-django/templates/event_home.html
@@ -48,7 +48,38 @@
           <form action="" method="post" class="form-signin">
             {% csrf_token %}
             {% include "form_snippet.html" with form=event_form %}
-            <button class="btn btn-primary btn-fixed" name="add-event" type="submit">Add Event</button>
+            <button class="btn btn-primary btn-fixed" name="add-event" type="submit">Add event</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    $('edit-event-modal').on('show.bs.modal', function(e) {
+    
+        //get data-id attribute of the clicked element -->
+        var eventId = $(e.relatedTarget).data('event-id');
+    
+        //populate the textbox -->
+        $(e.currentTarget).find('input[name="eventId"]').val(eventId);
+    });
+  </script>
+
+  <div class="modal fade" id="edit-event-modal" tabindex="-1" role="dialog" aria-labelledby="edit-event-modal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Edit Event</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="container">
+          <form action="" method="post" class="form-signin">
+            {% csrf_token %}
+            {% include "form_snippet.html" with form=event_form %}
+            <button class="btn btn-primary btn-fixed" name="edit-event" type="submit">Edit event</button>
           </form>
         </div>
       </div>
@@ -70,10 +101,11 @@
             <strong>Host: {{ event.host.get_full_name }} </strong><br>
             <small>Created: {{ event.added_datetime|date }}. Number of participants: {{ event.participants.all|length }} </small><br>
             <small>Start Date: {{ event.start_date }}. End Date: {{ event.end_date }}.</small><br>
-            {% if event.host == user %}
+            {% if event.host == user %} 
               <small>Share the class code: {{ url_prefix }}{% url 'event_add_participant' event.slug %} </small><br>
               </p>
               <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
+              <button class="btn btn-sm btn-secondary" data-toggle ="modal" data-target="#edit-event-modal-{{ event.id }}" data-event-id="{{ event.id }}">Edit event</button>
             {% endif %}
           </li>
       {% empty %}


### PR DESCRIPTION
Hosts have the ability to add events when creating new events. This pull request adds an edit event functionality to active events to enable editing of the form content including Event Name, Description, Start Date, End Date, Category and Allowed fields.

