### PR TITLE
limit approval of participants to event host who created event

### DIFF
--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -98,43 +98,42 @@ def event_home(request):
 
     form_error = False
 
-    if can_change_event:
-        # handle notifications to join an event
-        if request.method == 'POST' and 'participation_response' in request.POST.keys():
+    # handle notifications to join an event
+    if request.method == 'POST' and 'participation_response' in request.POST.keys():
 
-            formset = EventApplicationResponseFormSet(request.POST)
-            # only process the form that was submitted
-            for form in formset:
-                if form.instance.id == int(request.POST['participation_response']):
-                    if form.is_valid():
-                        event_application = form.save(commit=False)
-                        if event_application.status == EventApplication.EventApplicationStatus.APPROVED:
-                            event_application.accept(
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                            notification.notify_participant_event_decision(
-                                request=request,
-                                user=event_application.user,
-                                event=event_application.event,
-                                decision=EventApplication.EventApplicationStatus.APPROVED.label,
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                        elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
-                            event_application.reject(
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                            notification.notify_participant_event_decision(
-                                request=request,
-                                user=event_application.user,
-                                event=event_application.event,
-                                decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                    else:
-                        messages.error(request, form.errors)
-                    return redirect(event_home)
-            else:
-                form_error = True
+        formset = EventApplicationResponseFormSet(request.POST)
+        # only process the form that was submitted
+        for form in formset:
+            if form.instance.id == int(request.POST['participation_response']):
+                if form.is_valid():
+                    event_application = form.save(commit=False)
+                    if event_application.status == EventApplication.EventApplicationStatus.APPROVED:
+                        event_application.accept(
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                        notification.notify_participant_event_decision(
+                            request=request,
+                            user=event_application.user,
+                            event=event_application.event,
+                            decision=EventApplication.EventApplicationStatus.APPROVED.label,
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                    elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
+                        event_application.reject(
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                        notification.notify_participant_event_decision(
+                            request=request,
+                            user=event_application.user,
+                            event=event_application.event,
+                            decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                else:
+                    messages.error(request, form.errors)
+                return redirect(event_home)
+        else:
+            form_error = True
 
     # get all participation requests for Active events where the current user is the host and the participants are
     # waiting for a response

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -107,28 +107,32 @@ def event_home(request):
             if form.instance.id == int(request.POST['participation_response']):
                 if form.is_valid():
                     event_application = form.save(commit=False)
-                    if event_application.status == EventApplication.EventApplicationStatus.APPROVED:
-                        event_application.accept(
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
-                        notification.notify_participant_event_decision(
-                            request=request,
-                            user=event_application.user,
-                            event=event_application.event,
-                            decision=EventApplication.EventApplicationStatus.APPROVED.label,
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
-                    elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
-                        event_application.reject(
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
-                        notification.notify_participant_event_decision(
-                            request=request,
-                            user=event_application.user,
-                            event=event_application.event,
-                            decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
+                    event = event_application.event
+                    if event.host == user:
+                        if event_application.status == EventApplication.EventApplicationStatus.APPROVED:
+                            event_application.accept(
+                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                            )
+                            notification.notify_participant_event_decision(
+                                request=request,
+                                user=event_application.user,
+                                event=event_application.event,
+                                decision=EventApplication.EventApplicationStatus.APPROVED.label,
+                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                            )
+                        elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
+                            event_application.reject(
+                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                            )
+                            notification.notify_participant_event_decision(
+                                request=request,
+                                user=event_application.user,
+                                event=event_application.event,
+                                decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
+                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                            )
+                    else:
+                        messages.error(request, "You don't have permission to accept/reject this application")
                 else:
                     messages.error(request, form.errors)
                 return redirect(event_home)

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -105,37 +105,39 @@ def event_home(request):
         # only process the form that was submitted
         for form in formset:
             if form.instance.id == int(request.POST['participation_response']):
-                if form.is_valid():
-                    event_application = form.save(commit=False)
-                    event = event_application.event
-                    if event.host != user:
-                        messages.error(request, "You don't have permission to accept/reject this application")
-                        return redirect(event_home)
-                    elif event_application.status == EventApplication.EventApplicationStatus.APPROVED:
-                        event_application.accept(
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
-                        notification.notify_participant_event_decision(
-                            request=request,
-                            user=event_application.user,
-                            event=event_application.event,
-                            decision=EventApplication.EventApplicationStatus.APPROVED.label,
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
-                    elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
-                        event_application.reject(
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
-                        notification.notify_participant_event_decision(
-                            request=request,
-                            user=event_application.user,
-                            event=event_application.event,
-                            decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
-                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                        )
 
-                else:
+                if not form.is_valid():
                     messages.error(request, form.errors)
+                    return redirect(event_home)
+
+                event_application = form.save(commit=False)
+                event = event_application.event
+                if event.host != user:
+                    messages.error(request, "You don't have permission to accept/reject this application")
+                    return redirect(event_home)
+                elif event_application.status == EventApplication.EventApplicationStatus.APPROVED:
+                    event_application.accept(
+                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                    )
+                    notification.notify_participant_event_decision(
+                        request=request,
+                        user=event_application.user,
+                        event=event_application.event,
+                        decision=EventApplication.EventApplicationStatus.APPROVED.label,
+                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                    )
+                elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
+                    event_application.reject(
+                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                    )
+                    notification.notify_participant_event_decision(
+                        request=request,
+                        user=event_application.user,
+                        event=event_application.event,
+                        decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
+                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                    )
+
                 return redirect(event_home)
         else:
             form_error = True

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -104,41 +104,42 @@ def event_home(request):
         formset = EventApplicationResponseFormSet(request.POST)
         # only process the form that was submitted
         for form in formset:
-            if form.instance.id == int(request.POST['participation_response']):
+            if form.instance.id != int(request.POST['participation_response']):
+                continue
 
-                if not form.is_valid():
-                    messages.error(request, form.errors)
-                    return redirect(event_home)
-
-                event_application = form.save(commit=False)
-                event = event_application.event
-                if event.host != user:
-                    messages.error(request, "You don't have permission to accept/reject this application")
-                    return redirect(event_home)
-                elif event_application.status == EventApplication.EventApplicationStatus.APPROVED:
-                    event_application.accept(
-                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                    )
-                    notification.notify_participant_event_decision(
-                        request=request,
-                        user=event_application.user,
-                        event=event_application.event,
-                        decision=EventApplication.EventApplicationStatus.APPROVED.label,
-                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                    )
-                elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
-                    event_application.reject(
-                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                    )
-                    notification.notify_participant_event_decision(
-                        request=request,
-                        user=event_application.user,
-                        event=event_application.event,
-                        decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
-                        comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                    )
-
+            if not form.is_valid():
+                messages.error(request, form.errors)
                 return redirect(event_home)
+
+            event_application = form.save(commit=False)
+            event = event_application.event
+            if event.host != user:
+                messages.error(request, "You don't have permission to accept/reject this application")
+                return redirect(event_home)
+            elif event_application.status == EventApplication.EventApplicationStatus.APPROVED:
+                event_application.accept(
+                    comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                )
+                notification.notify_participant_event_decision(
+                    request=request,
+                    user=event_application.user,
+                    event=event_application.event,
+                    decision=EventApplication.EventApplicationStatus.APPROVED.label,
+                    comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                )
+            elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
+                event_application.reject(
+                    comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                )
+                notification.notify_participant_event_decision(
+                    request=request,
+                    user=event_application.user,
+                    event=event_application.event,
+                    decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
+                    comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                )
+
+            return redirect(event_home)
         else:
             form_error = True
 

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -108,31 +108,32 @@ def event_home(request):
                 if form.is_valid():
                     event_application = form.save(commit=False)
                     event = event_application.event
-                    if event.host == user:
-                        if event_application.status == EventApplication.EventApplicationStatus.APPROVED:
-                            event_application.accept(
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                            notification.notify_participant_event_decision(
-                                request=request,
-                                user=event_application.user,
-                                event=event_application.event,
-                                decision=EventApplication.EventApplicationStatus.APPROVED.label,
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                        elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
-                            event_application.reject(
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                            notification.notify_participant_event_decision(
-                                request=request,
-                                user=event_application.user,
-                                event=event_application.event,
-                                decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
-                                comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
-                            )
-                    else:
+                    if event.host != user:
                         messages.error(request, "You don't have permission to accept/reject this application")
+                        return redirect(event_home)
+                    elif event_application.status == EventApplication.EventApplicationStatus.APPROVED:
+                        event_application.accept(
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                        notification.notify_participant_event_decision(
+                            request=request,
+                            user=event_application.user,
+                            event=event_application.event,
+                            decision=EventApplication.EventApplicationStatus.APPROVED.label,
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                    elif event_application.status == EventApplication.EventApplicationStatus.NOT_APPROVED:
+                        event_application.reject(
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+                        notification.notify_participant_event_decision(
+                            request=request,
+                            user=event_application.user,
+                            event=event_application.event,
+                            decision=EventApplication.EventApplicationStatus.NOT_APPROVED.label,
+                            comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
+                        )
+
                 else:
                     messages.error(request, form.errors)
                 return redirect(event_home)


### PR DESCRIPTION
Context:
Similar change to https://github.com/MIT-LCP/physionet-build/pull/1899, 

For the view that allows event hosts to approve/disapprove participants, we were only checking if someone has the permission to create an event and allowing any user that has this permission to accept the participation request(on the `events.views.py`)(we were not verifying that the current user is the actual event host(the person who created the event).

Although its not a super security risk  as someone will need to guess the `EventApplication` id to submit a post request to exploit this, but it seems like a good idea to implement the validation

Also, this PR will later let us allow cohosts to handle participation request, So this PR sorts of acts as foundation for that.