### PR TITLE
Add libcap-dev as a build dependency

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -37,6 +37,7 @@ jobs:
                   build-essential \
                   flake8 \
                   git \
+                  libcap-dev \
                   libffi-dev \
                   libflac-dev \
                   libpq-dev \

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -21,6 +21,7 @@ jobs:
                   build-essential \
                   flake8 \
                   git \
+                  libcap-dev \
                   libffi-dev \
                   libflac-dev \
                   libpq-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-bullseye
 
 RUN apt-get update -y \
     && apt-get upgrade -y \
-    && apt-get install build-essential libflac-dev libseccomp-dev libpq-dev libpcre3-dev postgresql-client wget zip -y --no-install-recommends \
+    && apt-get install build-essential libcap-dev libflac-dev libseccomp-dev libpq-dev libpcre3-dev postgresql-client wget zip -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/bemoody/wfdb/archive/10.7.0.tar.gz -O wfdb.tar.gz \

--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -48,7 +48,7 @@ apt-get install -y \
         `# Python application server` \
         virtualenv python3-dev libpq-dev libffi-dev \
         `# Requirements for building LightWAVE` \
-        build-essential libflac-dev libseccomp-dev \
+        build-essential libcap-dev libflac-dev libseccomp-dev \
         `# Other tools required by PhysioNet` \
         zip unzip xfsprogs \
         `# Development and administration tools` \


### PR DESCRIPTION
The libcap-dev package is required in order to build the sandboxed-lightwave server to run in "unprivileged mode" (without using setuid).  

This pull request doesn't actually change anything about how we're installing lightwave; it merely makes it possible to compile the master branch of lightwave.
