### PR TITLE
Show permissions groups on Admin Console

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -238,6 +238,9 @@
             <li class="nav-item {% if group == 'all' %}active{% endif %}">
               <a id="nav_all_users" class="nav-link" href="{% url 'users' 'all' %}">All Users</a>
             </li>
+            <li class="nav-item {% if user_groups_nav%}active{% endif %}">
+              <a id="nav_user_groups" class="nav-link" href="{% url 'user_groups' %}">User Groups</a>
+            </li>
             <li class="nav-item {% if group == 'admin' %}active{% endif %}">
               <a id="nav_all_users" class="nav-link" href="{% url 'users' 'admin' %}"> {{admin}}Administrators</a>
             </li>

--- a/physionet-django/console/templates/console/user_group.html
+++ b/physionet-django/console/templates/console/user_group.html
@@ -1,0 +1,74 @@
+{% extends "console/base_console.html" %}
+
+{% block title %}{{ SITE_NAME }} User Group: {{ group }}{% endblock %}
+
+{% block content %}
+<h1>Group: {{ group }}</h1>
+
+<div class="card mb-3">
+  <div class="card-header">
+    Users  <span class="badge badge-pill badge-primary">{{ users | length }}</span>
+  </div>
+  <div class="card-body">
+      <div class="table-responsive">
+      <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Join Date</th>
+            <th>Last Login</th>
+            <th>Login (90 days)	</th>
+            <th>Credentialed</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for user in users %}
+          <tr>
+            <td><a href="{% url 'user_management' user.username %}">{{ user.username }}</a></td>
+            <td>{{ user.get_full_name }}</td>
+            <td>{{ user.email }}</td>
+            <td>{{ user.join_date }}</td>
+            <td>{{ user.last_login|date }}</td>
+            <td>{{ user.login_time_count }} </td>
+            <td>{{ user.credential_datetime|date}}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+    
+<div class="card mb-3">
+  <div class="card-header">
+    Permissions <span class="badge badge-pill badge-primary">{{ permissions | length }}</span>
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th>App Name</th>
+            <th>Model</th>
+            <th>Permission</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for permission in permissions %}
+          <tr>
+            <td>{{ permission.content_type.app_label }}</td>
+            <td>{{ permission.content_type.model }}</td>
+            <td>{{ permission.name }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+
+{% endblock %}

--- a/physionet-django/console/templates/console/user_groups.html
+++ b/physionet-django/console/templates/console/user_groups.html
@@ -20,7 +20,7 @@
         <tbody>
         {% for group in groups %}
           <tr>
-            <td><a href="">{{ group.name }}</a></td>
+            <td><a href="{% url 'user_group' group.name %}">{{ group.name }}</a></td>
             <td>{{ group.user_count }}</td>
             <td>{{ group.permissions.all.count }}</td>
           </tr>

--- a/physionet-django/console/templates/console/user_groups.html
+++ b/physionet-django/console/templates/console/user_groups.html
@@ -1,0 +1,33 @@
+{% extends "console/base_console.html" %}
+
+{% block title %}{{ SITE_NAME }} User Groups{% endblock %}
+
+{% block content %}
+<div class="card mb-3">
+  <div class="card-header">
+      {{ SITE_NAME }} User Groups <span class="badge badge-pill badge-info">{{ groups|length }}</span>
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Users</th>
+            <th>Permissions</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for group in groups %}
+          <tr>
+            <td><a href="">{{ group.name }}</a></td>
+            <td>{{ group.user_count }}</td>
+            <td>{{ group.permissions.all.count }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -93,7 +93,7 @@
         </div>
         <div class="col-md-9">
           {% for group in groups %}
-            {{ group.name }}
+              <a href="{% url 'user_group' group.name %}">{{ group.name }}</a>
           {% empty %}
             N/A
           {% endfor %}

--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -86,6 +86,22 @@
     </div>
   {% endif %}
 
+  {% if groups %}
+      <div class="row mb-1">
+        <div class="col-md-3">
+          User Groups:
+        </div>
+        <div class="col-md-9">
+          {% for group in groups %}
+            {{ group.name }}
+          {% empty %}
+            N/A
+          {% endfor %}
+        </div>
+      </div>
+
+  {% endif %}
+
   <br />
   <h3>Projects</h3>
   <hr>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -77,6 +77,7 @@ urlpatterns = [
     path('training/view/<int:pk>/', views.training_detail, name='training_detail'),
     path('training/process/<int:pk>/', views.training_process, name='training_process'),
     path('users/search/<group>/', views.users_search, name='users_list_search'),
+    path('users/groups/', views.user_groups, name='user_groups'),
     path('users/<group>/', views.users, name='users'),
     path('users/aws-access-list.json', views.users_aws_access_list_json,
          name='users_aws_access_list_json'),

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -78,6 +78,7 @@ urlpatterns = [
     path('training/process/<int:pk>/', views.training_process, name='training_process'),
     path('users/search/<group>/', views.users_search, name='users_list_search'),
     path('users/groups/', views.user_groups, name='user_groups'),
+    path('users/groups/<group>/', views.user_group, name='user_group'),
     path('users/<group>/', views.users, name='users'),
     path('users/aws-access-list.json', views.users_aws_access_list_json,
          name='users_aws_access_list_json'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1049,6 +1049,21 @@ def user_groups(request):
 
 
 @permission_required('user.view_user', raise_exception=True)
+def user_group(request, group):
+    """
+    Shows details of a user group, lists users in the group, lists permissions for the group
+    """
+    group = get_object_or_404(Group, name=group)
+    users = User.objects.filter(groups=group).order_by('username').annotate(login_time_count=Count('login_time'))
+    permissions = group.permissions.all().order_by('content_type__app_label', 'content_type__model')
+    return render(
+        request,
+        'console/user_group.html',
+        {'group': group, 'users': users, 'permissions': permissions, 'user_nav': True, 'user_groups_nav': True}
+    )
+
+
+@permission_required('user.view_user', raise_exception=True)
 def user_management(request, username):
     """
     Admin page for managing an individual user account.

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -13,6 +13,7 @@ from dal import autocomplete
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test, permission_required
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, DurationField, F, Q
@@ -1034,6 +1035,17 @@ def users(request, group='all'):
     users = paginate(request, user_list, 50)
 
     return render(request, 'console/users.html', {'users': users, 'group': group, 'user_nav': True})
+
+
+@permission_required('user.view_user', raise_exception=True)
+def user_groups(request):
+    """
+    List of all user groups
+    """
+    groups = Group.objects.all().order_by('name')
+    for group in groups:
+        group.user_count = User.objects.filter(groups=group).count()
+    return render(request, 'console/user_groups.html', {'groups': groups, 'user_nav': True, 'user_groups_nav': True})
 
 
 @permission_required('user.view_user', raise_exception=True)

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1070,8 +1070,12 @@ def user_management(request, username):
     projects['Published'] = PublishedProject.objects.filter(authors__user=user).order_by('-publish_datetime')
 
     credentialing_app = CredentialApplication.objects.filter(user=user).order_by("application_datetime")
+
+    groups = user.groups.all()
+
     return render(request, 'console/user_management.html', {'subject': user,
                                                             'profile': user.profile,
+                                                            'groups': groups,
                                                             'emails': emails,
                                                             'projects': projects,
                                                             'training_list': training,


### PR DESCRIPTION
Closes https://github.com/MIT-LCP/physionet-build/issues/1548

**Context:**
On https://github.com/MIT-LCP/physionet-build/pull/1487, we added a new feature to manage permission groups, and on https://github.com/MIT-LCP/physionet-build/pull/1719/files, we refactored the existing codebase to use remove the use of `is_admin` and use the permission groups.

With those two changes, the Admin(people who are in Permission Group `Admin`) list page that exists right now  http://localhost:8000/console/users/admin/ is a bit outdated. because now we should have an option to see all the existing Permission groups and detail of each permission group.

**This PR does the following**
1. Adds a Permission group list page that lists the permission group and shows basic details.
2. Adds a Permission group detail page, that shows details of permission group
3. updates the user management page to link to permission group detail page

**Screenshots for reference**

Permission group list page http://localhost:8000/console/users/groups/

![image](https://user-images.githubusercontent.com/24412619/223827909-060cb680-3170-459c-ae30-5bbf198b90c7.png)

Permission group detail page http://localhost:8000/console/users/groups/Admin/

![image](https://user-images.githubusercontent.com/24412619/223827721-b7e0398f-d6ab-4793-baf3-7e0833be0fbd.png)

**TODO after this**
1. Remove the admin url https://localhost:8000/console/users/admin/ as it will be less relevant after this PR