### PR TITLE
bug fix: edit event agreement

### DIFF
--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -632,6 +632,7 @@ class TestEventAgreements(TestMixin):
         self.event_agreement_slug_new_version = "a1b2c3d4e5"
         self.updated_event_agreement_name = "updated test event agreement"
         self.event_agreement_html_content = "<p>My test Event Agreement test content</p>"
+        self.updated_event_agreement_html_content = "<p>My updated test Event Agreement test content</p>"
         self.event_agreement_access_template = "<p>My test Event Agreement test content</p>"
 
         self.client.login(username='admin', password='Tester11!')
@@ -673,8 +674,8 @@ class TestEventAgreements(TestMixin):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'console/event_agreement_list.html')
 
-    def test_edit_event_agreement_valid(self):
-        """tests the view that edits a valid event agreement"""
+    def test_edit_event_agreement_valid_1(self):
+        """tests the view that edits name in event agreement"""
 
         event_agreement = self.test_add_event_agreement_valid()
 
@@ -693,6 +694,27 @@ class TestEventAgreements(TestMixin):
         self.assertEqual(response.status_code, 200)
         event_agreement = EventAgreement.objects.get(slug=self.event_agreement_slug)
         self.assertEqual(event_agreement.name, self.updated_event_agreement_name)
+
+    def test_edit_event_agreement_valid_2(self):
+        """tests the view that edits html_content in event agreement"""
+
+        event_agreement = self.test_add_event_agreement_valid()
+
+        # Edit the event Agreement
+        response = self.client.post(
+            reverse('event_agreement_detail', args=[event_agreement.pk]),
+            data={
+                'name': self.event_agreement_name,
+                'version': self.event_agreement_version,
+                'slug': self.event_agreement_slug,
+                'is_active': True,
+                'html_content': self.updated_event_agreement_html_content,
+                'access_template': self.event_agreement_access_template
+            })
+
+        self.assertEqual(response.status_code, 200)
+        event_agreement = EventAgreement.objects.get(slug=self.event_agreement_slug)
+        self.assertEqual(event_agreement.html_content, self.updated_event_agreement_html_content)
 
     def test_edit_event_agreement_invalid_version(self):
         """tests the view that edits an invalid event agreement(invalid version)"""

--- a/physionet-django/events/forms.py
+++ b/physionet-django/events/forms.py
@@ -100,6 +100,9 @@ class EventAgreementForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(EventAgreementForm, self).clean()
         if EventAgreement.objects.filter(name=cleaned_data['name'], version=cleaned_data['version']).exists():
+            if self.initial.get('name') == cleaned_data['name'] and \
+                    self.initial.get('version') == cleaned_data['version']:
+                return cleaned_data
             raise forms.ValidationError(
                 {"name": ["An agreement with this name and version already exists."],
                  "version": ["An agreement with this name and version already exists."]


### PR DESCRIPTION
Context:
On https://github.com/MIT-LCP/physionet-build/pull/1876, we introduced a bug on Event Agreement Edit. 
The bug is if you try to edit an Event Agreement for fields other than `title` and `version`, it will throw a validation error saying the "Name" and "Version" already exists.

The error comes from `EventAgreementForm`'s `clean` method. Here the if statement was throwing validation error if the name, version already exists as a row in database. The logic is wrong as it doesn't account for that fact that when you update an Event Agreement, the event agreement's name and version might be the same as before.
    
So in case of update/edit, we need to check if the existing row in the database is from the event agreement being edited; if yes, we shouldn't throw an error.

Changes
1. Form -  i updated the form to check if the current request is update, and if yes, dont throw the validation error
2. Tests - i added a new test that tries to edit just the html_content, so that it can test the edit functanality.

