### PR TITLE
Hide the lightwave link on the front page when a project is under embargo

### DIFF
--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -189,3 +189,20 @@ def mailto_link(*recipients, **params):
 @register.filter
 def filename(value):
     return os.path.basename(value.name)
+
+
+@register.simple_tag
+def call_method(obj, method_name, *args):
+    """
+    This provides a means to pass an argument to a method when calling it
+
+    Parameters:
+        obj: an object created from a model class
+        method_name: method available to the object
+        args: arguments to be passed to the method
+
+    Example:
+        {% call_method published_project 'has_access' request.user as user_has_access %}
+    """
+    method = getattr(obj, method_name)
+    return method(*args)

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -28,8 +28,9 @@
     <p class="pub-details">Published: {{ published_project.publish_datetime|date }}.
       Version: {{ published_project.version }}</p>
     {% if is_lightwave_supported %}
-      {% if published_project.has_wfdb and not published_project.deprecated_files %}
-      <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>
+      {% call_method published_project 'has_access' request.user as user_has_access %}
+      {% if published_project.has_wfdb and user_has_access %}
+        <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>
       {% endif %}
     {% endif %}
     <hr>


### PR DESCRIPTION
As noted in https://github.com/MIT-LCP/physionet-build/issues/1770 , the announcement on the front page for a new project will show a link to Lightwave if the project has compatible files. This isn't desired when the files in a project are under embargo. This PR hides the link to Lightwave if the project files are under embargo. 