### PR TITLE
Remove "toggle_cohost_status"

### DIFF
--- a/physionet-django/events/templates/events/event_entries.html
+++ b/physionet-django/events/templates/events/event_entries.html
@@ -18,9 +18,9 @@
             <td>{{ participant.user.is_credentialed }}</td>
             <td>
                 {% if participant.is_cohost %}
-                    <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ participant.id }}"  checked>
+                    <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ participant.id }}" disabled checked>
                 {% else %}
-                    <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ participant.id }}"  >
+                    <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ participant.id }}" disabled>
                 {% endif %}
             </td>
           </tr>

--- a/physionet-django/events/templates/events/event_home.html
+++ b/physionet-django/events/templates/events/event_home.html
@@ -241,28 +241,5 @@
        });
 
    });
-
-    $(document).ready(function() {
-        $('body').on('click', 'input[name="toggle-cohost-status"]', function(event) {
-            event.preventDefault(); // prevent the default action
-            console.log(event.target,'hello');
-            let checkbox = $(event.target);
-            let participant_id = checkbox.val();
-            let event_slug = checkbox.attr('event-slug');
-            let url = '/events/' + event_slug + '/participant/' + participant_id + '/toggle_cohost_status';
-
-            $.ajax({
-                url: url,
-                type: "GET",
-                success: function (data) {
-                  console.log(data);
-                  if(data[0].status===true){
-                    checkbox.prop('checked', !checkbox.prop('checked'));
-                  }
-                },
-            });
-        });
-    });
-
   </script>
 {% endblock %}

--- a/physionet-django/events/urls.py
+++ b/physionet-django/events/urls.py
@@ -8,8 +8,6 @@ urlpatterns = [
     path('<slug:event_slug>/', views.event_detail, name='event_detail'),
     path('<slug:event_slug>/edit_event/', views.update_event, name='update_event'),
     path('<slug:event_slug>/details/', views.get_event_details, name='get_event_details'),
-    path('<slug:event_slug>/participant/<int:participant_id>/toggle_cohost_status', views.toggle_cohost_status,
-         name='toggle_cohost_status'),
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -44,25 +44,6 @@ def get_event_details(request, event_slug):
 
 
 @login_required
-def toggle_cohost_status(request, event_slug, participant_id):
-    can_change_event = request.user.has_perm('events.add_event')
-    is_host = Event.objects.filter(slug=event_slug, host=request.user).exists()
-
-    if not can_change_event:
-        return JsonResponse([{'status': False, 'message': 'You don\'t have permission to edit event'}], safe=False)
-    if not is_host:
-        return JsonResponse([{'status': False, 'message': 'You are not the host of this event'}], safe=False)
-
-    event_participant = EventParticipant.objects.get(id=participant_id)
-    if event_participant.is_cohost:
-        event_participant.remove_cohost()
-    else:
-        event_participant.make_cohost()
-
-    return JsonResponse([{'status': True, 'message': 'Updated cohost status'}], safe=False)
-
-
-@login_required
 def event_home(request):
     """
     List of events


### PR DESCRIPTION

This function is broken.  It's a security problem waiting to happen.  The only reason it's not a problem right now is that right now (as far as I can tell) the "cohost" flag is meaningless.

This functionality, if it's desired, needs to be completely re-implemented.  There's no way to make it secure without breaking compatibility, so there's no reason to keep the function at all.
