### PR TITLE
Oauth Provider tests

### DIFF
--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -10,6 +10,7 @@ from oauth2_provider.models import get_access_token_model, get_application_model
 from django.urls import reverse
 from urllib.parse import parse_qs, urlparse
 from oauth2_provider.settings import oauth2_settings
+from django.utils.crypto import get_random_string
 
 Application = get_application_model()
 AccessToken = get_access_token_model()
@@ -67,18 +68,6 @@ class BaseTest(TestCase):
 
         return auth_headers
 
-    def get_random_string(
-        self,
-        length=12,
-        allowed_chars="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
-    ):
-        """
-        Return a securely generated random string.
-        The default length of 12 with the a-z, A-Z, 0-9 character set returns
-        a 71-bit value. log_2((26+26+10)^12) =~ 71 bits
-        """
-        return "".join(random.choice(allowed_chars) for i in range(length))
-
 
 class TestOAuth2Authentication(BaseTest):
     def test_unauthenticated(self):
@@ -102,7 +91,7 @@ class BaseAuthorizationCodeTokenView(BaseTest):
         """
         Generate a code verifier and a code challenge according to the PKCE
         """
-        verifier = self.get_random_string(length=length)
+        verifier = get_random_string(length=length)
         if algorithm == "S256":
             challenge = (
                 base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())

--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -1,56 +1,49 @@
-from django.test import TestCase
-from user.models import User
-from oauth2_provider.models import get_application_model, AccessToken
-from django.utils import timezone
 from datetime import timedelta
+from django.test import TestCase
+from django.utils import timezone
+from user.models import User
+from oauth2_provider.models import get_access_token_model, get_application_model
 
 Application = get_application_model()
+AccessToken = get_access_token_model()
 
-class OAuthTestCase(TestCase):
+
+class TestOAuth2Authentication(TestCase):
     def setUp(self):
-        self.test_user = User.objects.create_user("test_user", "test@user.com", "123456")
+        """
+        Create a demo user, an OAuth Application and an access token for use in testing.
+        """
+        self.test_user = User.objects.create_user("oauth_test_user", "oauth_test@example.com", "123456")
         self.application = Application.objects.create(
             name="Test Application",
-            redirect_uris="http://localhost:8000/oauth/hello/",
+            redirect_uris="http://localhost http://example.com http://example.org",
             user=self.test_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
         )
 
-def test_authorize(self):
-    # Set up test data
-    query_params = {
-        'client_id': self.application.client_id,
-        'response_type': 'code',
-        'state': 'random_state_string',
-        'redirect_uri': self.application.redirect_uris,
-    }
+        self.access_token = AccessToken.objects.create(
+            user=self.test_user,
+            scope="read write",
+            expires=timezone.now() + timedelta(seconds=300),
+            token="secret-access-token-key",
+            application=self.application,
+        )
 
-    # Log in the test user
-    self.client.login(username='test_user', password='123456')
+    def _create_authorization_header(self, token):
+        return "Bearer {0}".format(token)
 
-    # Make a GET request to the authorize endpoint with the query parameters
-    response = self.client.get('/oauth/authorize/', data=query_params)
+    def test_unauthenticated(self):
+        """
+        Hello is a demo resource endpoint that requires authentication. This test verifies that
+        """
+        response = self.client.get("/oauth/hello")
+        self.assertEqual(response.status_code, 403)
 
-    # Assert that the response status code is 200 (OK)
-    self.assertEqual(response.status_code, 200)
-
-def test_token(self):
-    # Set up test data
-    token = AccessToken.objects.create(
-        user=self.test_user,
-        token='1234567890',
-        application=self.application,
-        scope='read write',
-        expires=timezone.now() + timedelta(days=1)
-    )
-    auth_headers = {
-        'HTTP_AUTHORIZATION': 'Bearer ' + token.token,
-    }
-
-    # Make a GET request to the token endpoint with the authorization headers
-    response = self.client.get('/oauth/token/', **auth_headers)
-
-    # Assert that the response status code is 200 (OK)
-    self.assertEqual(response.status_code, 200)
-    self.assertEqual(response.json()['access_token'], token.token)
+    def test_authentication_allow(self):
+        """
+        This test verifies that a request with a valid access token is allowed.
+        """
+        auth = self._create_authorization_header(self.access_token.token)
+        response = self.client.get("/oauth/hello", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 200)

--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -2,6 +2,7 @@ import base64
 import random
 import hashlib
 from datetime import timedelta
+import re
 from django.test import TestCase
 from django.utils import timezone
 from user.models import User
@@ -183,6 +184,14 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
             reverse("oauth2_provider:token"), data=token_request_data, **auth_headers
         )
         self.assertEqual(response.status_code, 200)
+        token = response.json()["access_token"]
+
+        # Testing the Token Acquired through the above request
+        self.client.logout()
+
+        auth = self._create_authorization_header(token)
+        response = self.client.get("/oauth/hello", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 200)
 
     def test_secure_auth_pkce(self):
         """
@@ -210,4 +219,12 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         response = self.client.post(
             reverse("oauth2_provider:token"), data=token_request_data, **auth_headers
         )
+        self.assertEqual(response.status_code, 200)
+        token = response.json()["access_token"]
+
+        # Testing the Token Acquired through the above request
+        self.client.logout()
+
+        auth = self._create_authorization_header(token)
+        response = self.client.get("/oauth/hello", HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, 200)

--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -1,3 +1,56 @@
 from django.test import TestCase
+from user.models import User
+from oauth2_provider.models import get_application_model, AccessToken
+from django.utils import timezone
+from datetime import timedelta
 
-# Create your tests here.
+Application = get_application_model()
+
+class OAuthTestCase(TestCase):
+    def setUp(self):
+        self.test_user = User.objects.create_user("test_user", "test@user.com", "123456")
+        self.application = Application.objects.create(
+            name="Test Application",
+            redirect_uris="http://localhost:8000/oauth/hello/",
+            user=self.test_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+
+def test_authorize(self):
+    # Set up test data
+    query_params = {
+        'client_id': self.application.client_id,
+        'response_type': 'code',
+        'state': 'random_state_string',
+        'redirect_uri': self.application.redirect_uris,
+    }
+
+    # Log in the test user
+    self.client.login(username='test_user', password='123456')
+
+    # Make a GET request to the authorize endpoint with the query parameters
+    response = self.client.get('/oauth/authorize/', data=query_params)
+
+    # Assert that the response status code is 200 (OK)
+    self.assertEqual(response.status_code, 200)
+
+def test_token(self):
+    # Set up test data
+    token = AccessToken.objects.create(
+        user=self.test_user,
+        token='1234567890',
+        application=self.application,
+        scope='read write',
+        expires=timezone.now() + timedelta(days=1)
+    )
+    auth_headers = {
+        'HTTP_AUTHORIZATION': 'Bearer ' + token.token,
+    }
+
+    # Make a GET request to the token endpoint with the authorization headers
+    response = self.client.get('/oauth/token/', **auth_headers)
+
+    # Assert that the response status code is 200 (OK)
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response.json()['access_token'], token.token)

--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -1,4 +1,6 @@
-import base64, random, hashlib
+import base64
+import random
+import hashlib
 from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
@@ -19,8 +21,15 @@ class BaseTest(TestCase):
         """
         Create a demo user, an OAuth Application and an access token for use in testing.
         """
-        self.test_user = User.objects.create_user(username="oauth_test_user",email= "oauth_test@example.com", password="123456")
-        self.dev_user = User.objects.create_user(username="oauth_dev_user",email= "oauth_dev@example.com", password="123456")
+        self.test_user = User.objects.create_user(
+            username="oauth_test_user",
+            email="oauth_test@example.com",
+            password="123456",
+        )
+
+        self.dev_user = User.objects.create_user(
+            username="oauth_dev_user", email="oauth_dev@example.com", password="123456"
+        )
 
         self.oauth2_settings = oauth2_settings
 
@@ -30,7 +39,7 @@ class BaseTest(TestCase):
             user=self.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-            client_secret = CLEARTEXT_SECRET,
+            client_secret=CLEARTEXT_SECRET,
         )
 
         self.access_token = AccessToken.objects.create(
@@ -39,7 +48,7 @@ class BaseTest(TestCase):
             expires=timezone.now() + timedelta(seconds=300),
             token="secret-access-token-key",
             application=self.application,
-        )    
+        )
 
     def _create_authorization_header(self, token):
         return "Bearer {0}".format(token)
@@ -56,8 +65,12 @@ class BaseTest(TestCase):
         }
 
         return auth_headers
-    
-    def get_random_string(self, length=12, allowed_chars="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"):
+
+    def get_random_string(
+        self,
+        length=12,
+        allowed_chars="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+    ):
         """
         Return a securely generated random string.
         The default length of 12 with the a-z, A-Z, 0-9 character set returns
@@ -91,7 +104,9 @@ class BaseAuthorizationCodeTokenView(BaseTest):
         verifier = self.get_random_string(length=length)
         if algorithm == "S256":
             challenge = (
-                base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+                base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+                .decode()
+                .rstrip("=")
             )
         elif algorithm == "plain":
             challenge = verifier
@@ -114,7 +129,9 @@ class BaseAuthorizationCodeTokenView(BaseTest):
             "allow": True,
         }
 
-        response = self.client.post(reverse("oauth2_provider:authorize"), data=authcode_data)
+        response = self.client.post(
+            reverse("oauth2_provider:authorize"), data=authcode_data
+        )
         query_dict = parse_qs(urlparse(response["Location"]).query)
         return query_dict["code"].pop()
 
@@ -133,7 +150,9 @@ class BaseAuthorizationCodeTokenView(BaseTest):
             "code_challenge_method": code_challenge_method,
         }
 
-        response = self.client.post(reverse("oauth2_provider:authorize"), data=authcode_data)
+        response = self.client.post(
+            reverse("oauth2_provider:authorize"), data=authcode_data
+        )
         query_dict = parse_qs(urlparse(response["Location"]).query)
         return query_dict["code"].pop()
 
@@ -156,9 +175,13 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
             "code": authorization_code,
             "redirect_uri": "http://example.org",
         }
-        auth_headers = self.get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+        auth_headers = self.get_basic_auth_header(
+            self.application.client_id, CLEARTEXT_SECRET
+        )
 
-        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        response = self.client.post(
+            reverse("oauth2_provider:token"), data=token_request_data, **auth_headers
+        )
         self.assertEqual(response.status_code, 200)
 
     def test_secure_auth_pkce(self):
@@ -180,7 +203,11 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
             "redirect_uri": "http://example.org",
             "code_verifier": code_verifier,
         }
-        auth_headers = self.get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+        auth_headers = self.get_basic_auth_header(
+            self.application.client_id, CLEARTEXT_SECRET
+        )
 
-        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        response = self.client.post(
+            reverse("oauth2_provider:token"), data=token_request_data, **auth_headers
+        )
         self.assertEqual(response.status_code, 200)

--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -1,25 +1,36 @@
+import base64, random, hashlib
 from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 from user.models import User
 from oauth2_provider.models import get_access_token_model, get_application_model
+from django.urls import reverse
+from urllib.parse import parse_qs, urlparse
+from oauth2_provider.settings import oauth2_settings
 
 Application = get_application_model()
 AccessToken = get_access_token_model()
 
+CLEARTEXT_SECRET = "1234567890abcdefghijklmnopqrstuvwxyz"
 
-class TestOAuth2Authentication(TestCase):
-    def setUp(self):
+
+class BaseTest(TestCase):
+    def setUp(self, oauth2_settings=oauth2_settings):
         """
         Create a demo user, an OAuth Application and an access token for use in testing.
         """
-        self.test_user = User.objects.create_user("oauth_test_user", "oauth_test@example.com", "123456")
+        self.test_user = User.objects.create_user(username="oauth_test_user",email= "oauth_test@example.com", password="123456")
+        self.dev_user = User.objects.create_user(username="oauth_dev_user",email= "oauth_dev@example.com", password="123456")
+
+        self.oauth2_settings = oauth2_settings
+
         self.application = Application.objects.create(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.test_user,
+            user=self.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_secret = CLEARTEXT_SECRET,
         )
 
         self.access_token = AccessToken.objects.create(
@@ -28,11 +39,34 @@ class TestOAuth2Authentication(TestCase):
             expires=timezone.now() + timedelta(seconds=300),
             token="secret-access-token-key",
             application=self.application,
-        )
+        )    
 
     def _create_authorization_header(self, token):
         return "Bearer {0}".format(token)
 
+    def get_basic_auth_header(self, user, password):
+        """
+        Return a dict containing the correct headers to set to make HTTP Basic
+        Auth request
+        """
+        user_pass = "{0}:{1}".format(user, password)
+        auth_string = base64.b64encode(user_pass.encode("utf-8"))
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Basic " + auth_string.decode("utf-8"),
+        }
+
+        return auth_headers
+    
+    def get_random_string(self, length=12, allowed_chars="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"):
+        """
+        Return a securely generated random string.
+        The default length of 12 with the a-z, A-Z, 0-9 character set returns
+        a 71-bit value. log_2((26+26+10)^12) =~ 71 bits
+        """
+        return "".join(random.choice(allowed_chars) for i in range(length))
+
+
+class TestOAuth2Authentication(BaseTest):
     def test_unauthenticated(self):
         """
         Hello is a demo resource endpoint that requires authentication. This test verifies that
@@ -46,4 +80,107 @@ class TestOAuth2Authentication(TestCase):
         """
         auth = self._create_authorization_header(self.access_token.token)
         response = self.client.get("/oauth/hello", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 200)
+
+
+class BaseAuthorizationCodeTokenView(BaseTest):
+    def generate_pkce_codes(self, algorithm, length=43):
+        """
+        Generate a code verifier and a code challenge according to the PKCE
+        """
+        verifier = self.get_random_string(length=length)
+        if algorithm == "S256":
+            challenge = (
+                base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+            )
+        elif algorithm == "plain":
+            challenge = verifier
+        else:
+            raise ValueError("Unsupported code challenge method.")
+
+        return verifier, challenge
+
+    def get_auth(self):
+        """
+        Helper method to retrieve a valid authorization code
+        """
+
+        authcode_data = {
+            "client_id": self.application.client_id,
+            "state": "random_state_string",
+            "scope": "read write",
+            "redirect_uri": "http://example.org",
+            "response_type": "code",
+            "allow": True,
+        }
+
+        response = self.client.post(reverse("oauth2_provider:authorize"), data=authcode_data)
+        query_dict = parse_qs(urlparse(response["Location"]).query)
+        return query_dict["code"].pop()
+
+    def get_auth_pkce(self, code_challenge, code_challenge_method):
+        """
+        Helper method to retrieve a valid authorization code using pkce
+        """
+        authcode_data = {
+            "client_id": self.application.client_id,
+            "state": "random_state_string",
+            "scope": "read write",
+            "redirect_uri": "http://example.org",
+            "response_type": "code",
+            "allow": True,
+            "code_challenge": code_challenge,
+            "code_challenge_method": code_challenge_method,
+        }
+
+        response = self.client.post(reverse("oauth2_provider:authorize"), data=authcode_data)
+        query_dict = parse_qs(urlparse(response["Location"]).query)
+        return query_dict["code"].pop()
+
+
+class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
+    def test_basic_auth(self):
+        """
+        Request an access token using basic authentication for client authentication
+        """
+        self.client.login(username="oauth_test_user", password="123456")
+
+        # Disabled PKCE removes the need for a code_verifier
+        # Checkout details on PKCE : https://oauth.net/2/pkce/
+        self.oauth2_settings.PKCE_REQUIRED = False
+
+        authorization_code = self.get_auth()
+
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
+        }
+        auth_headers = self.get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_secure_auth_pkce(self):
+        """
+        Request an access token using client_type: public
+        and PKCE enabled with the S256 algorithm
+        """
+        self.client.login(username="oauth_test_user", password="123456")
+
+        self.application.client_type = Application.CLIENT_PUBLIC
+        self.application.save()
+
+        code_verifier, code_challenge = self.generate_pkce_codes("S256")
+        authorization_code = self.get_auth_pkce(code_challenge, "S256")
+
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
+            "code_verifier": code_verifier,
+        }
+        auth_headers = self.get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 200)

--- a/physionet-django/oauth/urls.py
+++ b/physionet-django/oauth/urls.py
@@ -5,30 +5,58 @@ from .views import hello
 
 # OAuth2 provider endpoints
 oauth2_endpoint_views = [
-    path('authorize/', oauth2_views.AuthorizationView.as_view(), name="authorize"),
-    path('token/', oauth2_views.TokenView.as_view(), name="token"),
-    path('revoke-token/', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
-    path('applications/register/', oauth2_views.ApplicationRegistration.as_view(), name="register"),
+    path("authorize/", oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    path("token/", oauth2_views.TokenView.as_view(), name="token"),
+    path("revoke-token/", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
 ]
 
 if settings.DEBUG:
     # OAuth2 Application Management endpoints
     oauth2_endpoint_views += [
-        path('applications/', oauth2_views.ApplicationList.as_view(), name="list"),
-        path('applications/<pk>/', oauth2_views.ApplicationDetail.as_view(), name="detail"),
-        path('applications/<pk>/delete/', oauth2_views.ApplicationDelete.as_view(), name="delete"),
-        path('applications/<pk>/update/', oauth2_views.ApplicationUpdate.as_view(), name="update"),
+        path("applications/", oauth2_views.ApplicationList.as_view(), name="list"),
+        path(
+            "applications/<pk>/",
+            oauth2_views.ApplicationDetail.as_view(),
+            name="detail",
+        ),
+        path(
+            "applications/<pk>/delete/",
+            oauth2_views.ApplicationDelete.as_view(),
+            name="delete",
+        ),
+        path(
+            "applications/<pk>/update/",
+            oauth2_views.ApplicationUpdate.as_view(),
+            name="update",
+        ),
+        path(
+            "applications/register/",
+            oauth2_views.ApplicationRegistration.as_view(),
+            name="register",
+        ),
     ]
 
     # OAuth2 Token Management endpoints
     oauth2_endpoint_views += [
-        path('authorized-tokens/', oauth2_views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),
-        path('authorized-tokens/<pk>/delete/', oauth2_views.AuthorizedTokenDeleteView.as_view(),
-             name="authorized-token-delete"),
+        path(
+            "authorized-tokens/",
+            oauth2_views.AuthorizedTokensListView.as_view(),
+            name="authorized-token-list",
+        ),
+        path(
+            "authorized-tokens/<pk>/delete/",
+            oauth2_views.AuthorizedTokenDeleteView.as_view(),
+            name="authorized-token-delete",
+        ),
     ]
 
 urlpatterns = [
     # OAuth 2 endpoints:
-    path('', include((oauth2_endpoint_views, 'oauth2_provider'), namespace="oauth2_provider")),
-    path('hello', hello.as_view(), name='hello'),  # an example resource endpoint
+    path(
+        "",
+        include(
+            (oauth2_endpoint_views, "oauth2_provider"), namespace="oauth2_provider"
+        ),
+    ),
+    path("hello", hello.as_view(), name="hello"),  # an example resource endpoint
 ]

--- a/physionet-django/oauth/urls.py
+++ b/physionet-django/oauth/urls.py
@@ -8,13 +8,13 @@ oauth2_endpoint_views = [
     path('authorize/', oauth2_views.AuthorizationView.as_view(), name="authorize"),
     path('token/', oauth2_views.TokenView.as_view(), name="token"),
     path('revoke-token/', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+    path('applications/register/', oauth2_views.ApplicationRegistration.as_view(), name="register"),
 ]
 
 if settings.DEBUG:
     # OAuth2 Application Management endpoints
     oauth2_endpoint_views += [
         path('applications/', oauth2_views.ApplicationList.as_view(), name="list"),
-        path('applications/register/', oauth2_views.ApplicationRegistration.as_view(), name="register"),
         path('applications/<pk>/', oauth2_views.ApplicationDetail.as_view(), name="detail"),
         path('applications/<pk>/delete/', oauth2_views.ApplicationDelete.as_view(), name="delete"),
         path('applications/<pk>/update/', oauth2_views.ApplicationUpdate.as_view(), name="update"),
@@ -30,5 +30,5 @@ if settings.DEBUG:
 urlpatterns = [
     # OAuth 2 endpoints:
     path('', include((oauth2_endpoint_views, 'oauth2_provider'), namespace="oauth2_provider")),
-    path('hello', ApiEndpoint.as_view()),  # an example resource endpoint
+    path('hello', ApiEndpoint.as_view(), name='hello'),  # an example resource endpoint
 ]

--- a/physionet-django/oauth/urls.py
+++ b/physionet-django/oauth/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 import oauth2_provider.views as oauth2_views
 from django.conf import settings
-from .views import ApiEndpoint
+from .views import hello
 
 # OAuth2 provider endpoints
 oauth2_endpoint_views = [
@@ -30,5 +30,5 @@ if settings.DEBUG:
 urlpatterns = [
     # OAuth 2 endpoints:
     path('', include((oauth2_endpoint_views, 'oauth2_provider'), namespace="oauth2_provider")),
-    path('hello', ApiEndpoint.as_view(), name='hello'),  # an example resource endpoint
+    path('hello', hello.as_view(), name='hello'),  # an example resource endpoint
 ]

--- a/physionet-django/oauth/views.py
+++ b/physionet-django/oauth/views.py
@@ -2,6 +2,6 @@ from django.http import HttpResponse
 from oauth2_provider.views.generic import ProtectedResourceView
 
 
-class ApiEndpoint(ProtectedResourceView):
+class hello(ProtectedResourceView):
     def get(self, request, *args, **kwargs):
         return HttpResponse('Hello, OAuth2!')


### PR DESCRIPTION
As Described by @bemoody in #2040, I've added the Test Case for OAuth. This test case allows access to a protected resource endpoint on the server. 

The Test first sets up an OAuth application and generates a token. This is the BaseTest, which is the parent and gets inherited for further tests. There are two testcases we want to set up - as mentioned in #2040. The first testcase checks the ability to access the protected resource once a user has a token. The second testcase focuses on authentication and achieving the token that can allow access. 

Testcase 1 : Once the person has a token, he can get authorized to access Hello - an endpoint emulating a protected resource. There are two tests added - One demonstrating a denial for unauthenticated access. The second one has an auth header with a bearer token and is allowed to access the protected resource. 

Testcase 2 : This test demonstrated the authorization code flow for two different kind of applications supported by OAuth Workflow. 

1. Confidential Application: OAuth2 client credentials is a grant flow that allows a web service or an app (confidential client) to use its own credentials, instead of impersonating a user, to authenticate when calling another web service or a web resource, such as a REST API. This is commonly used for server-to-server interactions that run in the background without immediate user interaction. The permissions are granted directly to the application itself by an administrator.

2. Public Applciation: A Public Application can not securely store client secrets, like a mobile application. These are untrusted and hence follow a [Proof Key for Code Exchange (PKCE) workflow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce).

There are two tests, each resembling one application type and the respective authentication flow to be used for implementing the authentication.

As can be seen, we can implement a direct channel between Physionet and Health Data Nexus, which is not exposed to the regular public. An authenticated user on Health Data Nexus can easily access a protected resource on Physionet(for Eg: Training), since the access will be granted to the HDN platform.