### PR TITLE
.github/workflows: mark git repository as a safe directory

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -53,6 +53,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Mark git repository as trusted
+        run: |
+          git config --global --add safe.directory $(pwd)
+
       - name: Create .env file
         run: |
           ln -sT .env.example .env

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Mark git repository as trusted
+        run: |
+          git config --global --add safe.directory $(pwd)
+
       - name: Install WFDB
         run: |
           wget https://github.com/bemoody/wfdb/archive/10.7.0.tar.gz \


### PR DESCRIPTION
Fix bug #1844:

Modern versions of git will complain if trying to operate on a repository directory not owned by you (which is, indeed, unsafe.)

In the GitHub workflows, this error is triggered for some reason, maybe because of something wrong in how the container is set up or maybe because of something weird about how "actions/checkout" works.

Regardless of the reason, there doesn't seem to be any reason not to mark the repository directory as safe, and doing this should be harmless if GitHub later fixes the issue.
