### PR TITLE
 Removed the use of private function to generate the signed url  and replaced it with our own wrapper function

### DIFF
--- a/physionet-django/physionet/storage.py
+++ b/physionet-django/physionet/storage.py
@@ -14,9 +14,9 @@ class StaticStorage(GoogleCloudStorage):
     location = ''
 
 
-def generate_signed_url_v4(blob_name, size, expiration=dt.timedelta(days=1)) -> str:
+def generate_signed_url(blob_name, size, expiration=dt.timedelta(days=1), version='v4') -> str:
     """
-    Generate a v4 signed URL to access project files on GCS
+    Generate a signed URL to access project files on GCS
 
     Parameters:
         blob_name (str): The name/path of the blob to be uploaded.
@@ -34,6 +34,7 @@ def generate_signed_url_v4(blob_name, size, expiration=dt.timedelta(days=1)) -> 
         api_access_endpoint='https://storage.googleapis.com',
         expiration=expiration,
         method='PUT',
-        headers={'X-Upload-Content-Length': str(size)}
+        headers={'X-Upload-Content-Length': str(size)},
+        version=version
     )
     return url

--- a/physionet-django/physionet/storage.py
+++ b/physionet-django/physionet/storage.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from django.conf import settings
 from storages.backends.gcloud import GoogleCloudStorage
 
@@ -10,3 +12,28 @@ class StaticStorage(GoogleCloudStorage):
     bucket_name = settings.GCP_STATIC_BUCKET_NAME
     default_acl = 'publicRead'
     location = ''
+
+
+def generate_signed_url_v4(blob_name, size, expiration=dt.timedelta(days=1)) -> str:
+    """
+    Generate a v4 signed URL to access project files on GCS
+
+    Parameters:
+        blob_name (str): The name/path of the blob to be uploaded.
+        size (int): The size of the blob to be uploaded.
+        expiration (datetime.timedelta): The time until the signed URL expires.
+
+    Returns:
+        str: The signed URL.
+    """
+    storage = MediaStorage()
+    bucket = storage.bucket()
+    blob = bucket.blob(blob_name)
+
+    url = blob.generate_signed_url(
+        api_access_endpoint='https://storage.googleapis.com',
+        expiration=expiration,
+        method='PUT',
+        headers={'X-Upload-Content-Length': str(size)}
+    )
+    return url

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1188,7 +1188,7 @@ class TestGenerateSignedUrl(TestMixin):
 
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
-    @mock.patch('project.views.generate_signed_url_v4')
+    @mock.patch('project.views.generate_signed_url')
     def test_valid_size_and_filename(self, signed_url_mock):
         signed_url_mock.return_value = 'https://example.com'
 
@@ -1199,7 +1199,7 @@ class TestGenerateSignedUrl(TestMixin):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content).get('url'), 'https://example.com')
 
-    @mock.patch('project.views.generate_signed_url_v4')
+    @mock.patch('project.views.generate_signed_url')
     def test_unauthorized_access(self, signed_url_mock):
         signed_url_mock.return_value = 'https://example.com'
 

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1189,29 +1189,23 @@ class TestGenerateSignedUrl(TestMixin):
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     @mock.patch('project.views.generate_signed_url_v4')
-    @mock.patch('project.views.MediaStorage')
-    def test_valid_size_and_filename(self, media_mock, signed_url_mock):
-        media_mock.return_value.bucket.name = "media-bucket"
+    def test_valid_size_and_filename(self, signed_url_mock):
         signed_url_mock.return_value = 'https://example.com'
 
         self.client.login(**self.user_credentials)
         response = self.client.post(self.url, self.valid_data, format='json')
 
-        media_mock.assert_called_once()
         signed_url_mock.assert_called_once()
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content).get('url'), 'https://example.com')
 
     @mock.patch('project.views.generate_signed_url_v4')
-    @mock.patch('project.views.MediaStorage')
-    def test_unauthorized_access(self, media_mock, signed_url_mock):
-        media_mock.return_value.bucket.name = "media-bucket"
+    def test_unauthorized_access(self, signed_url_mock):
         signed_url_mock.return_value = 'https://example.com'
 
         self.client.login(**self.unauthorized_user_credentials)
         response = self.client.post(self.url, self.valid_data, format='json')
 
-        media_mock.assert_not_called()
         signed_url_mock.assert_not_called()
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from physionet.forms import set_saved_fields_cookie
 from physionet.middleware.maintenance import ServiceUnavailable
-from physionet.storage import generate_signed_url_v4
+from physionet.storage import generate_signed_url
 from physionet.utility import serve_file
 from project import forms, utility
 from project.fileviews import display_project_file
@@ -2318,7 +2318,8 @@ def generate_signed_url(request, project_slug):
 
     canonical_resource = f'active-projects/{project_slug}/{filename.strip("/")}'
 
-    url = generate_signed_url_v4(
+    url = generate_signed_url(
+        version='v4',
         blob_name=canonical_resource,
         expiration=dt.timedelta(days=1),
         size=size


### PR DESCRIPTION
  **Context:** On project.views , `generate_signed_url` function, we were using a private google cloud function.
  This commit removes that by using a recommendation from google cloud documentation. https://cloud.google.com/storage/docs/samples/storage-generate-signed-url-v4#storage_generate_signed_url_v4-python

  The docs seem to recommend that we create a blog instance from google storage bucket, assign the blob name and use the `generate_signed_url` function from the blob instance.

  I added that to the `generate_signed_url` function and removed the private function call.

  1. Why did i create a wrapper function(`generate_signed_url`)?

  So turns out we need to mock call to the the `generate_signed_url` function and the MediaStorage class in the test(probably because we can actually call the during test as we dont have a gcp setup that can run during tests)
  So if i didnot create a wrapper, i was not sure how to mock calls to the `blob.generate_signed_url` function. So the easiest way was to create a wrapper function and mock that instead and edit the test case.

  I am not sure if that is the best way or even a decent way. I leave that to the reviewer to decide. :)

  2. Why i think the change should work same(i.e upload file in the right directory like 'active-project/slug/filename.txt')?

      The `MediaStorage` is just a wrapper to `GoogleCloudStorage` and to get the blob object we are doing the following:
          storage = MediaStorage()
          bucket = storage.bucket()
          blob = bucket.blob(blob_name)

          which should lead us to /google/cloud/storage/bucket.py#L680
          Here the blob_name is assigned as name for the `Blob` class.

          when we do blob.generate_signed_url, we are calling the `Blob` class's `generate_signed_url` function.
          this `generate_signed_url` function is defined in /google/cloud/storage/blob.py#L420 and on L596 we can see that,  its using this code to generate the resource

          resource = "/{bucket_name}/{quoted_name}".format(
              bucket_name=self.bucket.name, quoted_name=quoted_name
          )

          which should make the resource same as it was before this change.(i.e /bucket_name/blob_name)
          canonical_resource = f'/{storage.bucket.name}/active-projects/{project_slug}/{filename.strip("/")}'

      Other than that previously we were using the `from google.cloud.storage._signing import generate_signed_url_v4` function, which is the same function the `Blob.generate_signed_url` function is using.
      So it should be the same thing


Reference: Issue https://github.com/MIT-LCP/physionet-build/issues/1737