### PR TITLE
Use app label when searching for permissions

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -86,7 +86,9 @@ class AssignEditorForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['editor'].queryset = User.get_users_with_permission('can_edit_activeprojects').order_by('username')
+        self.fields['editor'].queryset = \
+            User.get_users_with_permission('project', 'can_edit_activeprojects') \
+                .order_by('username')
 
     def clean_project(self):
         pid = self.cleaned_data['project']
@@ -107,7 +109,8 @@ class ReassignEditorForm(forms.Form):
         Set the appropriate queryset
         """
         super().__init__(*args, **kwargs)
-        users = User.get_users_with_permission('can_edit_activeprojects').order_by('username')
+        users = User.get_users_with_permission('project', 'can_edit_activeprojects') \
+                    .order_by('username')
         users = users.exclude(username=user.username)
         self.fields['editor'].queryset = users
 

--- a/physionet-django/events/models.py
+++ b/physionet-django/events/models.py
@@ -38,7 +38,8 @@ class Event(models.Model):
         """
         with transaction.atomic():
             EventParticipant.objects.create(user=user, event=self)
-            permission = Permission.objects.get(codename="view_event_menu")
+            permission = Permission.objects.get(codename="view_event_menu",
+                                                content_type__app_label="events")
             user.user_permissions.add(permission)
 
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -434,13 +434,14 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.is_superuser or self.has_perm('user.can_view_admin_console')
 
     @staticmethod
-    def get_users_with_permission(permission_codename):
+    def get_users_with_permission(app_label, permission_codename):
         """
         Returns a queryset of users who have the specified permission.
         If the Permission object does not exist, an empty queryset is returned.
         """
         try:
-            perm = Permission.objects.get(codename=permission_codename)
+            perm = Permission.objects.get(codename=permission_codename,
+                                          content_type__app_label=app_label)
         except Permission.DoesNotExist:
             perm = None
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -440,13 +440,13 @@ class User(AbstractBaseUser, PermissionsMixin):
         If the Permission object does not exist, an empty queryset is returned.
         """
         try:
-            can_edit_activeprojects_perm = Permission.objects.get(codename=permission_codename)
+            perm = Permission.objects.get(codename=permission_codename)
         except Permission.DoesNotExist:
-            can_edit_activeprojects_perm = None
+            perm = None
 
-        if can_edit_activeprojects_perm:
-            users = User.objects.filter(Q(groups__permissions=can_edit_activeprojects_perm)
-                                        | Q(user_permissions=can_edit_activeprojects_perm)).distinct()
+        if perm:
+            users = User.objects.filter(Q(groups__permissions=perm)
+                                        | Q(user_permissions=perm)).distinct()
         else:
             users = User.objects.none()
 


### PR DESCRIPTION
Django "permission" objects are used to identify actions that a particular person or group is allowed to perform.

A permission is identified by a "codename" (like "can_edit_activeprojects" or "view_event_menu") as well as a "content type" (an internal Django object that corresponds to a particular model class, such as project.models.ActiveProject or events.models.Event.)

Although the "codename" should ideally be descriptive enough to be unique across the site, there's nothing preventing two Django apps from using the same codename; and as we found with the event migration, there's nothing to automatically remove or disable obsolete permissions or content types.

The general Django style is to identify permissions by app label *and* codename (see e.g. the `permission_required` decorator or the `perms` built-in template variable.)  So our `User.get_users_with_permission` function should do the same thing, as should `Event.enroll_user`.

This should solve the immediate issue with people being unable to join events.
