### PR TITLE
Making the filename validation consistent across view and form

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2303,11 +2303,10 @@ def generate_signed_url(request, project_slug):
     if size <= 0:
         return JsonResponse({'detail': 'The file size cannot be a negative value.'}, status=400)
 
-    if not filename.isascii():
-        return JsonResponse({'detail': 'The filename contains non-ascii characters.'}, status=400)
-
-    if ' ' in filename:
-        return JsonResponse({'detail': 'The filename contains whitespaces.'}, status=400)
+    try:
+        validate_filename(filename)
+    except ValidationError as e:
+        return JsonResponse({'detail': e.messages}, status=400)
 
     queryset = ActiveProject.objects.all()
     project = get_object_or_404(queryset, slug=project_slug)


### PR DESCRIPTION
From the TRA, we found out that the api `generate_signed_url` did not have the same filename validation as the form. This PR makes the validation consistent across the two by using the same validation function `validate_filename`.

I also removed two existing validation statements on the view as it was already covered by the existing validation function `validate_filename` I manually tested this by passing filename with space and non ascii characters and both were covered by the validation function `validate_filename`.

Followup to https://github.com/MIT-LCP/physionet-build/issues/1731