### PR TITLE
Tests on Debian 12

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    container: debian:11
+    container: ${{ matrix.container }}
     env:
       DJANGO_SETTINGS_MODULE: physionet.settings.settings
       TEST_GCS_INTEGRATION: false
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         pip3: ['poetry', 'requirements.txt']
+        container: ['debian:11', 'debian:12']
     steps:
 
       - name: Update packages

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -12,7 +12,10 @@ jobs:
   testupgrade:
     name: Upgrade Test
     runs-on: ubuntu-latest
-    container: debian:11
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        container: ['debian:11', 'debian:12']
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Debian 12 "bookworm" is hot off the presses.  There's no rush, but I would like to upgrade in the near future - probably mid to late July.

(While Health Data Nexus certainly doesn't have to upgrade at the same time PhysioNet does, it'll be easier if we don't have a long transitional period.)

This pull request should (I think - I still don't fully understand this GitHub stuff) run the test suites in parallel in both Debian 11 and Debian 12 containers (both running on an Ubuntu host VM.)

*For the time being, please continue to use Debian 11 and Python 3.9 for regular development* (though if you feel adventurous, go ahead and set up both environments to test stuff in parallel.)
