### PR TITLE
Update instructions for accessing data in Google Cloud. Ref #2009.

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
@@ -1,8 +1,6 @@
 Dear {{ user.get_full_name }},
-
 {% if successful %}
-{% if data_access.platform == 3 %}
-You have requested access to use {{ project }} in GCP Storage.
+{% if data_access.platform == 3 %}You have requested access to the "{{ project }}" project in GCP Storage.
 
 The URL for the storage bucket in GCP is:
 https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}
@@ -10,31 +8,24 @@ https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}
 You can use the following command to copy the content of the bucket to your computer:
 gsutil -m -u YOUR_PROJECT_ID cp -r gs://{{ project.gcp.bucket_name }} DESTINATION
 
-To access this bucket from the command line, you will need to set
-up Google Cloud credentials as described here:
+To access the bucket with command line tools, you will need to set up cloud credentials:
 https://cloud.google.com/storage/docs/gsutil_install#authenticate
+{% else %}You have requested access to {{ project }} in GCP BigQuery.
 
-{% else %}
-You have requested access to use {{ project }} in GCP BigQuery.
+To access this resource:
 
-For information on how to access this resource please follow these steps
 1. Navigate to: https://console.cloud.google.com/bigquery
-2. In the left sidebar, there will be a button saying "+ADD DATA". Click it and pin the project "physionet-data".
-3. You should now see the {{ SITE_NAME }} datasets in the left sidebar.
-   - If you don't have access to a particular dataset, no information will be displayed when you click on the dataset name (and you may see a spinning circle icon).
-   - If you cannot add the project "physionet-data", please access it through this link: https://console.cloud.google.com/bigquery?project=physionet-data&page=dataset
+2. Click the "+ADD DATA" button. 
+3. Select "Star a project by name", then enter "physionet-data".
+3. That's it! You should see the resources in the sidebar.
 {% endif %}
-{% else %}
-We are sorry to say that we were unable to grant access to {{ project }} in GCP.
+{% else %}We were unable to grant access to {{ project }} in GCP.
 
-Reasons might include:
- - An invalid cloud e-mail was specified. Please ensure the e-mail in your cloud profile is a valid
- Google e-mail. Only Google e-mails may be used for GCP access.
- - The service is no longer available.
+Reasons may include:
+- Your cloud ID or email is invalid. Please check the cloud credentials in your profile.
+- The service is no longer available.
 
 Please reapply for access if you are able to address the issue.
 
-If you think this was an error on our part, please contact {{ contact_email }}.
-{% endif %}
-
+If you think this was an error on our part, please contact {{ contact_email }}.{% endif %}
 {{ signature }}


### PR DESCRIPTION
When a user requests access to a project in Google Cloud, they receive an email with instructions. The instructions are outdated (see: https://github.com/MIT-LCP/physionet-build/issues/2009).  This pull request updates the instructions, and cleans up the email text.

e.g. old email:

```
Dear Admin Bot,



You have requested access to use myproject v1.0.0 in GCP BigQuery.

For information on how to access this resource please follow these steps
1. Navigate to: https://console.cloud.google.com/bigquery
2. In the left sidebar, there will be a button saying "+ADD DATA". Click it and pin the project "physionet-data".
3. You should now see the Datashare datasets in the left sidebar.
   - If you don't have access to a particular dataset, no information will be displayed when you click on the dataset name (and you may see a spinning circle icon).
   - If you cannot add the project "physionet-data", please access it through this link: https://console.cloud.google.com/bigquery?project=physionet-data&page=dataset


Regards, The Development Team
```

Some notes on edits:
- "If you don't have access to a particular dataset, no information will be displayed when you click on the dataset name ..." has been removed, because the bucket will be added regardless.
- The link to https://console.cloud.google.com/bigquery?project=physionet-data&page=dataset was removed, because this no longer works.
- Removes excess whitespace.

new email:

```
Dear Admin Bot,

You have requested access to myproject v1.0.0 in GCP BigQuery.

To access this resource:

1. Navigate to: https://console.cloud.google.com/bigquery
2. Click the "+ADD DATA" button. 
3. Select "Star a project by name", then enter "physionet-data".
3. That's it! You should see the resources in the sidebar.


Regards, The Development Team
```

Side note: `physionet-data` is hardcoded into the email. This should be fixed by moving the BigQuery project name to our configuration file (`.env`).