### PR TITLE
Add Event Detail page in console

### DIFF
--- a/physionet-django/console/templates/console/event.html
+++ b/physionet-django/console/templates/console/event.html
@@ -33,7 +33,7 @@
               <tbody>
               {% for event in events %}
                 <tr>
-                    <td>{{ event.title }}</td>
+                    <td><a href="{% url 'event_management' event.slug %}">{{ event.title }}</a></td>
                     <td>{{ event.get_category_display|title }}</td>
                     <td>{{ event.host }}</td>
                     <td>{{ event.added_datetime|date }}</td>

--- a/physionet-django/console/templates/console/event_management.html
+++ b/physionet-django/console/templates/console/event_management.html
@@ -1,0 +1,149 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}Event management{% endblock %}
+
+{% block content %}
+
+    <div class="col-md-9 no-pd">
+        <h1>{{ event.title }}</h1>
+        <br/>
+        <h3>Event Details</h3>
+        <hr>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Event Organizer:
+            </div>
+            <div class="col-md-9">
+                <a href="{% url 'user_management' event.host.username %}"> {{ event.host.username }}</a>
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Category:
+            </div>
+            <div class="col-md-9">
+                {{ event.category }}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Created on:
+            </div>
+            <div class="col-md-9">
+                {{ event.added_datetime | date:"d M Y" }}
+            </div>
+        </div>
+
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Start Date:
+            </div>
+            <div class="col-md-9">
+                {{ event.start_date | date:"d M Y" }}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                End Date:
+            </div>
+            <div class="col-md-9">
+                {{ event.end_date | date:"d M Y" }}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Allowed Domains:
+            </div>
+            <div class="col-md-9">
+                {% if event.allowed_domains %}
+                    {{ event.allowed_domains }}
+                {% else %}
+
+                {% endif %}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Total participants:
+            </div>
+            <div class="col-md-9">
+                <div class="row mb-1">
+                    <div class="col-md-1">
+                        {{ event.participants.count }}
+                    </div>
+                    <div class="col-md-11">
+                        <button class="btn btn-sm btn-primary" data-toggle="modal"
+                                data-target="#view-participants">View participants
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Description:
+            </div>
+            <div class="col-md-9">
+                {{ event.description }}
+            </div>
+        </div>
+
+        {% if profile.location %}
+            <div class="row mb-1">
+                <div class="col-md-3">
+                    Location:
+                </div>
+                <div class="col-md-9">
+                    {{ profile.location }}
+                </div>
+            </div>
+        {% endif %}
+
+        {% for status, group in emails.items %}
+            <div class="row mb-1">
+                <div class="col-md-3">
+                    Email ({{ status }}):
+                </div>
+                <div class="col-md-9">
+                    {% for email in group %}
+                        {{ email|join:", " }}
+                    {% empty %}
+                        N/A
+                    {% endfor %}
+                </div>
+            </div>
+        {% endfor %}
+
+        {% if profile.website %}
+            <div class="row mb-1">
+                <div class="col-md-3">
+                    Website:
+                </div>
+                <div class="col-md-9">
+                    <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a>
+                </div>
+            </div>
+        {% endif %}
+
+    </div>
+
+
+    <div class="modal fade" id="view-participants" tabindex="-1" role="dialog"
+         aria-labelledby="view-participants-modal" aria-hidden="true">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Participants</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% include 'events/event_entries.html' %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -143,5 +143,6 @@ urlpatterns = [
     path('code-of-conducts/<int:pk>/activate/', views.code_of_conduct_activate, name='code_of_conduct_activate'),
     # Lists of event components
     path('event/', views.event,
-         name='event')
+         name='event'),
+    path('event/manage/<event_slug>', views.event_management, name='event_management')
 ]

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2877,3 +2877,17 @@ def event(request):
                   {'events': events,
                    'events_nav': True
                    })
+
+
+@permission_required('user.view_all_events', raise_exception=True)
+def event_management(request, event_slug):
+    """
+    Admin page for managing an individual Event.
+    """
+    selected_event = get_object_or_404(Event, slug=event_slug)
+    return render(
+        request,
+        'console/event_management.html',
+        {
+            'event': selected_event
+        })


### PR DESCRIPTION
As discussed here https://github.com/MIT-LCP/physionet-build/issues/1839, we will later provide access to a dataset to an event. So this PR lays foundation for that by adding a simple Event detail page on the console.

Currently the following changes are added

An event detail page on console(same as credentialed application detail page) and admins can view the project details, and participants list on console

![image](https://user-images.githubusercontent.com/24412619/216666564-7e4bbd8d-4e67-4eb4-98dd-502086bbad7d.png)
