### PR TITLE
limit update event to the event host(Instructor) who created the event

### DIFF
--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -21,9 +21,12 @@ def update_event(request, event_slug, **kwargs):
     if request.method == 'POST':
         event = Event.objects.get(slug=event_slug)
         event_form = AddEventForm(user=user, data=request.POST, instance=event)
-        if event_form.is_valid() and can_change_event and event.host == user:
-            event_form.save()
-            messages.success(request, "Updated Event Successfully")
+        if event_form.is_valid():
+            if can_change_event and event.host == user:
+                event_form.save()
+                messages.success(request, "Updated Event Successfully")
+            else:
+                messages.error(request, "You don't have permission to edit this event")
         else:
             messages.error(request, event_form.errors)
     else:

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -21,7 +21,7 @@ def update_event(request, event_slug, **kwargs):
     if request.method == 'POST':
         event = Event.objects.get(slug=event_slug)
         event_form = AddEventForm(user=user, data=request.POST, instance=event)
-        if event_form.is_valid() and can_change_event:
+        if event_form.is_valid() and can_change_event and event.host == user:
             event_form.save()
             messages.success(request, "Updated Event Successfully")
         else:


### PR DESCRIPTION
Context:
On Events APP: Although, we don't allow other Instructor to edit someone else's event from the User Interface, There is a chance that someone can simulate a post request and edit someone else's event(As we were not verifying that the requester is the event host(Instructor) who created the event).

The change will do a check to make sure the current user making a request to edit an event is the right instructor.