### PR TITLE
Improve search functionality for projects

### DIFF
--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -81,9 +81,9 @@ def get_content(resource_type, orderby, direction, search_term):
     # Relevance
     for t in search_term:
         published_projects = (published_projects.annotate(has_keys=Case(
-                When(topics__description__iregex=r'{0}{1}{0}'.format(wb, t),
-                     then=Value(3)),
                 When(title__iregex=r'{0}{1}{0}'.format(wb, t),
+                     then=Value(3)),
+                When(topics__description__iregex=r'{0}{1}{0}'.format(wb, t),
                      then=Value(2)),
                 When(abstract__iregex=r'{0}{1}{0}'.format(wb, t),
                      then=Value(1)),

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -55,6 +55,19 @@ def get_content(resource_type, orderby, direction, search_term):
     Helper function to get content shown on a resource listing page
     """
 
+    if 'postgresql' in settings.DATABASES['default']['ENGINE']:
+        published_projects = get_content_postgres_full_text_search(resource_type, orderby, direction, search_term)
+    else:
+        published_projects = get_content_normal_search(resource_type, orderby, direction, search_term)
+
+    return published_projects
+
+
+def get_content_postgres_full_text_search(resource_type, orderby, direction, search_term):
+    pass
+
+
+def get_content_normal_search(resource_type, orderby, direction, search_term):
     # Word boundary for different database engines
     wb = r'\b'
     if 'postgresql' in settings.DATABASES['default']['ENGINE']:

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -79,9 +79,11 @@ def get_content_postgres_full_text_search(resource_type, orderby, direction, sea
               + SearchVector('topics__description', weight='C'))
 
     # Filter projects by latest version and annotate relevance field
-    published_projects = (PublishedProject.objects.annotate(search=vector).
-                          filter(query, is_latest_version=True).
-                          annotate(relevance=SearchRank(vector, search_query)))
+    published_projects = PublishedProject.objects.annotate(search=vector).filter(query, is_latest_version=True)
+
+    # get distinct projects with subquery and also include relevance from published_projects
+    published_projects = PublishedProject.objects.filter(id__in=published_projects.values('id')).annotate(
+        relevance=SearchRank(vector, search_query)).distinct()
 
     # Sorting
     direction = '-' if direction == 'desc' else ''

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -4,6 +4,7 @@ import re
 from functools import reduce
 
 from django.conf import settings
+from django.contrib.postgres.search import SearchQuery, SearchVector, SearchRank
 from django.db.models import Case, Count, IntegerField, Q, Sum, Value, When
 from django.http import Http404
 from django.shortcuts import redirect, render, reverse
@@ -54,7 +55,6 @@ def get_content(resource_type, orderby, direction, search_term):
     """
     Helper function to get content shown on a resource listing page
     """
-
     if 'postgresql' in settings.DATABASES['default']['ENGINE']:
         published_projects = get_content_postgres_full_text_search(resource_type, orderby, direction, search_term)
     else:
@@ -64,7 +64,35 @@ def get_content(resource_type, orderby, direction, search_term):
 
 
 def get_content_postgres_full_text_search(resource_type, orderby, direction, search_term):
-    pass
+
+    # Split search term by whitespace or punctuation
+    if search_term:
+        search_terms = re.split(r'\s*[\;\,\s]\s*', re.escape(search_term))
+        search_queries = [SearchQuery(term) for term in search_terms]
+        search_query = reduce(operator.and_, search_queries)
+        query = Q(resource_type__in=resource_type) & Q(search=search_query)
+    else:
+        search_query = SearchQuery('')
+        query = Q(resource_type__in=resource_type)
+
+    vector = (SearchVector('title', weight='A') + SearchVector('abstract', weight='B')
+              + SearchVector('topics__description', weight='C'))
+
+    # Filter projects by latest version and annotate relevance field
+    published_projects = (PublishedProject.objects.annotate(search=vector).
+                          filter(query, is_latest_version=True).
+                          annotate(relevance=SearchRank(vector, search_query)))
+
+    # Sorting
+    direction = '-' if direction == 'desc' else ''
+    order_string = '{}{}'.format(direction, orderby)
+
+    if orderby == 'relevance':
+        published_projects = published_projects.order_by('-relevance', '-publish_datetime')
+    else:
+        published_projects = published_projects.order_by(order_string, '-relevance')
+
+    return published_projects
 
 
 def get_content_normal_search(resource_type, orderby, direction, search_term):

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -80,17 +80,24 @@ def get_content(resource_type, orderby, direction, search_term):
 
     # Relevance
     for t in search_term:
-        published_projects = (published_projects.annotate(has_keys=Case(
-                When(title__iregex=r'{0}{1}{0}'.format(wb, t),
-                     then=Value(3)),
-                When(topics__description__iregex=r'{0}{1}{0}'.format(wb, t),
-                     then=Value(2)),
-                When(abstract__iregex=r'{0}{1}{0}'.format(wb, t),
-                     then=Value(1)),
+        published_projects = published_projects.annotate(
+            has_keys=Case(
+                When(title__iregex=r"{0}{1}{0}".format(wb, t), then=Value(3)),
                 default=Value(0),
-                output_field=IntegerField()
-            )).annotate(has_keys=Sum('has_keys'))
-        )
+                output_field=IntegerField(),
+            )
+            + Case(
+                When(topics__description__iregex=r"{0}{1}{0}".format(wb, t), then=Value(2)),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+            + Case(
+                When(abstract__iregex=r"{0}{1}{0}".format(wb, t), then=Value(1)),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        ).annotate(has_keys=Sum("has_keys"))
+
 
     # Sorting
     direction = '-' if direction == 'desc' else ''


### PR DESCRIPTION
**Context**
Related to https://github.com/MIT-LCP/physionet-build/issues/1971

The current search mechanism does
1. Takes the search term from user and breaks it into words
2. Finds projects that has the words on `title`, `abstract` and `description`
3. Calculate relevance score based on how many times the word appear on the above fields of the projects
4. calculate has_keys by checking on which field the words are found for the selected projects, and providing highest preference to the matches found in title
5. Sort results by relevance and has_keys and display to users



This PR implements full text search with Django Postgres for the project model. It adds the same logic as the normal search with Django Postgres full text search,

This PR improves the relevance/results by stemming the search terms which comes with `SearchRank`, which means that it will match different forms of the same word. For example, if someone searches for "ponies", "pony" or "ponying", they will still get results that have the word "pony" in them. This makes the search more flexible and accurate.

However, this PR doesn't do anything about the performance issues  which might happen when the project database gets very large. The documentation says to improve performance we should index the dataset

Indexing: https://docs.djangoproject.com/en/4.1/ref/contrib/postgres/search/#performance

SearchRank: https://docs.djangoproject.com/en/4.1/ref/contrib/postgres/search/#searchrank