### PR TITLE
Update user search to include last names

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1127,6 +1127,7 @@ def users_search(request, group):
 
         users = User.objects.filter(Q(username__icontains=search_field)
                                     | Q(profile__first_names__icontains=search_field)
+                                    | Q(profile__last_name__icontains=search_field)
                                     | Q(email__icontains=search_field)
                                     | Q(associated_emails__email__icontains=search_field)
                                     ).distinct()


### PR DESCRIPTION
This PR addresses #1990 to allow searching for a user by their last name.