### PR TITLE
API: Add "project" to the URL path

### DIFF
--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -22,8 +22,14 @@ class PublishedProjectSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PublishedProject
-        fields = ('id', 'title', 'abstract', 'license', 'dua', 'main_storage_size',
+        fields = ('slug', 'title', 'abstract', 'license', 'dua', 'main_storage_size',
                   'compressed_storage_size')
+
+
+class ProjectVersionsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PublishedProject
+        fields = ('slug', 'title', 'version', 'abstract')
 
 
 class PublishedProjectDetailSerializer(serializers.ModelSerializer):

--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -6,6 +6,8 @@ from export import views
 urlpatterns = [
     # API V1 Routes
     path('v1/project/published', views.PublishedProjectList.as_view(), name='Published_project_list'),
+    path('v1/project/published/<str:project_slug>', views.ProjectVersionList.as_view(),
+         name='Published_Project_versions'),
     path('v1/project/published/<str:project_slug>/<str:version>', views.PublishedProjectDetail.as_view(),
          name='Published_project_detail'),
 ]

--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -5,8 +5,8 @@ from export import views
 
 urlpatterns = [
     # API V1 Routes
-    path('v1/published', views.PublishedProjectList.as_view(), name='Published_project_list'),
-    path('v1/published/<str:project_slug>/<str:version>', views.PublishedProjectDetail.as_view(),
+    path('v1/project/published', views.PublishedProjectList.as_view(), name='Published_project_list'),
+    path('v1/project/published/<str:project_slug>/<str:version>', views.PublishedProjectDetail.as_view(),
          name='Published_project_detail'),
 ]
 

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import get_object_or_404
 
 from project.models import PublishedProject
 
-from export.serializers import PublishedProjectSerializer, PublishedProjectDetailSerializer
+from export.serializers import PublishedProjectSerializer, PublishedProjectDetailSerializer, ProjectVersionsSerializer
 from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication
 from rest_framework import mixins
@@ -29,6 +29,22 @@ class PublishedProjectList(mixins.ListModelMixin, generics.GenericAPIView):
     queryset = PublishedProject.objects.all().order_by('id')
     authentication_classes = [SessionAuthentication, BasicAuthentication]
     serializer_class = PublishedProjectSerializer
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+
+class ProjectVersionList(mixins.ListModelMixin, generics.GenericAPIView):
+    """
+    List all versions of a specific project
+    """
+
+    serializer_class = ProjectVersionsSerializer
+
+    def get_queryset(self):
+        project_slug = self.kwargs.get('project_slug')
+        queryset = PublishedProject.objects.filter(slug=project_slug).order_by('id')
+        return queryset
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)


### PR DESCRIPTION
Pull Request for Issue #1812 Project API: Add "project" to the URL path 

Current Implementation : 

- [x] `/api/v1/project/published `- all published projects
- [x] `/api/v1/project/published/<slug>` - all versions of the project with `slug=<slug>`
- [x] /`api/v1/project/published/<slug>/<version>` - <version> of the project with `slug=<slug>`

Pending : 

- [ ] `/api/v1/project/published/<slug>/latest` - latest version of the project with `slug=<slug>`

The aim is to provide access to the metadata for the Published Projects in directory-style access via the APIs, thus improving the user experience with the API querying. 