### PR TITLE
Show source context for flake errors in workflows

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -112,10 +112,39 @@ jobs:
         run: |
           git rev-parse --verify ${{ github.event.pull_request.base.sha }}
           git diff -U0 ${{ github.event.pull_request.base.sha }} HEAD | \
-              flake8 --diff
+              flake8 --diff | \
+              perl -ne '
+                print; if (/^([^:]+):(\d+):(\d+):/) {
+                  $path = $1; $line = $2; $col = $3;
+                  open F, $path or die;
+                  print "\n";
+                  while (<F>) {
+                    next if $. < $line - 2;
+                    print " $_";
+                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
+                  }
+                  close F;
+                  $status = 1;
+                }
+                END { exit $status }'
 
       - name: Run code style check relative to local dev branch
         if: github.event_name != 'pull_request'
         run: |
           git fetch origin dev
-          git diff -U0 origin/dev HEAD | flake8 --diff 
+          git diff -U0 origin/dev HEAD | \
+              flake8 --diff | \
+              perl -ne '
+                print; if (/^([^:]+):(\d+):(\d+):/) {
+                  $path = $1; $line = $2; $col = $3;
+                  open F, $path or die;
+                  print "\n";
+                  while (<F>) {
+                    next if $. < $line - 2;
+                    print " $_";
+                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
+                  }
+                  close F;
+                  $status = 1;
+                }
+                END { exit $status }'


### PR DESCRIPTION
In the GitHub workflow, when flake8 shows an error, display the actual source that it's complaining about.

This might make it easier to understand and fix such errors.

Before:
```
physionet-django/project/views.py:1046:26: E225 missing whitespace around operator
physionet-django/project/views.py:1050:63: E128 continuation line under-indented for visual indent
physionet-django/project/views.py:1069:25: E131 continuation line unaligned for hanging indent
```

After:
```
physionet-django/project/views.py:1046:26: E225 missing whitespace around operator

         elif 'submit_upload_agreement' in request.POST:
             try:
                 agreement= DataUploadAgreement.objects.get(project=project)
                          ^

physionet-django/project/views.py:1050:63: E128 continuation line under-indented for visual indent

                 agreement = None
             upload_agreement_form = forms.UploadedAgreementDataForm(project=project,
                                                               data=request.POST, instance=agreement)
                                                               ^

physionet-django/project/views.py:1069:25: E131 continuation line unaligned for hanging indent

         maintenance_message = settings.SYSTEM_MAINTENANCE_MESSAGE or (
             "The site is currently undergoing maintenance, and project "
                         "files cannot be edited.  Please try again later.")
                         ^

```
