### PR TITLE
Fix warning in usage of chown

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,8 +100,8 @@ cd /physionet
 # Copy over the .env file into /physionet/physionet-build
 scp <somewhere>/.env /physionet/physionet-build/
 # The software folder should be owned by the dedicated user. The socket file directory should be accessible by nginx.
-chown -R pn.pn /physionet
-chown pn.www-data /physionet/deploy
+chown -R pn:pn /physionet
+chown pn:www-data /physionet/deploy
 chmod g+w /physionet/deploy
 # Make the static and media roots
 mkdir /data
@@ -109,7 +109,7 @@ mkdir /data/pn-static
 mkdir /data/pn-static/published-projects
 mkdir /data/pn-media
 mkdir /data/pn-media/{active-projects,archived-projects,credential-applications,published-projects,users}
-chown -R pn.pn /data/{pn-media,pn-static}
+chown -R pn:pn /data/{pn-media,pn-static}
 ```
 
 The directory structure for the site's software and files will be:

--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -90,7 +90,7 @@ printf '%s\n%s\n' "$DBPASSWORD" "$DBPASSWORD" |
 su postgres -c 'createdb physionet -O physionet'
 
 mkdir -p /physionet /data/pn-static /data/pn-media
-chown pn.pn /physionet /data/pn-static /data/pn-media
+chown pn:pn /physionet /data/pn-static /data/pn-media
 su pn -c '
    set -e
    umask 0002
@@ -153,17 +153,17 @@ su pn -c '
    yes | python3 manage.py loaddemo
 '
 
-chown www-data.www-data -R /physionet/deploy
-chown www-data.www-data -R /data/pn-media
-chown www-data.www-data -R /data/pn-static/published-projects
+chown www-data:www-data -R /physionet/deploy
+chown www-data:www-data -R /data/pn-media
+chown www-data:www-data -R /data/pn-static/published-projects
 
 rm /etc/nginx/sites-enabled/default
 ln -s ../sites-available/physionet_nginx.conf \
    /etc/nginx/sites-enabled/physionet_nginx.conf
 
 mkdir /data/log /data/log/nginx /data/log/uwsgi /data/log/pn
-chown www-data.root /data/log/uwsgi
-chown pn.root /data/log/pn
+chown www-data:root /data/log/uwsgi
+chown pn:root /data/log/pn
 
 (
     cd /physionet/physionet-build/deploy/common


### PR DESCRIPTION
Using a dot instead of a colon in 'chown' commands is ambiguous, and will display warnings, e.g.:
```
chown: warning: '.' should be ':': ‘www-data.www-data’
chown: warning: '.' should be ':': ‘www-data.www-data’
chown: warning: '.' should be ':': ‘www-data.www-data’
chown: warning: '.' should be ':': ‘www-data.root’
chown: warning: '.' should be ':': ‘pn.root’
```
