### PR TITLE
remove print statement that i had forgotten to remove on PR #1817

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -707,7 +707,6 @@ class ReferenceFormSet(BaseGenericInlineFormSet):
         # change the value of order. set it as index of form
         for form in self.forms:
             form.instance.order = self.forms.index(form) + 1
-            print(form.instance.__dict__, 'Changed: ', form.has_changed())
         super().save(*args, **kwargs)
 
 


### PR DESCRIPTION
removing the print statement that i had forgotten to remove on PR #1817. I had a print statement i was using for debugging but forgot to remove it when committing the changes