### PR TITLE
Replaced id with slug

### DIFF
--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -22,7 +22,7 @@ class PublishedProjectSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PublishedProject
-        fields = ('id', 'title', 'abstract', 'license', 'dua', 'main_storage_size',
+        fields = ('slug', 'title', 'abstract', 'license', 'dua', 'main_storage_size',
                   'compressed_storage_size')
 
 


### PR DESCRIPTION
[Issue #1811](https://github.com/MIT-LCP/physionet-build/issues/1811)

Replaced `id` with `slug`, eliminating the public records of the primary key & adding slug for better querying of the API. 