### PR TITLE
Security: Restrict viewing of data access requests

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2029,7 +2029,9 @@ def data_access_request_status(request, project_slug, version):
 @login_required
 def data_access_request_status_detail(request, project_slug, version, pk):
     project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
-    access_request = get_object_or_404(DataAccessRequest, project=project, pk=pk)
+    access_request = get_object_or_404(
+        DataAccessRequest, requester=request.user, project=project, pk=pk
+    )
 
     return render(request, 'project/data_access_request_status_detail.html', {
         'access_request': access_request,

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -99,6 +99,11 @@ _demo_access_manager = {
     'version': '1.0.0',
     '_user_': 'george',
 }
+_demo_access_requester = {
+    'project_slug': 'demoselfmanaged',
+    'version': '1.0.0',
+    '_user_': 'tompollard',
+}
 TEST_DEFAULTS = {
     **_demo_open_access,
 }
@@ -111,7 +116,7 @@ TEST_CASES = {
     'display_published_project_file': {'full_file_name': 'Makefile'},
 
     'request_data_access': _demo_access_manager,
-    'data_access_request_status_detail': {**_demo_access_manager, 'pk': '1'},
+    'data_access_request_status_detail': {**_demo_access_requester, 'pk': '1'},
     'data_access_request_view': {**_demo_access_manager, 'pk': '1'},
     'data_access_requests_overview': _demo_access_manager,
     'manage_data_access_reviewers': _demo_access_manager,


### PR DESCRIPTION
**Note: this bug has now been patched on physionet.org; this pull request is to bring the dev branch up to date with our internal repository.**

For projects published as *contributor review*, visitors must submit a "data access request" (or possibly multiple requests) describing the purpose of their project.

The page at `/request-access-status/<project>/<version>/` (`data_access_request_status`) displays a list of your previously-submitted data access requests.  This page links to another page, `/request-access-status/<project>/<version>/<pk>/` (`data_access_request_status_detail`) which displays the full description of your request.

This latter function, however, didn't enforce access restrictions; *any* logged-in user would have been able to view any data access request for any project and any applicant.  This could have exposed some information (description of the research project, though not the names of the applicants) that applicants might have expected to keep private.

Note the `data_access_request_status_detail` page is separate from the interface used by *reviewers* (that one is `data_access_request_view`).

I haven't done a complete analysis, but currently I have no reason to think this bug was ever exploited on PhysioNet.

Amusingly, test_urls would have caught this issue if I'd been paying closer attention when writing the test cases.  C'est la vie.
