### PR TITLE
Project version for wfdb-python

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -6,7 +6,11 @@
 
 {% load project_templatetags %}
 
+{# Note: wfdb-python (<= 4.1.0) expects to find the project version #}
+{# number in the following format.  This is deprecated; relying on it #}
+{# is unwise, and it'll probably be removed someday. #}
 {% block meta %}
+  <!-- wfdb-python: <p>Version: {{ project.version }}</p> -->
   {% if project.short_description %}
     <meta name="description" content="{{ project.short_description }}">
   {% endif %}


### PR DESCRIPTION
wfdb-python does some silly and fragile parsing to try to extract the version number from the HTML project page.  This is really a bug in wfdb-python, and I knew about this issue ages ago and forgot about it, *but* I still don't want to break existing scripts.

This was broken I think due to pull #1823.

I *think* this should fix it but yeah, it's a terrible kludge, and I haven't tested it.
