### PR TITLE
Remove unused contact form, template, and function

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -43,26 +43,6 @@ def mailto_url(*recipients, **params):
     return url
 
 
-def send_contact_message(contact_form):
-    """
-    Send a message to the contact email
-    """
-    subject = contact_form.cleaned_data['subject']
-    body = contact_form.cleaned_data['message']
-    mail_from = formataddr((contact_form.cleaned_data['name'],
-        contact_form.cleaned_data['email']))
-    message = EmailMessage(
-        subject=subject,
-        body=body,
-        from_email=settings.DEFAULT_FROM_EMAIL,  # envelope sender
-        to=[settings.CONTACT_EMAIL],
-        headers={
-            'From': mail_from,
-            'Sender': settings.DEFAULT_FROM_EMAIL
-        })
-    message.send(fail_silently=False)
-
-
 # ---------- Project App ---------- #
 
 def get_url_prefix(request, bulk_download=False):

--- a/physionet-django/templates/about/contact.html
+++ b/physionet-django/templates/about/contact.html
@@ -1,8 +1,0 @@
-<section id="form">
-  <div>
-
-  <p>{{ SITE_NAME }} is maintained by researchers and engineers at the MIT Laboratory for Computational Physiology. 
-     To reach us, email <a href=mailto:contact@physionet.org>contact@physionet.org</a>.</p>
-
-  </div>
-</section>

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -669,27 +669,6 @@ class CredentialReferenceForm(forms.ModelForm):
         return application
 
 
-class ContactForm(forms.Form):
-    """
-    For contacting support
-    """
-    name = forms.CharField(max_length=100, widget=forms.TextInput(
-        attrs={'class': 'form-control', 'placeholder': 'Name *'}))
-    email = forms.EmailField(max_length=100, widget=forms.TextInput(
-        attrs={'class': 'form-control', 'placeholder': 'Email *'}))
-    subject = forms.CharField(max_length=100, widget=forms.TextInput(
-        attrs={'class': 'form-control', 'placeholder': 'Subject *'}))
-    message = forms.CharField(max_length=2000, widget=forms.Textarea(
-        attrs={'class': 'form-control', 'placeholder': 'Message *'}))
-
-    def clean_email(self):
-        # Disallow addresses that look like they come from this machine.
-        addr = self.cleaned_data['email'].lower()
-        for domain in settings.EMAIL_FROM_DOMAINS:
-            if addr.endswith('@' + domain) or addr.endswith('.' + domain):
-                raise forms.ValidationError('Please enter your email address.')
-        return self.cleaned_data['email']
-
 class CloudForm(forms.ModelForm):
     """
     Form to store the AWS ID, and point to the google GCP email.


### PR DESCRIPTION
This is a quick pull request to clean up some unused code (including the `ContactForm` referenced in #1504). The changes are:

1. Remove the unused `ContactForm`. This was previously displayed on a "contact us" page, mainly to help bots distribute spam.
2. Remove an unused `contact.html` template. The template contains hardcoded content such as email addresses and references to PhysioNet.
3. Remove an unused utility function called `send_contact_message()`. Possibly a function used by bots to send spam using the `ContactForm`?