### PR TITLE
Fix for flickering throughout project

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -593,3 +593,5 @@ a, code{
   border-radius: 0.25rem;
   border: 1px solid rgba(0, 0, 0, 0.15);
 }
+
+.list-group-item, .list-group-item:hover{ z-index: auto; }

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -594,4 +594,9 @@ a, code{
   border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
-.list-group-item, .list-group-item:hover{ z-index: auto; }
+/* fix layering of modal inside list-group-item
+   (https://github.com/twbs/bootstrap/issues/25206)
+   (https://github.com/MIT-LCP/physionet-build/issues/1764) */
+body .list-group-item:hover {
+  z-index: auto;
+}


### PR DESCRIPTION
Context: Several modals were flickering on physionet. Please check the issue for details https://github.com/MIT-LCP/physionet-build/issues/1764

In Summary, the flickering was caused by the modal being present inside a li tag with class `list-group-item`. The value of z-index on hover, was causing the flickering. The fix was to remove the z-index on hover.

The simple fix was to override the z-index on hover for the modal. We can do this by adding the following to the physionet.css file. This should make sure, that the override is applied throughout the site(as the physionet.css is loaded in base_css.html which is loaded in base.html)

The PR implements solution2 from the discussion