### PR TITLE
Event: Hide dataset section unless event has dataset

### DIFF
--- a/physionet-django/events/templates/events/event_detail.html
+++ b/physionet-django/events/templates/events/event_detail.html
@@ -53,8 +53,9 @@
 
     {% include  "events/event_participation.html" %}
      <hr>
-    {% include  "events/event_datasets.html" %}
-
+    {% if event_datasets|length != 0 %}
+      {% include  "events/event_datasets.html" %}
+    {% endif %}
     
 </div>
 {% endif %}


### PR DESCRIPTION
Closes https://github.com/MIT-LCP/physionet-build/issues/1926

**Context:**
As discussed on https://github.com/MIT-LCP/physionet-build/issues/1926, currently we show the dataset section on Event detail page even when there is no dataset attached to the event.
The Event app can be used by instructor in other ways where they might not need to use any dataset, so as suggested by @tompollard we shouldn't display the dataset section unless datasets are used on Event.