### PR TITLE
Fetch credentialed project example instead of hardcoding MIMIC-III

### DIFF
--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -23,12 +23,14 @@ If you are able to address the issue(s), please open a new credentialing applica
 
 {% elif application.status == CredentialApplication.Status.ACCEPTED %}Thank you for your interest in the {{ SITE_NAME }} Clinical Databases. We are pleased to say that your application for credentialed access has been approved.
 
-You are now able to access protected databases upon agreeing to the terms of usage and completing any required training. For example, you can access MIMIC-III by following the steps below:
+{% if example_project %}
+You are now able to access protected databases upon agreeing to the terms of usage and completing any required training. For example, you can access {{ example_project.title }} by following the steps below:
 
-- Go to the project page at {{ url_prefix }}{% url 'published_project_latest' 'mimiciii' %}
+- Go to the project page at {{ url_prefix }}{% url 'published_project_latest' example_project.slug %}
 - Find the “Files” section in the project description
 - Follow instructions to complete required training, if necessary.
 - Click “Sign the Data Use Agreement” to agree to the terms of usage for the dataset
+{% endif %}
 
 To check the status of your training or to submit training documents for review, please visit {{ url_prefix }}{% url 'edit_training' %}.
 

--- a/physionet-django/notification/templates/notification/email/process_training_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_training_complete.html
@@ -15,14 +15,14 @@ Dear {{ applicant_name }},
 If you are able to address the issue(s), please resubmit your training at: {{ url_prefix }}{% url 'edit_training' %}.
 
 {% elif training.status.name == "ACCEPTED" %}We are pleased to say that your "{{ training.training_type.name }}" training was approved.
-{% if training.user.is_credentialed %}
-You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access MIMIC-III by following the steps below:
+{% if training.user.is_credentialed and example_project %}
+You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access {{ example_project.title }} by following the steps below:
 
-- Go to the project page at {{ url_prefix }}{% url 'published_project_latest' 'mimiciii' %}
+- Go to the project page at {{ url_prefix }}{% url 'published_project_latest' example_project.slug %}
 - Find the “Files” section in the project description
 - Click “Sign the data use agreement” to agree to the terms of usage for this dataset
 {% else %}
-Before accessing protected databases such as MIMIC-III, you will also need to complete the credentialing process.  
+Before accessing protected databases such as MIMIC-III, you will also need to complete the credentialing process.
 
 You can submit a new credentialing application or check the status of an existing application at: {{ url_prefix }}{% url 'credential_application' %}
 {% endif %}


### PR DESCRIPTION
MIMIC-III is a dataset specific to PhysioNet. Right now the emails link to a page that does not exist for deployments other than PhysioNet.

This is just an example solution to this problem that we deployed to Health Data Nexus because we have an influx of credentialing applications at the moment. If you need to link a specific project (like MIMIC-III) and not the first one that the query finds, we could add a debranding envvar (e.g. `CREDENTIALING_EXAMPLE_PROJECT_SLUG`) which will specify which project should be linked or even combine the two approaches and default to the first one if the envvar is not present.

Also, using `example_project.title` will result in showing `...can access MIMIC-III Clinical Database
 by following the steps...` which is probably missing "the" before the title in this specific case. Other titles might not require the "the" article though