### PR TITLE
send notification to hosts, cohosts when someone joins the event wait…

### DIFF
--- a/physionet-django/events/templates/events/email/event_registration.html
+++ b/physionet-django/events/templates/events/email/event_registration.html
@@ -1,0 +1,13 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+Dear {{ name }},
+
+{{ registered_user_name }} has requested to join the Event : {{ event_title }}
+
+You can also use the following link to respond to the request:
+
+{{ url_prefix }}{{ events_home }}
+
+
+Regards
+The {{ SITE_NAME }} Team
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/events/templates/events/email/event_registration.html
+++ b/physionet-django/events/templates/events/email/event_registration.html
@@ -1,12 +1,10 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ name }},
 
-{{ registered_user_name }} has requested to join the Event : {{ event_title }}
+{{ registered_user_name }} has requested to join: {{ event_title }}
 
-You can also use the following link to respond to the request:
-
+You can use the following link to respond to the request:
 {{ url_prefix }}{{ events_home }}
-
 
 Regards
 The {{ SITE_NAME }} Team

--- a/physionet-django/events/utility.py
+++ b/physionet-django/events/utility.py
@@ -1,0 +1,23 @@
+import notification.utility as notification
+
+
+def notify_host_cohosts_new_registration(request, registered_user, event):
+    """
+    Notify the host and cohosts of an event of a message.
+    """
+
+    notification.notify_event_participant_application(
+        request=request,
+        user=event.host,
+        registered_user=registered_user,
+        event=event
+    )
+
+    for participant in event.participants.all():
+        if participant.is_cohost:
+            notification.notify_event_participant_application(
+                request=request,
+                user=participant.user,
+                registered_user=registered_user,
+                event=event
+            )

--- a/physionet-django/events/utility.py
+++ b/physionet-django/events/utility.py
@@ -3,7 +3,7 @@ import notification.utility as notification
 
 def notify_host_cohosts_new_registration(request, registered_user, event):
     """
-    Notify the host and cohosts of an event of a message.
+    Notify the host and cohosts that a user has submitted a request to join their event.
     """
 
     notification.notify_event_participant_application(

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 import notification.utility as notification
 from events.forms import AddEventForm, EventApplicationResponseForm
 from events.models import Event, EventApplication, EventParticipant
+from events.utility import notify_host_cohosts_new_registration
 
 
 @login_required
@@ -177,6 +178,7 @@ def event_detail(request, event_slug):
         if 'confirm_registration' in request.POST.keys():
             event.join_waitlist(user=user, comment_to_applicant='')
             notification.notify_participant_event_waitlist(request=request, user=user, event=event)
+            notify_host_cohosts_new_registration(request=request, registered_user=user, event=event)
             messages.success(request, "You have successfully requested to join this event")
             return redirect(event_home)
         elif 'confirm_withdraw' in request.POST.keys():

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -983,3 +983,22 @@ def notify_participant_event_decision(request, user, event, decision, comment_to
     body = loader.render_to_string('events/email/event_participation_decision.html', context)
     # Not resend the email if there was an integrity error
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)
+
+
+def notify_event_participant_application(request, user, registered_user, event):
+    """
+    Send email to host and co-host about new registration request on event.
+    """
+
+    subject = f"{settings.SITE_NAME} {event.title} New Participant Registration"
+    context = {
+        'name': user.get_full_name(),
+        'registered_user_name': registered_user.get_full_name(),
+        'url_prefix': get_url_prefix(request),
+        'events_home': reverse('event_home'),
+        'event_title': event.title,
+        'SITE_NAME': settings.SITE_NAME,
+    }
+    body = loader.render_to_string('events/email/event_registration.html', context)
+    # Not resend the email if there was an integrity error
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)


### PR DESCRIPTION
Context: Follow up PR to https://github.com/MIT-LCP/physionet-buildtps://github.com/MIT-LCP/physionet-build/pull/1865

This PR adds the logic to send email notification to event host when someone joins the event.


Email for reference

```
physionet-build-dev-1   | Content-Type: text/plain; charset="utf-8"
physionet-build-dev-1   | MIME-Version: 1.0
physionet-build-dev-1   | Content-Transfer-Encoding: 7bit
physionet-build-dev-1   | Subject: DataShare New Event Registration
physionet-build-dev-1   | From: localhost@localhost
physionet-build-dev-1   | To: aewj@mit.edu
physionet-build-dev-1   | Date: Sat, 18 Feb 2023 03:52:23 -0000
physionet-build-dev-1   | Message-ID: <167669234328.52.17528481204908402355@4360bbac4327>
physionet-build-dev-1   | 
physionet-build-dev-1   | 
physionet-build-dev-1   | Dear Alistair Edward William Johnson,
physionet-build-dev-1   | 
physionet-build-dev-1   | Tom Pollard has requested to join the Event : Test Event physionet.
physionet-build-dev-1   | 
physionet-build-dev-1   | You can also use the following link to respond to the request:
physionet-build-dev-1   | 
physionet-build-dev-1   | http://localhost:8000/events/
physionet-build-dev-1   | 
physionet-build-dev-1   | 
physionet-build-dev-1   | Regards
physionet-build-dev-1   | The DataShare Team
physionet-build-dev-1   | 
physionet-build-dev-1   | 
physionet-build-dev-1   | -------------------------------------------------------------------------------
```