### PR TITLE
Move Event authorization code to authorization module

### DIFF
--- a/physionet-django/events/models.py
+++ b/physionet-django/events/models.py
@@ -224,6 +224,7 @@ class EventDataset(models.Model):
 
     def has_access(self, user):
         """
+        Deprecated: use projects.authorization.access.has_access_to_event_dataset instead
         Checks if the user has access to this EventDataset.
         This does not check if the associated dataset(PublishedProject) is accessible
         """

--- a/physionet-django/events/templatetags/participation_status.py
+++ b/physionet-django/events/templatetags/participation_status.py
@@ -1,6 +1,7 @@
 from django import template
 
 from events.models import EventApplication
+from project.authorization.events import has_access_to_event_dataset as has_access_to_event_dataset_func
 
 register = template.Library()
 
@@ -21,4 +22,4 @@ def is_on_waiting_list(user, event):
 
 @register.filter(name='has_access_to_event_dataset')
 def has_access_to_event_dataset(user, dataset):
-    return dataset.has_access(user)
+    return has_access_to_event_dataset_func(user, dataset)

--- a/physionet-django/project/authorization/access.py
+++ b/physionet-django/project/authorization/access.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.db.models import Q
 
 from events.models import Event, EventDataset
+from project.authorization.events import has_access_to_event_dataset
 from project.models import AccessPolicy, DUASignature, DataAccessRequest, PublishedProject
 from user.models import Training, TrainingType
 
@@ -59,7 +60,7 @@ def get_projects_accessible_through_events(user):
 
     accessible_projects_ids = []
     for event_dataset in accessible_datasets:
-        if event_dataset.has_access(user):
+        if has_access_to_event_dataset(user, event_dataset):
             accessible_projects_ids.append(event_dataset.dataset.id)
 
     query = Q(id__in=accessible_projects_ids)

--- a/physionet-django/project/authorization/events.py
+++ b/physionet-django/project/authorization/events.py
@@ -1,0 +1,24 @@
+from django.utils import timezone
+
+
+def has_event_access(user, event):
+    """
+    Checks if the user has access to the event
+    """
+    return event.host == user or event.participants.filter(user=user).exists()
+
+
+def has_access_to_event_dataset(user, event_dataset):
+    """
+    Checks if the user has access to the event dataset
+    """
+    if not has_event_access(user, event_dataset.event):
+        return False
+
+    if not event_dataset.is_active:
+        return False
+
+    if timezone.now().date() > event_dataset.event.end_date:
+        return False
+
+    return True

--- a/physionet-django/project/managers/publishedproject.py
+++ b/physionet-django/project/managers/publishedproject.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.db.models import Manager, Q
 from events.models import Event, EventDataset
+from project.authorization.events import has_access_to_event_dataset
 from project.models import AccessPolicy, DUASignature, DataAccessRequest
 from user.models import Training, TrainingType
 
@@ -57,7 +58,7 @@ class PublishedProjectManager(Manager):
         accessible_datasets = EventDataset.objects.filter(event__in=active_events, is_active=True)
         accessible_projects_ids = []
         for event_dataset in accessible_datasets:
-            if event_dataset.has_access(user):
+            if has_access_to_event_dataset(user, event_dataset):
                 accessible_projects_ids.append(event_dataset.dataset.id)
         query |= Q(id__in=accessible_projects_ids)
 


### PR DESCRIPTION
As discussed on https://github.com/MIT-LCP/physionet-build/issues/2016,  we want to move all authorization related logic to projects.authorization module to centralize authorization logic.

Note: here i created an events.py file inside authorization, because if we try to add this func inside the projects.authorization.access.py, we will get circular import. Also, this kind of organizes the authorization for event in a single file(instead of mixing up on access.py)

In future, it might make sense to move authorization as a separate app.


For testing, i created a new event, added dataset to it, joined the event waitlist, and approved the event waitlist(The events workflow)