### PR TITLE
Improve TestURLs coverage

### DIFF
--- a/physionet-django/events/urls.py
+++ b/physionet-django/events/urls.py
@@ -11,4 +11,8 @@ urlpatterns = [
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)
-TEST_DEFAULTS = {'event_slug': 'iLII4L9jSDFh', 'participant_id': 1}
+TEST_DEFAULTS = {
+    'event_slug': 'iLII4L9jSDFh',
+    'participant_id': 1,
+    '_user_': 'rgmark',
+}

--- a/physionet-django/lightwave/urls.py
+++ b/physionet-django/lightwave/urls.py
@@ -11,3 +11,9 @@ urlpatterns = [
     path('projects/<project_slug>/server', views.lightwave_project_server,
          name='lightwave_project_server'),
 ]
+
+# Parameters for testing URLs (see physionet/test_urls.py)
+TEST_DEFAULTS = {
+    'project_slug': 'SHuKI1APLrwWCqxSQnSk',
+    '_user_': 'rgmark',
+}

--- a/physionet-django/physionet/test_urls.py
+++ b/physionet-django/physionet/test_urls.py
@@ -3,7 +3,6 @@ import textwrap
 import urllib.parse
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
 from django.urls import URLPattern, URLResolver, get_resolver
 from django.utils.regex_helper import normalize
 

--- a/physionet-django/physionet/test_urls.py
+++ b/physionet-django/physionet/test_urls.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 import urllib.parse
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import URLPattern, URLResolver, get_resolver
 from django.utils.regex_helper import normalize
@@ -149,7 +150,28 @@ class TestURLs(TestMixin):
                         name=name, parameter=exc.args[0], pattern=pattern,
                         module=mod.__name__, source_file=mod.__file__)
                     raise Exception(message) from None
-                self._handle_request(url, **args)
+
+                try:
+                    self._handle_request(url, **args)
+                except RedirectedToLogin:
+                    message = textwrap.dedent("""
+                        Login required for {name} in {module}
+                        (URL: {url!r})
+
+                        Note: you probably need to add something like this in
+                        {source_file}:
+
+                            TEST_CASES = {{
+                                {name!r}: {{
+                                    '_user_': 'somebody',
+                                    ...
+                                }},
+                                ...
+                            }}
+                    """).lstrip('\n').format(
+                        name=name, url=url,
+                        module=mod.__name__, source_file=mod.__file__)
+                    raise Exception(message) from None
 
     def _handle_request(self, url, _user_=None, _query_={}, _skip_=False,
                         **kwargs):
@@ -167,6 +189,13 @@ class TestURLs(TestMixin):
         response = self.client.get(url, _query_)
         self.assertGreaterEqual(response.status_code, 200)
         self.assertLess(response.status_code, 400)
+
+        # Assume if we are redirected to LOGIN_URL, that means we
+        # don't have permission to view this page.  An appropriate
+        # _user_ should be specified.
+        location = response.headers.get('Location', '')
+        if urllib.parse.urlparse(location).path == settings.LOGIN_URL:
+            raise RedirectedToLogin
 
         if self._dump_dir is not None:
             path = self._output_filename(url, _query_, response)
@@ -189,3 +218,8 @@ class TestURLs(TestMixin):
         if query:
             path += '?' + urllib.parse.urlencode(query)
         return path.lstrip('/')
+
+
+class RedirectedToLogin(Exception):
+    """Exception raised if a URL redirects to the login page."""
+    pass

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -94,6 +94,11 @@ _demo_open_access = {
     'project_slug': 'demoecg',
     'version': '10.5.24',
 }
+_demo_credentialed_access = {
+    'project_slug': 'demoeicu',
+    'version': '2.0.0',
+    '_user_': 'rgmark',
+}
 _demo_access_manager = {
     'project_slug': 'demoselfmanaged',
     'version': '1.0.0',
@@ -114,6 +119,8 @@ TEST_CASES = {
     'published_project_subdir': {'subdir': 'doc'},
     'serve_published_project_file': {'full_file_name': 'Makefile'},
     'display_published_project_file': {'full_file_name': 'Makefile'},
+
+    'sign_dua': _demo_credentialed_access,
 
     'request_data_access': _demo_access_manager,
     'data_access_request_status_detail': {**_demo_access_requester, 'pk': '1'},

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -122,7 +122,8 @@ TEST_CASES = {
 
     'sign_dua': _demo_credentialed_access,
 
-    'request_data_access': _demo_access_manager,
+    'request_data_access': _demo_access_requester,
+    'data_access_request_status': _demo_access_requester,
     'data_access_request_status_detail': {**_demo_access_requester, 'pk': '1'},
     'data_access_request_view': {**_demo_access_manager, 'pk': '1'},
     'data_access_requests_overview': _demo_access_manager,

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -6673,9 +6673,9 @@
     "email": "aewj@fake-gmail.com",
     "is_primary_email": false,
     "added_date": "2020-04-10T16:47:27.949Z",
-    "verification_date": "2020-04-10T16:47:34.922Z",
+    "verification_date": null,
     "verification_token": "oax3ZcG47GYUhAobbJyp",
-    "is_verified": true,
+    "is_verified": false,
     "is_public": false
   }
 },

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -66,3 +66,26 @@ if not settings.ENABLE_SSO:
         path('reset/complete/', views.reset_password_complete,
              name='reset_password_complete'),
     ])
+
+# Parameters for testing URLs (see physionet/test_urls.py)
+TEST_DEFAULTS = {
+    '_user_': 'aewj',
+    'training_id': 106,
+    'dua_signature_id': 1,
+    'application_slug': 'Osm0FMaavviixpsL26v2',
+    'username': 'rgmark',
+}
+TEST_CASES = {
+    'verify_email': {
+        'uidb64': 'MjEx',
+        'token': 'oax3ZcG47GYUhAobbJyp',
+    },
+
+    # Testing activate_user and reset_password_confirm requires a
+    # dynamically-generated token.  Skip these URLs for now.
+    'activate_user': {'uidb64': 'x', 'token': 'x', '_skip_': True},
+    'reset_password_confirm': {'uidb64': 'x', 'token': 'x', '_skip_': True},
+
+    # Testing auth_orcid requires a mock oauth server.  Skip this URL.
+    'auth_orcid': {'_skip_': True},
+}

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -43,8 +43,6 @@ urlpatterns = [
     path('credential-reference/<application_slug>/',
         views.credential_reference, name='credential_reference'),
     path('trainings/<int:training_id>/report/', views.training_report, name='training_report'),
-    path('credential-applications/<application_slug>/training-report/view/',
-        views.training_report_view, name='training_report_view'),
 ]
 
 if not settings.ENABLE_SSO:

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path('settings/training/', views.edit_training, name='edit_training'),
     path('settings/training/<int:training_id>/', views.edit_training_detail, name='edit_training_detail'),
     path('settings/agreements/', views.view_agreements, name='edit_agreements'),
-    path('settings/agreements/<int:id>/', views.view_signed_agreement, name='view_signed_agreement'),
+    path('settings/agreements/<int:dua_signature_id>/', views.view_signed_agreement, name='view_signed_agreement'),
 
     # Current tokens are 20 characters long and consist of 0-9A-Za-z
     # Obsolete tokens are 34 characters long and also include a hyphen

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -863,12 +863,12 @@ def view_agreements(request):
     )
 
 @login_required
-def view_signed_agreement(request, id):
+def view_signed_agreement(request, dua_signature_id):
     """
     View a printable agreement in the user profile.
     """
     user = request.user
-    signed = get_object_or_404(DUASignature, user=user, id=id)
+    signed = get_object_or_404(DUASignature, user=user, id=dua_signature_id)
 
     return render(request, 'user/view_signed_agreement.html',
                   {'user': user, 'signed': signed})

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -793,15 +793,6 @@ def training_report(request, training_id):
     return utility.serve_file(training.completion_report.path, attach=False)
 
 
-@login_required
-def training_report_view(request, application_slug):
-    """
-    Wrapper for training_report. Serves the training report in the browser
-    for KP's custom pages.
-    """
-    return training_report(request, application_slug, attach=False)
-
-
 # @login_required
 def credential_reference(request, application_slug):
     """


### PR DESCRIPTION
To improve test coverage and to more easily examine the HTML generated by the site, we added "URL testing" a few months ago.  See pull #1695 for an overview.

Currently, TestURLs covers URLs in the following apps:
- events
- export
- notification
- physionet
- search

This pull request adds coverage for:
- lightwave
- user

Still to be done:
- console
- project

In addition, this makes the test requirements slightly stricter - treat redirection to the login page as an error.  We want to see what these pages look like when viewed by a logged-in user, so authentication failure is an error.  A few existing tests had to be fixed as a consequence.
