### PR TITLE
Fix HttpError 412 error when provisioning access to GCP resources for users

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
@@ -1,5 +1,6 @@
 Dear {{ user.get_full_name }},
 
+{% if successful %}
 {% if data_access.platform == 3 %}
 You have requested access to use {{ project }} in GCP Storage.
 
@@ -22,6 +23,18 @@ For information on how to access this resource please follow these steps
 3. You should now see the {{ SITE_NAME }} datasets in the left sidebar.
    - If you don't have access to a particular dataset, no information will be displayed when you click on the dataset name (and you may see a spinning circle icon).
    - If you cannot add the project "physionet-data", please access it through this link: https://console.cloud.google.com/bigquery?project=physionet-data&page=dataset
+{% endif %}
+{% else %}
+We are sorry to say that we were unable to grant access to {{ project }} in GCP.
+
+Reasons might include:
+ - An invalid cloud e-mail was specified. Please ensure the e-mail in your cloud profile is a valid
+ Google e-mail. Only Google e-mails may be used for GCP access.
+ - The service is no longer available.
+
+Please reapply for access if you are able to address the issue.
+
+If you think this was an error on our part, please contact {{ contact_email }}.
 {% endif %}
 
 {{ signature }}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -733,7 +733,7 @@ def credential_application_request(request, application):
               [application.user.email], fail_silently=False)
 
 
-def notify_gcp_access_request(data_access, user, project):
+def notify_gcp_access_request(data_access, user, project, successful):
     """
     Notify user of GCP access
     """
@@ -747,6 +747,7 @@ def notify_gcp_access_request(data_access, user, project):
             'data_access': data_access,
             'user': user,
             'project': project,
+            'successful': successful,
             'footer': email_footer(),
             'SITE_NAME': settings.SITE_NAME,
         })

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -345,7 +345,9 @@ def grant_gcp_group_access(user, project, data_access):
             granted_access = True
             return '{0} was previously awarded to {1} for project: {2}'.format(
                 access, email, project), granted_access
-        raise error
+        else:
+            return 'Unable to grant {0} access to {1} for {2}'.format(
+                access, email, project), granted_access
 
 
 # The following regular expression defines user agents that are

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -341,6 +341,14 @@ def grant_gcp_group_access(user, project, data_access):
         raise Exception('Wrong access granted to {0} in GCP email {1}'.format(
             email, data_access.location))
     except HttpError as error:
+        if error.resp.status == 412:
+            # Google has a somewhat cryptic 412 error: "Condition not met"
+            # In our experience, this occurred when the user specified a non-Google
+            # e-mail in their cloud profile which could not be added to the group.
+            return (
+                'Unable to provision access, please verify '
+                '{0} is a valid Google account'.format(email)
+            ), granted_access
         if json.loads(error.content)['error']['message'] == 'Member already exists.':
             granted_access = True
             return '{0} was previously awarded to {1} for project: {2}'.format(

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2219,11 +2219,10 @@ def published_project_request_access(request, project_slug, version, access_type
     for access in data_access:
         if access_type == 2 and access.platform == access_type:
             message, granted_access = utility.grant_aws_open_data_access(user, project)
+            notification.notify_aws_access_request(user, project, access, granted_access)
             if granted_access:
-                notification.notify_aws_access_request(user, project, access, True)
                 messages.success(request, message)
             else:
-                notification.notify_aws_access_request(user, project, access, False)
                 messages.error(request, message)
         elif access_type in [3, 4] and access.platform == access_type:
             message, granted_access = utility.grant_gcp_group_access(user, project, access)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2227,9 +2227,11 @@ def published_project_request_access(request, project_slug, version, access_type
                 messages.error(request, message)
         elif access_type in [3, 4] and access.platform == access_type:
             message, granted_access = utility.grant_gcp_group_access(user, project, access)
+            notification.notify_gcp_access_request(access, user, project, granted_access)
             if granted_access:
-                notification.notify_gcp_access_request(access, user, project)
                 messages.success(request, message)
+            else:
+                messages.error(request, message)
 
     return redirect('published_project', project_slug=project_slug, version=version)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2218,18 +2218,16 @@ def published_project_request_access(request, project_slug, version, access_type
 
     for access in data_access:
         if access_type == 2 and access.platform == access_type:
-            message = utility.grant_aws_open_data_access(user, project)
-            error_messages = ["Access could not be granted.",
-                              "There was an error granting access."]
-            if message not in error_messages:
+            message, granted_access = utility.grant_aws_open_data_access(user, project)
+            if granted_access:
                 notification.notify_aws_access_request(user, project, access, True)
                 messages.success(request, message)
             else:
                 notification.notify_aws_access_request(user, project, access, False)
                 messages.error(request, message)
         elif access_type in [3, 4] and access.platform == access_type:
-            message = utility.grant_gcp_group_access(user, project, access)
-            if message:
+            message, granted_access = utility.grant_gcp_group_access(user, project, access)
+            if granted_access:
                 notification.notify_gcp_access_request(access, user, project)
                 messages.success(request, message)
 


### PR DESCRIPTION
Recently, we had a few error messages along the lines of:

```
Exception Type: HttpError at /projects/<project-slug>/<project-version>/request_access/4
Exception Value: <HttpError 412 when requesting https://admin.googleapis.com/admin/directory/v1/groups/<project-gcp-group-email>/members?alt=json returned "Condition not met">
```

These seem to occur when a user tries to request access to a project on GCP when their cloud e-mail is not a valid Google e-mail. This PR fixes this by:

1. Catching http errors from the Google Admin API rather than raising a 500
2. E-mailing the user that the request failed, and notifying them with an error message on the site
3. Add a special case for the 412 response code - the notification tells the user to verify their cloud e-mail is valid