### PR TITLE
Traffic light identity check status 

### DIFF
--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -268,12 +268,13 @@ def validate_institutional_email(value):
     if value.split('@')[-1].lower() in domains:
         raise ValidationError('Please provide an academic or institutional email address.')
 
+
 def is_institutional_email(value):
     """
     Returns True if the email address is from an institutional domain.
     """
     try:
-       validate_institutional_email(value)
-       return True
+        validate_institutional_email(value)
+        return True
     except ValidationError:
         return False

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -267,3 +267,13 @@ def validate_institutional_email(value):
     domains = ["yahoo.com", "163.com", "126.com", "outlook.com", "gmail.com", "qq.com", "foxmail.com"]
     if value.split('@')[-1].lower() in domains:
         raise ValidationError('Please provide an academic or institutional email address.')
+
+def is_institutional_email(value):
+    """
+    Returns True if the email address is from an institutional domain.
+    """
+    try:
+       validate_institutional_email(value)
+       return True
+    except ValidationError:
+        return False


### PR DESCRIPTION
This codebase implements rules from discussion of the traffic status pipeline as in #1712.

This adds a function `is_institutional_email()` which takes in a string value representing an email address and returns a Boolean indicating whether the email address is from an institutional domain. The function first tries to validate the email address using the `validate_institutional_email(value)`. If  no exception is raised, the function returns True. If the ValidationError exception is raised, the function returns False.

It also adds `has_orcid()`  method of the User object  that returns a Boolean indicating whether the user has an ORCID. The function first checks if the user object has an attribute orcid and if it is not None. If the attribute exists, the function returns True. If the attribute 'orcid' does not exist, the function raises an exception, and the function returns False. If the attribute does not exist and no exception is raised, the function returns False.

It also adds `get_traffic_status()` method for `CredentialApplication` object  that returns a string representing the traffic status of the user based on their email, ORCID, and webpage.
The function first checks if the user has an institutional email address, by calling the `is_institutional_email()` function from the validators module on every email address of the user. If any email is institutional, the variable has_inst_email is set to True.  It then calls the `has_orcid()` method on the user object to check if the user has an ORCID and the variable `has_orcid`  is set to True if the user has an ORCID. The function also checks if the `CredentialApplication` object has a webpage attribute, if it exists and is not None then `has_webpage` is set to True. Therefore:
- If the user has both an institutional email and an ORCID, the function returns 'green'.
- If the user has an institutional email or an ORCID or a webpage, the function returns 'orange'
- If the user does not have an institutional email or an ORCID or a webpage, the function returns 'red'

