### PR TITLE
Updates the research summary topic

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -491,7 +491,7 @@ class ResearchCAF(forms.ModelForm):
         }
 
     def clean_research_summary(self):
-        research_summary= self.cleaned_data['research_summary']
+        research_summary = self.cleaned_data['research_summary']
         if len(research_summary.split()) < 20:
             raise forms.ValidationError("Please provide more information about your research topic.")
         return research_summary

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -490,6 +490,11 @@ class ResearchCAF(forms.ModelForm):
             'research_summary': 'Research Topic'
         }
 
+    def clean_research_summary(self):
+        research_summary= self.cleaned_data['research_summary']
+        if len(research_summary.split()) < 20:
+            raise forms.ValidationError("Please provide more information about your research topic.")
+        return research_summary
 
 class ReferenceCAF(forms.ModelForm):
     """

--- a/physionet-django/user/test_integration.py
+++ b/physionet-django/user/test_integration.py
@@ -211,7 +211,9 @@ class TestCredentialing(TestMixin):
             'application-reference_email': 'root@example.com',
             'application-reference_organization': 'MIT',
             'application-reference_title': 'Administrator',
-            'application-research_summary': 'I am a researcher '*5,
+            'application-research_summary': 'I plan to access the MIMIC IV dataset and the \
+            Pediatric Intensive Care database.The datasets will be used to predict the \
+            outcome of pediatric anesthesia using machine learning.',
         }
 
         self.client.post(reverse('credential_application'), data=data)

--- a/physionet-django/user/test_integration.py
+++ b/physionet-django/user/test_integration.py
@@ -211,7 +211,7 @@ class TestCredentialing(TestMixin):
             'application-reference_email': 'root@example.com',
             'application-reference_organization': 'MIT',
             'application-reference_title': 'Administrator',
-            'application-research_summary': 'Effects of asdfghjk on zxcvbnm',
+            'application-research_summary': 'I am a researcher '*5,
         }
 
         self.client.post(reverse('credential_application'), data=data)


### PR DESCRIPTION
This PR updates the research summary topic as discussed in #1804. 

This code base adds a validator to the `research_summary` field of the `CredentialApplication` model. The validator is defined as a form, ResearchCAF, which inherits from the Django forms.ModelForm class.  The form defines a `clean_research_summary` method, which is used to validate the `research_summary` field.  The method checks whether the length of the research summary is less than 100 words and raises a validation error if this is the case. 

This also updates the test case. In the test named `test_credential_application` which it is a part of the `TestCredentialing` class that checks whether a user's credential application is created after the user submits an application.  It uses a string multiplication to update the `application-research_summary` field in the test data to be at least 100 words long to meet the validation criteria, so the application will be able create a new credential application. 
