### PR TITLE
Update deprecated files message

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -324,9 +324,15 @@
   <h2 id="files">Files</h2>
   {% if project.allow_file_downloads %}
   {% if project.deprecated_files %}
-    <div class="alert alert-danger col-md-8" role="alert">
-      The files for this project are no longer available.
-    </div>
+    {% if project.is_latest_version %}
+      <div class="alert alert-danger col-md-8" role="alert">
+        The files for this project are no longer available.
+      </div>
+    {% else %}
+      <div class="alert alert-danger col-md-8" role="alert">
+        The files for this version of the project ({{ project.version }}) are no longer available. The latest version of this project is <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>
+      </div>
+    {% endif %}
   {% elif project.embargo_active %}
     <div class="alert alert-danger col-md-8" role="alert">
       The files in this project version are under embargo until: {{ project.embargo_end_date|date }}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -324,15 +324,13 @@
   <h2 id="files">Files</h2>
   {% if project.allow_file_downloads %}
   {% if project.deprecated_files %}
-    {% if project.is_latest_version %}
-      <div class="alert alert-danger col-md-8" role="alert">
-        The files for this project are no longer available.
-      </div>
-    {% else %}
-      <div class="alert alert-danger col-md-8" role="alert">
-        The files for this version of the project ({{ project.version }}) are no longer available. The latest version of this project is <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>
-      </div>
-    {% endif %}
+    <div class="alert alert-danger col-md-8" role="alert">
+      {% if project.is_latest_version %}
+          The files for this project are no longer available.
+      {% else %}
+          The files for this version of the project ({{ project.version }}) are no longer available. The latest version of this project is <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>
+      {% endif %}
+    </div>
   {% elif project.embargo_active %}
     <div class="alert alert-danger col-md-8" role="alert">
       The files in this project version are under embargo until: {{ project.embargo_end_date|date }}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1803,6 +1803,7 @@ def published_project(request, project_slug, version, subdir=''):
     # derived_projects = project.derived_publishedprojects.all()
     data_access = DataAccess.objects.filter(project=project)
     user = request.user
+    _, _, _, _, _, latest_version = project.info_card()
     citations = project.citation_text_all()
     platform_citations = project.get_platform_citation()
     show_platform_wide_citation = any(platform_citations.values())
@@ -1852,6 +1853,7 @@ def published_project(request, project_slug, version, subdir=''):
         'has_required_training': has_required_training,
         'current_site': current_site,
         'bulk_url_prefix': bulk_url_prefix,
+        'latest_version': latest_version,
         'citations': citations,
         'news': news,
         'all_project_versions': all_project_versions,


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/1739, the message indicating that files have been deprecated wasn't very informative when a newer version of the project is available. 

This PR updates the previous message in cases when a newer version of the project is available. In this case it now states: "The files for this version of the project (<old version number>) are no longer available. The latest version of this project is <latest version number>", where <latest version number> is a hyperlink to the latest version of the project. 