### PR TITLE
Handle missing GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -826,7 +826,7 @@ def manage_published_project(request, project_slug, version):
     topic_form = forms.TopicForm(project=project)
     topic_form.set_initial()
     deprecate_form = None if project.deprecated_files else forms.DeprecateFilesForm()
-    has_credentials = os.path.exists(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
+    has_credentials = bool(settings.GOOGLE_APPLICATION_CREDENTIALS)
     data_access_form = forms.DataAccessForm(project=project)
     contact_form = forms.PublishedProjectContactForm(project=project,
                                                      instance=project.contact)

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -153,9 +153,12 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR,'static')]
 # Google Storge service account credentials
 if config('GOOGLE_APPLICATION_CREDENTIALS', default=None):
-    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = os.path.join(
+    GOOGLE_APPLICATION_CREDENTIALS = os.path.join(
         BASE_DIR,
         config('GOOGLE_APPLICATION_CREDENTIALS'))
+    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = GOOGLE_APPLICATION_CREDENTIALS
+else:
+    GOOGLE_APPLICATION_CREDENTIALS = None
 
 # Maintenance mode
 


### PR DESCRIPTION
The variable GOOGLE_APPLICATION_CREDENTIALS is not defined in .env.example, but trying to load /console/published-projects/demoeicu/2.0.0/ requires that this key be set in os.environ:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/os.py", line 676, in __getitem__
    value = self._data[self.encodekey(key)]

During handling of the above exception (b'GOOGLE_APPLICATION_CREDENTIALS'), another exception occurred:
  File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/physionet/python-env/physionet/lib/python3.9/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "./console/views.py", line 829, in manage_published_project
    has_credentials = os.path.exists(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
  File "/usr/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None

Exception Type: KeyError at /console/published-projects/demoeicu/2.0.0/
Exception Value: 'GOOGLE_APPLICATION_CREDENTIALS'
Request information:
USER: admin

GET: No GET data

POST: No POST data

FILES: No FILES data
```

The Google Cloud buttons in the console are an optional feature that's globally enabled or disabled.  The decision to enable the feature should be made by the settings module, not by individual views.  Personally I don't think checking the filesystem is desirable (if the file is missing for some reason, better for breakage to be visible), but if we want to check the filesystem then that should be done by the settings module and not by the views.
