### PR TITLE
Rs/search api

### DIFF
--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -6,12 +6,12 @@ from export import views
 urlpatterns = [
     # API V1 Routes
     path('v1/project/published/', views.PublishedProjectList.as_view(), name='Published_project_list'),
+    path('v1/project/published/search/', views.PublishedProjectSearch.as_view(), 
+         name='Published_project_search'),    
     path('v1/project/published/<str:project_slug>/', views.ProjectVersionList.as_view(),
          name='Published_Project_versions'),
     path('v1/project/published/<str:project_slug>/<str:version>/', views.PublishedProjectDetail.as_view(),
          name='Published_project_detail'),
-    path('v1/project/published/search/', views.PublishedProjectSearch.as_view(), 
-         name='Published_project_search'),
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)

--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -5,13 +5,13 @@ from export import views
 
 urlpatterns = [
     # API V1 Routes
-    path('v1/project/published/', views.PublishedProjectList.as_view(), name='Published_project_list'),
-    path('v1/project/published/search/', views.PublishedProjectSearch.as_view(), 
-         name='Published_project_search'),    
+    path('v1/project/published/', views.PublishedProjectList.as_view(), name='published_project_list'),
+    path('v1/project/published/search/', views.PublishedProjectSearch.as_view(),
+         name='published_project_search/'),
     path('v1/project/published/<str:project_slug>/', views.ProjectVersionList.as_view(),
-         name='Published_Project_versions'),
+         name='published_project_versions'),
     path('v1/project/published/<str:project_slug>/<str:version>/', views.PublishedProjectDetail.as_view(),
-         name='Published_project_detail'),
+         name='published_project_detail'),
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)

--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -10,6 +10,8 @@ urlpatterns = [
          name='Published_Project_versions'),
     path('v1/project/published/<str:project_slug>/<str:version>/', views.PublishedProjectDetail.as_view(),
          name='Published_project_detail'),
+    path('v1/project/published/search/', views.PublishedProjectSearch.as_view(), 
+         name='Published_project_search'),
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -8,6 +8,9 @@ from rest_framework.authentication import SessionAuthentication, BasicAuthentica
 from rest_framework import mixins
 from rest_framework.response import Response
 
+# Importing the get_content function from Search Module's views.py
+from search.views import get_content
+
 # Temporary imports for Database List Function.
 from django.http import JsonResponse
 
@@ -61,3 +64,28 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
         project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
         serializer = PublishedProjectDetailSerializer(project)
         return Response(serializer.data)
+
+
+class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
+    """
+    Search for a Published Project using the get_content function inside Search Module's views.py
+    """
+
+    # Getting the variables (resource_type, orderby, direction, search_term) from the API Call's Body.
+
+    def get_queryset(self):
+        resource_type = self.request.query_params.get('resource_type', 'types=0&types=1&types=2&types=3')
+        orderby = self.request.query_params.get('orderby', 'relevance-desc')
+        direction = self.request.query_params.get('direction', None)
+        search_term = self.request.query_params.get('search_term', None)
+
+        # Calling the get_content function inside Search Module's views.py
+        queryset = get_content(resource_type, orderby, direction, search_term)
+
+        return queryset
+    
+    authentication_classes = [SessionAuthentication, BasicAuthentication]
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+    

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -41,7 +41,6 @@ class ProjectVersionList(mixins.ListModelMixin, generics.GenericAPIView):
     """
     List all versions of a specific project
     """
-
     serializer_class = ProjectVersionsSerializer
 
     def get_queryset(self):
@@ -57,7 +56,6 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
     """
     Retrieve an Published Project
     """
-
     authentication_classes = [SessionAuthentication, BasicAuthentication]
 
     def get(self, request, project_slug, version, *args, **kwargs):
@@ -67,19 +65,15 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
 
 
 class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
-
     """
     Search for a Published Project using the get_content function inside Search Module's views.py
     """
-
     serializer_class = PublishedProjectSerializer
 
     def check_resource_type(self, resource_type):
-
         """
         Check if the resource_type requested is valid. Returns True if valid, else False
         """
-
         available_resource_types = ProjectType.objects.all().values_list('name', flat=True)
         for r_type in resource_type:
             if r_type != 'all' and r_type.capitalize() not in available_resource_types:
@@ -87,11 +81,9 @@ class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
         return True
 
     def get_queryset(self):
-
         """
         Modifying the get_queryset method to return the queryset based on the search_term and resource_type
         """
-
         resource_type = self.request.GET.getlist('resource_type', ['all'])
         search_term = self.request.GET.get('search_term', ' ')
 
@@ -111,12 +103,10 @@ class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
         return queryset
 
     def get(self, request, *args, **kwargs):
-
         """
         Default get method for PublishedProjectSearch that takes in the search_term
         and resource_type as query parameters
         """
-
         # check if the resource_type requested is valid
         resource_type = self.request.GET.getlist('resource_type', ['all'])
         if not self.check_resource_type(resource_type):

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -67,9 +67,6 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
         return Response(serializer.data)
 
 
-from rest_framework import generics, mixins
-from search.views import get_content
-
 class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
     """
     Search for a Published Project using the get_content function inside Search Module's views.py
@@ -102,4 +99,3 @@ class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
-    


### PR DESCRIPTION
This PR adds search functionality to the API-based access. 

**Usage :** 

API Endpoint : `http://127.0.0.1:8000/api/v1/project/published/search`

Type of requests : only `GET`

A direct GET request will give list of all the projects, same as the published endpoint.

For simple search of a keyword, you can send a get request to the endpoint with param `search_term` key and the actual keyword as the `value`. This includes all resources types : databases, software projects, challenges, and models.

Further granular access is possible via adding `resource_type` to params : 
for each resource_type, you can add `&resource_type=<chosen-resource-type>`
![image](https://github.com/MIT-LCP/physionet-build/assets/46196557/e82ca158-35e6-40c0-bc19-e71ea100fcae)


