### PR TITLE
Update Help text for research_summary on Credentialing Application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,3 +162,6 @@ ENABLE_CREDENTIALING_AUTO_REJECTION = false
 # total applications to reject every time the management command is run
 DEFAULT_NUMBER_OF_APPLICATIONS_TO_REJECT = 5
 #### Auto rejection of credentialing applications End ####
+
+# minimum number of word needed for research_summary field for Credentialing Model.
+MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING = 20

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -601,3 +601,6 @@ MAX_EMAILS_PER_USER = config('MAX_EMAILS_PER_USER', cast=int, default=10)
 # Starting at 3.2, new projects are generated with DEFAULT_AUTO_FIELD set to BigAutoField
 # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# minimum number of word needed for research_summary field for Credentialing Model.
+MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING = config('MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING', cast=int, default=20)

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -33,6 +33,8 @@ from user.widgets import ProfilePhotoInput
 
 from django.db.models import OuterRef, Exists
 
+RESEARCH_SUMMARY_MINIMUM_WORDS = 20
+
 
 class AssociatedEmailChoiceForm(forms.Form):
     """
@@ -478,9 +480,10 @@ class ResearchCAF(forms.ModelForm):
         model = CredentialApplication
         fields = ('research_summary',)
         help_texts = {
-            'research_summary': """Please provide a detailed description of how you plan to use the data,
+            'research_summary': f"""Please provide a detailed description of how you plan to use the data,
             including the name of any specific dataset(s) you intend to use. If you will be using the
-            data for a class, please also include the name and number of the course.""",
+            data for a class, please also include the name and number of the course.
+            (Minimum : {RESEARCH_SUMMARY_MINIMUM_WORDS} words)""",
         }
         widgets = {
            'research_summary': forms.Textarea(attrs={'rows': 2}),
@@ -492,7 +495,7 @@ class ResearchCAF(forms.ModelForm):
 
     def clean_research_summary(self):
         research_summary = self.cleaned_data['research_summary']
-        if len(research_summary.split()) < 20:
+        if len(research_summary.split()) < RESEARCH_SUMMARY_MINIMUM_WORDS:
             raise forms.ValidationError("Please provide more information about your research topic.")
         return research_summary
 

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -33,7 +33,7 @@ from user.widgets import ProfilePhotoInput
 
 from django.db.models import OuterRef, Exists
 
-RESEARCH_SUMMARY_MINIMUM_WORDS = 20
+MIN_WORDS_RESEARCH_SUMMARY = settings.MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING
 
 
 class AssociatedEmailChoiceForm(forms.Form):
@@ -483,7 +483,7 @@ class ResearchCAF(forms.ModelForm):
             'research_summary': f"""Please provide a detailed description of how you plan to use the data,
             including the name of any specific dataset(s) you intend to use. If you will be using the
             data for a class, please also include the name and number of the course.
-            (Minimum : {RESEARCH_SUMMARY_MINIMUM_WORDS} words)""",
+            (Minimum : {MIN_WORDS_RESEARCH_SUMMARY} words)""",
         }
         widgets = {
            'research_summary': forms.Textarea(attrs={'rows': 2}),
@@ -495,7 +495,7 @@ class ResearchCAF(forms.ModelForm):
 
     def clean_research_summary(self):
         research_summary = self.cleaned_data['research_summary']
-        if len(research_summary.split()) < RESEARCH_SUMMARY_MINIMUM_WORDS:
+        if len(research_summary.split()) < MIN_WORDS_RESEARCH_SUMMARY:
             raise forms.ValidationError("Please provide more information about your research topic.")
         return research_summary
 


### PR DESCRIPTION
Currently, during credentialing, we have a minimum limit of 20 words(but this is not obvious to the user as this information is not displayed to user). Users only see the message to provide the details about their research. So when trying to submit credentialing application with less than 20 words, they will keep getting served error by validators(but the error doesnot make it clear about the issue)

As pointed out by January, it will be a good idea if we could show the minimum word limit explicitly.