### PR TITLE
refactor events app code to follow pep guidelines

### DIFF
--- a/physionet-django/events/forms.py
+++ b/physionet-django/events/forms.py
@@ -101,7 +101,7 @@ class EventAgreementForm(forms.ModelForm):
         cleaned_data = super(EventAgreementForm, self).clean()
         if EventAgreement.objects.filter(name=cleaned_data['name'], version=cleaned_data['version']).exists():
             if (self.initial.get('name') == cleaned_data['name']
-                 and self.initial.get('version') == cleaned_data['version']):
+                    and self.initial.get('version') == cleaned_data['version']):
                 return cleaned_data
             raise forms.ValidationError(
                 {"name": ["An agreement with this name and version already exists."],

--- a/physionet-django/events/forms.py
+++ b/physionet-django/events/forms.py
@@ -100,8 +100,8 @@ class EventAgreementForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(EventAgreementForm, self).clean()
         if EventAgreement.objects.filter(name=cleaned_data['name'], version=cleaned_data['version']).exists():
-            if self.initial.get('name') == cleaned_data['name'] and \
-                    self.initial.get('version') == cleaned_data['version']:
+            if (self.initial.get('name') == cleaned_data['name']
+                 and self.initial.get('version') == cleaned_data['version']):
                 return cleaned_data
             raise forms.ValidationError(
                 {"name": ["An agreement with this name and version already exists."],

--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -184,8 +184,10 @@ def event_detail(request, event_slug):
         registration_allowed = False
         registration_error_message = 'You are registered for this event'
     else:  # we don't need to check for waitlisted / other stuff if the user is already registered
-        event_participation_request = EventApplication.objects. \
-            filter(event=event, user=user, status=EventApplication.EventApplicationStatus.WAITLISTED)
+        event_participation_request = EventApplication.objects.filter(
+            event=event,
+            user=user,
+            status=EventApplication.EventApplicationStatus.WAITLISTED)
         # currently we are not blocking rejected, revoked access users from registering again
         if event_participation_request.exists():
             registration_allowed = False
@@ -198,9 +200,9 @@ def event_detail(request, event_slug):
             domain_match = [domain for domain in domains if any('@' + domain.strip() in email for email in emails)]
             if not domain_match:
                 registration_allowed = False
-                registration_error_message = f"To register for the event, your account must be linked with " \
-                                             f"an email address from the following domains: {domains}. " \
-                                             f"You can add email addresses to your account in the settings menu."
+                registration_error_message = ("To register for the event, your account must be linked with "
+                                              f"an email address from the following domains: {domains}. "
+                                              "You can add email addresses to your account in the settings menu.")
 
     if request.method == 'POST':
         if 'confirm_registration' in request.POST.keys():
@@ -210,8 +212,10 @@ def event_detail(request, event_slug):
             messages.success(request, "You have successfully requested to join this event")
             return redirect(event_home)
         elif 'confirm_withdraw' in request.POST.keys():
-            event_participation_request = EventApplication.objects. \
-                filter(event=event, user=user, status=EventApplication.EventApplicationStatus.WAITLISTED)
+            event_participation_request = EventApplication.objects.filter(
+                event=event,
+                user=user,
+                status=EventApplication.EventApplicationStatus.WAITLISTED)
             if event_participation_request.exists():
                 event_participation_request = event_participation_request.first()
                 event_participation_request.withdraw(comment_to_applicant='Withdrawn by user')


### PR DESCRIPTION
Context:
Previously on some of the PRs, the code was using backslash in multiple places for events app. It looks like PEP recommends to use parenthesis over backslash. 


https://peps.python.org/pep-0008/#multiline-if-statements
https://doc.casthighlight.com/alt_multilineinstruction-backslash-line-continuation-makes-code-less-readable/#:~:text=This%20is%20helpful%20in%20some,use%20parentheses%20around%20your%20elements.

Thanks to @tompollard  for pointing this out. 