### PR TITLE
Add Django redirects app to allow URLs to be redirected. Fixes #1946

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -314,7 +314,7 @@
       {% endif %}
 
       <!-- Pages -->
-      {% if perms.user.change_staticpage or perms.user.change_frontpagebutton %}
+      {% if perms.user.change_staticpage or perms.user.change_frontpagebutton or perms.redirect.view_redirect %}
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if frontpage_buttons_nav or static_pages_nav %}
           <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#pagesComponent" data-parent="#sideAccordion" aria-expanded="true">
@@ -325,16 +325,19 @@
             <span class="nav-link-text">Pages</span>
           </a>
           <!-- submenu -->
-        {% if frontpage_buttons_nav or static_pages_nav %}
+        {% if frontpage_buttons_nav or static_pages_nav or redirects_nav %}
           <ul class="sidenav-second-level collapse show" id="pagesComponent" style="">
         {% else %}
           <ul class="sidenav-second-level collapse" id="pagesComponent">
         {% endif %}
             <li class="nav-item {% if static_pages_nav %}active{% endif %}">
-              <a id="nav_console_news" class="nav-link" href="{% url 'static_pages' %}">Static Pages</a>
+              <a id="nav_pages_dropdown" class="nav-link" href="{% url 'static_pages' %}">Static Pages</a>
             </li>
             <li class="nav-item {% if frontpage_buttons_nav %}active{% endif %}">
-              <a id="nav_console_news" class="nav-link" href="{% url 'frontpage_buttons' %}">Frontpage Buttons</a>
+              <a id="nav_pages_dropdown" class="nav-link" href="{% url 'frontpage_buttons' %}">Frontpage Buttons</a>
+            </li>
+            <li class="nav-item {% if redirects_nav %}active{% endif %}">
+              <a id="nav_pages_dropdown" class="nav-link" href="{% url 'redirects' %}">Redirects</a>
             </li>
           </ul>
       </li>

--- a/physionet-django/console/templates/console/redirects.html
+++ b/physionet-django/console/templates/console/redirects.html
@@ -1,0 +1,41 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}Redirects{% endblock %}
+
+{% block local_js_top %}
+{% endblock %}
+
+{% block local_css %}
+{% endblock %}
+
+{% block content %}
+
+ <div class="card mb-3">
+  <div class="card-header">
+    Redirects <span class="badge badge-pill badge-info">{{ redirects.count }}</span>
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Site</th>
+            <th>Old path</th>
+            <th>New path</th>
+          </tr>
+        </thead>
+          {% for redirect in redirects %}
+            <tr>
+              <td>{{ redirect.site }}</td>
+              <td>{{ redirect.old_path }}</td>
+              <td>{{ redirect.new_path }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -104,6 +104,9 @@ urlpatterns = [
     path('usage/credentialing/stats/', views.credentialing_stats, name='credentialing_stats'),
     path('usage/submission/stats/', views.submission_stats, name='submission_stats'),
 
+    # redirects
+    path('redirects/', views.view_redirects, name='redirects'),
+
     # front pages
     path('front-page-button/add/', views.frontpage_button_add, name='frontpage_button_add'),
     path('front-page-button/<int:button_pk>/edit/', views.frontpage_button_edit, name='frontpage_button_edit'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -16,6 +16,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test, per
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.redirects.models import Redirect
 from django.db.models import Count, DurationField, F, Q
 from django.db.models.functions import Cast
 from django.forms import Select, Textarea, modelformset_factory
@@ -2456,6 +2457,18 @@ def known_references(request):
 
     return render(request, 'console/known_references.html', {
         'all_known_ref': all_known_ref, 'known_ref_nav': True})
+
+
+@permission_required('physionet.view_redirect', raise_exception=True)
+def view_redirects(request):
+    """
+    Display a list of redirected URLs.
+    """
+    redirects = Redirect.objects.all().order_by("old_path")
+    return render(
+        request,
+        'console/redirects.html',
+        {'redirects': redirects, 'redirects_nav': True})
 
 
 @permission_required('physionet.change_frontpagebutton', raise_exception=True)

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
+    'django.contrib.redirects',
 
     'ckeditor',
     # 'django_cron',
@@ -78,7 +79,10 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware'
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # RedirectFallbackMiddleware should go at end of list, according
+    # to the docs: https://docs.djangoproject.com/en/4.1/ref/contrib/redirects/
+    'django.contrib.redirects.middleware.RedirectFallbackMiddleware'
 ]
 
 REST_FRAMEWORK = {

--- a/physionet-django/physionet/test_urls.py
+++ b/physionet-django/physionet/test_urls.py
@@ -5,6 +5,7 @@ import urllib.parse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.redirects.models import Redirect
+from django.test import TestCase
 from django.urls import URLPattern, URLResolver, get_resolver
 from django.utils.regex_helper import normalize
 
@@ -226,7 +227,7 @@ class RedirectedToLogin(Exception):
     pass
 
 
-class TestRedirect(TestMixin):
+class TestRedirect(TestCase):
     """
     Test the redirect app.
 
@@ -257,6 +258,3 @@ class TestRedirect(TestMixin):
 
         response = self.client.get(old_path)
         self.assertEqual(response.status_code, 301)
-
-        redirect = Redirect.objects.get(old_path=old_path)
-        redirect.delete()

--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -14471,6 +14471,11 @@
         "can_review_training",
         "user",
         "trainingtype"
+      ],
+      [
+        "view_redirect",
+        "redirects",
+        "redirect"
       ]
     ]
   }


### PR DESCRIPTION
We often find the external websites, articles, etc, include links to non-existent URLs on the physionet.org domain. This pull request adds the Django Redirects App, allowing us to set up URL redirects (addressing #1946). 

The changes are:

1) Add the Redirects App, following instructions at: https://github.com/MIT-LCP/physionet-build/issues/1946
2) Add a test to confirm that setting up a redirect results in URLs being redirected.
3) Display a new page in the console that lists redirects: http://localhost:8000/console/redirects/. The page is listed under the "Pages" item in the console menu. Not an ideal place, but the best I could think of. The whole menu needs a clean up.
4) Grant the admin user the permission necessary to view the redirects page in the console (`redirects.redirect.view_redirect`).

Couple of notes:

- We will need to add the new permission (`redirects.redirect.view_redirect`) to relevant permissions groups if/once the change is merged.
- For now, redirects will need to be added via the shell using the syntax below:

```
from django.conf import settings
from django.contrib.redirects.models import Redirect
# Add a new redirect.
redirect = Redirect.objects.create(site_id=settings.SITE_ID,
                                   old_path='/contact-us/',
                                   new_path='/contact/')
```