### PR TITLE
removed extra newline in email template

### DIFF
--- a/physionet-django/events/templates/events/email/event_participation_decision.html
+++ b/physionet-django/events/templates/events/email/event_participation_decision.html
@@ -11,7 +11,6 @@ We were unable to register you for the following event: {{ event_title }}.
 You can view further information about the event using the following link:
 {{ url_prefix }}{{ event_url }}
 
-
 Regards
 The {{ SITE_NAME }} Team
 {% endfilter %}{% endautoescape %}

--- a/physionet-django/events/templates/events/email/event_participation_waitlist.html
+++ b/physionet-django/events/templates/events/email/event_participation_waitlist.html
@@ -6,7 +6,6 @@ Thanks for your interest in joining: {{ event_title }}. You will receive an emai
 You can also use the following link to check your registration status at any time:
 {{ url_prefix }}{{ event_url }}
 
-
 Regards
 The {{ SITE_NAME }} Team
 {% endfilter %}{% endautoescape %}

--- a/physionet-django/events/templates/events/email/event_participation_withdraw.html
+++ b/physionet-django/events/templates/events/email/event_participation_withdraw.html
@@ -2,9 +2,7 @@
 Dear {{ name }},
 
 You have withdrawn your registration for the following event: {{ event_title }}. If this was a mistake, you can register again using the following link:
-
 {{ url_prefix }}{{ event_url }}
-
 
 Regards
 The {{ SITE_NAME }} Team


### PR DESCRIPTION
For `events` app, there were two new lines before the final line of the email template. This is inconsistent with the other templates(`user` app)

As pointed out by @tompollard on https://github.com/MIT-LCP/physionet-build/pull/1888#discussion_r1115198521, it is a good idea to have the consistency.