### PR TITLE
Feature: Make signed url expiration time configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,9 @@ GCP_STATIC_BUCKET_NAME=
 GCP_PROJECT_ID=
 GCP_BUCKET_LOCATION=
 
+# Expiration time of signed urls used to upload files to Google Cloud Platform
+GCS_SIGNED_URL_LIFETIME_IN_MINUTES=1440
+
 # Site-specific content
 SITE_NAME="DataShare"
 STRAPLINE="Data sharing for everyone"

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -30,6 +30,7 @@ SECRET_KEY = config('SECRET_KEY')
 ENABLE_SSO = config('ENABLE_SSO', default=False, cast=bool)
 SSO_REMOTE_USER_HEADER = config('SSO_REMOTE_USER_HEADER', default='HTTP_REMOTE_USER')
 SSO_LOGIN_BUTTON_TEXT = config('SSO_LOGIN_BUTTON_TEXT', default='Login')
+GCS_SIGNED_URL_LIFETIME_IN_MINUTES = config('GCS_SIGNED_URL_LIFETIME_IN_MINUTES', default=1440, cast=int)
 
 
 # Application definition

--- a/physionet-django/physionet/storage.py
+++ b/physionet-django/physionet/storage.py
@@ -14,7 +14,7 @@ class StaticStorage(GoogleCloudStorage):
     location = ''
 
 
-def generate_signed_url_helper(blob_name, size, expiration=dt.timedelta(days=1), version='v4') -> str:
+def generate_signed_url_helper(blob_name, size, expiration, version='v4') -> str:
     """
     Generate a signed URL to access project files on GCS
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2313,7 +2313,7 @@ def generate_signed_url(request, project_slug):
     url = generate_signed_url_helper(
         version='v4',
         blob_name=canonical_resource,
-        expiration=dt.timedelta(days=1),
+        expiration=dt.timedelta(minutes=settings.GCS_SIGNED_URL_LIFETIME_IN_MINUTES),
         size=size
     )
 


### PR DESCRIPTION
As the issue of having 24 hours long expiration time of signed urls rose I would like to introduce this PR  that makes the time value configurable using simple ENV variable. By adding those changes we can prevent unwanted uploads of already existing files or changes to the files of a project after the before-mentioned project has already been accepted by the revisor. I have also removed he default value of signed url inside of generate_signed_url_helper - we should be passing that value explicitly for better understanding of code.