### PR TITLE
Refactor the wrapper function to use prevent any possible override(Cleanup)

### DIFF
--- a/physionet-django/physionet/storage.py
+++ b/physionet-django/physionet/storage.py
@@ -14,7 +14,7 @@ class StaticStorage(GoogleCloudStorage):
     location = ''
 
 
-def generate_signed_url(blob_name, size, expiration=dt.timedelta(days=1), version='v4') -> str:
+def generate_signed_url_helper(blob_name, size, expiration=dt.timedelta(days=1), version='v4') -> str:
     """
     Generate a signed URL to access project files on GCS
 

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1188,7 +1188,7 @@ class TestGenerateSignedUrl(TestMixin):
 
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
-    @mock.patch('project.views.generate_signed_url')
+    @mock.patch('project.views.generate_signed_url_helper')
     def test_valid_size_and_filename(self, signed_url_mock):
         signed_url_mock.return_value = 'https://example.com'
 
@@ -1199,7 +1199,7 @@ class TestGenerateSignedUrl(TestMixin):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content).get('url'), 'https://example.com')
 
-    @mock.patch('project.views.generate_signed_url')
+    @mock.patch('project.views.generate_signed_url_helper')
     def test_unauthorized_access(self, signed_url_mock):
         signed_url_mock.return_value = 'https://example.com'
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from physionet.forms import set_saved_fields_cookie
 from physionet.middleware.maintenance import ServiceUnavailable
-from physionet.storage import generate_signed_url
+from physionet.storage import generate_signed_url_helper
 from physionet.utility import serve_file
 from project import forms, utility
 from project.fileviews import display_project_file
@@ -2320,7 +2320,7 @@ def generate_signed_url(request, project_slug):
 
     canonical_resource = f'active-projects/{project_slug}/{filename.strip("/")}'
 
-    url = generate_signed_url(
+    url = generate_signed_url_helper(
         version='v4',
         blob_name=canonical_resource,
         expiration=dt.timedelta(days=1),


### PR DESCRIPTION
On PR: https://github.com/MIT-LCP/physionet-build/pull/1763 , i added a wrapper function to remove use of the private function On the PR i had named the function `generate_signed_url` which ironically was also name of the view function that uses the wrapper function on the project/views.py

So, i have renamed the wrapper function to `generate_signed_url_helper` to prevent any possible function override and confusion.

Weird that the test didnot fail with this.

