### PR TITLE
Fix: Archiving files throws "No such file or directory" error

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -281,7 +281,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             self.clear_files()
         else:
             # Move over files
-            os.rename(self.file_root(), archived_project.file_root())
+            ProjectFiles().rename(self.file_root(), archived_project.file_root())
 
         # Copy the ActiveProject timestamp to the ArchivedProject.
         # Since this is an auto_now field, save() doesn't allow

--- a/physionet-django/project/modelcomponents/archivedproject.py
+++ b/physionet-django/project/modelcomponents/archivedproject.py
@@ -3,6 +3,7 @@ import os
 from django.conf import settings
 from django.db import models
 
+from project.projectfiles import ProjectFiles
 from project.modelcomponents.metadata import Metadata
 from project.modelcomponents.unpublishedproject import UnpublishedProject
 from project.modelcomponents.submission import SubmissionInfo
@@ -20,7 +21,7 @@ class ArchivedProject(Metadata, UnpublishedProject, SubmissionInfo):
     archive_reason = models.PositiveSmallIntegerField()
 
     # Where all the archived project files are kept
-    FILE_ROOT = os.path.join(settings.MEDIA_ROOT, 'archived-projects')
+    FILE_ROOT = os.path.join(ProjectFiles().file_root, 'archived-projects')
 
     class Meta:
         default_permissions = ('change',)


### PR DESCRIPTION
Changing those parts will lead to reactive implementation that can be used both by local files system and remote one by setting proper ENV variables.