### PR TITLE
 Update View and Form for better User experience with adding edit_emails

### DIFF
--- a/physionet-django/user/templates/user/edit_emails.html
+++ b/physionet-django/user/templates/user/edit_emails.html
@@ -91,15 +91,20 @@
 
 <hr>
 <h4>Add Email</h4>
-<p>Add a new email address.</p>
-<form action="{% url 'edit_emails' %}" method="post" class="form-signin row no-pd" name="add_email">
-  {% csrf_token %}
-  <div class='col-md-9'>
-    {% include "form_snippet_no_labels.html" with form=add_email_form %}
-  </div>
-  <div class="btn-container-rsp mg-left">
-    <button class="btn btn-primary btn-rsp" name="add_email" type="submit">Add Email</button>
-  </div>
+    {% if total_associated_emails < max_associated_emails_allowed %}
+        <p>Add a new email address. <br> <small>Maximum Emails  allowed: {{total_associated_emails}}/{{max_associated_emails_allowed}}</small></p>
+        <form action="{% url 'edit_emails' %}" method="post" class="form-signin row no-pd" name="add_email">
+          {% csrf_token %}
+
+          <div class='col-md-9'>
+            {% include "form_snippet_no_labels.html" with form=add_email_form %}
+          </div>
+          <div class="btn-container-rsp mg-left">
+            <button class="btn btn-primary btn-rsp" name="add_email" type="submit">Add Email</button>
+          </div>
+    {% else %}
+        <p class="text-warning"> You have reached the maximum number of emails allowed. Please remove one or more of existing emails to continue.</p>
+    {% endif %}
 </form>
 
 {% endblock %}

--- a/physionet-django/user/templates/user/edit_emails.html
+++ b/physionet-django/user/templates/user/edit_emails.html
@@ -91,19 +91,18 @@
 
 <hr>
 <h4>Add Email</h4>
-    {% if total_associated_emails < max_associated_emails_allowed %}
-        <p>Add a new email address. <br> <small>Maximum Emails  allowed: {{total_associated_emails}}/{{max_associated_emails_allowed}}</small></p>
-        <form action="{% url 'edit_emails' %}" method="post" class="form-signin row no-pd" name="add_email">
-          {% csrf_token %}
+<p>Add a new email address(Max emails: {{ max_associated_emails_allowed }}).</p>
+<form action="{% url 'edit_emails' %}" method="post" class="form-signin row no-pd" name="add_email">
+  {% csrf_token %}
 
-          <div class='col-md-9'>
-            {% include "form_snippet_no_labels.html" with form=add_email_form %}
-          </div>
-          <div class="btn-container-rsp mg-left">
-            <button class="btn btn-primary btn-rsp" name="add_email" type="submit">Add Email</button>
-          </div>
-    {% else %}
-        <p class="text-warning"> You have reached the maximum number of emails allowed. Please remove one or more of existing emails to continue.</p>
+    <div class='col-md-9'>
+        {% include "form_snippet_no_labels.html" with form=add_email_form %}
+    </div>
+    <div class="btn-container-rsp mg-left">
+        <button class="btn btn-primary btn-rsp" name="add_email" type="submit" {% if total_associated_emails >= max_associated_emails_allowed %} disabled  {% endif %}>Add Email</button>
+    </div>
+    {% if total_associated_emails >= max_associated_emails_allowed %}
+        <p>You have reached the maximum number of emails. Please remove an existing email to add another.</p>
     {% endif %}
 </form>
 
@@ -119,5 +118,9 @@
         alert('You should use an institutional email address if you are a Student, PostDoc, Professor, Researcher, Employee, or Physician. Applications using non-institutional addresses may not be approved.')
       }
     });
+
+  (function () {
+      {% if total_associated_emails >= max_associated_emails_allowed %} document.getElementById('id_email').readOnly = true; {% endif %}
+  })();
 </script>
 {% endblock %}

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -338,7 +338,7 @@ def edit_emails(request):
             if associated_emails.count() >= settings.MAX_EMAILS_PER_USER:
                 messages.error(
                     request,
-                    f'You have reached the maximum number of email addresses allowed.'
+                    'You have reached the maximum number of email addresses allowed.'
                 )
             else:
                 add_email_form = forms.AddEmailForm(request.POST)
@@ -347,12 +347,12 @@ def edit_emails(request):
                 # Update the associated_emails count after adding a new email
                 total_associated_emails = AssociatedEmail.objects.filter(user=user).count()
 
-    context = {'associated_emails':associated_emails,
-        'primary_email_form':primary_email_form,
-        'add_email_form':add_email_form,
-        'public_email_form':public_email_form,
-        'total_associated_emails':total_associated_emails,
-        'max_associated_emails_allowed':max_associated_emails_allowed}
+    context = {'associated_emails': associated_emails,
+               'primary_email_form': primary_email_form,
+               'add_email_form': add_email_form,
+               'public_email_form': public_email_form,
+               'total_associated_emails': total_associated_emails,
+               'max_associated_emails_allowed': max_associated_emails_allowed}
 
     context['messages'] = messages.get_messages(request)
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -333,7 +333,7 @@ def edit_emails(request):
             if associated_emails.count() >= settings.MAX_EMAILS_PER_USER:
                 messages.error(
                     request,
-                    f'You cannot add more than {settings.MAX_EMAILS_PER_USER} email addresses.'
+                    f'You have reached the maximum number of email addresses allowed.'
                 )
             else:
                 add_email_form = forms.AddEmailForm(request.POST)

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -309,6 +309,8 @@ def edit_emails(request):
 
     associated_emails = AssociatedEmail.objects.filter(
         user=user).order_by('-is_verified', '-is_primary_email')
+    total_associated_emails = associated_emails.count()
+    max_associated_emails_allowed = settings.MAX_EMAILS_PER_USER
     primary_email_form = forms.AssociatedEmailChoiceForm(user=user,
                                                    selection_type='primary')
     public_email_form = forms.AssociatedEmailChoiceForm(user=user,
@@ -320,6 +322,9 @@ def edit_emails(request):
             # No form. Just get button value.
             email_id = int(request.POST['remove_email'])
             remove_email(request, email_id)
+
+            # Update the associated_emails count after removing an email
+            total_associated_emails = AssociatedEmail.objects.filter(user=user).count()
         elif 'set_primary_email' in request.POST:
             primary_email_form = forms.AssociatedEmailChoiceForm(user=user,
                 selection_type='primary', data=request.POST)
@@ -339,10 +344,15 @@ def edit_emails(request):
                 add_email_form = forms.AddEmailForm(request.POST)
                 add_email(request, add_email_form)
 
+                # Update the associated_emails count after adding a new email
+                total_associated_emails = AssociatedEmail.objects.filter(user=user).count()
+
     context = {'associated_emails':associated_emails,
         'primary_email_form':primary_email_form,
         'add_email_form':add_email_form,
-        'public_email_form':public_email_form}
+        'public_email_form':public_email_form,
+        'total_associated_emails':total_associated_emails,
+        'max_associated_emails_allowed':max_associated_emails_allowed}
 
     context['messages'] = messages.get_messages(request)
 


### PR DESCRIPTION
Context: Followup to https://github.com/MIT-LCP/physionet-build/pull/1754 

Changes
Updated view and forms, to show users how many emails they have currently attached, and the total limit.

if the user has reached the limit, the form will not be shown.Instead a warning message will be shown.

Screenshots:
UI before email limit has been reached
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/24412619/209215639-3a631db1-bdbb-40ea-b0f1-f986a66a47bf.png">


UI after email limit has been reached
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/24412619/209215584-ec4b8c36-9998-41f7-b555-e25cab080cdb.png">
