### PR TITLE
Fix to verify pdf file type and limit pdf size

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,3 +134,6 @@ PRIMARY='#002A5C'
 # Users settings
 # maximum number of emails that can be associated to a user model
 MAX_EMAILS_PER_USER = 10
+
+
+MAX_TRAINING_REPORT_UPLOAD_SIZE_MB = 1

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -534,6 +534,7 @@ PLATFORM_WIDE_CITATION = {
 
 SOURCE_CODE_REPOSITORY_LINK = config('SOURCE_CODE_REPOSITORY_LINK',
                                      default='https://github.com/MIT-LCP/physionet-build')
+MAX_TRAINING_REPORT_UPLOAD_SIZE_MB = config('MAX_TRAINING_REPORT_UPLOAD_SIZE_MB', cast=int, default=1)
 
 # User model configurable settings
 MAX_EMAILS_PER_USER = config('MAX_EMAILS_PER_USER', cast=int, default=10)

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -329,3 +329,19 @@ def paginate(request, to_paginate, maximum):
     paginator = Paginator(to_paginate, maximum)
     paginated = paginator.get_page(page)
     return paginated
+
+
+def validate_pdf_file_type(pdf_file) -> bool:
+    """
+    Function to validate a pdf file.
+
+    Parameters
+    ----------
+    pdf_file : File to validate. Django InMemoryUploadedFile.
+
+    Returns True if the file is a pdf file.
+    """
+    chunk = next(pdf_file.chunks())
+    if chunk.startswith(b'%PDF-'):
+        return True
+    return False

--- a/physionet-django/user/test_views.py
+++ b/physionet-django/user/test_views.py
@@ -15,7 +15,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core import mail
 from django.core.management import call_command
-from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -536,7 +536,9 @@ class TrainingTestCase(TestCase):
         }
 
     def setUp(self):
-        self.training_report = SimpleUploadedFile('training-report.pdf', b'training_report')
+        pdf_content = b'%PDF-1.3\n%\x93\x8c\x8b\x9e ReportLab Generated PDF document http://www.reportlab.com\n1 0 obj\n<<\n/F1 2 0 R\n>>\nendobj\n2 0 obj\n<<\n/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font\n>>\nendobj\n3 0 obj\n<<\n/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<\n/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]\n>> /Rotate 0 /Trans <<\n\n>> \n  /Type /Page\n>>\nendobj\n4 0 obj\n<<\n/PageMode /UseNone /Pages 6 0 R /Type /Catalog\n>>\nendobj\n5 0 obj\n<<\n/Author (anonymous) /CreationDate (D:20221219130742+05\'00\') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20221219130742+05\'00\') /Producer (ReportLab PDF Library - www.reportlab.com) \n  /Subject (unspecified) /Title (untitled) /Trapped /False\n>>\nendobj\n6 0 obj\n<<\n/Count 1 /Kids [ 3 0 R ] /Type /Pages\n>>\nendobj\n7 0 obj\n<<\n/Filter [ /ASCII85Decode /FlateDecode ] /Length 104\n>>\nstream\nGapQh0E=F,0U\\H3T\\pNYT^QKk?tc>IP,;W#U1^23ihPEM_M(M8&8HllJH6UCj=4hfUupb!lR8"\\(ZhG@C+=mI.>2AcPUg\\R!\'_YE[f~>endstream\nendobj\nxref\n0 8\n0000000000 65535 f \n0000000073 00000 n \n0000000104 00000 n \n0000000211 00000 n \n0000000414 00000 n \n0000000482 00000 n \n0000000778 00000 n \n0000000837 00000 n \ntrailer\n<<\n/ID \n[<cb45d718ea09b37c9695ca3758dbd4ba><cb45d718ea09b37c9695ca3758dbd4ba>]\n% ReportLab generated PDF document -- digest (http://www.reportlab.com)\n\n/Info 5 0 R\n/Root 4 0 R\n/Size 8\n>>\nstartxref\n1031\n%%EOF\n' # noqa
+        self.training_report = SimpleUploadedFile(name='training-report.pdf', content=pdf_content,
+                                                  content_type='application/pdf')
         self.training_payload_valid = {
             'training_type': self.training_type_1.pk,
             'completion_report': self.training_report,

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -1,5 +1,6 @@
 import re
 
+from django.conf import settings
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
@@ -255,3 +256,11 @@ def validate_domain_list(value):
     """
     if not re.fullmatch(r'(\w+\.\w+,*\s*)*', value):
         raise ValidationError('Must be separated with commas.')
+
+
+def validate_file_size(value):
+    """
+    Validate the file size of a file.
+    """
+    if value.size > settings.MAX_TRAINING_REPORT_UPLOAD_SIZE_MB * 1024 * 1024:
+        raise ValidationError('The maximum file size that can be uploaded is 5MB.')


### PR DESCRIPTION
1. Added a utility function to verify if the uploaded file is a pdf file or not.

    Currently users are able to upload any file type by changing the file extension in the training form.
    This commit adds a utility function to verify if the uploaded file is a pdf file or not.

2. Update test to work with the training pdf validation The new change makes sure that the file uploaded is a valid pdf and is readable. Our previous test was using django core SimpleUploadedFile to create a plain/txt file and uploading that which is not a valid pdf(even if we change the content type). So the solution to this would be to either create pdf on the fly during the test or use a static valid pdf file.

    I chose the later option, because creating pdf on the fly would require us to add a new dependency to the project which might introduce a security risk and need more discussion.

3. Added a file size limit for pdf Also, earlier there was no limit on the file size, i added a limit of 1MB Default(but customizable from .env) for the pdf file For the file size validation function, i added it in the user.validators instead of adding it somewhere else like physionet.utility because, i thought we might to implement different sizes for different applications, so i didnot try to make it generic.