### PR TITLE
Fix bug in StaticPage 

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -822,7 +822,8 @@ class StaticPageForm(forms.ModelForm):
 
     def save(self):
         static_page = super().save(commit=False)
-        static_page.nav_order = StaticPage.objects.count() + 1
+        if not self.initial:
+            static_page.nav_order = StaticPage.objects.count() + 1
         static_page.save()
         return static_page
 

--- a/physionet-django/physionet/models.py
+++ b/physionet-django/physionet/models.py
@@ -47,6 +47,13 @@ class StaticPage(models.Model):
         self.nav_order = nav_order + 1
         self.save()
 
+    def delete(self, *args, **kwargs):
+        nav_order = self.nav_order
+
+        super().delete(*args, **kwargs)
+
+        StaticPage.objects.filter(nav_order__gt=nav_order).update(nav_order=models.F('nav_order') - 1)
+
 
 class Section(models.Model):
     """

--- a/physionet-django/physionet/models.py
+++ b/physionet-django/physionet/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-
+from django.db import transaction
 from project.models import SafeHTMLField
 
 
@@ -25,7 +25,8 @@ class StaticPage(models.Model):
             return
 
         count = StaticPage.objects.count()
-        self.nav_order = count + 1
+        # hack to avoid unique constraint(10000 has no significance, it's just a large number)
+        self.nav_order = count + 10000
         self.save()
 
         StaticPage.objects.filter(nav_order=nav_order - 1).update(nav_order=nav_order)
@@ -38,8 +39,8 @@ class StaticPage(models.Model):
         nav_order = self.nav_order
         if nav_order == count:
             return
-
-        self.nav_order = count + 1
+        # hack to avoid unique constraint(10000 has no significance, it's just a large number)
+        self.nav_order = count + 10000
         self.save()
 
         StaticPage.objects.filter(nav_order=nav_order + 1).update(nav_order=nav_order)
@@ -50,9 +51,12 @@ class StaticPage(models.Model):
     def delete(self, *args, **kwargs):
         nav_order = self.nav_order
 
-        super().delete(*args, **kwargs)
-
-        StaticPage.objects.filter(nav_order__gt=nav_order).update(nav_order=models.F('nav_order') - 1)
+        with transaction.atomic():
+            super().delete(*args, **kwargs)
+            pages = StaticPage.objects.filter(nav_order__gt=nav_order).order_by('nav_order')
+            for page in pages:
+                page.nav_order = page.nav_order - 1
+                page.save()
 
 
 class Section(models.Model):


### PR DESCRIPTION
## Context
Previously, when a StaticPage instance was deleted, the nav_order values of the remaining instances were not properly adjusted, leading to gaps or duplicates in the nav_order sequence. This caused issues when trying to move the remaining instances up or down in the sequence. Similarly, on static page edit, we were increasing the nav_order on every edit, which leads to the same error as described above.

To fix this issue, i overode the delete method of the StaticPage model to properly update the nav_order values of remaining instances when an instance is deleted. This change ensures that the nav_order sequence remains valid and consistent even after instances are deleted. Similarly, i also fixed the save method in StaticPage form.

## To reproduce the bug

### Method 1:
1. Edit any static page which is not on the bottom of the list(maybe edit the top static page or the one in the middle)
2. Notice that you will see 500 error which will complain about duplicate nav_order

### Method2:
1. Go to the admin panel 
2. Delete the static page with nav_order = 2 from the list. This will leave a gap in the nav_order sequence: 1, 3, 4.
3. Try to move the static page with nav_order = 4 up in the order by clicking on the “Up Arrow” button next to it. This will cause an IntegrityError, because it will try to update the nav_order of the static page with nav_order = 3 to 4, which is already taken by another static page.


## Question
1. For the already existing nav_orders in database which might have gaps in nav_order and can potentially lead to the integrity error, do we write a migration file to change the order for existing staticpages

Thanks to @january-adams for finding the bug
