### PR TITLE
Upsidelab chore/bump hdn research environment

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -743,13 +743,13 @@ protobuf = ">=3.12.0"
 
 [[package]]
 name = "hdn-research-environment"
-version = "1.2.2"
+version = "1.4.0"
 description = "A Django app for supporting cloud-native research environments"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "hdn-research-environment-1.2.2.tar.gz", hash = "sha256:e98c544a7eb3eaf8ac65b3dab54f79cc8a7768f651449308bf89486838083dc1"},
+    {file = "hdn-research-environment-1.4.0.tar.gz", hash = "sha256:296a336847c1078c149baa6773654a2e2a5b16cc1b03ca25f6f19f8606980e5b"},
 ]
 
 [package.dependencies]
@@ -1369,4 +1369,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f7768d36e94d9d8dabd4e9333d6739d354ee03b757c2d266a8aed4e97da69b62"
+content-hash = "4c3c85a0be45f1d0a8c783538fc63d4a8d85f68fc43fc31a54bfc16437363d22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ zxcvbn = "^4.4.28"
 certifi = "^2022.12.7"
 setuptools = "65.5.1"
 django-js-asset = "2.0.0"
-hdn-research-environment = "^1.2.2"
+hdn-research-environment = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^4.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -287,8 +287,8 @@ grpcio==1.51.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:f1fec3abaf274cdb85bf3878167cfde5ad4a4d97c68421afda95174de85ba813 \
     --hash=sha256:f96ace1540223f26fbe7c4ebbf8a98e3929a6aa0290c8033d12526847b291c0f \
     --hash=sha256:fbdbe9a849854fe484c00823f45b7baab159bdd4a46075302281998cb8719df5
-hdn-research-environment==1.2.2 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:e98c544a7eb3eaf8ac65b3dab54f79cc8a7768f651449308bf89486838083dc1
+hdn-research-environment==1.4.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:296a336847c1078c149baa6773654a2e2a5b16cc1b03ca25f6f19f8606980e5b
 html2text==2018.1.9 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662 \
     --hash=sha256:627514fb30e7566b37be6900df26c2c78a030cc9e6211bda604d8181233bcdd4


### PR DESCRIPTION
Adds to https://github.com/MIT-LCP/physionet-build/pull/1895 by bumping requirements.txt with:

```
poetry export -f requirements.txt --output requirements.txt --with dev
```