### PR TITLE
customizable theming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,9 @@ WARNING='#F1C500'
 DANGER='#DC4633'
 LIGHT='#007FA3'
 
+## physionet background image(direct download url)
+BACKGROUND_IMAGE='https://physionet.org/static/images/background.jpg'
+
 
 # Users settings
 # maximum number of emails that can be associated to a user model

--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,13 @@ SOURCE_CODE_REPOSITORY_LINK='https://github.com/MIT-LCP/physionet-build'
 # These variables are used to set the theme colors for the site
 DARK='#343A40'
 PRIMARY='#002A5C'
+SECONDARY='#6D247A'
+SUCCESS='#8DBF2E'
+INFO='#6FC7EA'
+WARNING='#F1C500'
+DANGER='#DC4633'
+LIGHT='#007FA3'
+
 
 # Users settings
 # maximum number of emails that can be associated to a user model

--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,11 @@ WARNING='#F1C500'
 DANGER='#DC4633'
 LIGHT='#007FA3'
 
+## Gradient colors on homepage
+
+GRADIENT_60 = 'rgba(42, 47, 52, 0.6)'
+GRADIENT_85 = 'rgba(42, 47, 52, 0.85)'
+
 ## physionet background image(direct download url)
 BACKGROUND_IMAGE='https://physionet.org/static/images/background.jpg'
 

--- a/physionet-django/static/custom/scss/_home.scss
+++ b/physionet-django/static/custom/scss/_home.scss
@@ -1,0 +1,150 @@
+$primary: map-get($theme-colors, "primary");
+$gradient_60: map-get($theme-colors, "gradient_60");
+$gradient_85: map-get($theme-colors, "gradient_85");
+
+/* Adapted from startbootstrap-agency */
+@keyframes move {
+	0% {
+		margin-top: 0px;
+	}
+	50% {
+		margin-top: 50px;
+	}
+	100% {
+		margin-top: 50px;
+	}
+}
+html {
+	scroll-behavior: smooth;
+}
+.main-content {
+	box-sizing: border-box;
+}
+.main-news {
+	box-sizing: border-box;
+}
+.btn-pn {
+	margin-right: 5px;
+	margin-left: 5px;
+}
+.intro-badge {
+	font-weight: 700;
+}
+.main-header {
+	display: flex;
+	overflow: hidden;
+	background: linear-gradient(
+		  $gradient_60,
+	      $gradient_85 35%,
+	      $gradient_85 75%,
+	      $gradient_60 100%),
+	url("../../images/background.jpg");
+	background-size: cover;
+	background-attachment: fixed;
+	height: calc(100% - 65px);
+	position: relative;
+	.float {
+		display: inline-block;
+		position: absolute;
+		right: -15px;
+		bottom: 1em;
+		height: calc(100px + 20vh);
+	}
+	* {
+		&:not(.float) {
+			z-index: 1;
+		}
+	}
+	.center {
+		color: white;
+		margin: auto;
+		text-align: center;
+		h1 {
+			font-size: calc(30px + 5vw);
+		}
+		a {
+			display: inline-block;
+			text-align: center;
+			padding: 10px 25px;
+			border-radius: 10px;
+			background-color: white;
+			margin: 10px;
+			font-size: calc(16px + 0.5vw);
+			color: white;
+			background-color: $primary;
+			border: 1px white solid;
+			transition: all 0.5s;
+			&:hover {
+				text-decoration: none;
+				background-color: white;
+				color: $primary;
+			}
+		}
+		p {
+			font-size: calc(16px + 1vw);
+		}
+	}
+	.citation {
+		display: inline-block;
+		width: 50%;
+		padding: 20px;
+		border-radius: 10px;
+		border: 1px white solid;
+	}
+	.down-container {
+		position: absolute;
+		bottom: 50px;
+		left: calc(50% - 0.5em);
+		height: calc(1em + 60px);
+		width: 2em;
+	}
+	.down {
+		width: 1em;
+		height: 1em;
+		margin-left: 8px;
+		border: solid white;
+		border-width: 0 1px 1px 0;
+		transform: rotate(45deg) translateY(1px);
+		animation: move 2s infinite;
+	}
+}
+.main-side {
+	h3 {
+		font-size: 1.25rem;
+	}
+	h4 {
+		font-size: 1.25rem;
+	}
+}
+@media screen and (min-width: 1000px) {
+	.main {
+		align-items: flex-start;
+	}
+	.main-side {
+		margin: 50px;
+		border-radius: 10px;
+		border: 1px silver solid;
+		hyphens: auto;
+		-ms-hyphens: auto;
+		-webkit-hyphens: auto;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+	}
+	.main-content {
+		padding: 50px 0;
+	}
+	.content-box {
+		display: inline-block;
+		vertical-align: top;
+		margin-left: 50px;
+		width: calc(50% - 50px);
+		padding: 30px;
+		border: 1px silver solid;
+		border-radius: 10px;
+		hyphens: auto;
+		-ms-hyphens: auto;
+		-webkit-hyphens: auto;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+	}
+}

--- a/physionet-django/user/management/commands/compilestatic.py
+++ b/physionet-django/user/management/commands/compilestatic.py
@@ -18,23 +18,33 @@ def theme_generator(themes_colors):
         f.write('@import "bootstrap"\n')
 
 
+def setup_theme_colors(colors):
+    """
+    Setups a map of theme colors from environment variables, validates them and returns a dictionary
+    :param colors: a map of colors to be set
+    :return: a dictionary of theme colors
+    """
+    themes_colors = {}
+    for key, value in colors.items():
+        value = config(key, default=value)
+        if len(value) != 7:
+            raise CommandError(f'{key} environment variable is not a valid hex color')
+        themes_colors[key.lower()] = value
+    return themes_colors
+
+
 class Command(BaseCommand):
     help = 'Compile static Sass files'
 
     def handle(self, *args, **options):
 
         # getting the environment variables
-        dark = config('DARK', default='#343A40')
-        if len(dark) != 7:
-            raise CommandError('DARK environment variable is not a valid hex color')
-
-        primary = config('PRIMARY', default='#002A5C')
-        if len(primary) != 7:
-            raise CommandError('PRIMARY environment variable is not a valid hex color')
-        themes_colors = {
-            'dark': dark,
-            'primary': primary,
+        colors = {
+            'DARK': '#343A40',
+            'PRIMARY': '#002A5C',
         }
+        themes_colors = setup_theme_colors(colors)
+
         # calling the theme generator function
         theme_generator(themes_colors)
         # calling the compile static command

--- a/physionet-django/user/management/commands/compilestatic.py
+++ b/physionet-django/user/management/commands/compilestatic.py
@@ -42,6 +42,12 @@ class Command(BaseCommand):
         colors = {
             'DARK': '#343A40',
             'PRIMARY': '#002A5C',
+            'SECONDARY': '#6C757D',
+            'SUCCESS': '#28A745',
+            'INFO': '#17A2B8',
+            'WARNING': '#FFC107',
+            'DANGER': '#DC3545',
+            'LIGHT': '#F8F9FA',
         }
         themes_colors = setup_theme_colors(colors)
 

--- a/physionet-django/user/management/commands/compilestatic.py
+++ b/physionet-django/user/management/commands/compilestatic.py
@@ -5,15 +5,15 @@ from decouple import config
 from django.core.management import call_command
 
 
-def theme_generator(dark, primary):
+def theme_generator(themes_colors):
     # creating the theme file
     with open('static/bootstrap/scss/theme.scss', 'w') as f:
         # cleaning the current contents of the file
         f.truncate(0)
         # writing the new contents to the file
         f.write('$theme-colors: (\n')
-        f.write('"primary" : ' + primary + ',\n')
-        f.write('"dark" : ' + dark + ',\n')
+        for key, value in themes_colors.items():
+            f.write(f'"{key}" : {value},\n')
         f.write(');\n')
         f.write('@import "bootstrap"\n')
 
@@ -31,9 +31,12 @@ class Command(BaseCommand):
         primary = config('PRIMARY', default='#002A5C')
         if len(primary) != 7:
             raise CommandError('PRIMARY environment variable is not a valid hex color')
-
+        themes_colors = {
+            'dark': dark,
+            'primary': primary,
+        }
         # calling the theme generator function
-        theme_generator(dark, primary)
+        theme_generator(themes_colors)
         # calling the compile static command
         call_command('sass', 'static/bootstrap/scss/theme.scss', 'static/bootstrap/css/bootstrap.css')
 

--- a/physionet-django/user/management/commands/compilestatic.py
+++ b/physionet-django/user/management/commands/compilestatic.py
@@ -7,7 +7,7 @@ from decouple import config
 from django.core.management import call_command
 
 
-def theme_generator(themes_colors):
+def theme_generator(themes_colors, imports=['bootstrap']):
     # creating the theme file
     with open('static/bootstrap/scss/theme.scss', 'w') as f:
         # cleaning the current contents of the file
@@ -17,7 +17,8 @@ def theme_generator(themes_colors):
         for key, value in themes_colors.items():
             f.write(f'"{key}" : {value},\n')
         f.write(');\n')
-        f.write('@import "bootstrap"\n')
+        for imp in imports:
+            f.write(f'@import "{imp}";\n')
 
 
 def setup_theme_colors(colors):
@@ -29,7 +30,7 @@ def setup_theme_colors(colors):
     themes_colors = {}
     for key, value in colors.items():
         value = config(key, default=value)
-        if len(value) != 7:
+        if len(value) != 7 and value[0] == '#':
             raise CommandError(f'{key} environment variable is not a valid hex color')
         themes_colors[key.lower()] = value
     return themes_colors
@@ -65,6 +66,8 @@ class Command(BaseCommand):
             'WARNING': '#FFC107',
             'DANGER': '#DC3545',
             'LIGHT': '#F8F9FA',
+            'GRADIENT_60': 'rgba(42, 47, 52, 0.6)',
+            'GRADIENT_85': 'rgba(42, 47, 52, 0.85)',
         }
         themes_colors = setup_theme_colors(colors)
 
@@ -81,3 +84,7 @@ class Command(BaseCommand):
         image_destination = 'static/images/background.jpg'
         setup_static_file(image_source, image_destination)
         self.stdout.write(self.style.SUCCESS('Successfully setup background image'))
+
+        # Demo section for home.css
+        theme_generator(themes_colors, imports=['../../custom/scss/home'])
+        call_command('sass', 'static/bootstrap/scss/theme.scss', 'static/custom/css/home.css')

--- a/physionet-django/user/management/commands/compilestatic.py
+++ b/physionet-django/user/management/commands/compilestatic.py
@@ -1,5 +1,7 @@
 # Management Command to compile static Sass files
 import os
+import urllib.request
+import urllib.error
 from django.core.management.base import BaseCommand, CommandError
 from decouple import config
 from django.core.management import call_command
@@ -33,6 +35,21 @@ def setup_theme_colors(colors):
     return themes_colors
 
 
+def setup_static_file(source, destination):
+    """
+    Copies a static file from source to destination
+    :param source: the source file path(direct url)
+    :param destination: the destination file path
+    """
+
+    try:
+        urllib.request.urlretrieve(source, destination)
+    except urllib.error.HTTPError:
+        raise CommandError(f'Could not download {source}')
+    except urllib.error.URLError:
+        raise CommandError(f'Could not download {source}')
+
+
 class Command(BaseCommand):
     help = 'Compile static Sass files'
 
@@ -58,3 +75,9 @@ class Command(BaseCommand):
 
         # writing the success message
         self.stdout.write(self.style.SUCCESS('Successfully compiled static Sass files'))
+
+        # setup background image
+        image_source = config('BACKGROUND_IMAGE', default='https://physionet.org/static/images/background.jpg')
+        image_destination = 'static/images/background.jpg'
+        setup_static_file(image_source, image_destination)
+        self.stdout.write(self.style.SUCCESS('Successfully setup background image'))


### PR DESCRIPTION
## Context:

Healthdatanexus theme is a  bit different from physionet. HDN has a bluish color and different gradient color and also other smaller css changes and background images.

Currently, this is achieved by modifying the forked physionet code directly, which requires us to manually edit the css and copy the css files during deployment. (Check https://github.com/T-CAIREM/physionet-build/pull/3/files to see what changes are needed on HDN )

This PR adds environment variable, and makes the theme customizable through them.

Changes
1. update scss files to use the environment variables. by default the theme is set to normal physionet colors, gradient
2. make background image customizable through environment variable
3. Demo change to get feedback on making the existing css(such as home.css) customizable(as hdn tweaks color on some other css also)

So if this [commit](https://github.com/MIT-LCP/physionet-build/commit/ce458e4656bf5ce6620a9d53c5feed68a502d4d5)  looks acceptable, i can go ahead  and make the rest of relevant  customizable like this(Is it a good idea to replace use of all css with scss or maybe we just modify the ones we need?)


## To test(to get the healthdatanexus tints), please add the following to your .env

```
# SCSS Theme Variables
# These variables are used to set the theme colors for the site
DARK='#1E3765'
PRIMARY='#337ab7'
SECONDARY='#6D247A'
SUCCESS='#8DBF2E'
INFO='#6FC7EA'
WARNING='#F1C500'
DANGER='#DC4633'
LIGHT='#007FA3'

## Gradient colors on homepage

GRADIENT_60 = 'rgba(30, 55, 101, 0.6)'
GRADIENT_85 = 'rgba(30, 55, 101, 0.85)'

## physionet background image(local path or direct download url)
BACKGROUND_IMAGE='https://storage.googleapis.com/healthdatanexus-prod-hdn-static/images/background.jpg'
```

Many thanks to @kshalot for the help