### PR TITLE
Add instructions for updating python dependencies. Ref #1870

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ If the migration behavior interacts with other changes that have been applied to
  * `./manage.py migrate && ./manage.py test`
  * `git add */migrations/ && git commit`
 
-
 #### Theming instructions
 
 The PRIMARY and DARK environment variables can be configured in the .env file.
@@ -130,9 +129,18 @@ Here are the loations where you might want to add your cronjobs.
 
 3. `deploy/production/etc/cron.d/` (For cronjobs that should run on production environment)
 
-
 Here is an example of existing cronjob from `deploy/production/etc/cron.d/physionet`:
 
 ```sh
 31 23 * * *  www-data  env DJANGO_SETTINGS_MODULE=physionet.settings.production /physionet/python-env/physionet/bin/python3 /physionet/physionet-build/physionet-django/manage.py clearsessions
 ```
+
+## Package management
+
+`pyproject.toml` is the primary record of dependencies. This file is typically [used by pip](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) for package management. Dependencies are also tracked in [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) and [`requirements.txt`](https://pip.pypa.io/en/stable/reference/requirements-file-format/).
+
+The process for updating packages is:
+
+1. Add the dependency to `pyproject.toml`
+2. Generate a new `poetry.lock` file with: `poetry lock --no-update`
+3. Generate a new requirements.txt with: `poetry export -f requirements.txt --output requirements.txt --with dev`


### PR DESCRIPTION
As discussed in #1870, we now follow the steps below to update packages:

1. Add the dependency to `pyproject.toml`
2. Generate a new `poetry.lock` via for example `poetry lock --no-update`
3. Generate a new `requirements.txt` via `poetry export -f requirements.txt --output requirements.txt --with dev`

This pull request adds these instructions to the `README.md` file.