### PR TITLE
[WIP] Customizable theming fix background images issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,10 @@ LIGHT='#007FA3'
 GRADIENT_60 = 'rgba(42, 47, 52, 0.6)'
 GRADIENT_85 = 'rgba(42, 47, 52, 0.85)'
 
+## physionet background image(local path to image or a download url)
+## currently a jpg image is expected
+BACKGROUND_IMAGE='static/images/background.jpg'
+
 # Users settings
 # maximum number of emails that can be associated to a user model
 MAX_EMAILS_PER_USER = 10

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -174,7 +174,10 @@ MAX_ATTEMPTS = 5
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
-STATICFILES_DIRS = [os.path.join(BASE_DIR,'static')]
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static-overrides'),
+    os.path.join(BASE_DIR, 'static'),
+]
 # Google Storge service account credentials
 if config('GOOGLE_APPLICATION_CREDENTIALS', default=None):
     GOOGLE_APPLICATION_CREDENTIALS = os.path.join(

--- a/physionet-django/static-overrides/.gitignore
+++ b/physionet-django/static-overrides/.gitignore
@@ -1,0 +1,1 @@
+static-overrides/*


### PR DESCRIPTION
Closes https://github.com/MIT-LCP/physionet-build/issues/1996

**Background:** On PR https://github.com/MIT-LCP/physionet-build/pull/1986, we started to allow specific deployments of Physionet customize the theme of platform. This involved making the css styles, and static images configurable by using the .env file.

This https://github.com/MIT-LCP/physionet-build/pull/1986, introduced few bad designs and issues as pointed out by https://github.com/MIT-LCP/physionet-build/issues/1989 (tracked css files are being edited), and https://github.com/MIT-LCP/physionet-build/pull/1995 (downloading of files during installation). 
This PR uses the suggestion provided by @alistairewj  on https://github.com/MIT-LCP/physionet-build/issues/1996


**Context:**
This PR allows us to modify/customize the static files without messing with tracked file. As suggested by @alistairewj , we added a  new directory `static-overrides`(where the updated static files are saved during `compilestatic` command)

```
STATICFILES_DIRS = [
    os.path.join(BASE_DIR, 'static-overrides'),
    os.path.join(BASE_DIR, 'static'),
]
```

So when the collectstatic command is ran it will first look inside the `static-overrides` directory, and copy the files to the `STATIC_ROOT`. As mentioned in https://docs.djangoproject.com/en/dev/howto/static-files/#serving-static-files-during-development, the files in `static-overrides` will be used in case we have files with same name in `static-overrides` and `static`.

During deployment, It is expected that `compilestatic` command will be ran first(which will generate the css, image files and store them to the static-override folder),  and then `collectstatic` command will be ran which will collect static files
from static and static-override directories


**Note:** Regarding the part of code which lets us customize background image, i also added the option to allow someone to provide a link to background image because i am not sure if we can provide a local image path where the deployment happens in a container.



WIP: Currently, when the static files are generated in `static-overrides` by `compilestatic` and copied to `STATIC_ROOT`  by `collectstatic` command. The static files are still loaded directly from `static` instead of `STATIC_ROOT` directory.(Happens when i run the dev environment through docker).
I tried to play around with `DEBUG`, `STATIC_ROOT`, and `STATIC_URL` in local dev settings.
