### PR TITLE
Update fixtures for event so that we have a testable event in the Events tab

### DIFF
--- a/physionet-django/events/fixtures/demo-events.json
+++ b/physionet-django/events/fixtures/demo-events.json
@@ -15,23 +15,5 @@
       "slug": "iLII4L9jSDFh",
       "allowed_domains": null
     }
-  },
-  {
-    "model": "auth.group",
-    "fields": {
-      "name": "Host",
-      "permissions": [
-        [
-          "add_event",
-          "events",
-          "event"
-        ],
-        [
-          "view_event_menu",
-          "events",
-          "event"
-        ]
-      ]
-    }
   }
 ]

--- a/physionet-django/events/fixtures/demo-events.json
+++ b/physionet-django/events/fixtures/demo-events.json
@@ -15,5 +15,22 @@
       "slug": "iLII4L9jSDFh",
       "allowed_domains": null
     }
+  },
+  {
+    "model": "events.event",
+    "pk": 2,
+    "fields": {
+        "title": "Test Event physionet",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tincidunt lobortis feugiat vivamus at augue eget. Ligula ullamcorper malesuada proin libero nunc consequat interdum varius. Rhoncus mattis rhoncus urna neque viverra justo nec ultrices. Porttitor rhoncus dolor purus non enim praesent. Vitae et leo duis ut diam quam nulla. Pretium viverra suspendisse potenti nullam ac tortor. Libero enim sed faucibus turpis in eu mi. Iaculis nunc sed augue lacus viverra. Non diam phasellus vestibulum lorem. Nulla at volutpat diam ut venenatis tellus in metus. Habitant morbi tristique senectus et netus. Lacus vel facilisis volutpat est velit egestas dui id ornare. Nisi quis eleifend quam adipiscing vitae proin sagittis nisl rhoncus. Semper risus in hendrerit gravida rutrum quisque non tellus. Condimentum lacinia quis vel eros donec ac odio tempor orci. Elit at imperdiet dui accumsan sit amet nulla facilisi morbi. Senectus et netus et malesuada fames ac turpis egestas integer. Pharetra diam sit amet nisl suscipit adipiscing bibendum est. Lectus quam id leo in vitae.\r\n\r\nQuam vulputate dignissim suspendisse in est ante. Volutpat ac tincidunt vitae semper quis. Ac ut consequat semper viverra nam libero justo laoreet. Ac auctor augue mauris augue neque. Enim nec dui nunc mattis enim. Ut faucibus pulvinar elementum integer enim neque volutpat ac tincidunt. Tristique et egestas quis ipsum suspendisse. Risus pretium quam vulputate dignissim suspendisse in est. Lorem dolor sed viverra ipsum. Sagittis aliquam malesuada bibendum arcu vitae. Nibh cras pulvinar mattis nunc sed blandit libero volutpat. Sodales neque sodales ut etiam sit amet. Faucibus pulvinar elementum integer enim neque. Erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit. Vestibulum lectus mauris ultrices eros in cursus turpis massa tincidunt.",
+        "category": "Course",
+        "host": [
+          "rgmark"
+        ],
+        "added_datetime": "2023-02-14T19:58:29.752Z",
+        "start_date": "2033-06-14",
+        "end_date": "2033-10-14",
+        "slug": "PsenZXNhPluI",
+        "allowed_domains": null
+    }
   }
 ]

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -14537,6 +14537,24 @@
   }
 },
 {
+  "model": "auth.group",
+  "fields": {
+    "name": "Host",
+    "permissions": [
+      [
+        "add_event",
+        "events",
+        "event"
+      ],
+      [
+        "view_event_menu",
+        "events",
+        "event"
+      ]
+    ]
+  }
+},
+{
   "model": "user.training",
   "pk": 1,
   "fields": {

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -30,7 +30,10 @@
     "is_active": true,
     "is_admin": false,
     "is_credentialed": true,
-    "credential_datetime": "2018-11-14T20:45:53.071Z"
+    "credential_datetime": "2018-11-14T20:45:53.071Z",
+    "groups": [
+      8
+    ]
   }
 },
 {

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -14539,7 +14539,7 @@
 {
   "model": "auth.group",
   "fields": {
-    "name": "Host",
+    "name": "Event Host",
     "permissions": [
       [
         "add_event",


### PR DESCRIPTION
Context:
Currently, the fixtures for event has just 1 event(but that event is in past, already finished). So that makes it difficult to test the Event app(unless we create a new Event).

So this PR should add a new event to the fixtures, so that we can quickly do our tests after doing `loaddemo`

1. Also, the event fixture had one small bug, where we hadn't assigned the `Event Host` permission to the existing event's host `rgmark`, this PR also adds the user to the `Event Host` auth group.
2. Also, refactored the fixture to move the `auth group` definition to demo-user.json fixture.

Conclusion: After this change, once you do `loaddemo`, you should be able to see the `Events` tab when you login as `User` `rgmark` , and can play around with an Active Event.