### PR TITLE
refactor boolean `is_instructor` to `can_change_event` for clarity

### DIFF
--- a/physionet-django/events/templates/events/event_home.html
+++ b/physionet-django/events/templates/events/event_home.html
@@ -26,7 +26,7 @@
   {% include "message_snippet.html" %}
   <div class="jumbotron">
     <h1>Events Home</h1>
-      {% if is_instructor %}
+      {% if can_change_event %}
       <p class="lead">Create new events and access event details.</p>
       <p>
         <button class = "btn btn-success" data-toggle="modal" data-target="#add-event-modal">


### PR DESCRIPTION
Context: 
@tompollard  pointed out on the PR https://github.com/MIT-LCP/physionet-build/pull/1874#issuecomment-1433656882 that the two variable  have slightly confusing terminology. 


`is_instructor` is someone who has permission to create events 
`is_host` is someone who is host of an existing event

On this PR, i changed the  boolean `is_instructor` to `can_change_event` so that its easier to understand what it is even without any context.