### PR TITLE
Updated Instructions Page with link to CITI website

### DIFF
--- a/physionet-django/templates/about/citi_course.html
+++ b/physionet-django/templates/about/citi_course.html
@@ -8,9 +8,9 @@
 <div class="container">
   <h1>CITI Course Instructions</h1>
   <hr>
-  <p>To access certain resources on {{ SITE_NAME }}, you must complete training in human research and data privacy. We recommend the CITI Program's "Data or Specimens Only Research" course. Follow the instructions below to complete the course:</p>
+  <p>To access certain resources on {{ SITE_NAME }}, you must complete training in human research and data privacy. We recommend the CITI Program's "Data or Specimens Only Research" course. A link to the website can be found here: <a href="https://about.citiprogram.org/">CITI Program.</a> You must create an account with CITI Program before proceeding. Follow the instructions below to complete the course:</p>
   <ol>
-    <li>Click "Add affiliation"</li>
+    <li>Once you have created an account, go to 'My Courses' on the top of the page. Click "Add affiliation"</li>
     <img src="{% static 'images/about/citi-course-instructions-1.png' %}" alt="Citi Course instructions 1" class="screenshot">
     <li>Search for "Massachusetts Institute of Technology Affiliates". Click the checkmarks to agree. You are affiliating with MIT for the purpose of accessing data hosted on MIT servers.</li>
     <img src="{% static 'images/about/citi-course-instructions-2.png' %}" alt="Citi Course instructions 2" class="screenshot"> 


### PR DESCRIPTION
Changes as discussed in #1993. I added a link to the CITI website on the newly formatted instructions page and adjusted some of the directions for the first step to make it more clear how we reached the affiliation page. 