### PR TITLE
Relax validators to allow non risk characters

### DIFF
--- a/physionet-django/user/test_validators.py
+++ b/physionet-django/user/test_validators.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from django.core.exceptions import ValidationError
+
+from user.validators import validate_organization, validate_reference_response, validate_research_summary
+
+
+class TestValidators(TestCase):
+
+    def test_organization_with_newline_is_invalid(self):
+        self.assertRaises(ValidationError, validate_organization, 'Johnson\nJohnson')
+
+    def test_organization_with_special_character_is_valid(self):
+        self.assertIsNone(validate_organization('Johnson & Johnson'))
+
+    def test_organization_with_number_as_first_character_is_valid(self):
+        self.assertIsNone(validate_organization('21st century fox'))
+
+    def test_organization_with_special_character_as_first_character_is_invalid(self):
+        self.assertRaises(ValidationError, validate_organization, '&Johnson')

--- a/physionet-django/user/test_validators.py
+++ b/physionet-django/user/test_validators.py
@@ -33,3 +33,14 @@ class TestValidators(TestCase):
         self.assertRaises(ValidationError, validate_reference_response, '. An excellent researcher. '
                                                                         'I worked with them directly')
 
+    def test_research_summary_with_special_character_is_valid(self):
+        self.assertIsNone(validate_research_summary('I have done lots of research. 100% awesome!'))
+
+    def test_research_summary_with_newline_is_valid(self):
+        self.assertIsNone(validate_research_summary('An excellent researcher.  \n200 publications and counting.'))
+
+    def test_research_summary_with_number_as_first_character_is_valid(self):
+        self.assertIsNone(validate_research_summary('200 publications and counting. An excellent researcher.'))
+
+    def test_research_summary_with_special_character_as_first_character_is_invalid(self):
+        self.assertRaises(ValidationError, validate_research_summary, '. 200 publications and counting.')

--- a/physionet-django/user/test_validators.py
+++ b/physionet-django/user/test_validators.py
@@ -18,3 +18,18 @@ class TestValidators(TestCase):
 
     def test_organization_with_special_character_as_first_character_is_invalid(self):
         self.assertRaises(ValidationError, validate_organization, '&Johnson')
+
+    def test_reference_response_with_special_character_is_valid(self):
+        self.assertIsNone(validate_reference_response('An excellent researcher. I worked with them directly '
+                                                      '& they were very helpful. This person is 100% awesome!'))
+
+    def test_reference_response_with_newline_is_valid(self):
+        self.assertIsNone(validate_reference_response('An excellent researcher.  \nI worked with them directly'))
+
+    def test_reference_response_with_number_as_first_character_is_valid(self):
+        self.assertIsNone(validate_reference_response('1. An excellent researcher. I worked with them directly'))
+
+    def test_reference_response_with_special_character_as_first_character_is_invalid(self):
+        self.assertRaises(ValidationError, validate_reference_response, '. An excellent researcher. '
+                                                                        'I worked with them directly')
+

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -187,12 +187,10 @@ def validate_reference_title(value):
 
 def validate_reference_response(value):
     """
-    Validate the reference response that start with an
-    alphabetical character followed by alphanumeric characters,
-    spaces, underscores, hyphens, apostrophes, periods and commas.
+    Validate that the reference response starts with a letter or digit.
     """
-    if not re.fullmatch(r'[^\W_0-9]([\w\',. -])+', value):
-        raise ValidationError('Letters, numbers, spaces, hyphens, underscores, apostrophes, periods, and commas only. Must begin with a letter.')
+    if not re.fullmatch(r'\w.*', value, re.DOTALL):
+        raise ValidationError('Must begin with a letter or a digit.')
 
 
 def validate_research_summary(value):

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -87,12 +87,10 @@ def validate_location(value):
 
 def validate_organization(value):
     """
-    Validate the organization that start with an alphabetical character
-    followed by alphanumeric characters, spaces, underscores, hyphens, apostrophes,
-    periods and commas
+    Validate the organization that start with an alphanumeric character.
     """
-    if not re.fullmatch(r'[^\W_0-9]([\w\',. -])+', value):
-        raise ValidationError('Letters, numbers, spaces, hyphens, underscores, apostrophes, periods, and commas only. Must begin with a letter.')
+    if not re.fullmatch(r'^[a-zA-Z0-9].*', value):
+        raise ValidationError('Must begin with a letter or a number.')
 
 
 def validate_job_title(value):

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -197,13 +197,10 @@ def validate_reference_response(value):
 
 def validate_research_summary(value):
     """
-    Validate the research summary e that start with an
-    alphabetical character followed by alphanumeric characters,
-    spaces, underscores, apostrophes and the following special
-    characters: !@#$%&*()[]~+={};:"<>?,./`-
+    Validate that the research summary starts with a letter or digit.
     """
-    if not re.fullmatch(r'[a-zA-Z][\w\'\[\]\n\r~!@#$%&*()+={};:‘’“”"<>?,./` -]+', value):
-        raise ValidationError('Letters, numbers, spaces, apostrophes and [!@#$%&*()[]~_+-={ };:"<>?,./`] characters only. Must begin with a letter.')
+    if not re.fullmatch(r'\w.*', value, re.DOTALL):
+        raise ValidationError('Must begin with a letter or a digit.')
 
 
 def validate_nan(value):


### PR DESCRIPTION


## Context:
As discussed on [Issue#1982](https://github.com/MIT-LCP/physionet-build/issues/1982), we want to make the validators less restrictive unless there is a security concern. This is a summary of the changes that will be made to the validators(mostly validators for longer text).



## Changes Summary:

### Unit tests (Added unit tests for validators Pilot)

When writing code i often seem to make mistakes, so i wanted to experiment with TDD. I tried to write unit tests for all the validators first and then the code to make the tests pass.
It seemed to make the coding process easier and i was able to catch some bugs that i would have missed otherwise.
So i wanted to see what others thought of adding unit test for all the small methods/functions as well(Normally we seem to be doing this for just views) in the future or maybe if it looks like an overkill, i can remove the tests.

### Validators

### validate_reference_response

Before the change, the reference response is very restrictive, users can only selected special characters are permitted.

After the change, we allow everything as long as the first character is a letter or a number.

`re.fullmatch(r'[^\W_0-9]([\w\',. -])+', value) (OLD)`
`re.fullmatch(r'\w.*', value, re.DOTALL) (NEW)`



### validate_research_summary

Before the change, the research summary is very restrictive, users can only use from a list of authorized special characters.

After the change, we allow everything as long as the first character is a letter or a number.


`re.fullmatch(r'[a-zA-Z][\w\'\[\]\n\r~!@#$%&*()+={};:‘’“”"<>?,./` -]+', value) (OLD)`
`re.fullmatch(r'\w.*', value, re.DOTALL) (NEW)`


### validate_organization

Previously we didn't allow special characters in org names, which fails for cases like Johnson & Johnson or 21st century fox.
Currently, we only validate that the first character is not a special character and there is no new line(i dont think Organization names have new lines)

`r'[^\W_0-9]([\w\',. -])+' (OLD)`
`r'^[a-zA-Z0-9].*' (NEW)`


I also checked all existing `validator_*` functions and they seemed fine to me.