### PR TITLE
refactor authorization to separate module

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -54,6 +54,7 @@ from project.models import (
     Topic,
     exists_project_slug,
 )
+from project.authorization.access import can_view_project_files
 from project.projectfiles import ProjectFiles
 from project.utility import readable_size
 from project.validators import MAX_PROJECT_SLUG_LENGTH
@@ -1169,7 +1170,7 @@ def users_aws_access_list_json(request):
             dataset['name'] = project_name
             dataset['accounts'] = []
             for user in users_with_awsid:
-                if project.can_view_files(user):
+                if can_view_project_files(project, user):
                     dataset['accounts'].append(user.cloud_information.aws_id)
             datasets['datasets'].append(dataset)
 

--- a/physionet-django/project/authorization/access.py
+++ b/physionet-django/project/authorization/access.py
@@ -86,7 +86,13 @@ def get_accessible_projects(user):
 
 
 def can_access_project(project, user):
-    """Checks if the project is accessible by the user"""
+    """
+    Checks if the project is accessible by the user
+    Users may access a project through different ways, for example, thorough direct download on the physionet website,
+    or through s3 bucket links, or gcs storage.
+    This function only checks access to the project in general, users might still not be able to access the files
+    even if they can access the project.
+    """
     if project.deprecated_files:
         return False
 
@@ -122,3 +128,11 @@ def can_access_project(project, user):
             == project.required_trainings.count()
         )
     return False
+
+
+def can_view_project_files(project, user):
+    """
+    Checks if the project files are  directly accessible by the user
+    Currently used to allow direct file downloads and to show project files on the platform
+    """
+    return can_access_project(project, user) and project.allow_file_downloads

--- a/physionet-django/project/authorization/access.py
+++ b/physionet-django/project/authorization/access.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+from django.db.models import Q
+
+from events.models import Event, EventDataset
+from project.models import AccessPolicy, DUASignature, DataAccessRequest, PublishedProject
+from user.models import Training, TrainingType
+
+
+def get_accessible_projects(user):
+    """
+    Returns query filter for published projects accessible by a specified user
+    """
+    query = Q(access_policy=AccessPolicy.OPEN) & Q(deprecated_files=False)
+
+    dua_signatures = DUASignature.objects.filter(user=user)
+
+    if user.is_authenticated:
+        query |= Q(access_policy=AccessPolicy.RESTRICTED) & Q(
+            duasignature__in=dua_signatures
+        )
+
+    if user.is_credentialed:
+        completed_training = (
+            Training.objects.get_valid()
+            .filter(user=user)
+            .values_list("training_type")
+        )
+        not_completed_training = TrainingType.objects.exclude(
+            pk__in=completed_training
+        )
+        required_training_complete = ~Q(
+            required_trainings__in=not_completed_training
+        )
+
+        accepted_data_access_requests = DataAccessRequest.objects.filter(
+            requester=user, status=DataAccessRequest.ACCEPT_REQUEST_VALUE
+        )
+        contributor_review_with_access = Q(
+            access_policy=AccessPolicy.CONTRIBUTOR_REVIEW
+        ) & Q(data_access_requests__in=accepted_data_access_requests)
+
+        credentialed_with_dua_signed = Q(
+            access_policy=AccessPolicy.CREDENTIALED
+        ) & Q(duasignature__in=dua_signatures)
+
+        query |= required_training_complete & (
+            contributor_review_with_access | credentialed_with_dua_signed
+        )
+
+    # add projects that are accessible through events
+    events_all = Event.objects.filter(Q(host=user) | Q(participants__user=user))
+    active_events = set(events_all.filter(end_date__gte=datetime.now()))
+    accessible_datasets = EventDataset.objects.filter(event__in=active_events, is_active=True)
+    accessible_projects_ids = []
+    for event_dataset in accessible_datasets:
+        if event_dataset.has_access(user):
+            accessible_projects_ids.append(event_dataset.dataset.id)
+    query |= Q(id__in=accessible_projects_ids)
+
+    return PublishedProject.objects.filter(query).distinct()

--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -6,6 +6,7 @@ from django.utils.html import format_html, escape
 from django.utils.http import urlencode
 import html2text
 
+from project.authorization.access import can_view_project_files as can_view_project_files_func
 from project.models import AccessPolicy
 from notification.utility import mailto_url
 
@@ -206,3 +207,8 @@ def call_method(obj, method_name, *args):
     """
     method = getattr(obj, method_name)
     return method(*args)
+
+
+@register.simple_tag(name='can_view_project_files')
+def can_view_project_files(project, user):
+    return can_view_project_files_func(project, user)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -50,6 +50,7 @@ from project.models import (
     Topic,
     UploadedDocument,
 )
+from project.authorization.access import can_view_project_files, can_access_project
 from project.projectfiles import ProjectFiles
 from project.validators import validate_filename, validate_gcs_bucket_object
 from user.forms import AssociatedEmailChoiceForm
@@ -1568,7 +1569,7 @@ def published_files_panel(request, project_slug, version):
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
     has_passphrase = project.get_anonymous_url() == an_url
 
-    if project.can_view_files(user) or has_passphrase:
+    if can_view_project_files(project, user) or has_passphrase:
         (display_files, display_dirs, dir_breadcrumbs, parent_dir,
          file_error) = get_project_file_info(project=project, subdir=subdir)
 
@@ -1630,7 +1631,7 @@ def serve_published_project_file(request, project_slug, version,
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
     has_passphrase = project.get_anonymous_url() == an_url
 
-    if project.can_view_files(user) or has_passphrase:
+    if can_view_project_files(project, user) or has_passphrase:
         file_path = os.path.join(project.file_root(), full_file_name)
         try:
             attach = ('download' in request.GET)
@@ -1673,7 +1674,7 @@ def display_published_project_file(request, project_slug, version,
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
     has_passphrase = project.get_anonymous_url() == an_url
 
-    if project.can_view_files(user) or has_passphrase:
+    if can_view_project_files(project, user) or has_passphrase:
         return display_project_file(request, project, full_file_name)
 
     # Display error message: "you must [be a credentialed user and]
@@ -1706,7 +1707,7 @@ def serve_published_project_zip(request, project_slug, version):
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60*60)
     has_passphrase = project.get_anonymous_url() == an_url
 
-    if project.can_view_files(user) or has_passphrase:
+    if can_view_project_files(project, user) or has_passphrase:
         try:
             return serve_file(project.zip_name(full=True))
         except FileNotFoundError:
@@ -1802,8 +1803,8 @@ def published_project(request, project_slug, version, subdir=''):
     an_url = request.get_signed_cookie('anonymousaccess', None, max_age=60 * 60)
     has_passphrase = project.get_anonymous_url() == an_url
 
-    can_view_files = project.can_view_files(user) or has_passphrase
-    is_authorized = project.is_authorized(user) or has_passphrase
+    can_view_files = can_view_project_files(project, user) or has_passphrase
+    is_authorized = can_access_project(project, user) or has_passphrase
     has_signed_dua = False if not user.is_authenticated else DUASignature.objects.filter(
         project=project,
         user=user
@@ -1921,7 +1922,7 @@ def sign_dua(request, project_slug, version):
         project.deprecated_files
         or project.embargo_active()
         or project.access_policy not in {AccessPolicy.RESTRICTED, AccessPolicy.CREDENTIALED}
-        or project.is_authorized(user)
+        or can_access_project(project, user)
     ):
         return redirect('published_project',
                         project_slug=project_slug, version=version)
@@ -2206,7 +2207,7 @@ def published_project_request_access(request, project_slug, version, access_type
                                             platform=access_type)
 
     # Check if the person has access to the project.
-    if not project.is_authorized(request.user):
+    if not can_access_project(project, user):
         return redirect('published_project', project_slug=project_slug,
             version=version)
 

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -28,8 +28,8 @@
     <p class="pub-details">Published: {{ published_project.publish_datetime|date }}.
       Version: {{ published_project.version }}</p>
     {% if is_lightwave_supported %}
-      {% call_method published_project 'can_view_files' request.user as user_can_view_files %}
-      {% if published_project.has_wfdb and user_can_view_files %}
+      {% can_view_project_files published_project request.user as user_can_view_project_files %}
+      {% if published_project.has_wfdb and user_can_view_project_files %}
         <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>
       {% endif %}
     {% endif %}


### PR DESCRIPTION
Context:
This PR is a small part of https://github.com/MIT-LCP/physionet-build/issues/1927#issuecomment-1468633078
On this PR, i tried to move all the code related to authorization into a separate module, so that in future, we would only need to worry about making changes here(like maybe once `DataSource` is refactored` we could just change the implementation inside the authorization module).

Here the summary of change is that i only copied the code from `PublishedProject.has_access` and `PublishedProject.objects.accessible_by`(used by healthdatanexus) into `projects.authorization.access. can_access_project` and `projects.authorization.access.get_accessible_projects`


To take this even further and make everything super simply, we might be able to put all the authorization code into just a single method `projects.authorization.access.get_accessible_projects`  and use this instead of `project.has_access`

For example:
Currently, to check if a user has access to a project
```
has_access = project.has_access(user)
```

we could do the following using just the single new method `get_accessible_projects`

```
>>> from project.authorization.access import get_accessible_projects
>>> from user.models import User
>>> user = User(username='amitupreti')
>>> queryset = get_accessible_projects(user)
>>> has_access = queryset.contains(project) #boolean result
```