### PR TITLE
Feature: Add logging module for actions performed inside admin panel

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -428,6 +428,9 @@ LOGGING = {
             'format': '%(created)s %(name)s %(levelname)s %(message)s %(sinfo)s',
             '()': 'physionet.log.UwsgiJsonFormatter',
         },
+        'admin': {
+            'format': '%(levelname)s %(asctime)-15s %(user)s %(message)s'
+        }
     },
     'handlers': {
         'console': {
@@ -451,6 +454,12 @@ LOGGING = {
             'filters': ['require_debug_false'],
             'class': 'physionet.log.SaferAdminEmailHandler',
         },
+        'admin_logging': {
+            'level': 'INFO',
+            'class': _class,
+            'formatter': 'admin',
+            'stream': _logfile,
+        },
     },
     'loggers': {
         '': {
@@ -460,6 +469,11 @@ LOGGING = {
         'user': {
             'level': 'INFO',
             'handlers': ['custom_logging'],
+            'propagate': False,
+        },
+        'admin': {
+            'level': 'INFO',
+            'handlers': ['admin_logging'],
             'propagate': False,
         },
         'django.security.DisallowedHost': {


### PR DESCRIPTION
This PR adds logging configuration and the module itself to post admin activity to the standard output, so for example google platform could collect them. The log format is. as below:
![image](https://user-images.githubusercontent.com/63898848/214323310-364ff98d-6a59-48df-8136-1a36a7c40915.png)
The whole implementation is based on the LogEntry model that is django build-in model, which is saving any changes to the database. I am simply redirecting those entries to the output with a more specific format.

The main question is - Should it be an optional feature or logging those events is actually important and we should be adding this permanently?