### PR TITLE
Remove hardcoded "quality guidelines"

### DIFF
--- a/physionet-django/project/templates/project/project_overview.html
+++ b/physionet-django/project/templates/project/project_overview.html
@@ -37,14 +37,6 @@
    <a href="{% url 'static_view' static_url='publish' %}#author_guidelines"> author
 guidelines</a>.</p>
 <hr>
-<h3>Quality Guidelines</h3>
-<p>Your contribution must satisfy the following guidelines:</p>
-{% if project.resource_type.id == 0 %}
-  {% include "about/data_quality_guidelines.html" %}
-{% else %}
-  {% include "about/software_quality_guidelines.html" %}
-{% endif %}
-<hr>
 {% if is_submitting %}
   <div class="btn-container-rsp btn-left">
     <button type="button" class="btn btn-danger btn-rsp" data-toggle="modal" data-target="#delete-project-modal" {% if under_submission %}disabled title="Cannot delete while under submission"{% endif %}>Delete Project</button>

--- a/physionet-django/project/templates/project/project_proofread.html
+++ b/physionet-django/project/templates/project/project_proofread.html
@@ -6,24 +6,7 @@
 <h2 class="form-signin-heading">7. Project Proofread</h2>
 <hr>
 {% include "about/proofread.html" %}
-<p>In addition, ensure that the following quality assurance guidelines are met:</p>
 
-{# data guidelines #}
-{% if project.resource_type.id == 0 %}
-  {% include "about/data_quality_guidelines.html" %}
-{# software guidelines #}
-{% elif project.resource_type.id == 1 %}
-  {% include "about/software_quality_guidelines.html" %}
-{# challenge guidelines #}
-{% elif project.resource_type.id == 2 %}
-  {% include "about/challenge_quality_guidelines.html" %}
-{# model guidelines #}
-{% elif project.resource_type.id == 3 %}
-  {% include "about/model_quality_guidelines.html" %}
-{# other guidelines #}
-{% else %}
-  {% include "about/software_quality_guidelines.html" %}
-{% endif %}
 <hr>
 <div class="btn-container-rsp">
 	<a id="view_preview" class="btn btn-primary btn-rsp" href="{% url 'project_preview' project.slug %}" role="button">View Project Preview</a>

--- a/physionet-django/templates/about/challenge_quality_guidelines.html
+++ b/physionet-django/templates/about/challenge_quality_guidelines.html
@@ -1,9 +1,0 @@
-<ul>
-  <li>The challenge is produced in a sound manner.</li>
-  <li>The challenge is adequately described.</li>
-  <li>Any challenge files are provided in an open format.</li>
-  <li>Any challenge files are machine readable.</li>
-  <li>All the information needed for reuse is present.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
-  <li>The content is suitable for {{ SITE_NAME }}.</li>
-</ul>

--- a/physionet-django/templates/about/data_quality_guidelines.html
+++ b/physionet-django/templates/about/data_quality_guidelines.html
@@ -1,9 +1,0 @@
-<ul>
-  <li>The data is produced in a sound manner.</li>
-  <li>The data is adequately described.</li>
-  <li>The data files are provided in an open format.</li>
-  <li>The data files are machine readable.</li>
-  <li>All the information needed for reuse is present.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
-  <li>The content is suitable for {{ SITE_NAME }}.</li>
-</ul>

--- a/physionet-django/templates/about/model_quality_guidelines.html
+++ b/physionet-django/templates/about/model_quality_guidelines.html
@@ -1,9 +1,0 @@
-<ul>
-  <li>The project follows good practice in software and model development.</li>
-  <li>The model is adequately described.</li>
-  <li>The model is provided in an open format.</li>
-  <li>Files are machine readable.</li>
-  <li>All the information needed for reuse is present.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
-  <li>The content is suitable for {{ SITE_NAME }}.</li>
-</ul>

--- a/physionet-django/templates/about/software_quality_guidelines.html
+++ b/physionet-django/templates/about/software_quality_guidelines.html
@@ -1,8 +1,0 @@
-<ul>
-  <li>The project follows good practice in software development.</li>
-  <li>The software is adequately described.</li>
-  <li>The software is provided in an open format.</li>
-  <li>No <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html">protected health information</a> is contained.</li>
-  <li>All the information needed for reuse is present.</li>
-  <li>The content is suitable for {{ SITE_NAME }}.</li>
-</ul>


### PR DESCRIPTION
When an author is submitting a project, they see a section titled "Quality guidelines". 

This quality guidelines are repeated twice, once at http://localhost:8000/projects/SLUG/overview/ and once at http://localhost:8000/projects/SLUG/proofread/

The guidelines differ by project type (model, data, software, etc). The content is stored in a hardcoded template file. An example is shown in the screenshot below:

---

![Screen Shot 2022-12-15 at 4 14 33 PM](https://user-images.githubusercontent.com/822601/207968821-ab2f5d43-d42e-4e1e-87c4-2a8d4546e677.png)

---

I think it makes sense to remove this section for several reasons, including:
1. we already refer people to the author guidelines, which contain a more detailed version of the recommendations;
2. the important parts appear in the submission process in more relevant places, e.g. on the file upload page;
3. this kind of hardcoded content is tricky to update, so it becomes stale quickly;
4. the hardcoded templates are inflexible, making it trickier to introduce improvements like managing data types using the database
