### PR TITLE
Change anonymous URL passphrase timeout from 60 days to 180 days. Ref #1447

### DIFF
--- a/physionet-django/project/modelcomponents/access.py
+++ b/physionet-django/project/modelcomponents/access.py
@@ -227,7 +227,7 @@ class AnonymousAccess(models.Model):
         Return a boolean of whether the raw_password was correct. Handles
         hashing formats behind the scenes.
         """
-        expire_datetime = self.creation_datetime + timedelta(days=60)
+        expire_datetime = self.creation_datetime + timedelta(days=180)
         isnot_expired = timezone.now() < expire_datetime
 
         return isnot_expired and check_password(raw_passphrase, self.passphrase)


### PR DESCRIPTION
Currently anonymous URL passphrases time out after 60 days. This is too short a period. The most common use for the passphrase is for granting anonymous access to scientific journals for peer review. Peer review almost always takes longer than 60 days.

This pull request bumps the timeout period from 60 days to 180 days. While this change should reduce the number of emails we get from people complaining about expired private URLs, I think more improvement is needed. For example, we should: 

1. display the expiry date in the admin console
2. provide an "extend expiry date" button in the console
3. notify the corresponding author when the passphrase expires (or better, before the link expires)