### PR TITLE
Remove hardcoded redirects to physiobank and physiotools

### DIFF
--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -79,7 +79,6 @@ urlpatterns = [
     path('charts/', views.charts, name='charts'),
 
     # Redirect from legacy
-    path('physiotools/', views.physiotools),
     path('physiobank/database/wfdbcal', views.wfdbcal),
     re_path('^physiobank/database/(?P<project_slug>[\w\-]+)/$', views.redirect_project),
     re_path('^physiotools/(?P<project_slug>[\w\-]+)/$', views.redirect_project),

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -79,8 +79,6 @@ urlpatterns = [
     path('charts/', views.charts, name='charts'),
 
     # Redirect from legacy
-    path('physiobank/', views.physiobank),
-    path('physiobank/database/', views.physiobank),
     path('physiotools/', views.physiotools),
     path('physiobank/database/wfdbcal', views.wfdbcal),
     re_path('^physiobank/database/(?P<project_slug>[\w\-]+)/$', views.redirect_project),

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -229,11 +229,6 @@ def charts(request):
                            'plural_label': plural_label})
 
 
-def physiotools(request):
-    """Redirect"""
-    return redirect('software_index')
-
-  
 def wfdbcal(request):
     return redirect(static('wfdbcal'))
 

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -229,11 +229,6 @@ def charts(request):
                            'plural_label': plural_label})
 
 
-def physiobank(request):
-    """Redirect"""
-    return redirect('database_index')
-
-
 def physiotools(request):
     """Redirect"""
     return redirect('software_index')


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/1948 we added functionality for managing URL redirects. Our current code has some hardcoded redirects that could be replaced with this new functionality.

This pull request removes the following hardcoded redirects:
- https://physionet.org/physiobank/ -> https://physionet.org/data/
- https://physionet.org/physiobank/database/ -> https://physionet.org/data/
- https://physionet.org/physiotools/ -> https://physionet.org/software/

I have added these redirects to our database on production, so removing this code should have no effect on the live platform.