### PR TITLE
gracefully handle event participation request

### DIFF
--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -117,6 +117,9 @@ def event_home(request):
                 messages.error(request, "You don't have permission to accept/reject this application")
                 return redirect(event_home)
             elif event_application.status == EventApplication.EventApplicationStatus.APPROVED:
+                if EventParticipant.objects.filter(event=event, user=event_application.user).exists():
+                    messages.error(request, "Application was already approved")
+                    return redirect(event_home)
                 event_application.accept(
                     comment_to_applicant=form.cleaned_data.get('comment_to_applicant')
                 )


### PR DESCRIPTION
Closes https://github.com/MIT-LCP/physionet-build/issues/1945

**Context:**
An IntegrityError was thrown with 500 status code when Event host tries  approving a user's participation request for an event that they(user) have already been approved for.

By design EventParticipant can only have 1 entry per (event,user). which caused the integrity error when same application was approved twice. 

**How to reproduce the bug?**

- Log in as an event host and create an event with some participants.
- Open two tabs in your browser and navigate to the event page on both tabs.
- On the first tab, approve a user’s participation request by clicking on the green check mark next to their name.
- On the second tab, without refreshing the page, try to approve the same user’s participation request again by clicking on the green check mark next to their name.
- You should see an IntegrityError message saying that the EventParticipant object already exists.

**Solution:**

Here we are checking if the user is an active participant before attempting to approve a participation request and show an error message to Event Host if user was already approved.