### PR TITLE
Update actions/checkout@v2 to actions/checkout@v3

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout physionet-build repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Note: run checkout after updating git
       - name: Checkout physionet-build repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -32,7 +32,7 @@ jobs:
                   zip
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
We currently use GitHub actions for running tests, style checks, etc. All three actions use `actions/checkout@v2` to check out this git repo. See: https://github.com/actions/checkout for documentation on `actions/checkout`.

The current version of `actions/checkout@v2` is raising the following node12 deprecation warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This pull request updates all actions to use `actions/checkout@v3`, the latest version. V3 uses node16 runtime, so the update should fix the deprecation warning.