### PR TITLE
Django 4.1.9 file upload compatibility, and tests

### DIFF
--- a/physionet-django/project/urls.py
+++ b/physionet-django/project/urls.py
@@ -94,3 +94,11 @@ urlpatterns = [
         name='generate_signed_url',
     ),
 ]
+
+TEST_CASES = {
+    'project_files': {
+        '_user_': 'rgmark',
+        'project_slug': 'T108xFtYkRAxiRiuOLEJ',
+        'subdir': 'notes',
+    }
+}


### PR DESCRIPTION

Between Django 4.1.7 and 4.1.9 there have been some changes to how multiple-file form fields are handled.  Here's what the announcement says (https://www.djangoproject.com/weblog/2023/may/03/security-releases/):

> CVE-2023-31047: Potential bypass of validation when uploading multiple files using one form field
>
> Uploading multiple files using one form field has never been supported by forms.FileField or forms.ImageField as only the last uploaded file was validated. Unfortunately, Uploading multiple files topic suggested otherwise.
>
> In order to avoid the vulnerability, ClearableFileInput and FileInput form widgets now raise ValueError when the multiple HTML attribute is set on them. To prevent the exception and keep the old behavior, set allow_multiple_selected to True.
>
> For more details on using the new attribute and handling of multiple files through a single field, see Uploading multiple files.
>
> Thanks Moataz Al-Sharida and nawaik for reports.

And this I guess is the relevant commit: https://github.com/django/django/commit/e7c3a2ccc3a562328600be05068ed9149e12ce64

Actually, "setting allow_multiple_selected to True" doesn't exactly keep the old behavior - there's also something funky going on (something to do with `value_from_datadict`, I guess) which means that in addition to subclassing `FileInput` we also have to subclass `FileField`.

The code here is lifted from the current Django docs (https://docs.djangoproject.com/en/4.2/topics/http/file-uploads/#uploading-multiple-files), but also explicitly sets the 'multiple' attribute for backward compatibility with Django 4.1.7.

This *should* work, but please test it before merging.
