### PR TITLE
Ru/latest paths

### DIFF
--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -8,6 +8,8 @@ urlpatterns = [
     path('v1/project/published/', views.PublishedProjectList.as_view(), name='Published_project_list'),
     path('v1/project/published/<str:project_slug>/', views.ProjectVersionList.as_view(),
          name='Published_Project_versions'),
+    path('v1/project/published/<str:project_slug>/latest/', views.PublishedProjectLatestDetail.as_view(),
+         name='Published_Project_latest_detail'),         
     path('v1/project/published/<str:project_slug>/<str:version>/', views.PublishedProjectDetail.as_view(),
          name='Published_project_detail'),
 ]

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -50,6 +50,21 @@ class ProjectVersionList(mixins.ListModelMixin, generics.GenericAPIView):
         return self.list(request, *args, **kwargs)
 
 
+class PublishedProjectLatestDetail(mixins.RetrieveModelMixin, generics.GenericAPIView):
+    """
+    Retrieve an Published Project
+    """
+
+    authentication_classes = [SessionAuthentication, BasicAuthentication]
+
+    def get(self, request, project_slug, *args, **kwargs):
+        version = PublishedProject.objects.get(slug=project_slug,
+                  is_latest_version=True).version
+        project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
+        serializer = PublishedProjectDetailSerializer(project)
+        return Response(serializer.data)
+
+
 class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView):
     """
     Retrieve an Published Project

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -19,6 +19,8 @@ urlpatterns = [
     re_path('^(?P<anonymous_url>[\w\d]{64})/$', project_views.anonymous_login,
         name='anonymous_login'),
     path('content/<project_slug>/', project_views.published_project_latest,
+        name='published_project_base'),
+    path('content/<project_slug>/latest/', project_views.published_project_latest,
         name='published_project_latest'),
     path('content/<project_slug>/<version>/', project_views.published_project,
         name='published_project'),

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
         name='published_project_latest'),
     path('content/<project_slug>/<version>/', project_views.published_project,
         name='published_project'),
+    re_path('^content/(?P<project_slug>[\w\-]+)/latest/(?P<subdir>.+)/$',
+        project_views.published_project_latest, name='published_project_latest_subdir'),
     re_path('^content/(?P<project_slug>[\w\-]+)/(?P<version>[\d\.]+)/(?P<subdir>.+)/$',
         project_views.published_project, name='published_project_subdir'),
     path('content/<project_slug>/files-panel/<version>/',


### PR DESCRIPTION
Added `/latest/` Paths for API and actual project. The point was referenced in several outstanding issues. 

1. Issue #821 
2. Issue #1381 

The Current implementation adds `content/<project_slug>/latest/` & `content/<project_slug>/latest/sub-dir`.

The idea behind the current implementation is to have a website that can be bookmarked by the general public for browsing, that will provide the latest data. Thus, to serve the purpose, the latest is not redirected but serves the exact latest version of the project.

There are several other functions, such as get-zip, files-panel, etc that are not yet implemented.