### PR TITLE
Do not check if downloads are allowed when authorizing access to project

### DIFF
--- a/physionet-django/project/authorization/access.py
+++ b/physionet-django/project/authorization/access.py
@@ -96,9 +96,6 @@ def can_access_project(project, user):
     if project.deprecated_files:
         return False
 
-    if not project.allow_file_downloads:
-        return False
-
     if project.access_policy == AccessPolicy.OPEN:
         return True
     elif project.access_policy == AccessPolicy.RESTRICTED:


### PR DESCRIPTION
We found a regression in the way we display access to projects with disabled downloads. The usual issue with an empty requirements list showing up after the user is already authorised to access the project:
![Clipboard 2023-09-08 at 1 13 50 PM](https://github.com/MIT-LCP/physionet-build/assets/43988137/195b426e-a2ce-4271-9e47-e364303694b9)

The issue is that the [template](https://github.com/MIT-LCP/physionet-build/blob/aba2cb7412235a738f87e82b80c88c8b0775d4fa/physionet-django/project/templates/project/published_project.html#L366C7-L367) checks for `allow_file_downloads` after `is_authorized` which already returns False for projects with disabled downloads.

I think this is an oversight in the `can_access_project` function since there's a separate function that checks whether the files are viewable (by checking `project.allow_file_downloads`):
```python
def can_view_project_files(project, user):
    """
    Checks if the project files are  directly accessible by the user
    Currently used to allow direct file downloads and to show project files on the platform
    """
    return can_access_project(project, user) and project.allow_file_downloads
```

I checked the uses of the `can_access_project` and my change will fix bugs in all the places it's used. For example [this](https://github.com/MIT-LCP/physionet-build/blob/aba2cb7412235a738f87e82b80c88c8b0775d4fa/physionet-django/project/views.py#L1923) would never evaluate to `True` for projects with disabled downloads.
