### PR TITLE
CITI class to store account information

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,3 +167,10 @@ DEFAULT_NUMBER_OF_APPLICATIONS_TO_REMIND = 5
 
 # minimum number of word needed for research_summary field for Credentialing Model.
 MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING = 20
+
+# CITISOAPService API
+# This is the WebServices username and password to access the CITI SOAP Service to obtain users training report details
+# The account can be created at https://webservices.citiprogram.org/login/CreateAccount.aspx
+# The SOAP Service Access can be tested at https://webservices.citiprogram.org/Client/CITISOAPClient_Simple.aspx 
+CITI_USERNAME=
+CITI_PASSWORD=

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -236,6 +236,10 @@ ORCID_CLIENT_ID = config('ORCID_CLIENT_ID', default=False)
 ORCID_CLIENT_SECRET = config('ORCID_CLIENT_SECRET', default=False)
 ORCID_SCOPE = config('ORCID_SCOPE', default=False)
 
+# Tags for the CITISOAPService API
+CITI_USER = config('CITI_USERNAME', default='')
+CITI_PASSWORD = config('CITI_PASSWORD', default='')
+
 # List of permitted HTML tags and attributes for rich text fields.
 # The 'default' configuration permits all of the tags below.  Other
 # configurations may be added that permit different sets of tags.

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -725,6 +725,30 @@ class Orcid(models.Model):
         return settings.ORCID_DOMAIN
 
 
+class CITI(models.Model):
+    """
+    Class for storing CITI account information.
+    Here are examples of expected formats from a CITI account:
+    member_id: int MemberID e.g 12102652
+    course_id: int GroupID e.g 43007
+    course_name: str CompletionReport e.g Human Research
+    course_expiration: datetime Expiration e.g 2026-03-13T17:03:34.18-04:00
+    report_score: int Score e.g 95
+    """
+    user = models.OneToOneField('user.User', related_name='citi',
+                                on_delete=models.CASCADE)
+    member_id = models.CharField(max_length=20, default='', blank=True,
+                                validators=[validators.validate_member_id])
+    course_id = models.CharField(max_length=20, default='', blank=True)
+    course_name = models.CharField(max_length=50, default='', blank=True)
+    course_expiration = models.DateTimeField(null=True, validators=[validators.validate_course_expiration])
+    report_score = models.CharField(max_length=3, default='', 
+                                    validators=[validators.validate_report_score], blank=True)
+    
+    class Meta:
+        default_permissions = ()
+
+
 class CredentialApplication(models.Model):
     """
     An application to become credentialed

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -1,4 +1,5 @@
 import re
+import datetime
 
 from django.conf import settings
 from django.contrib.auth.validators import UnicodeUsernameValidator
@@ -230,6 +231,24 @@ def validate_orcid_id(value):
     """
     if not re.fullmatch(r'^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$', value):
         raise ValidationError('ORCID ID is not in expected format.')
+
+def validate_report_score(value):
+    """
+    Validator function to ensure that the value is a valid CITI Score.
+    """
+    if not value.isdigit() or not (0 <= int(value) <= 100):
+        raise ValidationError('Score should be an integer between 0 and 100')
+
+def validate_course_expiration(value):
+    """
+    Validator function to ensure that the value is a valid datetime in the format
+    yyyy-mm-ddTHH:MM:SS.ssZ (e.g. 2023-03-21T15:30:00.00Z).
+    """
+    try:
+        # Check if the string is a valid datetime in the expected format
+        datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+    except ValueError:
+        raise ValidationError('Invalid datetime format.')
 
 # DEPRECATED VALIDATIONS KEPT FOR MIGRATIONS
 def validate_alphaplus(value):


### PR DESCRIPTION
This PR will create the CITI class (a Django model) that creates a database table to store CITI account information.

The CITI class has five fields: user, member_id, course_id, course_name, course_expiration, and report_score. The user field is a one-to-one relationship with Django's built-in User model and is used to associate each CITI account with a specific user. The remaining fields correspond to the information stored in a CITI account, including the member ID, course ID, course name, course expiration date and time, and report score. These fields are defined as CharField and DateTimeField with appropriate lengths and validators to ensure that the data stored in the fields adhere to the expected format. 