### PR TITLE
allow curly apostrophe in research summary

### DIFF
--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -204,7 +204,7 @@ def validate_research_summary(value):
     spaces, underscores, apostrophes and the following special
     characters: !@#$%&*()[]~+={};:"<>?,./`-
     """
-    if not re.fullmatch(r'[a-zA-Z][\w\'\[\]\n\r~!@#$%&*()+={};:"<>?,./` -]+', value):
+    if not re.fullmatch(r'[a-zA-Z][\w\'\[\]\n\r~!@#$%&*()+={};:‘’“”"<>?,./` -]+', value):
         raise ValidationError('Letters, numbers, spaces, apostrophes and [!@#$%&*()[]~_+-={ };:"<>?,./`] characters only. Must begin with a letter.')
 
 


### PR DESCRIPTION
Closes https://github.com/MIT-LCP/physionet-build/issues/1972

Context: During testing, a user had reported that they couldn't use curly apostrophe on the summary. After discussion, we decided to call it a day and allow curly apostrophe. See https://github.com/MIT-LCP/physionet-build/issues/1972

Changes:
Here i added the opening and closing single and double curly apostrophe. 
