### PR TITLE
Switch order of OAuth2TokenMiddleware middleware

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -80,9 +80,9 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'corsheaders.middleware.CorsMiddleware',
-    'oauth2_provider.middleware.OAuth2TokenMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'oauth2_provider.middleware.OAuth2TokenMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     # RedirectFallbackMiddleware should go at end of list, according


### PR DESCRIPTION
The Oauth authentication middleware (`oauth2_provider.middleware.OAuth2TokenMiddleware`) is currently sitting above the default authentication middleware (`django.contrib.auth.middleware.AuthenticationMiddleware`).

As discussed in https://github.com/MIT-LCP/physionet-build/issues/2034#issuecomment-1616756186, this appears to be the cause of occasional server errors.

This pull request moves `OAuth2TokenMiddleware` so that it appears after the default `AuthenticationMiddleware`.

