### PR TITLE
Fix keyerror on production

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -783,7 +783,7 @@ class TrainingForm(forms.ModelForm):
             raise forms.ValidationError('You have already submitted a training of this type.')
 
         # Check if the uploaded file is a PDF
-        if data['completion_report'] is not None:
+        if data.get('completion_report') is not None:
             if not validate_pdf_file_type(data['completion_report']):
                 raise forms.ValidationError('Invalid PDF file.')
 


### PR DESCRIPTION
Looks like because of an improperly handled dictionary access, there was an error when someone tried to access their training report url. Incase where user has training url instead of a training pdf, the training form, sends us `completion_report_url`. so the code i added last week was to check for validation of pdf, and the key for training pdf was `completion_report` Since the user didnot have this key in their trainingform, the code threw error.

A simple get statement will fix the issue