### PR TITLE
Only send the reminder email for a project in "Awaiting Author Revisions" to the submitting author

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -291,8 +291,11 @@ def edit_decision_notify(request, project, edit_log, reminder=False):
     # Prepend reminder to the subject if needed
     if reminder:
         subject = "Reminder - {}".format(subject)
+        author_list = [project.author_contact_info(only_submitting=True)]
+    else:
+        author_list = project.author_contact_info()
 
-    for email, name in project.author_contact_info():
+    for email, name in author_list:
         body = loader.render_to_string(template, {
             'name': name,
             'project': project,


### PR DESCRIPTION
This PR changes the current behavior of emailing all authors of a project when a reminder is sent, to instead only email the submitting author. As explained in https://github.com/MIT-LCP/physionet-build/issues/1760 the email being sent was confusing authors who were not the submitter. 