### PR TITLE
Add Event Update Features

### DIFF
--- a/physionet-django/events/forms.py
+++ b/physionet-django/events/forms.py
@@ -24,11 +24,15 @@ class AddEventForm(forms.ModelForm):
         super(AddEventForm, self).__init__(*args, **kwargs)
 
     def save(self):
-        Event.objects.create(title=self.cleaned_data['title'],
-                             category=self.cleaned_data['category'],
-                             host=self.host,
-                             description=self.cleaned_data['description'],
-                             start_date=self.cleaned_data['start_date'],
-                             end_date=self.cleaned_data['end_date'],
-                             allowed_domains=self.cleaned_data['allowed_domains']
-                             )
+        # Handle updating the event
+        if self.initial:
+            self.instance.save()
+        else:
+            Event.objects.create(title=self.cleaned_data['title'],
+                                 category=self.cleaned_data['category'],
+                                 host=self.host,
+                                 description=self.cleaned_data['description'],
+                                 start_date=self.cleaned_data['start_date'],
+                                 end_date=self.cleaned_data['end_date'],
+                                 allowed_domains=self.cleaned_data['allowed_domains']
+                                 )

--- a/physionet-django/events/forms.py
+++ b/physionet-django/events/forms.py
@@ -26,7 +26,13 @@ class AddEventForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(AddEventForm, self).clean()
         if Event.objects.filter(title=cleaned_data['title'], host=self.host).exists():
-            raise forms.ValidationError({"title": ["Event with this title already exists"]})
+            # in case of update, we don't want to raise an error if the title is the same
+            if self.initial.get('title'):  # in case of update we have an initial value
+                # if the instance title is different from the new title, then we have a duplicate with another event
+                if self.instance.title != cleaned_data['title']:
+                    raise forms.ValidationError({"title": ["Event with this title already exists"]})
+            else:
+                raise forms.ValidationError({"title": ["Event with this title already exists"]})
 
     def save(self):
         # Handle updating the event

--- a/physionet-django/events/forms.py
+++ b/physionet-django/events/forms.py
@@ -23,6 +23,11 @@ class AddEventForm(forms.ModelForm):
         self.host = user
         super(AddEventForm, self).__init__(*args, **kwargs)
 
+    def clean(self):
+        cleaned_data = super(AddEventForm, self).clean()
+        if Event.objects.filter(title=cleaned_data['title'], host=self.host).exists():
+            raise forms.ValidationError({"title": ["Event with this title already exists"]})
+
     def save(self):
         # Handle updating the event
         if self.initial:

--- a/physionet-django/events/templates/events/event_home.html
+++ b/physionet-django/events/templates/events/event_home.html
@@ -55,6 +55,26 @@
     </div>
   </div>
 
+    <div class="modal fade" id="edit-event-modal" tabindex="-1" role="dialog" aria-labelledby="edit-event-modal" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Edit Event</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="container">
+              <form action="" method="post" class="form-signin edit-event" >
+                {% csrf_token %}
+                {% include "form_snippet.html" with form=event_form %}
+                <button class="btn btn-primary btn-fixed" name="edit-event" type="submit">Edit event</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+
 <!-- Active events -->
 
   <div class="card" >
@@ -74,6 +94,7 @@
               <small>Share the class code: {{ url_prefix }}{% url 'event_add_participant' event.slug %} </small><br>
               </p>
               <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
+              <button class="btn btn-sm btn-secondary edit-btn" data-toggle ="modal" data-target="#edit-event-modal"  data-event-url="{% url 'get_event_details' event.slug %}" data-form-url="{% url 'update_event' event.slug %}" >Edit Event</button>
             {% endif %}
           </li>
       {% empty %}
@@ -148,4 +169,32 @@
     {% endfor %}
   {% endif %}
   </div>
+{% endblock %}
+
+
+{% block local_js_bottom %}
+  <script>
+   $('.edit-btn').click(function(e) {
+       $('#edit-event-modal').modal('hide');
+       let url = $(this).data('event-url');
+       let form_url = $(this).data('form-url');
+        $.ajax({
+           url: url,
+           type: 'GET',
+           success: function(data) {
+                console.log(data);
+                let event = data[0];
+                $('#edit-event-modal').find('#id_title').val(event.title);
+                $('#edit-event-modal').find('#id_description').val(event.description);
+                $('#edit-event-modal').find('#id_start_date').val(event.start_date);
+                $('#edit-event-modal').find('#id_end_date').val(event.end_date);
+                $('#edit-event-modal').find('#id_slug').val(event.slug);
+                $('#edit-event-modal').find('#id_category').val(event.category);
+                $('#edit-event-modal').find('#id_allowed_domains').val(event.allowed_domains);
+                $('form.edit-event').attr('action', form_url);
+           }
+       });
+
+   });
+  </script>
 {% endblock %}

--- a/physionet-django/events/templates/events/event_home.html
+++ b/physionet-django/events/templates/events/event_home.html
@@ -27,7 +27,7 @@
       {% if is_instructor %}
       <p class="lead">Create new events and access event details.</p>
       <p>
-        <button class = "btn btn-success" data-toggle ="modal" data-target="#add-event-modal">
+        <button class = "btn btn-success" data-toggle="modal" data-target="#add-event-modal">
           <i class="fa fa-cloud-upload-alt"></i> Create New Event </button>
       </p>
       {% else %}
@@ -68,7 +68,7 @@
               <form action="" method="post" class="form-signin edit-event" >
                 {% csrf_token %}
                 {% include "form_snippet.html" with form=event_form %}
-                <button class="btn btn-primary btn-fixed" name="edit-event" type="submit">Edit event</button>
+                <button class="btn btn-primary btn-fixed" name="edit-event" type="submit">Save</button>
               </form>
             </div>
           </div>
@@ -182,7 +182,6 @@
            url: url,
            type: 'GET',
            success: function(data) {
-                console.log(data);
                 let event = data[0];
                 $('#edit-event-modal').find('#id_title').val(event.title);
                 $('#edit-event-modal').find('#id_description').val(event.description);

--- a/physionet-django/events/tests.py
+++ b/physionet-django/events/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/physionet-django/events/tests_views.py
+++ b/physionet-django/events/tests_views.py
@@ -45,22 +45,8 @@ class TestEvents(TestMixin):
     def test_add_event_invalid(self):
         """tests the view that adds an invalid event(event with duplicate title for same host)"""
 
-        self.client.login(username='admin', password='Tester11!')
         # Create an event
-
-        response = self.client.post(
-            reverse('event_home'),
-            data={
-                'title': self.new_event_name,
-                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-                'start_date': self.new_event_start_date_str,
-                'end_date': self.new_event_end_date_str,
-                'category': 'Course',
-                'allowed_domains': ''
-            })
-        self.assertEqual(response.status_code, 302)
-        event = Event.objects.get(title=self.new_event_name)
-        self.assertEqual(event.title, self.new_event_name)
+        self.test_add_event_valid()
 
         # Create another event with same title
         response = self.client.post(

--- a/physionet-django/events/tests_views.py
+++ b/physionet-django/events/tests_views.py
@@ -1,0 +1,142 @@
+import datetime
+import logging
+
+from django.urls import reverse
+
+from events.models import Event
+from user.test_views import TestMixin
+
+
+class TestEvents(TestMixin):
+    """ Test that all views are behaving as expected """
+
+    def setUp(self):
+        """Setup for tests"""
+
+        super().setUp()
+        self.new_event_name = "test event"
+        self.updated_event_name = "updated test event"
+        self.new_event_start_date = datetime.date.today() + datetime.timedelta(days=7)
+        self.new_event_end_date = datetime.date.today() + datetime.timedelta(days=14)
+        self.new_event_start_date_str = self.new_event_start_date.strftime("%Y-%m-%d")
+        self.new_event_end_date_str = self.new_event_end_date.strftime("%Y-%m-%d")
+
+        self.client.login(username='admin', password='Tester11!')
+
+    def test_add_event_valid(self):
+        """tests the view that adds an event"""
+
+        # Create an event
+        response = self.client.post(
+            reverse('event_home'),
+            data={
+                'title': self.new_event_name,
+                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                'start_date': self.new_event_start_date_str,
+                'end_date': self.new_event_end_date_str,
+                'category': 'Course',
+                'allowed_domains': ''
+            })
+
+        self.assertEqual(response.status_code, 302)
+        event = Event.objects.get(title=self.new_event_name)
+        self.assertEqual(event.title, self.new_event_name)
+
+    def test_add_event_invalid(self):
+        """tests the view that adds an invalid event(event with duplicate title for same host)"""
+
+        self.client.login(username='admin', password='Tester11!')
+        # Create an event
+
+        response = self.client.post(
+            reverse('event_home'),
+            data={
+                'title': self.new_event_name,
+                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                'start_date': self.new_event_start_date_str,
+                'end_date': self.new_event_end_date_str,
+                'category': 'Course',
+                'allowed_domains': ''
+            })
+        self.assertEqual(response.status_code, 302)
+        event = Event.objects.get(title=self.new_event_name)
+        self.assertEqual(event.title, self.new_event_name)
+
+        # Create another event with same title
+        response = self.client.post(
+            reverse('event_home'),
+            data={
+                'title': self.new_event_name,
+                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit2.',
+                'start_date': self.new_event_start_date_str,
+                'end_date': self.new_event_end_date_str,
+                'category': 'Course',
+                'allowed_domains': ''
+            })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'events/event_home.html')
+        self.assertContains(response, 'Event with this title already exists')
+
+    def test_edit_event_valid(self):
+        """edits an existing event"""
+
+        # add an event first
+        self.test_add_event_valid()
+        event = Event.objects.get(title=self.new_event_name)
+        slug = event.slug
+
+        response = self.client.post(
+            reverse('update_event', kwargs={'event_slug': slug}),
+            data={
+                'title': self.updated_event_name,
+                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                'start_date': self.new_event_start_date_str,
+                'end_date': self.new_event_end_date_str,
+                'category': 'Course',
+                'allowed_domains': ''
+            })
+
+        self.assertEqual(response.status_code, 302)
+        event = Event.objects.get(title=self.updated_event_name)
+        self.assertEqual(event.title, self.updated_event_name)
+
+    def test_edit_event_invalid(self):
+        """tests the view that edits an invalid event(event with duplicate title for same host)"""
+
+        # add an event first
+        self.test_add_event_valid()
+        event = Event.objects.get(title=self.new_event_name)
+        slug = event.slug
+
+        # Create another event with another title
+        response = self.client.post(
+            reverse('event_home'),
+            data={
+                'title': self.updated_event_name,
+                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                'start_date': self.new_event_start_date_str,
+                'end_date': self.new_event_end_date_str,
+                'category': 'Course',
+                'allowed_domains': ''
+            })
+
+        self.assertEqual(response.status_code, 302)
+        event = Event.objects.get(title=self.new_event_name)
+        self.assertEqual(event.title, self.new_event_name)
+
+        # try to edit the first event with the title of the second event
+        response = self.client.post(
+            reverse('update_event', kwargs={'event_slug': slug}),
+            data={
+                'title': self.updated_event_name,
+                'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                'start_date': self.new_event_start_date_str,
+                'end_date': self.new_event_end_date_str,
+                'category': 'Workshop',
+                'allowed_domains': ''
+            })
+
+        self.assertEqual(response.status_code, 302)
+        event = Event.objects.get(slug=slug)
+        self.assertEqual(event.title, self.new_event_name)

--- a/physionet-django/events/urls.py
+++ b/physionet-django/events/urls.py
@@ -6,6 +6,8 @@ from events import views
 urlpatterns = [
     path('', views.event_home, name='event_home'),
     path('<slug:event_slug>/', views.event_add_participant, name='event_add_participant'),
+    path('<slug:event_slug>/edit_event/', views.update_event, name='update_event'),
+    path('<slug:event_slug>/details/', views.get_event_details, name='get_event_details'),
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -22,7 +22,7 @@ def update_event(request, event_slug, **kwargs):
             event_form.save()
             messages.success(request, "Updated Event Successfully")
         else:
-            messages.error(request, "Error Updating Event")
+            messages.error(request, event_form.errors)
     else:
         messages.error(request, "Invalid request")
     return redirect(event_home)

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.http import JsonResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib import messages
 from django.db.models import Q
@@ -8,6 +9,32 @@ from django.contrib.auth.decorators import login_required
 import notification.utility as notification
 from events.forms import AddEventForm
 from events.models import Event
+
+
+@login_required
+def update_event(request, event_slug, **kwargs):
+    user = request.user
+    is_instructor = user.has_perm('user.add_event')
+    if request.method == 'POST':
+        event = Event.objects.get(slug=event_slug)
+        event_form = AddEventForm(user=user, data=request.POST, instance=event)
+        if event_form.is_valid() and is_instructor:
+            event_form.save()
+            messages.success(request, "Updated Event  Successfully")
+        else:
+            messages.error(request, "Error Updating Event")
+    else:
+        messages.error(request, "Invalid request")
+    return redirect(event_home)
+
+
+@login_required
+def get_event_details(request, event_slug):
+    is_instructor = request.user.has_perm('user.add_event')
+    if not is_instructor:
+        return JsonResponse([{'error': 'You don\'t have permission to access event'}], safe=False)
+    event = Event.objects.filter(slug=event_slug).values()
+    return JsonResponse(list(event), safe=False)
 
 
 @login_required

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -20,7 +20,7 @@ def update_event(request, event_slug, **kwargs):
         event_form = AddEventForm(user=user, data=request.POST, instance=event)
         if event_form.is_valid() and is_instructor:
             event_form.save()
-            messages.success(request, "Updated Event  Successfully")
+            messages.success(request, "Updated Event Successfully")
         else:
             messages.error(request, "Error Updating Event")
     else:


### PR DESCRIPTION
On PR https://github.com/MIT-LCP/physionet-build/pull/1729, Dana started working on the event update feature.

This PR adds on top of that work.

The following changes are added:

1. Event update form Updated the `save` method in `AddEventForm` so that it will work for both creating and updating events. The form will now check if the event is being created or updated. If the event is being updated, it will update the event instead of creating a new one.

2. Event Home template(event_home.html) I updated the modal for event update, and added javascript codes that renders the data in the update event modal by sending a get request to url `get_event_details`. The url loads the event details and returns a json response. The javascript then renders the data in the modal.

3. Event Views and urls updated views and urls.py to support the event update feature.

Question: Do we add a test for event create and update event now?(or should we wait till we add other features for events). probably now sound like a good idea, as it will be a simple test now and we can add more cases as we add features


