### PR TITLE
Sanity check pip in github workflow

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -76,6 +76,7 @@ jobs:
           else
             pip3 install -r requirements.txt
           fi
+          pip3 freeze
 
       - name: Setup postgres
         run: |


### PR DESCRIPTION
Installing packages using pip can break pip for weird reasons (see issue #1915).

Add a sanity check to catch seriously broken cases before they're merged.  This may be unnecessary if we stop doing pip upgrades (see issue #1921 / pull #1939) but isn't a bad idea anyway.
