### PR TITLE
Allow DATA_UPLOAD_MAX_NUMBER_FILES and DATA_UPLOAD_MAX_MEMORY_SIZE to be configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,3 +191,8 @@ MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING = 20
 CITI_USERNAME=
 CITI_PASSWORD=
 CITI_SOAP_URL="https://webservices.citiprogram.org/SOAP/CITISOAPService.asmx"
+
+# Django configuration for file upload
+# See https://docs.djangoproject.com/en/4.2/ref/settings/
+DATA_UPLOAD_MAX_NUMBER_FILES=1000
+DATA_UPLOAD_MAX_MEMORY_SIZE=2621440

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -623,3 +623,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # minimum number of word needed for research_summary field for Credentialing Model.
 MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING = config('MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING', cast=int, default=20)
+
+# Django configuration for file upload (see https://docs.djangoproject.com/en/4.2/ref/settings/)
+DATA_UPLOAD_MAX_NUMBER_FILES = config('DATA_UPLOAD_MAX_NUMBER_FILES', cast=int, default=1000)
+DATA_UPLOAD_MAX_MEMORY_SIZE = config('DATA_UPLOAD_MAX_MEMORY_SIZE', cast=int, default=2621440)


### PR DESCRIPTION
This pull request addresses https://github.com/MIT-LCP/physionet-build/issues/2035.  When users attempt to upload more than 100 files (which is fairly common when data contributors are submitting new projects) the following error is raised:

```
The number of files exceeded settings.DATA_UPLOAD_MAX_NUMBER_FILES.

TooManyFilesSent at /projects/SLUG/files/
The number of files exceeded settings.DATA_UPLOAD_MAX_NUMBER_FILES.
``` 

The "100" file limit is Django's default (see: https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-DATA_UPLOAD_MAX_NUMBER_FILES). 

This pull request:

1) Allows the `DATA_UPLOAD_MAX_NUMBER_FILES` to be configured in the .env file.
2) Also allows `DATA_UPLOAD_MAX_MEMORY_SIZE` to be configured in the .env file.
