### PR TITLE
Fix projects not being copyeditable by their author

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -621,10 +621,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Whether the user can edit the project
         """
-        if self.authors.filter(is_submitting=True, user=user).exists():
-            if self.author_editable():
-                return True
-        elif user == self.editor:
-            if self.copyeditable():
-                return True
-        return False
+        author_submitting = self.author_editable() and self.authors.filter(is_submitting=True, user=user).exists()
+        editor_copyediting = self.copyeditable() and user == self.editor
+
+        return author_submitting or editor_copyediting


### PR DESCRIPTION
We could also do:
```python
if self.author_editable() and self.authors.filter(is_submitting=True, user=user).exists():
    return True
if self.copyeditable() and user == self.editor:
    return True
return False
```
but the version proposed in the PR makes it clear what the logic behind a project being editable is without forcing the reader to analyze the branches. Python evaluates boolean conditions lazily so at worst this version is adding an additional call to `self.copyeditable()` which is very light.