### PR TITLE
Set correct corresponding email when creating a new version

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -428,7 +428,9 @@ class NewProjectVersionForm(forms.ModelForm):
                 or emails.filter(is_public=True).first()
                 or p_author.user.get_primary_email()
             )
-            author = Author.objects.create(project=project, user=p_author.user,
+            author = Author.objects.create(
+                project=project,
+                user=p_author.user,
                 display_order=p_author.display_order,
                 is_submitting=p_author.is_submitting,
                 is_corresponding=p_author.is_corresponding,

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -418,11 +418,21 @@ class NewProjectVersionForm(forms.ModelForm):
 
         # Copy over the author/affiliation objects
         for p_author in self.latest_project.authors.all():
+            if p_author.is_corresponding:
+                old_address = p_author.corresponding_email
+            else:
+                old_address = None
+            emails = p_author.user.associated_emails.filter(is_verified=True)
+            corresponding_email = (
+                emails.filter(email__iexact=old_address).first()
+                or emails.filter(is_public=True).first()
+                or p_author.user.get_primary_email()
+            )
             author = Author.objects.create(project=project, user=p_author.user,
                 display_order=p_author.display_order,
                 is_submitting=p_author.is_submitting,
                 is_corresponding=p_author.is_corresponding,
-                corresponding_email=self.user.get_primary_email(),)
+                corresponding_email=corresponding_email)
 
             for p_affiliation in p_author.affiliations.all():
                 Affiliation.objects.create(name=p_affiliation.name,

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -318,6 +318,13 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                 self.integrity_errors.append('Author {0} has not fill in name'.format(author.user.username))
             if not author.affiliations.all():
                 self.integrity_errors.append('Author {0} has not filled in affiliations'.format(author.user.username))
+            if author.is_corresponding:
+                if not author.user.associated_emails.filter(
+                        is_verified=True,
+                        email=author.corresponding_email).exists():
+                    self.integrity_errors.append(
+                        f'Corresponding author {author.user.username} '
+                        'has not set a corresponding email')
 
         # Metadata
         for attr in ActiveProject.REQUIRED_FIELDS[self.resource_type.id]:


### PR DESCRIPTION
If you are the submitting author of a project and not the corresponding author, then when you create a new version, the new version's corresponding author will have the name of the original corresponding author, and *the submitting author's primary email address*.  This is issue #1623.

This pull also prevents such broken projects from being submitted/published.  This is issue #1419.

There are 21 published projects, and likely many active projects as well, with nonsensical corresponding authors, which will have to be fixed manually.

This does **not** fix the other problems with corresponding emails, such as the initial selection of corresponding email (#1158) or the fact that people can delete addresses while the project is in submission (#1159).
