### PR TITLE
Feature: Add absolute timeout to sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,3 +137,7 @@ MAX_EMAILS_PER_USER = 10
 
 # Max training report size in bytes
 MAX_TRAINING_REPORT_UPLOAD_SIZE = 1048576
+
+# Absolute cookie timeout in seconds -
+# In-built django variable that logouts user if cookie expiration time has been exceeded
+SESSION_COOKIE_AGE=43200

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -15,7 +15,7 @@ import logging.config
 import os
 import sys
 
-from decouple import config
+from decouple import config, UndefinedValueError
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -115,6 +115,12 @@ WSGI_APPLICATION = 'physionet.wsgi.application'
 # Session management
 
 SESSION_COOKIE_SECURE = True
+
+# Absolute timeout
+try:
+    SESSION_COOKIE_AGE = config('SESSION_COOKIE_AGE', cast=int)
+except UndefinedValueError:
+    pass
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators


### PR DESCRIPTION
This PR was separated from the main one with the whole session management. It adds a config value that is being used in django to set the absolute session time.

Using django native SESSION_COOKIE_AGE session timeout can be set to a certain period of time by setting the value using cookies stored in user browser. Then when the requests are made by server the before-mentioned cookie time is checked. If the cookie already expired user is logged out. It is client-side timeout only 
