### PR TITLE
Display project creation date in submission timeline.

### DIFF
--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -212,4 +212,16 @@
     </div>
   </li>
 
+  <!-- created -->
+  {# Created #}
+  <li class="list-group-item">
+    <div class="row">
+      <div class="col-md-2">{{ project.creation_datetime|date }}</div>
+      <div class="col-md-10">
+        <p>The project was created.</p>
+      </div>
+    </div>
+  </li>
+
+
 </ul>

--- a/physionet-django/project/templates/project/static_submission_timeline.html
+++ b/physionet-django/project/templates/project/static_submission_timeline.html
@@ -107,11 +107,21 @@
     <div class="row">
       <div class="col-md-2">{{ project.submission_datetime|date }}</div>
       <div class="col-md-10">
-        <p>The project was submitted for review.</p>
+        The project was submitted for review.
         {% if project.author_comments %}
           <p>The submitting author included the following comments:</p>
           <a class="editor-comments">{{ project.author_comments|linebreaks }}</a>
         {% endif %}
+      </div>
+    </div>
+  </li>
+
+  <!-- created -->
+  <li class="list-group-item">
+    <div class="row">
+      <div class="col-md-2">{{ project.creation_datetime|date }}</div>
+      <div class="col-md-10">
+        The project was created.
       </div>
     </div>
   </li>


### PR DESCRIPTION
The "submission timeline" pages display a timeline of events for a project (for example, "The project was submitted for review"; "Waiting for editor to be assigned.", etc...). 

There are times when it may be helpful to view the date of project creation.  This is a minor change that adds the date of project creation.

<img width="496" alt="Screenshot 2023-06-01 at 10 43 42 PM" src="https://github.com/MIT-LCP/physionet-build/assets/822601/9a8b4775-fb4d-417c-9f56-587597ac49c9">

