### PR TITLE
allow participants to access dataset through events

### DIFF
--- a/physionet-django/events/models.py
+++ b/physionet-django/events/models.py
@@ -189,6 +189,27 @@ class EventDataset(models.Model):
             return False
         return True
 
+    def has_access(self, user):
+        """
+        checks if the user has access to the dataset for the Event
+        This method is independent of the PublishedProject.has_access method. it will only check if the user should
+        have access to the dataset for the event.
+        It is expected that the PublishedProject.has_access method will use this method to check if the user has access
+        in case the dataset access is made through an event.
+        """
+        if not self.is_accessible():
+            return False
+
+        # check if the user is a participant of the event or the host of the event
+        # In addition to participants, host should also have access to the dataset of their own event
+        # we dont need to worry about cohosts here as they are already participants
+        if not self.event.participants.filter(user=user).exists() and not self.event.host == user:
+            return False
+
+        # TODO once Event Agreement/DUA is merged, check if the user has accepted the agreement
+
+        return True
+
     def revoke_dataset_access(self):
         """
         Revokes access to the dataset for the event.

--- a/physionet-django/events/templates/events/event_datasets.html
+++ b/physionet-django/events/templates/events/event_datasets.html
@@ -28,7 +28,7 @@
                     {% elif is_waitlisted%}
                       <a class="btn btn-secondary" href="#">On waiting list</a>
                     {% elif user|has_access_to_event_dataset:dataset %}
-                      <a class="btn btn-success" href="">Access here</a>
+                      <a class="btn btn-success" href="/environments/">Access here</a>
                     {% else %}
                       <p>Please register to the event for access</p>
                     {% endif %}

--- a/physionet-django/events/templates/events/event_datasets.html
+++ b/physionet-django/events/templates/events/event_datasets.html
@@ -1,0 +1,4 @@
+<div class="container">
+  <h5>Event Datasets</h5>
+
+</div>

--- a/physionet-django/events/templates/events/event_datasets.html
+++ b/physionet-django/events/templates/events/event_datasets.html
@@ -1,4 +1,45 @@
-<div class="container">
-  <h5>Event Datasets</h5>
+{% load participation_status %}
 
+<div class="container">
+  <h5>Datasets</h5>
+  <div class="card mb-3">
+    <div class="card-body">
+      {% if event_datasets %}
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th scope="col">Title</th>
+              <th scope="col">Version</th>
+              <th scope="col">Access Type</th>
+              <th scope="col">Access</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for dataset in event_datasets %}
+              <tr>
+                <td>
+                  <a href="{% url 'published_project' dataset.dataset.slug dataset.dataset.version %}">{{ dataset.dataset.title }}</a>
+                </td>
+                <td>{{ dataset.dataset.version }}</td>
+                <td>{{ dataset.get_access_type_display }}</td>
+                <td>
+                    {% if not dataset.is_accessible %}
+                      <a class="btn btn-success" href="#">Access Archieved</a>
+                    {% elif is_waitlisted%}
+                      <a class="btn btn-secondary" href="#">On waiting list</a>
+                    {% elif user|has_access_to_event_dataset:dataset %}
+                      <a class="btn btn-success" href="">Access here</a>
+                    {% else %}
+                      <p>Please register to the event for access</p>
+                    {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p>No datasets available.</p>
+      {% endif %}
+    </div>
+  </div>
 </div>

--- a/physionet-django/events/templates/events/event_detail.html
+++ b/physionet-django/events/templates/events/event_detail.html
@@ -52,6 +52,8 @@
     <hr>
 
     {% include  "events/event_participation.html" %}
+     <hr>
+    {% include  "events/event_datasets.html" %}
 
     
 </div>

--- a/physionet-django/events/templatetags/participation_status.py
+++ b/physionet-django/events/templatetags/participation_status.py
@@ -17,3 +17,8 @@ def is_on_waiting_list(user, event):
         event=event,
         status=EventApplication.EventApplicationStatus.WAITLISTED
     ).exists()
+
+
+@register.filter(name='has_access_to_event_dataset')
+def has_access_to_event_dataset(user, dataset):
+    return dataset.has_access(user)

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -210,6 +210,10 @@ def event_detail(request, event_slug):
 
     # Handle Event Registration  End #
 
+    # Handle Event Datastore  Start #
+    event_datasets = event.datasets.filter(is_active=True)
+    # Handle Event Datastore  End #
+
     return render(
         request,
         'events/event_detail.html',
@@ -217,4 +221,5 @@ def event_detail(request, event_slug):
          'registration_allowed': registration_allowed,
          'registration_error_message': registration_error_message,
          'is_waitlisted': is_waitlisted,
+         'event_datasets': event_datasets,
          })

--- a/physionet-django/project/managers/publishedproject.py
+++ b/physionet-django/project/managers/publishedproject.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 from django.db.models import Manager, Q
+from events.models import Event, EventDataset
 from project.models import AccessPolicy, DUASignature, DataAccessRequest
 from user.models import Training, TrainingType
 
@@ -48,4 +51,18 @@ class PublishedProjectManager(Manager):
                 contributor_review_with_access | credentialed_with_dua_signed
             )
 
+        # Event related logic
+        # get all projects that are accessible by user through Events(Used by `hdn-research-environment` package)
+        # get all active events that user is a participant/host of
+        events_all = Event.objects.filter(Q(host=user) | Q(participants__user=user))
+        active_events = set(events_all.filter(end_date__gte=datetime.now()))
+        # get all accessible datasets for the events
+        accessible_datasets = EventDataset.objects.filter(event__in=active_events, is_active=True)
+        # get all projects that are accessible to the user
+        accessible_projects_ids = []
+        for event_dataset in accessible_datasets:
+            if event_dataset.has_access(user):
+                accessible_projects_ids.append(event_dataset.dataset.id)
+
+        query |= Q(id__in=accessible_projects_ids)
         return self.filter(query)


### PR DESCRIPTION
Context: This PR implements the last part of https://github.com/MIT-LCP/physionet-build/issues/1839
Here we will allow users who have been accepted to events to view the project/datasets.
The change should also allow HDN to access the project in the research environment.

Quick notes
1. So far the change doesnot make use of `access_type` from `EventDataset` model. It currently will let users registered to events access the dataset through Research environment(as the hdn-reserch-environment uses `PublishedProject.objects.accessible_by(user)`) , and view the files on the project page.

Screenshots to explain userstory
1. before user joins waitlist

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/24412619/220758020-0bec35f4-a805-4891-8403-e2bd3203ffdb.png">

2. After user joins waitlist
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/24412619/220763030-98faf2c8-9df8-4f32-b7c5-fb7e60d788ce.png">

3. After user is approved to join the event
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/24412619/220758402-5ff399fb-9184-4a46-95ca-c615d1a8418a.png">

4. project page if user visits the project page through the correct link example(http://localhost:8000/content/demoeicu/2.0.0/?event=qoL47ZfEZjKw)
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/24412619/220758576-4b68e668-dbd9-422b-a84d-7269dcc24a36.png">

PS: if the user who has access to the dataset through event, visits the project through normal link http://localhost:8000/content/demoeicu/2.0.0 , they can still access the dataset and see files, but wont see the message.

I didnot restrict access to user when the link doesnot have `event=slug` because it might cause issues in cases where same user has access to the project through event and in normal way(credentialing and training).

---

**Explanation of the changes/Workflow, users and projects involved(or how everything is supposed to happen /happens)**

1. Event is first created by an Event Host
2. Event host will request the Platform Admin to add one or more dataset(s) to the Event
3. Platform Admin will then link one or more published project/dataset to the Event.
4. At this point the Event Host can access all the projects/dataset linked to the Event(until the Event ends or until the Admin unlinks the dataset/project from the Event)
5. The Event Host will share the event link to the students/participants, and the participants can request to join the event through the event link(the participants donot have access to project at this point).
6. Now the Event Host has the authority to grant access to dataset to the students by approving their request to join the event.
7. As soon as the Event Host approves students to join the event, student will have access the the project/dataset

**In Summary**

The Platform Admin has the highest Control, they have the ability to grant or revoke access to the project through the admin console.
After the Platform Admin, the Event host has the ability to let participants access the dataset by approving them to join the event.
Any dataset that is linked by the Platform Admin to an Event will be instantly accessible to the Host and Participants of that Event
The access expires after the event ends or if the Admin removes the project/dataset from Event.


**Quick note:**
There is also supposed to be further control on how the data is supposed to be accessed (currently)
1. Through Research Environment
2. Or through Google BigQuery
The current PR only works for the Research Environment at the moment.

