### PR TITLE
Symbolic names for submission_status

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -27,6 +27,7 @@ from project.models import (
     PublishedAffiliation,
     PublishedAuthor,
     PublishedProject,
+    SubmissionStatus,
     exists_project_slug,
 )
 from project.projectfiles import ProjectFiles
@@ -93,7 +94,7 @@ class AssignEditorForm(forms.Form):
     def clean_project(self):
         pid = self.cleaned_data['project']
         validate_integer(pid)
-        if ActiveProject.objects.get(id=pid) not in ActiveProject.objects.filter(submission_status=10):
+        if ActiveProject.objects.get(id=pid) not in ActiveProject.objects.filter(submission_status=SubmissionStatus.NEEDS_ASSIGNMENT):
             raise forms.ValidationError('Incorrect project selected.')
         return pid
 
@@ -230,13 +231,13 @@ class EditSubmissionForm(forms.ModelForm):
                 edit_log = EditLog.objects.get(id=edit_log.id)
             # Resubmit with revisions
             elif edit_log.decision == 1:
-                project.submission_status = 30
+                project.submission_status = SubmissionStatus.NEEDS_RESUBMISSION
                 project.revision_request_datetime = now
                 project.latest_reminder = now
                 project.save()
             # Accept
             else:
-                project.submission_status = 40
+                project.submission_status = SubmissionStatus.NEEDS_COPYEDIT
                 project.editor_accept_datetime = now
                 project.latest_reminder = now
 
@@ -289,7 +290,7 @@ class CopyeditForm(forms.ModelForm):
             project = copyedit_log.project
             now = timezone.now()
             copyedit_log.complete_datetime = now
-            project.submission_status = 50
+            project.submission_status = SubmissionStatus.NEEDS_APPROVAL
             project.copyedit_completion_datetime = now
             project.latest_reminder = now
             copyedit_log.save()

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -92,10 +92,12 @@ class AssignEditorForm(forms.Form):
                 .order_by('username')
 
     def clean_project(self):
-        pid = self.cleaned_data['project']
+        pid = self.cleaned_data["project"]
         validate_integer(pid)
-        if ActiveProject.objects.get(id=pid) not in ActiveProject.objects.filter(submission_status=SubmissionStatus.NEEDS_ASSIGNMENT):
-            raise forms.ValidationError('Incorrect project selected.')
+        if ActiveProject.objects.get(id=pid) not in ActiveProject.objects.filter(
+            submission_status=SubmissionStatus.NEEDS_ASSIGNMENT
+        ):
+            raise forms.ValidationError("Incorrect project selected.")
         return pid
 
 

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -22,7 +22,7 @@
         <a class="nav-link {% if passphrase %} active {% endif %}" id="embargo-tab" data-toggle="tab" href="#embargo" role="tab" aria-controls="reassign" aria-selected="false">Embargo</a>
       </li>
       {% endif %}
-      {% if project.submission_status >= 40 %}
+      {% if project.submission_status >= SubmissionStatus.NEEDS_COPYEDIT %}
       <li class="nav-item">
         <a class="nav-link" id="doi-tab" data-toggle="tab" href="#doi" role="tab" aria-controls="timeline" aria-selected="false">DOIs</a>
       </li>

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -17,6 +17,7 @@ from project.models import (
     License,
     PublishedProject,
     StorageRequest,
+    SubmissionStatus,
 )
 from user.models import User
 from physionet.models import FrontPageButton, StaticPage
@@ -55,7 +56,7 @@ class TestState(TestMixin):
             'editor':editor.id})
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
         self.assertTrue(project.editor, editor)
-        self.assertEqual(project.submission_status, 20)
+        self.assertEqual(project.submission_status, SubmissionStatus.NEEDS_DECISION)
 
     def test_reassign_editor(self):
         """
@@ -71,7 +72,7 @@ class TestState(TestMixin):
             'project': project.id, 'editor': editor.id})
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
         self.assertTrue(project.editor, editor)
-        self.assertEqual(project.submission_status, 20)
+        self.assertEqual(project.submission_status, SubmissionStatus.NEEDS_DECISION)
 
         # Reassign editor
         editor = User.objects.get(username='amitupreti')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1102,10 +1102,12 @@ def user_management(request, username):
                                                           is_verified=False)
 
     projects = {}
-    projects['Unsubmitted'] = ActiveProject.objects.filter(authors__user=user,
-                                                           submission_status=SubmissionStatus.UNSUBMITTED).order_by('-creation_datetime')
-    projects['Submitted'] = ActiveProject.objects.filter(authors__user=user,
-                                                         submission_status__gt=SubmissionStatus.UNSUBMITTED).order_by('-submission_datetime')
+    projects["Unsubmitted"] = ActiveProject.objects.filter(
+        authors__user=user, submission_status=SubmissionStatus.UNSUBMITTED
+    ).order_by("-creation_datetime")
+    projects["Submitted"] = ActiveProject.objects.filter(
+        authors__user=user, submission_status__gt=SubmissionStatus.UNSUBMITTED
+    ).order_by("-submission_datetime")
     projects['Archived'] = ArchivedProject.objects.filter(authors__user=user).order_by('-archive_datetime')
     projects['Published'] = PublishedProject.objects.filter(authors__user=user).order_by('-publish_datetime')
 

--- a/physionet-django/physionet/context_processors.py
+++ b/physionet-django/physionet/context_processors.py
@@ -1,10 +1,16 @@
 from django.conf import settings
 
-from project.models import AccessPolicy
+from project.models import (
+    AccessPolicy,
+    SubmissionStatus,
+)
 
 
-def access_policy(request):
-    return {'AccessPolicy': AccessPolicy}
+def project_enums(request):
+    return {
+        'AccessPolicy': AccessPolicy,
+        'SubmissionStatus': SubmissionStatus,
+    }
 
 
 def storage_type(request):

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -116,7 +116,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'physionet.context_processors.access_policy',
+                'physionet.context_processors.project_enums',
                 'physionet.context_processors.storage_type',
                 'physionet.context_processors.platform_config',
                 'sso.context_processors.sso_enabled',

--- a/physionet-django/project/management/commands/list_projects.py
+++ b/physionet-django/project/management/commands/list_projects.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 import html2text
 
-from project.models import ActiveProject
+from project.models import ActiveProject, SubmissionStatus
 from user.models import AssociatedEmail, User
 
 
@@ -68,10 +68,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         projects = ActiveProject.objects
         if options['unsubmitted']:
-            projects = projects.filter(submission_status__lt=10)
+            projects = projects.filter(submission_status__lt=SubmissionStatus.NEEDS_ASSIGNMENT)
             order = 'creation_datetime'
         else:
-            projects = projects.filter(submission_status__gte=10)
+            projects = projects.filter(submission_status__gte=SubmissionStatus.NEEDS_ASSIGNMENT)
             order = 'submission_datetime'
 
         if options['title']:

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -135,6 +135,8 @@ class SubmissionStatus(IntEnum):
     NEEDS_APPROVAL = 50
     NEEDS_PUBLICATION = 60
 
+    do_not_call_in_templates = True
+
 
 class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
     """

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 import logging
 import os
 import uuid
@@ -71,21 +72,76 @@ def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
         published_project.make_zip()
 
 
+class SubmissionStatus(IntEnum):
+    """
+    Numeric codes to indicate submission status of a project.
+
+    These codes are stored in the submission_status field of
+    ActiveProject.
+
+    0: UNSUBMITTED
+    --------------
+    The project has not been submitted.  In this stage, the
+    submitting author may edit the project content.  When they are
+    ready, the submitting author may submit the project, which moves
+    it to NEEDS_ASSIGNMENT.
+
+    10: NEEDS_ASSIGNMENT ("Awaiting Editor Assignment")
+    ---------------------------------------------------
+    The project has been submitted, but has no editor assigned.  A
+    managing editor may assign the project to an editor, which moves
+    it to NEEDS_DECISION.
+
+    20: NEEDS_DECISION ("Awaiting Decision")
+    ----------------------------------------
+    An editor has been assigned and needs to review the project.  The
+    editor may accept the project, which moves it to NEEDS_COPYEDIT;
+    may request resubmission, which moves the project to
+    NEEDS_RESUBMISSION; or may reject the project, which deletes the
+    ActiveProject and transfers its content to an ArchivedProject.
+
+    30: NEEDS_RESUBMISSION ("Awaiting Author Revisions")
+    -------------------------------------------------
+    The editor has requested a resubmission with revisions.  In this
+    stage, the submitting author may edit the project content.  When
+    they are ready, the submitting author may resubmit the project,
+    which moves it back to NEEDS_DECISION.
+
+    40: NEEDS_COPYEDIT ("Awaiting Copyedit")
+    ----------------------------------------
+    The editor has accepted the project.  In this stage, the editor
+    may edit the project content.  When they are ready, the editor may
+    complete copyediting, which moves the project to NEEDS_APPROVAL.
+
+    50: NEEDS_APPROVAL ("Awaiting Author Approval")
+    -----------------------------------------------
+    The editor has copyedited the project.  Each author needs to
+    approve the final version.  When all authors have done so, this
+    moves the project to NEEDS_PUBLICATION; alternatively, the editor
+    may reopen copyediting, which moves the project back to
+    NEEDS_COPYEDIT.
+
+    60: NEEDS_PUBLICATION ("Awaiting Publication")
+    ----------------------------------------------
+    All authors have approved the project.  The editor may publish the
+    project, which deletes the ActiveProject and transfers its content
+    to a PublishedProject.
+    """
+    UNSUBMITTED = 0
+    NEEDS_ASSIGNMENT = 10
+    NEEDS_DECISION = 20
+    NEEDS_RESUBMISSION = 30
+    NEEDS_COPYEDIT = 40
+    NEEDS_APPROVAL = 50
+    NEEDS_PUBLICATION = 60
+
 
 class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
     """
     The project used for submitting
 
-    The submission_status field:
-    - 0 : Not submitted
-    - 10 : Submitting author submits. Awaiting editor assignment.
-    - 20 : Editor assigned. Awaiting editor decision.
-    - 30 : Revisions requested. Waiting for resubmission. Loops back
-          to 20 when author resubmits.
-    - 40 : Accepted. In copyedit stage. Awaiting editor to copyedit.
-    - 50 : Editor completes copyedit. Awaiting authors to approve.
-    - 60 : Authors approve copyedit. Ready for editor to publish
-
+    The submission_status field is a number indicating the current
+    "phase" of submission; see SubmissionStatus.
     """
     submission_status = models.PositiveSmallIntegerField(default=0)
 

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -524,7 +524,11 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Check whether a project may be published
         """
-        if self.submission_status == SubmissionStatus.NEEDS_PUBLICATION and self.check_integrity() and self.all_authors_approved():
+        if (
+            self.submission_status == SubmissionStatus.NEEDS_PUBLICATION
+            and self.check_integrity()
+            and self.all_authors_approved()
+        ):
             return True
         return False
 

--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -3,7 +3,7 @@
 
     <!-- author approval -->
     {# Awaiting authors to approve final project #}
-    {% if project.submission_status == 50 %}
+    {% if project.submission_status == SubmissionStatus.NEEDS_APPROVAL %}
       <li class="list-group-item">
         <div class="row">
           <div class="col-md-2">Currently</div>
@@ -44,7 +44,7 @@
       </li>
 
     <!-- editor approval -->
-    {% elif project.submission_status == 60 %}
+    {% elif project.submission_status == SubmissionStatus.NEEDS_PUBLICATION %}
       <li class="list-group-item">
         <div class="row">
           <div class="col-md-2">Currently</div>
@@ -61,7 +61,7 @@
 
   <!-- copyediting -->
   {# Waiting for revisions #}
-  {% if project.submission_status == 30 %}
+  {% if project.submission_status == SubmissionStatus.NEEDS_RESUBMISSION %}
     <li class="list-group-item">
       <div class="row">
       <div class="col-md-2">Currently</div>
@@ -96,7 +96,7 @@
         {% endif %}
         </div>
       </li>
-    {% elif project.submission_status >= 40 %}
+    {% elif project.submission_status >= SubmissionStatus.NEEDS_COPYEDIT %}
       {# At this point, there may have been any number of copyedits #}
       {% for c in copyedit_logs reversed %}
         {% if c.is_reedit %}
@@ -180,7 +180,7 @@
 
   <!-- editor assigned -->
   {# Waiting for editor #}
-  {% if project.submission_status == 10 %}
+  {% if project.submission_status == SubmissionStatus.NEEDS_ASSIGNMENT %}
   <li class="list-group-item">
     <div class="row">
       <div class="col-md-2">Currently</div>

--- a/physionet-django/project/templates/project/project_home.html
+++ b/physionet-django/project/templates/project/project_home.html
@@ -174,7 +174,7 @@
             <p class="list-group-item-text text-muted">
             <strong>Submitting Author: {{ project.submitting_author.get_full_name }}</strong><br>
             <small>Created: {{ project.creation_datetime|date }}. Modified: {{ project.modified_datetime|date }}.</small><br>
-            <small>Status: {{ project.submission_status_label }} {% if project.submission_status == 0 %}Deadline: {{ project.submission_deadline|date }}.{% endif %}</small>
+            <small>Status: {{ project.submission_status_label }} {% if project.submission_status == SubmissionStatus.UNSUBMITTED %}Deadline: {{ project.submission_deadline|date }}.{% endif %}</small>
             </p>
           </li>
         {% endfor %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -47,6 +47,7 @@ from project.models import (
     PublishedProject,
     Reference,
     StorageRequest,
+    SubmissionStatus,
     Topic,
     UploadedDocument,
 )
@@ -248,16 +249,16 @@ def project_home(request):
     missing_affiliations = []
     pending_revisions = []
     for p in projects:
-        if (p.submission_status == 50
+        if (p.submission_status == SubmissionStatus.NEEDS_APPROVAL
                 and not p.all_authors_approved()):
             if p.authors.get(user=user).is_submitting:
                 pending_author_approvals.append(p)
             elif not p.authors.get(user=user).approval_datetime:
                 pending_author_approvals.append(p)
-        if (p.submission_status == 30
+        if (p.submission_status == SubmissionStatus.NEEDS_RESUBMISSION
                 and p.authors.get(user=user).is_submitting):
             pending_revisions.append(p)
-        if p.submission_status == 0 and p.authors.get(user=user).affiliations.count() == 0:
+        if p.submission_status == SubmissionStatus.UNSUBMITTED and p.authors.get(user=user).affiliations.count() == 0:
             missing_affiliations.append([p, p.authors.get(user=user).creation_date])
     archived_projects = [a.project for a in archived_authors]
 
@@ -485,7 +486,7 @@ def edit_affiliation(request, project_slug, **kwargs):
     project, authors = kwargs['project'], kwargs['authors']
     author = authors.get(user=request.user)
 
-    if project.submission_status not in [0, 30]:
+    if project.submission_status not in [SubmissionStatus.UNSUBMITTED, SubmissionStatus.NEEDS_RESUBMISSION]:
         raise Http404()
 
     # Reload the formset with the first empty form
@@ -1332,7 +1333,7 @@ def project_submission(request, project_slug, **kwargs):
                     pass
             # Register the approval if valid
             if project.approve_author(author):
-                if project.submission_status == 60:
+                if project.submission_status == SubmissionStatus.NEEDS_PUBLICATION:
                     messages.success(request, 'You have approved the project for publication. The editor will publish it shortly')
                     notification.authors_approved_notify(request, project)
                 else:
@@ -1349,7 +1350,7 @@ def project_submission(request, project_slug, **kwargs):
         for e in edit_logs:
             e.set_quality_assurance_results()
         # Awaiting authors
-        if project.submission_status == 50:
+        if project.submission_status == SubmissionStatus.NEEDS_APPROVAL:
             authors = authors.order_by('approval_datetime')
             for a in authors:
                 a.set_display_info()
@@ -1420,7 +1421,7 @@ def project_ethics(request, project_slug, **kwargs):
 def edit_ethics(request, project_slug, **kwargs):
     project = kwargs['project']
 
-    if project.submission_status not in [0, 30]:
+    if project.submission_status not in [SubmissionStatus.UNSUBMITTED, SubmissionStatus.NEEDS_RESUBMISSION]:
         raise Http404()
 
     # Reload the formset with the first empty form


### PR DESCRIPTION
The submission_status field of ActiveProject uses integer codes to indicate the status of a project.  These values are hard to read and hard to search for.  Symbolic constants should be easier to read and maintain.

There should not be any functional changes here.  Verifying I didn't change anything accidentally in the last commit:
```
for f in $(git diff --name-only HEAD HEAD^) ; do diff --label $f -u <(git show HEAD^:$f) <(git show HEAD:$f | sed 's/SubmissionStatus.UNSUBMITTED/0/;s/SubmissionStatus.NEEDS_ASSIGNMENT/10/;s/SubmissionStatus.NEEDS_DECISION/20/;s/SubmissionStatus.NEEDS_RESUBMISSION/30/;s/SubmissionStatus.NEEDS_COPYEDIT/40/;s/SubmissionStatus.NEEDS_APPROVAL/50/;s/SubmissionStatus.NEEDS_PUBLICATION/60/'); done
```

