### PR TITLE
Remove calls to HttpRequest.is_ajax() method

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -922,9 +922,6 @@ def project_files_panel(request, project_slug, **kwargs):
     else:
         files_editable = False
 
-    if not request.is_ajax():
-        return redirect('project_files', project_slug=project_slug)
-
     (display_files, display_dirs, dir_breadcrumbs, parent_dir,
      file_error) = get_project_file_info(project=project, subdir=subdir)
     file_warning = get_project_file_warning(display_files, display_dirs,
@@ -1145,9 +1142,6 @@ def preview_files_panel(request, project_slug, **kwargs):
     """
     project = kwargs['project']
     subdir = request.GET['subdir']
-
-    if not request.is_ajax():
-        return redirect('project_preview', project_slug=project_slug)
 
     (display_files, display_dirs, dir_breadcrumbs, parent_dir,
      file_error) = get_project_file_info(project=project, subdir=subdir)
@@ -1567,10 +1561,6 @@ def published_files_panel(request, project_slug, version):
     subdir = request.GET.get('subdir')
     if subdir is None:
         raise Http404()
-
-    if not request.is_ajax():
-        return redirect('published_project', project_slug=project_slug,
-            version=version)
 
     user = request.user
 


### PR DESCRIPTION
In future releases of Django, [`HttpRequest.is_ajax()` is deprecated](https://docs.djangoproject.com/en/3.1/releases/3.1/#id2):

> The HttpRequest.is_ajax() method is deprecated as it relied on a jQuery-specific way of signifying AJAX calls, while current usage tends to use the JavaScript [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). Depending on your use case, you can either write your own AJAX detection method, or use the new [HttpRequest.accepts()](https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.HttpRequest.accepts) method if your code depends on the client Accept HTTP header.

As noted by @bemoody in https://github.com/MIT-LCP/physionet-build/pull/1805, our calls to `HttpRequest.is_ajax()` are unnecessary and can be removed anyway. Doing this will help us to upgrade to the latest version of Django. 