### PR TITLE
news:increase fontsize of Readmore section

### DIFF
--- a/physionet-django/notification/templates/notification/news_content.html
+++ b/physionet-django/notification/templates/notification/news_content.html
@@ -6,5 +6,5 @@
   {{ news.content|safe }}
 </div>
 {% if news.url %}
-<p class="pub-details">Read more: <a href="{{ news.url }}">{{ news.url }}</a></p>
+<p class="pub-details-read-more">Read more: <a href="{{ news.url }}">{{ news.url }}</a></p>
 {% endif %}

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -288,6 +288,11 @@ a{
   margin: 0;
 }
 
+.pub-details-read-more{
+  color: grey;
+  margin: 0;
+}
+
 .news-content{
   margin-top: 1em;
 


### PR DESCRIPTION
Closes https://github.com/MIT-LCP/physionet-build/issues/1958

As reported on the issue #1958 , the font size can be made more readable.

Before

<img width="851" alt="image" src="https://user-images.githubusercontent.com/24412619/232107855-ea3a2a26-3b30-4c95-8a5d-04d373d251dd.png">


After

<img width="851" alt="image" src="https://user-images.githubusercontent.com/24412619/232107805-1102bbb8-30a2-4671-b9a3-72ef5344f528.png">
