### PR TITLE
URLs representing "directories" should end in a slash

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       DJANGO_SETTINGS_MODULE: physionet.settings.settings
       TEST_GCS_INTEGRATION: false
+      PHYSIONET_TEST_HTML_DIR: /tmp/pn-test-html-output
     defaults:
       run:
         shell: bash

--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -5,10 +5,10 @@ from export import views
 
 urlpatterns = [
     # API V1 Routes
-    path('v1/project/published', views.PublishedProjectList.as_view(), name='Published_project_list'),
-    path('v1/project/published/<str:project_slug>', views.ProjectVersionList.as_view(),
+    path('v1/project/published/', views.PublishedProjectList.as_view(), name='Published_project_list'),
+    path('v1/project/published/<str:project_slug>/', views.ProjectVersionList.as_view(),
          name='Published_Project_versions'),
-    path('v1/project/published/<str:project_slug>/<str:version>', views.PublishedProjectDetail.as_view(),
+    path('v1/project/published/<str:project_slug>/<str:version>/', views.PublishedProjectDetail.as_view(),
          name='Published_project_detail'),
 ]
 


### PR DESCRIPTION
A URL that represents a "directory" should end in a slash.  URLs that don't end in a slash are "files", and in that case the trailing component should be an appropriate filename for the resource.       

On the one hand, you can say this is just a stylistic convention.  But, aside from the fact that we want to be internally consistent, a lot of existing software makes assumptions that are broken if you don't do things the conventional way.

Note that Django will, in any event, redirect clients from `foo` to `foo/` or from `foo/` to `foo` as appropriate.
