### PR TITLE
Bump python from 3.8 to 3.9 and update dependencies. Ref #1870.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,35 +16,6 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "backports.zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
-    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
-]
-
-[package.extras]
-tzdata = ["tzdata"]
-
-[[package]]
 name = "bleach"
 version = "3.3.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -287,7 +258,6 @@ files = [
 
 [package.dependencies]
 asgiref = ">=3.5.2,<4"
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 sqlparse = ">=0.2.2"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -1398,5 +1368,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "360a87931f2fa71c89fa73d254027f5957b4fa4bad74b5217f08a9ebb9bd91ee"
+python-versions = "^3.9"
+content-hash = "1281f2cf3358e5906758eef7eece6277e43ebc462ad285b4d0dc6de3ef779a72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 bleach = "^3.3.0"
 chardet = "^3.0.4"
 Django = "4.1.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,16 @@
-asgiref==3.5.2 ; python_version >= "3.8" and python_version < "4.0" \
+asgiref==3.5.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4 \
     --hash=sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424
-backports-zoneinfo==0.2.1 ; python_version >= "3.8" and python_version < "3.9" \
-    --hash=sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf \
-    --hash=sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328 \
-    --hash=sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546 \
-    --hash=sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6 \
-    --hash=sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570 \
-    --hash=sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9 \
-    --hash=sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7 \
-    --hash=sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987 \
-    --hash=sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722 \
-    --hash=sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582 \
-    --hash=sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc \
-    --hash=sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b \
-    --hash=sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1 \
-    --hash=sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08 \
-    --hash=sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac \
-    --hash=sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2
-bleach==3.3.0 ; python_version >= "3.8" and python_version < "4.0" \
+bleach==3.3.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125 \
     --hash=sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433
-cachetools==4.2.2 ; python_version >= "3.8" and python_version < "4.0" \
+cachetools==4.2.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001 \
     --hash=sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff
-certifi==2022.12.7 ; python_version >= "3.8" and python_version < "4.0" \
+certifi==2022.12.7 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
     --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
-cffi==1.15.1 ; python_version >= "3.8" and python_version < "4.0" \
+cffi==1.15.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \
     --hash=sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef \
     --hash=sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104 \
@@ -92,13 +75,13 @@ cffi==1.15.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b \
     --hash=sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01 \
     --hash=sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0
-chardet==3.0.4 ; python_version >= "3.8" and python_version < "4.0" \
+chardet==3.0.4 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-charset-normalizer==2.0.12 ; python_version >= "3.8" and python_version < "4.0" \
+charset-normalizer==2.0.12 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
     --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
-coverage==4.5.4 ; python_version >= "3.8" and python_version < "4" \
+coverage==4.5.4 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6 \
     --hash=sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650 \
     --hash=sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5 \
@@ -131,7 +114,7 @@ coverage==4.5.4 ; python_version >= "3.8" and python_version < "4" \
     --hash=sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7 \
     --hash=sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0 \
     --hash=sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025
-cryptography==40.0.1 ; python_version >= "3.8" and python_version < "4.0" \
+cryptography==40.0.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0a4e3406cfed6b1f6d6e87ed243363652b2586b2d917b0609ca4f97072994405 \
     --hash=sha256:1e0af458515d5e4028aad75f3bb3fe7a31e46ad920648cd59b64d3da842e4356 \
     --hash=sha256:2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472 \
@@ -151,57 +134,57 @@ cryptography==40.0.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:d36bbeb99704aabefdca5aee4eba04455d7a27ceabd16f3b3ba9bdcc31da86c4 \
     --hash=sha256:d8aa3609d337ad85e4eb9bb0f8bcf6e4409bfb86e706efa9a027912169e89122 \
     --hash=sha256:f5d7b79fa56bc29580faafc2ff736ce05ba31feaa9d4735048b0de7d9ceb2b94
-django-autocomplete-light==3.9.4 ; python_version >= "3.8" and python_version < "4.0" \
+django-autocomplete-light==3.9.4 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0f6da75c1c7186698b867a467a8cdb359f0513fdd8e09288a0c2fb018ae3d94e
-django-background-tasks-updated==1.2.7 ; python_version >= "3.8" and python_version < "4.0" \
+django-background-tasks-updated==1.2.7 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:b8cdb115350e7c4706dd1ae8061df7d9d7827906c8563c6228abbf0867236954 \
     --hash=sha256:d137c095e174c28e85aceb9c5071af22572d41f134a85ead22eb102b33027625
-django-ckeditor==6.5.1 ; python_version >= "3.8" and python_version < "4.0" \
+django-ckeditor==6.5.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1321f24df392f30698513930ce5c9f6d899f9bd0ef734c3b64fe936d809e11b3 \
     --hash=sha256:57cd8fb7cd150adca354cd4e5c35a743fadaab7073f957d2b7167f0d9fe1fcaf
-django-debug-toolbar==3.2.4 ; python_version >= "3.8" and python_version < "4.0" \
+django-debug-toolbar==3.2.4 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:644bbd5c428d3283aa9115722471769cac1bec189edf3a0c855fd8ff870375a9 \
     --hash=sha256:6b633b6cfee24f232d73569870f19aa86c819d750e7f3e833f2344a9eb4b4409
-django-js-asset==2.0.0 ; python_version >= "3.8" and python_version < "4.0" \
+django-js-asset==2.0.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:86f9f300d682537ddaf0487dc2ab356581b8f50c069bdba91d334a46e449f923 \
     --hash=sha256:adc1ee1efa853fad42054b540c02205344bb406c9bddf87c9e5377a41b7db90f
-django-sass==1.1.0 ; python_version >= "3.8" and python_version < "4.0" \
+django-sass==1.1.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:992f39d97a7b2d7d891255e5f99512ffd616b2e0aae1ca9b76983c5ecd603342 \
     --hash=sha256:da163cd7ad7b9c2f1f10f2ec8b76939640d5b32d21ee74a240ca50a059c5fe7a
-django-storages[google]==1.12.3 ; python_version >= "3.8" and python_version < "4.0" \
+django-storages[google]==1.12.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:204a99f218b747c46edbfeeb1310d357f83f90fa6a6024d8d0a3f422570cee84 \
     --hash=sha256:a475edb2f0f04c4f7e548919a751ecd50117270833956ed5bd585c0575d2a5e7
-django==4.1.7 ; python_version >= "3.8" and python_version < "4.0" \
+django==4.1.7 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:44f714b81c5f190d9d2ddad01a532fe502fa01c4cb8faf1d081f4264ed15dcd8 \
     --hash=sha256:f2f431e75adc40039ace496ad3b9f17227022e8b11566f4b363da44c7e44761e
-djangorestframework==3.14.0 ; python_version >= "3.8" and python_version < "4.0" \
+djangorestframework==3.14.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8 \
     --hash=sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08
-google-api-core==1.34.0 ; python_version >= "3.8" and python_version < "4.0" \
+google-api-core==1.34.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:6fb380f49d19ee1d09a9722d0379042b7edb06c0112e4796c7a395078a043e71 \
     --hash=sha256:7421474c39d396a74dfa317dddbc69188f2336835f526087c7648f91105e32ff
-google-api-core[grpc]==1.34.0 ; python_version >= "3.8" and python_version < "4.0" \
+google-api-core[grpc]==1.34.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:6fb380f49d19ee1d09a9722d0379042b7edb06c0112e4796c7a395078a043e71 \
     --hash=sha256:7421474c39d396a74dfa317dddbc69188f2336835f526087c7648f91105e32ff
-google-api-python-client==1.12.8 ; python_version >= "3.8" and python_version < "4.0" \
+google-api-python-client==1.12.8 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:3c4c4ca46b5c21196bec7ee93453443e477d82cbfa79234d1ce0645f81170eaf \
     --hash=sha256:f3b9684442eec2cfe9f9bb48e796ef919456b82142c7528c5fd527e5224f08bb
-google-auth-httplib2==0.1.0 ; python_version >= "3.8" and python_version < "4.0" \
+google-auth-httplib2==0.1.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10 \
     --hash=sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac
-google-auth==1.32.0 ; python_version >= "3.8" and python_version < "4.0" \
+google-auth==1.32.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:b3a67fa9ba5b768861dacf374c2135eb09fa14a0e40c851c3b8ea7abe6fc8fef \
     --hash=sha256:e34e5f5de5610b202f9b40ebd9f8b27571d5c5537db9afed3a72b2db5a345039
-google-cloud-core==1.7.0 ; python_version >= "3.8" and python_version < "4.0" \
+google-cloud-core==1.7.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2ab0cf260c11d0cc334573301970419abb6a1f3909c6cd136e4be996616372fe \
     --hash=sha256:9bd528810423aeaa428a9a178e7320883bbb690a8b0bb38297b794dc319c415a
-google-cloud-storage==1.42.3 ; python_version >= "3.8" and python_version < "4.0" \
+google-cloud-storage==1.42.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:71ee3a0dcf2c139f034a054181cd7658f1ec8f12837d2769c450a8a00fcd4c6d \
     --hash=sha256:7754d4dcaa45975514b404ece0da2bb4292acbc67ca559a69e12a19d54fcdb06
-google-cloud-workflows==1.9.1 ; python_version >= "3.8" and python_version < "4.0" \
+google-cloud-workflows==1.9.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:3267373a5caa51d84eaeb2f3aa847e4cb7688f97faa67a879c3d89cefbdd7c8c \
     --hash=sha256:e4b7fb22387caf45a5f4a25780911f71af9faa53093e0b020b8f46fa8cfe0578
-google-crc32c==1.1.2 ; python_version >= "3.8" and python_version < "4.0" \
+google-crc32c==1.1.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0ae3cf54e0d4d83c8af1afe96fc0970fbf32f1b29275f3bfd44ce25c4b622a2b \
     --hash=sha256:0dd9b61d0c63043b013349c9ec8a83ec2b05c96410c5bc257da5d0de743fc171 \
     --hash=sha256:110157fb19ab5db15603debfaf5fcfbac9627576787d9caf8618ff96821a7a1f \
@@ -231,16 +214,16 @@ google-crc32c==1.1.2 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:e6458c41236d37cb982120b070ebcc115687c852bee24cdd18792da2640cf44d \
     --hash=sha256:ea170341a4a9078a067b431044cd56c73553425833a7c2bb81734777a230ad4b \
     --hash=sha256:ef2ed6d0ac4de4ac602903e203eccd25ec8e37f1446fe1a3d2953a658035e0a5
-google-resumable-media==1.3.1 ; python_version >= "3.8" and python_version < "4.0" \
+google-resumable-media==1.3.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:106db689574283a7d9d154d5a97ab384153c55a1195cecb8c01cad9e6e827628 \
     --hash=sha256:1a1eb743d13f782d1405437c266b2c815ef13c2b141ba40835c74a3317539d01
-googleapis-common-protos==1.58.0 ; python_version >= "3.8" and python_version < "4.0" \
+googleapis-common-protos==1.58.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
-grpcio-status==1.48.2 ; python_version >= "3.8" and python_version < "4.0" \
+grpcio-status==1.48.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2c33bbdbe20188b2953f46f31af669263b6ee2a9b2d38fa0d36ee091532e21bf \
     --hash=sha256:53695f45da07437b7c344ee4ef60d370fd2850179f5a28bb26d8e2aa1102ec11
-grpcio==1.51.1 ; python_version >= "3.8" and python_version < "4.0" \
+grpcio==1.51.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:094e64236253590d9d4075665c77b329d707b6fca864dd62b144255e199b4f87 \
     --hash=sha256:0dc5354e38e5adf2498312f7241b14c7ce3484eefa0082db4297189dcbe272e6 \
     --hash=sha256:0e1a9e1b4a23808f1132aa35f968cd8e659f60af3ffd6fb00bcf9a65e7db279f \
@@ -286,18 +269,18 @@ grpcio==1.51.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:f1fec3abaf274cdb85bf3878167cfde5ad4a4d97c68421afda95174de85ba813 \
     --hash=sha256:f96ace1540223f26fbe7c4ebbf8a98e3929a6aa0290c8033d12526847b291c0f \
     --hash=sha256:fbdbe9a849854fe484c00823f45b7baab159bdd4a46075302281998cb8719df5
-hdn-research-environment==1.4.0 ; python_version >= "3.8" and python_version < "4.0" \
+hdn-research-environment==1.4.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:296a336847c1078c149baa6773654a2e2a5b16cc1b03ca25f6f19f8606980e5b
-html2text==2018.1.9 ; python_version >= "3.8" and python_version < "4.0" \
+html2text==2018.1.9 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662 \
     --hash=sha256:627514fb30e7566b37be6900df26c2c78a030cc9e6211bda604d8181233bcdd4
-httplib2==0.19.1 ; python_version >= "3.8" and python_version < "4.0" \
+httplib2==0.19.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d \
     --hash=sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4
-idna==2.10 ; python_version >= "3.8" and python_version < "4.0" \
+idna==2.10 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
-libsass==0.21.0 ; python_version >= "3.8" and python_version < "4.0" \
+libsass==0.21.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:06c8776417fe930714bdc930a3d7e795ae3d72be6ac883ff72a1b8f7c49e5ffb \
     --hash=sha256:12f39712de38689a8b785b7db41d3ba2ea1d46f9379d81ea4595802d91fa6529 \
     --hash=sha256:1e25dd9047a9392d3c59a0b869e0404f2b325a03871ee45285ee33b3664f5613 \
@@ -308,16 +291,16 @@ libsass==0.21.0 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:c9ec490609752c1d81ff6290da33485aa7cb6d7365ac665b74464c1b7d97f7da \
     --hash=sha256:d5ba529d9ce668be9380563279f3ffe988f27bc5b299c5a28453df2e0b0fbaf2 \
     --hash=sha256:e2b1a7d093f2e76dc694c17c0c285e846d0b0deb0e8b21dc852ba1a3a4e2f1d6
-oauthlib==3.2.2 ; python_version >= "3.8" and python_version < "4.0" \
+oauthlib==3.2.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca \
     --hash=sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918
-packaging==20.9 ; python_version >= "3.8" and python_version < "4.0" \
+packaging==20.9 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5 \
     --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
-pdfminer-six==20211012 ; python_version >= "3.8" and python_version < "4.0" \
+pdfminer-six==20211012 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0351f17d362ee2d48b158be52bcde6576d96460efd038a3e89a043fba6d634d7 \
     --hash=sha256:d3efb75c0249b51c1bf795e3a8bddf1726b276c77bf75fb136adea471ee2825b
-pillow==9.3.0 ; python_version >= "3.8" and python_version < "4.0" \
+pillow==9.3.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:03150abd92771742d4a8cd6f2fa6246d847dcd2e332a18d0c15cc75bf6703040 \
     --hash=sha256:073adb2ae23431d3b9bcbcff3fe698b62ed47211d0716b067385538a1b0f28b8 \
     --hash=sha256:0b07fffc13f474264c336298d1b4ce01d9c5a011415b79d4ee5527bb69ae6f65 \
@@ -379,10 +362,10 @@ pillow==9.3.0 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:e6ea6b856a74d560d9326c0f5895ef8050126acfdc7ca08ad703eb0081e82b74 \
     --hash=sha256:ebf2029c1f464c59b8bdbe5143c79fa2045a581ac53679733d3a91d400ff9efb \
     --hash=sha256:f1ff2ee69f10f13a9596480335f406dd1f70c3650349e2be67ca3139280cade0
-proto-plus==1.22.2 ; python_version >= "3.8" and python_version < "4.0" \
+proto-plus==1.22.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165 \
     --hash=sha256:de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d
-protobuf==3.20.3 ; python_version < "4.0" and python_version >= "3.8" \
+protobuf==3.20.3 ; python_version < "4.0" and python_version >= "3.9" \
     --hash=sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7 \
     --hash=sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c \
     --hash=sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2 \
@@ -406,7 +389,7 @@ protobuf==3.20.3 ; python_version < "4.0" and python_version >= "3.8" \
     --hash=sha256:e67f9af1b607eb3a89aafc9bc68a9d1172aae788b2445cb9fd781bd97531f1f1 \
     --hash=sha256:f4bd856d702e5b0d96a00ec6b307b0f51c1982c2bf9c0052cf9019e9a544ba99 \
     --hash=sha256:f4c42102bc82a51108e449cbb32b19b180022941c727bac0cfd50170341f16ee
-psycopg2==2.9.5 ; python_version >= "3.8" and python_version < "4.0" \
+psycopg2==2.9.5 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:093e3894d2d3c592ab0945d9eba9d139c139664dcf83a1c440b8a7aa9bb21955 \
     --hash=sha256:190d51e8c1b25a47484e52a79638a8182451d6f6dff99f26ad9bd81e5359a0fa \
     --hash=sha256:1a5c7d7d577e0eabfcf15eb87d1e19314c8c4f0e722a301f98e0e3a65e238b4e \
@@ -420,7 +403,7 @@ psycopg2==2.9.5 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f \
     --hash=sha256:f5b6320dbc3cf6cfb9f25308286f9f7ab464e65cfb105b64cc9c52831748ced2 \
     --hash=sha256:fc04dd5189b90d825509caa510f20d1d504761e78b8dfb95a0ede180f71d50e5
-pyasn1-modules==0.2.8 ; python_version >= "3.8" and python_version < "4.0" \
+pyasn1-modules==0.2.8 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8 \
     --hash=sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199 \
     --hash=sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811 \
@@ -434,7 +417,7 @@ pyasn1-modules==0.2.8 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0 \
     --hash=sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d \
     --hash=sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405
-pyasn1==0.4.8 ; python_version >= "3.8" and python_version < "4.0" \
+pyasn1==0.4.8 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359 \
     --hash=sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576 \
     --hash=sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf \
@@ -448,65 +431,65 @@ pyasn1==0.4.8 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba \
     --hash=sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2 \
     --hash=sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3
-pycparser==2.20 ; python_version >= "3.8" and python_version < "4.0" \
+pycparser==2.20 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0 \
     --hash=sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705
-pyopenssl==23.1.1 ; python_version >= "3.8" and python_version < "4.0" \
+pyopenssl==23.1.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:841498b9bec61623b1b6c47ebbc02367c07d60e0e195f19790817f10cc8db0b7 \
     --hash=sha256:9e0c526404a210df9d2b18cd33364beadb0dc858a739b885677bc65e105d4a4c
-pyparsing==2.4.7 ; python_version >= "3.8" and python_version < "4.0" \
+pyparsing==2.4.7 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
-python-decouple==3.4 ; python_version >= "3.8" and python_version < "4.0" \
+python-decouple==3.4 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2e5adb0263a4f963b58d7407c4760a2465d464ee212d733e2a2c179e54c08d8f \
     --hash=sha256:a8268466e6389a639a20deab9d880faee186eb1eb6a05e54375bdf158d691981
-python-json-logger==2.0.2 ; python_version >= "3.8" and python_version < "4.0" \
+python-json-logger==2.0.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:202a4f29901a4b8002a6d1b958407eeb2dd1d83c18b18b816f5b64476dde9096 \
     --hash=sha256:99310d148f054e858cd5f4258794ed6777e7ad2c3fd7e1c1b527f1cba4d08420
-pytz==2022.1 ; python_version >= "3.8" and python_version < "4.0" \
+pytz==2022.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
     --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
-requests-mock==1.9.3 ; python_version >= "3.8" and python_version < "4.0" \
+requests-mock==1.9.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970 \
     --hash=sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba
-requests-oauthlib==1.3.0 ; python_version >= "3.8" and python_version < "4.0" \
+requests-oauthlib==1.3.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d \
     --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a \
     --hash=sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc
-requests==2.27.1 ; python_version >= "3.8" and python_version < "4.0" \
+requests==2.27.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
     --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
-rsa==4.7.2 ; python_version >= "3.8" and python_version < "4" \
+rsa==4.7.2 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
-selenium==3.141.0 ; python_version >= "3.8" and python_version < "4.0" \
+selenium==3.141.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
     --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
-sentry-sdk==1.14.0 ; python_version >= "3.8" and python_version < "4.0" \
+sentry-sdk==1.14.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:273fe05adf052b40fd19f6d4b9a5556316807246bd817e5e3482930730726bb0 \
     --hash=sha256:72c00322217d813cf493fe76590b23a757e063ff62fec59299f4af7201dd4448
-setuptools==65.5.1 ; python_version >= "3.8" and python_version < "4.0" \
+setuptools==65.5.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31 \
     --hash=sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f
-six==1.16.0 ; python_version >= "3.8" and python_version < "4.0" \
+six==1.16.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-sqlparse==0.4.2 ; python_version >= "3.8" and python_version < "4.0" \
+sqlparse==0.4.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
     --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d
-tzdata==2022.7 ; python_version >= "3.8" and python_version < "4.0" and sys_platform == "win32" \
+tzdata==2022.7 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32" \
     --hash=sha256:2b88858b0e3120792a3c0635c23daf36a7d7eeeca657c323da299d2094402a0d \
     --hash=sha256:fe5f866eddd8b96e9fcba978f8e503c909b19ea7efda11e52e39494bad3a7bfa
-uritemplate==3.0.1 ; python_version >= "3.8" and python_version < "4.0" \
+uritemplate==3.0.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f \
     --hash=sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae
-urllib3==1.26.15 ; python_version >= "3.8" and python_version < "4.0" \
+urllib3==1.26.15 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305 \
     --hash=sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42
-uwsgi==2.0.21 ; python_version >= "3.8" and python_version < "4.0" \
+uwsgi==2.0.21 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:35a30d83791329429bc04fe44183ce4ab512fcf6968070a7bfba42fc5a0552a9
-webencodings==0.5.1 ; python_version >= "3.8" and python_version < "4.0" \
+webencodings==0.5.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-zxcvbn==4.4.28 ; python_version >= "3.8" and python_version < "4.0" \
+zxcvbn==4.4.28 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1


### PR DESCRIPTION
This pull request bumps Python from >=3.8 to >=3.9 in `pyproject.toml` and updates dependencies with the following steps:

1. Generate a new poetry.lock file with: `poetry lock --no-update`
2. Generate a new requirements.txt with: `poetry export -f requirements.txt --output requirements.txt --with dev`

The change is a response to the following comment by @bemoody in https://github.com/MIT-LCP/physionet-build/issues/1870: 

>  I would be fine with increasing the minimum python version to 3.9 (in pyproject.toml) which might help remove some of the cruft *(in the requirement file).*
 



