### PR TITLE
refactor data access part 1 models validators [Please donot merge]

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -21,6 +21,7 @@ from project.models import (
     Contact,
     CopyeditLog,
     DataAccess,
+    DataSource,
     DUA,
     EditLog,
     License,
@@ -687,6 +688,26 @@ class DataAccessForm(forms.ModelForm):
         data_access.project = self.project
         data_access.save()
         return data_access
+
+
+class DataSourceForm(forms.ModelForm):
+    class Meta:
+        model = DataSource
+        fields = ('data_location', 'access_mechanism', 'files_available', 'email', 'uri' )
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+        if not settings.ENABLE_CLOUD_RESEARCH_ENVIRONMENTS:
+            self.fields['access_mechanism'].choices = [
+                choice for choice in self.fields['access_mechanism'].choices if choice[0] != 'research-environment']
+
+    def save(self):
+        data_source = super(DataSourceForm, self).save(commit=False)
+        data_source.project = self.project
+        data_source.save()
+        return data_source
 
 
 class PublishedProjectContactForm(forms.ModelForm):

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -360,6 +360,46 @@
         {% endif %}
       </li>
       <li class="list-group-item">
+        <h5 class="card-title mt-0 mb-1">Data Source</h5>
+        <p>Add and remove Data Source options.</p>
+{#        <div class="alert alert-danger">#}
+{#          <p class='m-0'>Note: The remove button will remove the option for requesting cloud access that appears in the files section of a project. It will not (1) delete/deactivate the bucket or (2) remove access for users who are already using the bucket.</p>#}
+{#        </div>#}
+        <form action="" method="post">
+          {% csrf_token %}
+          {% include "project/content_inline_form_snippet.html" with form=data_source_form %}
+          <button class="btn btn-primary" type="submit">Submit</button>
+        </form>
+        {% if data_sources %}
+        <table class="table table-bordered">
+            <tr>
+              <th>Location</th>
+              <th>Access Mechanism</th>
+              <th>Files Available</th>
+              <th>Email</th>
+              <th>Uri</th>
+              <th>Remove</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in data_sources %}
+            <tr>
+              <td>{{item.data_location}}</td>
+              <td>{{item.access_mechanism}}</td>
+              <td>{{item.files_available}}</td>
+              <td>{{item.email}}</td>
+              <td>{{item.uri}}</td>
+              <form action="" method="post">
+                {% csrf_token %}
+                <td><button class='btn btn-danger' name='data_source_removal' value='{{item.id}}'>Remove</button></td>
+              </form>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% endif %}
+      </li>
+      <li class="list-group-item">
         <h5 class="card-title mt-3 mb-1">Google Cloud</h5>
         {% if not has_credentials %}
           <p>You are missing the Google Cloud credentials.</p>
@@ -388,6 +428,7 @@
     </ul>
 
   </div>
+
 </div>
 
 {% endblock %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -43,6 +43,7 @@ from project.models import (
     ActiveProject,
     ArchivedProject,
     DataAccess,
+    DataSource,
     DUA,
     DataAccessRequest,
     DUASignature,
@@ -829,6 +830,7 @@ def manage_published_project(request, project_slug, version):
     deprecate_form = None if project.deprecated_files else forms.DeprecateFilesForm()
     has_credentials = bool(settings.GOOGLE_APPLICATION_CREDENTIALS)
     data_access_form = forms.DataAccessForm(project=project)
+    data_source_form = forms.DataSourceForm(project=project)
     contact_form = forms.PublishedProjectContactForm(project=project,
                                                      instance=project.contact)
     legacy_author_form = forms.CreateLegacyAuthorForm(project=project)
@@ -895,6 +897,18 @@ def manage_published_project(request, project_slug, version):
             if data_access_form.is_valid():
                 data_access_form.save()
                 messages.success(request, "Stored method to access the files")
+        elif 'data_location' in request.POST:
+            data_source_form = forms.DataSourceForm(project=project, data=request.POST)
+            if data_source_form.is_valid():
+                data_source_form.save()
+                messages.success(request, "Stored method to access the files")
+        elif 'data_source_removal' in request.POST and request.POST['data_source_removal'].isdigit():
+            try:
+                data_source = DataSource.objects.get(project=project, id=request.POST['data_source_removal'])
+                data_source.delete()
+                # Deletes the object if it exists for that specific project.
+            except DataSource.DoesNotExist:
+                pass
         elif 'data_access_removal' in request.POST and request.POST['data_access_removal'].isdigit():
             try:
                 data_access = DataAccess.objects.get(project=project, id=request.POST['data_access_removal'])
@@ -921,6 +935,7 @@ def manage_published_project(request, project_slug, version):
                 legacy_author_form = forms.CreateLegacyAuthorForm(project=project)
 
     data_access = DataAccess.objects.filter(project=project)
+    data_sources = DataSource.objects.filter(project=project)
     authors, author_emails, storage_info, edit_logs, copyedit_logs, latest_version = project.info_card()
 
     tasks = list(get_associated_tasks(project))
@@ -946,7 +961,9 @@ def manage_published_project(request, project_slug, version):
             'deprecate_form': deprecate_form,
             'has_credentials': has_credentials,
             'data_access_form': data_access_form,
+            'data_source_form': data_source_form,
             'data_access': data_access,
+            'data_sources': data_sources,
             'rw_tasks': rw_tasks,
             'ro_tasks': ro_tasks,
             'anonymous_url': anonymous_url,


### PR DESCRIPTION
Context:
We are breaking the PR https://github.com/MIT-LCP/physionet-build/pull/1967 into smaller PR(easy to review and work on). This branch is expected to merge on the 1967, not dev.

This PR introduces the `DataAccess` model and validators

**Quick Summary about the model,** `DataSource` model should be used to decide where the files are
stored(determined by `data_location`) for project and how they can be accessed(determined by `access_mechanism`). 
A single project can have multiple DataSource.

About the fields
`files_available` - determines if the files can be viewed/downloaded for the given type of datasource.(@kshalot had notes about this field here https://github.com/MIT-LCP/physionet-build/pull/1967#discussion_r1170257746)

`email` - For GCP group access, this would store the email of the group.

`uri` - The URI for the data on the external service. For s3 this would be of the form s3://<bucket_name>, for gsutil this would be of the form gs://<bucket_name>

**Quick Summary about validators**

The validation is based on four aspects: required fields, forbidden fields, required access mechanisms, and forbidden access mechanisms. 

1.  **Required Fields**: For each data location (such as Google BigQuery, Google Cloud Storage, AWS Open Data, and AWS S3), certain fields must be present. For instance, Google BigQuery requires an 'email', while Google Cloud Storage, AWS Open Data, and AWS S3 require a 'uri'. If a required field is missing, a validation error is raised.
    
2.  **Forbidden Fields**: Conversely, for certain data locations, some fields must not be present. For example, for 'Direct' data location, 'uri' and 'email' fields should not be present. If they are found, a validation error is raised.
    
3.  **Required Access Mechanisms**: Each data location may also require one of several specified access mechanisms. For instance, Google BigQuery and Google Cloud Storage can require either a 'Google Group Email' or a 'Research Environment' access mechanism, while AWS Open Data and AWS S3 require an 'S3' access mechanism. If none of the acceptable access mechanisms are found, a validation error is raised.
    
4.  **Forbidden Access Mechanisms**: Finally, some data locations forbid certain access mechanisms. Specifically, the 'Direct' data location forbids the 'Google Group Email', 'S3', and 'Research Environment' access mechanisms. If any of these are present, a validation error is raised.
    

**Quick Note about the interface**
This is so that we can quickly test if the validators work. and create datasources.
