### PR TITLE
Feature: Make lightwave switchable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,7 @@ MAX_EMAILS_PER_USER = 10
 
 # Max training report size in bytes
 MAX_TRAINING_REPORT_UPLOAD_SIZE = 1048576
+ENABLE_LIGHTWAVE=True
 
 # Absolute cookie timeout in seconds -
 # In-built django variable that logouts user if cookie expiration time has been exceeded

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -28,6 +28,7 @@ ENVIRONMENT = config('ENVIRONMENT', default='production')
 DEBUG = config('DEBUG', default=False, cast=bool)
 SECRET_KEY = config('SECRET_KEY')
 ENABLE_SSO = config('ENABLE_SSO', default=False, cast=bool)
+ENABLE_LIGHTWAVE = config('ENABLE_LIGHTWAVE', default=True, cast=bool)
 SSO_REMOTE_USER_HEADER = config('SSO_REMOTE_USER_HEADER', default='HTTP_REMOTE_USER')
 SSO_LOGIN_BUTTON_TEXT = config('SSO_LOGIN_BUTTON_TEXT', default='Login')
 GCS_SIGNED_URL_LIFETIME_IN_MINUTES = config('GCS_SIGNED_URL_LIFETIME_IN_MINUTES', default=1440, cast=int)
@@ -57,7 +58,6 @@ INSTALLED_APPS = [
     'export',
     'notification',
     'search',
-    'lightwave',
     'physionet',
     'django_sass',
     'events',
@@ -65,6 +65,9 @@ INSTALLED_APPS = [
 
 if ENABLE_SSO:
     INSTALLED_APPS += ['sso']
+
+if ENABLE_LIGHTWAVE:
+    INSTALLED_APPS += ['lightwave']
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -83,7 +83,7 @@ urlpatterns = [
          name='database_list')
 ]
 
-if ProjectFiles().is_lightwave_supported:
+if ProjectFiles().is_lightwave_supported and settings.ENABLE_LIGHTWAVE:
     urlpatterns.append(path('lightwave/', include('lightwave.urls')))
     # backward compatibility for LightWAVE
     urlpatterns.append(path('cgi-bin/lightwave',

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -83,7 +83,7 @@ urlpatterns = [
          name='database_list')
 ]
 
-if ProjectFiles().is_lightwave_supported and settings.ENABLE_LIGHTWAVE:
+if settings.ENABLE_LIGHTWAVE and ProjectFiles().is_lightwave_supported:
     urlpatterns.append(path('lightwave/', include('lightwave.urls')))
     # backward compatibility for LightWAVE
     urlpatterns.append(path('cgi-bin/lightwave',


### PR DESCRIPTION
Context of those changes:
We would like to separate lightwave to a package that is pip installable, after doing that we also should be adding the app conditionally to the django itself. Doing that would solve potential vulnerability.