### PR TITLE
display details of credentialing status on view participants modal

### DIFF
--- a/physionet-django/events/templates/events/event_entries.html
+++ b/physionet-django/events/templates/events/event_entries.html
@@ -15,7 +15,7 @@
             <td>{{ participant.user.username }}</td>
             <td>{{ participant.user.get_full_name }}</td>
             <td>{{ participant.user.email }}</td>
-            <td>{{ participant.user.is_credentialed }}</td>
+            <td>{{ participant.user.get_credentialing_status }}</td>
             <td>
                 {% if participant.is_cohost %}
                     <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ participant.id }}" disabled checked>

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -1037,7 +1037,7 @@ class CredentialApplication(models.Model):
         elif self.credential_review.status <= 20:
             status = 'Awaiting review'
         elif self.credential_review.status == 30:
-            status = 'Awaiting a response from your reference'
+            status = 'Awaiting a response from reference'
         elif self.credential_review.status >= 40:
             status = 'Awaiting final approval'
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -473,6 +473,23 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         return users
 
+    def get_credentialing_status(self):
+        """
+        Returns the credentialing status of the user.
+        If the user is not credentialed, returns the status of the user's credentialing application.
+        """
+        if self.is_credentialed:
+            return 'Credentialed'
+        else:
+            application = self.credential_applications.last()
+            if not application:
+                return 'No application found'
+
+            if application.status == CredentialApplication.Status.PENDING:
+                return application.get_review_status()
+
+            return 'No application found'
+
 
 class UserLogin(models.Model):
     """Represent users' logins, one per record"""


### PR DESCRIPTION
Context:
As discussed on https://github.com/MIT-LCP/physionet-build/issues/1908, On Event Participation list, we just display True or False for credentialing status of a user, which is not super helpful.
As suggested in the issue, showing the actual status will be helpful.

On this PR, i added a method to user model that shows the status of the latest credentialing application for a user.

![image](https://user-images.githubusercontent.com/24412619/222793533-39dc9a17-f10e-4556-8bde-9e147836b68a.png)

