### PR TITLE
Fix server error if username is none

### DIFF
--- a/physionet-django/user/backends.py
+++ b/physionet-django/user/backends.py
@@ -12,6 +12,10 @@ class DualAuthModelBackend(ModelBackend):
     This is a ModelBacked that allows authentication with either a username or an email address.
     """
     def authenticate(self, request, username=None, password=None):
+        # After implementation of OAuth2, (presumably) many crawlers started to attempt
+        # authentication with tokens, causing server errors due to the comparison below.
+        if username is None:
+            return None
         if '@' in username:
             kwargs = {'email': username.lower()}
         else:


### PR DESCRIPTION
We're receiving a lot of `TypeError` due to, presumably, crawlers trying to login using token based auth (e.g. user agent Microsoft Excel 2014). This is a quick fix to prevent the server errors so we can investigate further.

Ref: #2034