### PR TITLE
add orcid to datacite payload

### DIFF
--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -485,6 +485,12 @@ def generate_doi_payload(project, core_project=False, event="draft"):
             author_metadata = {"givenName": author.first_names,
                                "familyName": author.last_name,
                                "name": author.get_full_name(reverse=True)}
+            if author.user.has_orcid():
+                author_metadata["nameIdentifiers"] = [{
+                    "nameIdentifier": f'https://orcid.org/{author.user.get_orcid_id()}',
+                    "nameIdentifierScheme": "ORCID",
+                    "schemeUri": "https://orcid.org/"
+                }]
             authors.append(author_metadata)
 
     # link to parent or child projects

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -482,9 +482,10 @@ def generate_doi_payload(project, core_project=False, event="draft"):
     if event == "publish":
         author_list = project.author_list().order_by('display_order')
         for author in author_list:
-            authors.append({"givenName": author.first_names,
-                            "familyName": author.last_name,
-                            "name": author.get_full_name(reverse=True)})
+            author_metadata = {"givenName": author.first_names,
+                               "familyName": author.last_name,
+                               "name": author.get_full_name(reverse=True)}
+            authors.append(author_metadata)
 
     # link to parent or child projects
     if event == "publish" and core_project:

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -444,6 +444,15 @@ class User(AbstractBaseUser, PermissionsMixin):
             pass
         return False
 
+    def get_orcid_id(self):
+        """
+        Returns the user's orcid.
+        """
+        try:
+            return self.orcid.orcid_id
+        except Orcid.DoesNotExist:
+            return None
+
     @staticmethod
     def get_users_with_permission(app_label, permission_codename):
         """


### PR DESCRIPTION
Related to https://github.com/MIT-LCP/physionet-build/issues/1478

**Context:**
On https://github.com/MIT-LCP/physionet-build/issues/1478 we discussed that we wanted to credit the dataset creators on DataCite. This PR updates the DataCite payload to include `ORCID` of authors(it authors have updated linked ORCID to their profile.

**DataCite Documentation**

https://support.datacite.org/docs/api-create-dois#create-a-findable-doi-with-rich-metadata
http://schema.datacite.org/meta/kernel-4.4/doc/DataCite-MetadataKernel_v4.4.pdf




@tompollard  regarding the comment from  https://github.com/MIT-LCP/physionet-build/issues/1478#issuecomment-1039790164  (also copied below for convenience) , i checked the documentation for DataCite and couldn't find information if they will let us add custom metadata, but i couldn't find anything for that. 

> Note to self: see: https://developers.google.com/search/docs/advanced/structured-data/dataset for a longer list of fields that we could consider adding (e.g: "isAccessibleForFree", "Keywords", etc.)

The closest i could find was https://support.datacite.org/docs/enriching-igsn-id-metadata-in-the-datacite-metadata-schema#linking-to-custom-metadata 

Here is the direct text from the link above

> Your institution may maintain metadata about your samples in schemata specific to your institution, discipline, or samples community. We recommend that you link to this external metadata using the relatedIdentifier property with a “HasMetadata” relationType attribute. If you are pointing to a web-hosted metadata file, the relatedIdentifierType “URL” will likely be appropriate. The relatedMetadataScheme attribute can be used to specify the name of the metadata scheme. See the [DataCite Metadata Schema](https://schema.datacite.org/).