### PR TITLE
Make required text more visible for state/province on Credentialing form

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -439,7 +439,7 @@ class PersonalCAF(forms.ModelForm):
             'job_title': """Your job title or position (e.g., student) within
                 your institution or organization.""",
             'city': "The city where you live.",
-            'state_province': "The state or province where you live. (Required for residents of Canada or the US.)",
+            'state_province': "The state or province where you live.",
             'zip_code': "The zip code of the city where you live.",
             'country': "The country where you live.",
             'webpage': """Please include a link to a webpage with your
@@ -454,7 +454,7 @@ class PersonalCAF(forms.ModelForm):
            'suffix': forms.TextInput(attrs={'autocomplete': 'off'}),
         }
         labels = {
-            'state_province': 'State/Province',
+            'state_province': 'State/Province (Required for Canada/U.S.)',
             'first_names': 'First (given) name(s)',
             'last_name': 'Last (family) name(s)',
             'suffix': 'Suffix, if applicable:',


### PR DESCRIPTION
**Context:**

During onboarding users to healthdatanexus.ai platform, January noticed that many users were confused with the State/Province field(on Credentialing form) as with a quick glance it looks like an optional field(but is actually required for US/Canada residents). This caused them to have to resubmit the form.

It seems like a good idea to have the Required message on the input label, as the eye seems to see that first.(see screenshots below, on the 2nd screenshot its very noticeable) 

Before
![image](https://user-images.githubusercontent.com/24412619/235793578-c0991ad5-abbc-44d4-817c-8ebe3ce24dda.png)


After
![image](https://user-images.githubusercontent.com/24412619/235793542-3ad73a84-cc42-4def-80a4-4d803ddb25d5.png)

PS: Because this was such a small change, i opened a PR instead of an issue(as we close this if this doesn"t seem necessary or quickly review it if it makes sense)

Thanks to @january-adams for reporting it and solution.