### PR TITLE
fix duplicate results returned by is_accessible

### DIFF
--- a/physionet-django/project/managers/publishedproject.py
+++ b/physionet-django/project/managers/publishedproject.py
@@ -61,4 +61,4 @@ class PublishedProjectManager(Manager):
                 accessible_projects_ids.append(event_dataset.dataset.id)
         query |= Q(id__in=accessible_projects_ids)
 
-        return self.filter(query)
+        return self.filter(query).distinct()


### PR DESCRIPTION
For some reason the queries are returning duplicates, which causes us to see multiple projects listed on healthdatanexus.ai website

![Duplicate projects](https://user-images.githubusercontent.com/24412619/222474238-42d0ccf3-5538-4a52-80ad-2a3273020def.png)

 It cannot be from the code that checks access through events, because even if the list `accessible_projects_ids` has duplicates, the result returned should not have duplicates
    ```
    >>> PublishedProject.objects.filter(id__in=[4,4,4])
        <QuerySet [<PublishedProject: COVID-19 Epidemiology and Vaccination Dataset v1.0.0>]>
    ```


It looks like it might be because of union operation somehow, although I am not sure why exactly, but i have hacky fix with .distinct() (Thanks to @kshalot)

On this commit, i added .distinct() to remove the duplicates so that method only returns unique projects/datasets