### PR TITLE
Fix File uploads on gcp uploads

### DIFF
--- a/physionet-django/physionet/storage.py
+++ b/physionet-django/physionet/storage.py
@@ -27,8 +27,7 @@ def generate_signed_url_helper(blob_name, size, expiration=dt.timedelta(days=1),
         str: The signed URL.
     """
     storage = MediaStorage()
-    bucket = storage.bucket()
-    blob = bucket.blob(blob_name)
+    blob = storage.bucket.blob(blob_name)
 
     url = blob.generate_signed_url(
         api_access_endpoint='https://storage.googleapis.com',

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1150,7 +1150,8 @@ class TestGenerateSignedUrl(TestMixin):
         cls.invalid_size_data_3 = {'filename': 'random.txt'}
         cls.invalid_filename_data_1 = {'size': 250000, 'filename': 'ran dom.txt'}
         cls.invalid_filename_data_2 = {'size': 250000, 'filename': 'random§.txt'}
-        cls.valid_data = {'size': 250000, 'filename': 'random.txt'}
+        cls.invalid_filename_length_data_1 = {'size': 250000, 'filename': 'invalid' * 100 + '.txt'}
+        cls.valid_data = {'size': 250000, 'filename': 'folder1/folder2/random.txt'}
 
     def test_invalid_size(self):
         self.client.login(**self.user_credentials)
@@ -1185,6 +1186,11 @@ class TestGenerateSignedUrl(TestMixin):
 
         with self.subTest('Non-numeric file size returns a bad request.'):
             response = self.client.post(self.url, self.invalid_size_data_2, format='json')
+
+            self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+        with self.subTest('A filename cannot be longer than 256 characters.'):
+            response = self.client.post(self.url, self.invalid_filename_length_data_1, format='json')
 
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext as _
 
 MAX_FILENAME_LENGTH = 100
 MAX_PROJECT_SLUG_LENGTH = 30
+MAX_GCS_OBJECT_NAME_LENGTH = 256
 
 _good_name_pattern = re.compile(r'\w+([\w\-\.]*\w+)?', re.ASCII)
 _bad_name_pattern = re.compile(r'^(?:con|nul|aux|prn|com\d|lpt\d)(?:\.|$)',
@@ -127,3 +128,33 @@ def validate_topic(value):
     """
     if not re.fullmatch(r'[a-zA-Z\d][\w -]*', value):
         raise ValidationError('Letters, numbers, spaces, underscores, and hyphens only. Must begin with a letter or number.')
+
+
+def validate_gcs_bucket_object(filename, size):
+    """
+    Validate a filename and size for upload to gcs bucket objects.
+
+    File names may be at most 256 characters long.
+    Only letters, numbers, dashes, underscores, dots, and / allowed,
+    or empty. No consecutive dots or fwd slashes.
+
+    File size cannot be negative.
+    """
+    if not filename or not size:
+        raise ValidationError('You must provide the filename and the size.')
+
+    if not size.isnumeric():
+        raise ValidationError('The size must be a numeric value.')
+
+    size = int(size)
+    if size <= 0:
+        raise ValidationError('The file size cannot be a negative value.')
+
+    if len(filename) > MAX_GCS_OBJECT_NAME_LENGTH:
+        raise ValidationError(
+            f'Invalid file name "{filename}". '
+            f'File names may be at most {MAX_GCS_OBJECT_NAME_LENGTH} characters long.'
+        )
+
+    for path_segment in filename.split('/'):
+        validate_filename(path_segment)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -58,7 +58,6 @@ from user.models import CloudInformation, CredentialApplication, LegacyCredentia
 from django.db.models import F, DateTimeField, ExpressionWrapper
 
 LOGGER = logging.getLogger(__name__)
-MAX_GCS_OBJECT_NAME_LENGTH = 256
 
 def project_auth(auth_mode=0, post_auth_mode=0):
     """


### PR DESCRIPTION
Context: The `generate_signed_url` view is responsible to generate the signed url needed to upload the file to the gcp bucket. This view also checks the file names and rejects files names with non-ascii characters, files names with spaces etc. On this PR(https://github.com/MIT-LCP/physionet-build/pull/1768) Amit(me :D) started using `validate_filename` function to validate the file names. (Details on the need for that change is on that PR).

Problem: The above PR broke the GCP file uploads because gcp allows file names with `/` in them (https://cloud.google.com/storage/docs/objects) . The `validate_filename` function rejects file names with `/` in them.

Fix: The current change uses another existing function `validate_subdir` which has similar validation logic(the `validate_subdir` doesnot check for filename length) as `validate_filename` but doesn't reject file names with `/` in them.


Question: Do we want to add file length validation like filenames can have 100 characters only? I didnot go ahead and add such limit because gcp allows you to specify path like `folder/subfolder/subsubfolder/myfile.txt`. So that might sometime stop someone from uploading files in case they have a lot of nested folders.
