### PR TITLE
Catch "conflicting" migrations in getmigrationtargets

### DIFF
--- a/physionet-django/user/management/commands/getmigrationtargets.py
+++ b/physionet-django/user/management/commands/getmigrationtargets.py
@@ -128,6 +128,13 @@ class Command(BaseCommand):
                 # migrations.
                 desired.append((app, name))
 
+        # Check if there are conflicts (multiple leaf nodes in same app.)
+        conflicts = executor.loader.detect_conflicts()
+        if conflicts:
+            raise CommandError("Conflicting migrations detected; "
+                               "multiple leaf nodes in the migration "
+                               "graph ({})".format(conflicts))
+
         # Check if there are any migrations applied that we don't know
         # about.
         ghosts = applied.keys() - set(desired)


### PR DESCRIPTION
The custom `getmigrationtargets` command is used to sanity-check the migration graph before upgrading the server (invoked by `deploy/update`), as well as to execute "early"/"late" migrations (invoked by `deploy/post-receive`.)

We rely on the Django builtin `migrate` command to do the actual work of migrating, and that command doesn't work if there are *two leaf migrations for the same app* (resulting from parallel development on the same app in two git branches.)

(It's honestly a bit weird that Django internally treats migrations as a graph while the `migrate` command can only really handle a linear series.  But anyway...)

To catch mistakes, `getmigrationtargets` should fail if the existing migrations are incompatible with `migrate`.  Currently this works in some situations and not others; for example:

```
git checkout 075b7e0bd43b954411c9302266a66c4355b505a9
./manage.py resetdb
git checkout 369408bcab626c83d2e340316b4018719d651ccf
./manage.py getmigrationtargets                 # fails

git checkout 03ba3220270965af19aa5e82fc6c0837d4260aa2
./manage.py resetdb
git checkout 369408bcab626c83d2e340316b4018719d651ccf
./manage.py getmigrationtargets                 # succeeds
./manage.py migrate                             # fails
./manage.py migrate project 0064_20221209_1300  # (this fails too!)
```

Note that `test-upgrade.sh` explicitly invokes `makemigrations --dry-run --no-input --check`, which will also raise an error for conflicting leaf migrations, but we aren't doing that in `update` and I'm not sure we want to.
