### PR TITLE
update event registration page

### DIFF
--- a/physionet-django/events/templates/events/event_detail.html
+++ b/physionet-django/events/templates/events/event_detail.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %}Events Home{% endblock %}
+{% block title %}Event - {{ event.title }}{% endblock %}
 
 {% block local_css %}
 <link rel="stylesheet" type="text/css" href="{% static 'project/css/project-home.css' %}">
@@ -11,18 +11,11 @@
 {% block content %}
 <div class="container">
 {% if event %}
-    <h2 class="form-signin-heading">Event Registration</h2>
+    <h2 class="form-signin-heading">{{ event.title }}</h2>
     <div class="col-md-9 no-pd">
         <br/>
+        <h4>Event Details</h4>
         <hr>
-        <div class="row mb-1">
-                <div class="col-md-3">
-                    Event name:
-                </div>
-                <div class="col-md-9">
-                     {{ event.title }}
-                </div>
-        </div>
 {#        <div class="row mb-1">#}
 {#            <div class="col-md-3">#}
 {#                Hosted by:#}

--- a/physionet-django/events/templates/events/event_detail.html
+++ b/physionet-django/events/templates/events/event_detail.html
@@ -34,15 +34,6 @@
         </div>
         <div class="row mb-1">
             <div class="col-md-3">
-                Created on:
-            </div>
-            <div class="col-md-9">
-                {{ event.added_datetime | date:"M. d, Y" }}
-            </div>
-        </div>
-
-        <div class="row mb-1">
-            <div class="col-md-3">
                 Start Date:
             </div>
             <div class="col-md-9">
@@ -74,13 +65,11 @@
 
 
     <br>
-    <p>You may request to join this event below.</p>
-
-    <strong><p>Requesting participation adds your details to a waiting list. You will receive a notification when your request has been processed.</p></strong>
+    <strong><p>Click the button below to join the waiting list. You will receive a notification when your registration is confirmed.</p></strong>
 
     <form  method="post">
         {% csrf_token %}
-        <button type="submit" class="btn btn-sm btn-primary" name="confirm_event" value="confirm" role="button">Request Participation</button>
+        <button type="submit" class="btn btn-sm btn-primary" name="confirm_event" value="confirm" role="button">Join waitlist</button>
     </form>
 
 </div>

--- a/physionet-django/events/templates/events/event_home.html
+++ b/physionet-django/events/templates/events/event_home.html
@@ -93,7 +93,7 @@
             <small>Created: {{ event.added_datetime|date }}.  {% if event.host == user %} Number of participants: {{ event.participants.all|length }} {% endif %} </small><br>
             <small>Start Date: {{ event.start_date }}. End Date: {{ event.end_date }}.</small><br>
             {% if event.host == user %}
-              <small>Share the class code: {{ url_prefix }}{% url 'event_add_participant' event.slug %} </small><br>
+              <small>Share the class code: {{ url_prefix }}{% url 'event_detail' event.slug %} </small><br>
               </p>
               <button class="btn btn-sm btn-primary" data-toggle ="modal" data-target="#add-participant-modal-{{ event.id }}">View participants</button>
               <button class="btn btn-sm btn-secondary edit-btn" data-toggle ="modal" data-target="#edit-event-modal"  data-event-url="{% url 'get_event_details' event.slug %}" data-form-url="{% url 'update_event' event.slug %}" >Edit Event</button>

--- a/physionet-django/events/templates/events/event_participant.html
+++ b/physionet-django/events/templates/events/event_participant.html
@@ -23,14 +23,14 @@
                      {{ event.title }}
                 </div>
         </div>
-        <div class="row mb-1">
-            <div class="col-md-3">
-                Hosted by:
-            </div>
-            <div class="col-md-9">
-                {{ event.host.get_full_name }}
-            </div>
-        </div>
+{#        <div class="row mb-1">#}
+{#            <div class="col-md-3">#}
+{#                Hosted by:#}
+{#            </div>#}
+{#            <div class="col-md-9">#}
+{#                {{ event.host.get_full_name }}#}
+{#            </div>#}
+{#        </div>#}
         <div class="row mb-1">
             <div class="col-md-3">
                 Category:

--- a/physionet-django/events/templates/events/event_participant.html
+++ b/physionet-django/events/templates/events/event_participant.html
@@ -12,12 +12,84 @@
 <div class="container">
 {% if event %}
     <h2 class="form-signin-heading">Event Registration</h2>
-    <p>You have been invited to join {{ event.host.get_full_name }}'s {{ event.title }} from {{ event.start_date }} to {{ event.end_date }}.</p>
-    <p>Click confirm to join the waiting list for this event.</p>
+    <div class="col-md-9 no-pd">
+        <br/>
+        <hr>
+        <div class="row mb-1">
+                <div class="col-md-3">
+                    Event name:
+                </div>
+                <div class="col-md-9">
+                     {{ event.title }}
+                </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Hosted by:
+            </div>
+            <div class="col-md-9">
+                {{ event.host.get_full_name }}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Category:
+            </div>
+            <div class="col-md-9">
+                {{ event.category }}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Created on:
+            </div>
+            <div class="col-md-9">
+                {{ event.added_datetime | date:"M. d, Y" }}
+            </div>
+        </div>
+
+        <div class="row mb-1">
+            <div class="col-md-3">
+                Start Date:
+            </div>
+            <div class="col-md-9">
+                {{ event.start_date | date:"M. d, Y"}}
+            </div>
+        </div>
+        <div class="row mb-1">
+            <div class="col-md-3">
+                End Date:
+            </div>
+            <div class="col-md-9">
+                {{ event.end_date | date:"M. d, Y" }}
+            </div>
+        </div>
+
+        <div class="row mb-1">
+            <div class="row col-md-3">
+                Description:
+            </div>
+            <div class="row col-md-12">
+                {{ event.description }}
+            </div>
+        </div>
+
+
+
+    </div>
+        <hr>
+
+
+    <br>
+    <p>You may request to join this event below.</p>
+
+    <strong><p>Requesting participation adds your details to a waiting list. You will receive a notification when your request has been processed.</p></strong>
+
     <form  method="post">
         {% csrf_token %}
-        <button type="submit" class="btn btn-sm btn-primary" name="confirm_event" value="confirm" role="button">Confirm</button>
+        <button type="submit" class="btn btn-sm btn-primary" name="confirm_event" value="confirm" role="button">Request Participation</button>
     </form>
+
 </div>
 {% endif %}
 {% endblock %}

--- a/physionet-django/events/urls.py
+++ b/physionet-django/events/urls.py
@@ -5,7 +5,7 @@ from events import views
 
 urlpatterns = [
     path('', views.event_home, name='event_home'),
-    path('<slug:event_slug>/', views.event_add_participant, name='event_add_participant'),
+    path('<slug:event_slug>/', views.event_detail, name='event_detail'),
     path('<slug:event_slug>/edit_event/', views.update_event, name='update_event'),
     path('<slug:event_slug>/details/', views.get_event_details, name='get_event_details'),
 ]

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -104,9 +104,9 @@ def event_home(request):
 
 
 @login_required
-def event_add_participant(request, event_slug):
+def event_detail(request, event_slug):
     """
-    Adds participants to an event.
+    Detail page of an event
     """
     user = request.user
 
@@ -148,4 +148,4 @@ def event_add_participant(request, event_slug):
             messages.success(request, "You have successfully requested to join this event")
             return redirect(event_home)
 
-    return render(request, 'events/event_participant.html', {'event': event})
+    return render(request, 'events/event_detail.html', {'event': event})

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -116,11 +116,6 @@ def event_detail(request, event_slug):
         messages.error(request, "This event has now finished")
         return redirect(event_home)
 
-    # host should not be able to add themselves as a participant
-    if event.host == user:
-        messages.error(request, "You are the host of this event. You cannot add yourself as a participant")
-        return redirect(event_home)
-
     if event.participants.filter(user=user).exists():
         messages.error(request, "Your request to join this event is already accepted")
         return redirect(event_home)


### PR DESCRIPTION
Address https://github.com/MIT-LCP/physionet-build/issues/1858

Context: The current Event Registration page is very minimal and doesnot provide details about the event. It also shows who is the organizer of the event(on the issue https://github.com/MIT-LCP/physionet-build/issues/1858 we discussed that we dont want to always show the event host as in some cases events will have event managers)

Similarly, the current page doesnot explain what the participants should expect after registration.

The PR adds more details about the event in a more organized manner, and also adds note on what to expect

Before:
![image](https://user-images.githubusercontent.com/24412619/217647401-dc399123-b874-4bb1-ae11-0bf9c443f436.png)

After(first look)

![image](https://user-images.githubusercontent.com/24412619/217647432-184ceefc-3e88-4259-92b5-c14f113ca86a.png)
