### PR TITLE
Search all user emails in console, not just primary emails. Fixes #1978.

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1126,7 +1126,9 @@ def users_search(request, group):
 
         users = User.objects.filter(Q(username__icontains=search_field)
                                     | Q(profile__first_names__icontains=search_field)
-                                    | Q(email__icontains=search_field))
+                                    | Q(email__icontains=search_field)
+                                    | Q(associated_emails__email__icontains=search_field)
+                                    ).distinct()
 
         if 'inactive' in group:
             users = users.filter(is_active=False)


### PR DESCRIPTION
This is a quick fix for the issue described in https://github.com/MIT-LCP/physionet-build/issues/1978. Currently, our search tool in the user console will only search for primary emails (not for other linked emails).

This pull request updates the search query so that associated emails are also searched. To test the change: 

1) On a fresh database on the dev branch, try searching for `admin3@mit.edu` in the user console at http://localhost:8000/console/users/active/. No results are returned.
2) Now switch to the feature branch and run the same search. You'll see that the admin user is returned (because `admin3@mit.edu` is a secondary email address for this user).