### PR TITLE
Display personal website for credentialed users only on public profile

### DIFF
--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -68,14 +68,14 @@ Profile for {{ public_user.username }}
       {% endif %}
 
       {% if public_user.is_credentialed and profile.website %}
-    <div class="row mb-1">
-      <div class="col-md-2">
-        Website:
-      </div>
-      <div class="col-md-10">
-        <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a> 
-      </div>
-    </div>
+        <div class="row mb-1">
+          <div class="col-md-2">
+            Website:
+          </div>
+          <div class="col-md-10">
+            <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a> 
+          </div>
+        </div>
       {% endif %} 
       
       {% if projects %}

--- a/physionet-django/user/templates/user/public_profile.html
+++ b/physionet-django/user/templates/user/public_profile.html
@@ -67,16 +67,16 @@ Profile for {{ public_user.username }}
         </div>
       {% endif %}
 
-      {% if profile.website %}
-        <div class="row mb-1">
-          <div class="col-md-2">
-            Website:
-          </div>
-          <div class="col-md-10">
-            <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a>
-          </div>
-        </div>
-      {% endif %}
+      {% if public_user.is_credentialed and profile.website %}
+    <div class="row mb-1">
+      <div class="col-md-2">
+        Website:
+      </div>
+      <div class="col-md-10">
+        <a href="{{ profile.website }}" rel="nofollow">{{ profile.website }}</a> 
+      </div>
+    </div>
+      {% endif %} 
       
       {% if projects %}
       <br />


### PR DESCRIPTION
This PR addresses #715 by only displaying a user's website link if they are a credentialed user and if they have a link available to display. If both these conditions are not met, there will be no link listed on the public profile.