### PR TITLE
JSON export of AWS user accounts (restricted to MIMIC-IV 2.2)

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1156,7 +1156,9 @@ def users_aws_access_list_json(request):
         "mimiciv-0.3",
         "mimiciv-0.4",
         "mimiciv-1.0",
-        "mimiciv-2.0"
+        "mimiciv-2.0",
+        "mimiciv-2.1",
+        "mimiciv-2.2"
     ]
     published_projects = PublishedProject.objects.all()
     users_with_awsid = User.objects.filter(cloud_information__aws_id__isnull=False)

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1154,11 +1154,6 @@ def users_aws_access_list_json(request):
     2022).  Don't rely on this function; it will go away.
     """
     projects_datathon = [
-        "mimiciv-0.3",
-        "mimiciv-0.4",
-        "mimiciv-1.0",
-        "mimiciv-2.0",
-        "mimiciv-2.1",
         "mimiciv-2.2"
     ]
     published_projects = PublishedProject.objects.all()

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import os
+import re
 from collections import OrderedDict
 from datetime import datetime
 from itertools import chain
@@ -1164,6 +1165,7 @@ def users_aws_access_list_json(request):
     users_with_awsid = User.objects.filter(cloud_information__aws_id__isnull=False)
     datasets = {}
     datasets['datasets'] = []
+    aws_id_pattern = r"\b\d{12}\b"
 
     for project in published_projects:
         dataset = {}
@@ -1173,7 +1175,8 @@ def users_aws_access_list_json(request):
             dataset['accounts'] = []
             for user in users_with_awsid:
                 if can_view_project_files(project, user):
-                    dataset['accounts'].append(user.cloud_information.aws_id)
+                    if re.search(aws_id_pattern, user.cloud_information.aws_id):
+                        dataset['accounts'].append(user.cloud_information.aws_id)
             datasets['datasets'].append(dataset)
 
     return JsonResponse(datasets)


### PR DESCRIPTION
This PR provides a JSON file of AWS user accounts that can be downloaded by administrators. It includes only the latest version of mimic-iv that is currently mirrored on AWS (i.e., version 2.2). 