### PR TITLE
Allow an associated publication to be added on the management page for published projects

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -708,7 +708,7 @@ class PublishedProjectContactForm(forms.ModelForm):
         return contact
 
 
-class PublishedProjectAddPublication(forms.ModelForm):
+class AddPublishedPublicationForm(forms.ModelForm):
     class Meta:
         model = PublishedPublication
         fields = ('citation', 'url')
@@ -717,10 +717,20 @@ class PublishedProjectAddPublication(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.project = project
 
-    def save(self):
+    def clean(self):
+        cleaned_data = super().clean()
+        existing_publication = PublishedPublication.objects.filter(project=self.project).first()
+
+        if existing_publication:
+            raise forms.ValidationError("A publication already exists for this project.")
+
+        return cleaned_data
+
+    def save(self, commit=True):
         publication = super().save(commit=False)
         publication.project = self.project
-        publication.save()
+        if commit:
+            publication.save()
         return publication
 
 

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -1,9 +1,4 @@
-import pdb
 import re
-
-from django.forms.widgets import RadioSelect
-
-from django.forms.widgets import RadioSelect
 
 from console.utility import generate_doi_payload, register_doi
 from dal import autocomplete

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -27,6 +27,7 @@ from project.models import (
     PublishedAffiliation,
     PublishedAuthor,
     PublishedProject,
+    PublishedPublication,
     SubmissionStatus,
     exists_project_slug,
 )
@@ -705,6 +706,22 @@ class PublishedProjectContactForm(forms.ModelForm):
         contact.project = self.project
         contact.save()
         return contact
+
+
+class PublishedProjectAddPublication(forms.ModelForm):
+    class Meta:
+        model = PublishedPublication
+        fields = ('citation', 'url')
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+    def save(self):
+        publication = super().save(commit=False)
+        publication.project = self.project
+        publication.save()
+        return publication
 
 
 class CreateLegacyAuthorForm(forms.ModelForm):

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -49,6 +49,7 @@
     </div>
   </div>
 </div>
+
 <!-- legacy project management -->
 {% if project.is_legacy %}
 <div class="card mb-3">
@@ -66,6 +67,28 @@
     </div>
 </div>
 {% endif %}
+
+<!-- Associated publication -->
+<div class="card mb-3">
+  <div class="card-header">
+    Associated publication
+  </div>
+  <div class="card-body">
+    {% if project.publications.all %}
+      {% for publication in project.publications.all %}
+        <p><strong>Citation</strong>: {{ publication.citation }}<br />
+          <strong>URL</strong>: {{ publication.url }}</p>
+      {% endfor %}
+    {% else %}
+      <form method="POST" id="publication_form">
+        {% include "inline_form_snippet.html" with form=publication_form %}
+        <button class="btn btn-primary btn-fixed" name="set_publication" type="submit">Add publication</button>
+      </form>
+    {% endif %}
+
+  </div>
+</div>
+
 
 <div class="card mb-3">
     <div class="card-header">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -833,6 +833,7 @@ def manage_published_project(request, project_slug, version):
     contact_form = forms.PublishedProjectContactForm(project=project,
                                                      instance=project.contact)
     legacy_author_form = forms.CreateLegacyAuthorForm(project=project)
+    publication_form = forms.PublishedProjectAddPublication(project=project)
 
     if request.method == 'POST':
         if any(x in request.POST for x in ['create_doi_core',
@@ -914,6 +915,12 @@ def manage_published_project(request, project_slug, version):
             if contact_form.is_valid():
                 contact_form.save()
                 messages.success(request, 'The contact information has been updated')
+        elif 'set_publication' in request.POST:
+            publication_form = forms.PublishedProjectAddPublication(
+                project=project, data=request.POST)
+            if publication_form.is_valid():
+                publication_form.save()
+                messages.success(request, 'The associated publication has been added')
         elif 'set_legacy_author' in request.POST:
             legacy_author_form = forms.CreateLegacyAuthorForm(project=project,
                                                               data=request.POST)
@@ -957,6 +964,7 @@ def manage_published_project(request, project_slug, version):
             'bulk_url_prefix': bulk_url_prefix,
             'contact_form': contact_form,
             'legacy_author_form': legacy_author_form,
+            'publication_form': publication_form,
             'can_make_zip': project.files.can_make_zip(),
             'can_make_checksum': project.files.can_make_checksum(),
         },

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -833,7 +833,7 @@ def manage_published_project(request, project_slug, version):
     contact_form = forms.PublishedProjectContactForm(project=project,
                                                      instance=project.contact)
     legacy_author_form = forms.CreateLegacyAuthorForm(project=project)
-    publication_form = forms.PublishedProjectAddPublication(project=project)
+    publication_form = forms.AddPublishedPublicationForm(project=project)
 
     if request.method == 'POST':
         if any(x in request.POST for x in ['create_doi_core',
@@ -916,7 +916,7 @@ def manage_published_project(request, project_slug, version):
                 contact_form.save()
                 messages.success(request, 'The contact information has been updated')
         elif 'set_publication' in request.POST:
-            publication_form = forms.PublishedProjectAddPublication(
+            publication_form = forms.AddPublishedPublicationForm(
                 project=project, data=request.POST)
             if publication_form.is_valid():
                 publication_form.save()


### PR DESCRIPTION
## Background

On the landing page for published projects, we display three suggested citations:

1) The citation for the data/software/etc publication itself. This is required to meet the FAIR criteria. People should be able to directly cite the published object.
2) [Optional] A citation to an associated paper, such as a data paper in NPJ Scientific Data. This is partly to support the legacy of proxy papers being needed to gain credit for data sharing.
3) A citation to a PhysioNet paper.

## Problem

After publication of a dataset, it is fairly common for us to receive a request to add a citation for point 2. Right now, adding the paper involves either (a) creating a new version of the dataset (burdensome) (b) or manually adding the paper via the shell (risky).

I think option (a) is still desirable, because it is best if the paper is also added as a formal reference. It is burdensome to release new versions though, and so we often end up doing (b).

## What is the change introduced in this pull request?

This pull request adds a section to the project management form at http://localhost:8000/console/published-projects/SLUG/VERSION/ (e.g. http://localhost:8000/console/published-projects/demowave/1.0.0/). The new section allows a citation to a paper to be added (but not edited for now).

Example of a project with an associated publication:

<img width="991" alt="Screenshot 2023-07-14 at 5 32 06 PM" src="https://github.com/MIT-LCP/physionet-build/assets/822601/891599c3-0171-4ed8-9957-8c3e4a53852c">

Example of a project without an associated publication:

<img width="505" alt="Screenshot 2023-07-14 at 5 31 25 PM" src="https://github.com/MIT-LCP/physionet-build/assets/822601/78e819d5-c8b3-4339-a965-0e385e0dab9b">

