### PR TITLE
Bump lightwave version to 0.72

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install and setup lightwave
         run: |
-          wget https://github.com/bemoody/lightwave/archive/0.71.tar.gz -O lightwave.tar.gz
+          wget https://github.com/bemoody/lightwave/archive/0.72.tar.gz -O lightwave.tar.gz
           tar -xf lightwave.tar.gz
           (cd lightwave-* && make CGIDIR=/usr/local/bin sandboxed-server)
 

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install lightwave
         run: |
-          wget https://github.com/bemoody/lightwave/archive/0.71.tar.gz \
+          wget https://github.com/bemoody/lightwave/archive/0.72.tar.gz \
                -O lightwave.tar.gz
           tar -xf lightwave.tar.gz
           (cd lightwave-* && make CGIDIR=/usr/local/bin sandboxed-server)

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN wget https://github.com/bemoody/wfdb/archive/10.7.0.tar.gz -O wfdb.tar.gz \
     && ldconfig \
     && rm -rf wfdb*
 
-RUN wget https://github.com/bemoody/lightwave/archive/0.71.tar.gz -O lightwave.tar.gz \
+RUN wget https://github.com/bemoody/lightwave/archive/0.72.tar.gz -O lightwave.tar.gz \
     && tar -xf lightwave.tar.gz \
     && (cd lightwave-* && make sandboxed-lightwave && mkdir -p /usr/local/bin && install -m 4755 sandboxed-lightwave /usr/local/bin) \
     && rm -rf lightwave*


### PR DESCRIPTION
LightWAVE version 0.72 fixes the sandboxed server to work with newer versions of glibc.  This is messy and maybe not the best permanent solution; see https://github.com/bemoody/lightwave/issues/3 .

This is a prerequisite for upgrading to Debian 12 (see pull #2020).

Note, I haven't tested this extensively and should do so before *actually* upgrading the systems to bookworm; this pull is just for the benefit of the test suite.
