### PR TITLE
Refactoring ProjectFiles creation and usage

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -30,7 +30,6 @@ from project.models import (
     SubmissionStatus,
     exists_project_slug,
 )
-from project.projectfiles import ProjectFiles
 from project.validators import MAX_PROJECT_SLUG_LENGTH, validate_doi, validate_slug
 from user.models import CodeOfConduct, CredentialApplication, CredentialReview, User, TrainingQuestion
 
@@ -318,7 +317,7 @@ class PublishForm(forms.Form):
         else:
             self.fields['slug'].initial = project.slug
 
-        if not ProjectFiles().can_make_zip():
+        if not project.files.can_make_zip():
             self.fields['make_zip'].disabled = True
             self.fields['make_zip'].required = False
             self.fields['make_zip'].initial = 0

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -57,7 +57,6 @@ from project.models import (
     exists_project_slug,
 )
 from project.authorization.access import can_view_project_files
-from project.projectfiles import ProjectFiles
 from project.utility import readable_size
 from project.validators import MAX_PROJECT_SLUG_LENGTH
 from project.views import get_file_forms, get_project_file_info, process_files_post
@@ -958,8 +957,8 @@ def manage_published_project(request, project_slug, version):
             'bulk_url_prefix': bulk_url_prefix,
             'contact_form': contact_form,
             'legacy_author_form': legacy_author_form,
-            'can_make_zip': ProjectFiles().can_make_zip(),
-            'can_make_checksum': ProjectFiles().can_make_checksum(),
+            'can_make_zip': project.files.can_make_zip(),
+            'can_make_checksum': project.files.can_make_checksum(),
         },
     )
 

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -9,7 +9,6 @@ from django.http import HttpResponse
 from django.urls import path
 from physionet import views
 from physionet.settings.base import StorageTypes
-from project.projectfiles import ProjectFiles
 
 from export.views import database_list
 
@@ -85,7 +84,7 @@ urlpatterns = [
          name='database_list')
 ]
 
-if settings.ENABLE_LIGHTWAVE and ProjectFiles().is_lightwave_supported:
+if settings.ENABLE_LIGHTWAVE:
     urlpatterns.append(path('lightwave/', include('lightwave.urls')))
     # backward compatibility for LightWAVE
     urlpatterns.append(path('cgi-bin/lightwave',

--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -13,7 +13,6 @@ from django.db.models.functions import Lower
 from django.http import Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from notification.models import News
-from project.projectfiles import ProjectFiles
 from physionet.models import FrontPageButton, Section, StaticPage
 from physionet.middleware.maintenance import allow_post_during_maintenance
 from project.models import AccessPolicy, DUA, License, ProjectType, PublishedProject
@@ -38,7 +37,6 @@ def home(request):
             'news_pieces': news_pieces,
             'front_page_buttons': front_page_buttons,
             'front_page_banner': front_page_banner,
-            'is_lightwave_supported': ProjectFiles().is_lightwave_supported(),
         },
     )
 

--- a/physionet-django/project/fileviews/base.py
+++ b/physionet-django/project/fileviews/base.py
@@ -4,7 +4,6 @@ import os
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from physionet.utility import file_content_type
-from project.projectfiles import ProjectFiles
 from project.utility import get_dir_breadcrumbs
 
 MAX_PLAIN_SIZE = 5 * 1024 * 1024
@@ -89,7 +88,7 @@ class FileView:
         parameter indicating that we should try to force the browser
         to save the file rather than displaying it.
         """
-        return ProjectFiles().download_url(self.project, self.path)
+        return self.project.files.download_url(self.project, self.path)
 
     def raw_url(self):
         """
@@ -99,7 +98,7 @@ class FileView:
         according to the browser's default settings for the
         corresponding content type.
         """
-        return ProjectFiles().raw_url(self.project, self.path)
+        return self.project.files.raw_url(self.project, self.path)
 
     def size(self):
         """

--- a/physionet-django/project/fileviews/main.py
+++ b/physionet-django/project/fileviews/main.py
@@ -8,7 +8,6 @@ from project.fileviews.csv import CSVFileView, GzippedCSVFileView
 from project.fileviews.image import ImageFileView
 from project.fileviews.inline import InlineFileView
 from project.fileviews.text import TextFileView
-from project.projectfiles import ProjectFiles
 
 _suffixes = {
     '.bmp': ImageFileView,
@@ -35,7 +34,7 @@ def display_project_file(request, project, file_path):
     try:
         abs_path = os.path.join(project.file_root(), file_path)
 
-        infile = ProjectFiles().open(abs_path)
+        infile = project.files.open(abs_path)
     except IsADirectoryError:
         return redirect(request.path + '/')
     except (FileNotFoundError, NotADirectoryError):

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -218,7 +218,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         versions of this CoreProject.  (The QuotaManager should ensure
         that the same file is not counted twice in this total.)
         """
-        current = ProjectFiles().active_project_storage_used(self)
+        current = self.files.active_project_storage_used(self)
         published = self.core_project.total_published_size
 
         return current + published
@@ -339,7 +339,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
             self.clear_files()
         else:
             # Move over files
-            ProjectFiles().rename(self.file_root(), archived_project.file_root())
+            self.files.rename(self.file_root(), archived_project.file_root())
 
         # Copy the ActiveProject timestamp to the ArchivedProject.
         # Since this is an auto_now field, save() doesn't allow
@@ -536,7 +536,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Delete the project file directory
         """
-        ProjectFiles().rmtree(self.file_root())
+        self.files.rmtree(self.file_root())
 
     def publish(self, slug=None, make_zip=True, title=None):
         """
@@ -562,7 +562,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         # Create project file root if this is first version or the first
         # version with a different access policy
 
-        ProjectFiles().publish_initial(self, published_project)
+        self.files.publish_initial(self, published_project)
 
         try:
             with transaction.atomic():
@@ -671,11 +671,11 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                 self.delete()
 
         except BaseException:
-            ProjectFiles().publish_rollback(self, published_project)
+            self.files.publish_rollback(self, published_project)
 
             raise
 
-        ProjectFiles().publish_complete(self, published_project)
+        self.files.publish_complete(self, published_project)
 
         return published_project
 

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -29,7 +29,6 @@ from project.modelcomponents.metadata import (
 from project.modelcomponents.publishedproject import PublishedProject
 from project.modelcomponents.submission import CopyeditLog, EditLog, SubmissionInfo
 from project.modelcomponents.unpublishedproject import UnpublishedProject
-from project.projectfiles import ProjectFiles
 from project.validators import validate_subdir
 
 LOGGER = logging.getLogger(__name__)
@@ -150,9 +149,9 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
     # Max number of active submitting projects a user is allowed to have
     MAX_SUBMITTING_PROJECTS = 10
     INDIVIDUAL_FILE_SIZE_LIMIT = 10 * 1024**3
-    # Where all the active project files are kept
 
-    FILE_ROOT = os.path.join(ProjectFiles().file_root, 'active-projects')
+    # Subdirectory (under self.files.file_root) where files are stored
+    FILE_STORAGE_SUBDIR = 'active-projects'
 
     REQUIRED_FIELDS = (
         # 0: Database

--- a/physionet-django/project/modelcomponents/archivedproject.py
+++ b/physionet-django/project/modelcomponents/archivedproject.py
@@ -3,7 +3,6 @@ import os
 from django.conf import settings
 from django.db import models
 
-from project.projectfiles import ProjectFiles
 from project.modelcomponents.metadata import Metadata
 from project.modelcomponents.unpublishedproject import UnpublishedProject
 from project.modelcomponents.submission import SubmissionInfo
@@ -20,8 +19,8 @@ class ArchivedProject(Metadata, UnpublishedProject, SubmissionInfo):
     archive_datetime = models.DateTimeField(auto_now_add=True)
     archive_reason = models.PositiveSmallIntegerField()
 
-    # Where all the archived project files are kept
-    FILE_ROOT = os.path.join(ProjectFiles().file_root, 'archived-projects')
+    # Subdirectory (under self.files.file_root) where files are stored
+    FILE_STORAGE_SUBDIR = 'archived-projects'
 
     class Meta:
         default_permissions = ('change',)

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -11,7 +11,6 @@ from html2text import html2text
 from project.modelcomponents.access import AccessPolicy, AnonymousAccess
 from project.modelcomponents.fields import SafeHTMLField
 from project.modelcomponents.authors import Affiliation
-from project.projectfiles import ProjectFiles
 from project.utility import LinkFilter, get_directory_info, get_file_info, list_items
 from project.validators import validate_title, validate_topic, validate_version
 
@@ -311,7 +310,7 @@ class Metadata(models.Model):
         project directory, replacing any existing file with that name.
         """
         fname = os.path.join(self.file_root(), 'LICENSE.txt')
-        ProjectFiles().fwrite(fname, self.license_content(fmt='text'))
+        self.files.fwrite(fname, self.license_content(fmt='text'))
 
     def get_directory_content(self, subdir=''):
         """
@@ -319,7 +318,7 @@ class Metadata(models.Model):
         the project's file root.
         """
         inspect_dir = self.get_inspect_dir(subdir)
-        return ProjectFiles().get_project_directory_content(inspect_dir, subdir, self.file_display_url, self.file_url)
+        return self.files.get_project_directory_content(inspect_dir, subdir, self.file_display_url, self.file_url)
 
     def schema_org_resource_type(self):
         """

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -89,20 +89,20 @@ class PublishedProject(Metadata, SubmissionInfo):
         This is the parent directory of the main and special file
         directories.
         """
-        return ProjectFiles().get_project_file_root(self.slug, self.version, self.access_policy, PublishedProject)
+        return self.files.get_project_file_root(self.slug, self.version, self.access_policy, PublishedProject)
 
     def file_root(self):
         """
         Root directory where the main user uploaded files are located
         """
-        return ProjectFiles().get_file_root(self.slug, self.version, self.access_policy, PublishedProject)
+        return self.files.get_file_root(self.slug, self.version, self.access_policy, PublishedProject)
 
     def storage_used(self):
         """
         Bytes of storage used by main files and compressed file if any
         """
-        storage_used = ProjectFiles().published_project_storage_used(self)
-        zip_file_size = ProjectFiles().get_zip_file_size(self)
+        storage_used = self.files.published_project_storage_used(self)
+        zip_file_size = self.files.get_zip_file_size(self)
 
         return storage_used, zip_file_size
 
@@ -134,7 +134,7 @@ class PublishedProject(Metadata, SubmissionInfo):
         """
         Make a (new) zip file of the main files.
         """
-        return ProjectFiles().make_zip(project=self)
+        return self.files.make_zip(project=self)
 
     def remove_zip(self):
         fname = self.zip_name(full=True)
@@ -157,13 +157,13 @@ class PublishedProject(Metadata, SubmissionInfo):
         """
         Make the checksums file for the main files
         """
-        return ProjectFiles().make_checksum_file(self)
+        return self.files.make_checksum_file(self)
 
     def remove_files(self):
         """
         Remove files of this project
         """
-        ProjectFiles().rm_dir(self.file_root(), remove_zip=self.remove_zip)
+        self.files.rm_dir(self.file_root(), remove_zip=self.remove_zip)
         self.set_storage_info()
 
     def deprecate_files(self, delete_files):

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -14,7 +14,6 @@ from project.modelcomponents.fields import SafeHTMLField
 from project.modelcomponents.metadata import Metadata, PublishedTopic
 from project.modelcomponents.submission import SubmissionInfo
 from project.models import AccessPolicy
-from project.projectfiles import ProjectFiles
 from project.utility import StorageInfo, clear_directory, get_tree_size
 from project.validators import MAX_PROJECT_SLUG_LENGTH, validate_slug, validate_subdir
 from user.models import Training

--- a/physionet-django/project/modelcomponents/unpublishedproject.py
+++ b/physionet-django/project/modelcomponents/unpublishedproject.py
@@ -7,7 +7,6 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from physionet.settings.base import StorageTypes
 from project.modelcomponents.metadata import Metadata
-from project.projectfiles import ProjectFiles
 from project.utility import StorageInfo
 from project.validators import MAX_PROJECT_SLUG_LENGTH
 
@@ -99,7 +98,7 @@ class UnpublishedProject(models.Model):
         """
         Whether the project has wfdb files.
         """
-        return ProjectFiles().has_wfdb_files(self)
+        return self.files.has_wfdb_files(self)
 
     def content_modified(self):
         """

--- a/physionet-django/project/modelcomponents/unpublishedproject.py
+++ b/physionet-django/project/modelcomponents/unpublishedproject.py
@@ -51,13 +51,16 @@ class UnpublishedProject(models.Model):
         """
         Root directory containing the project's files
         """
-        return os.path.join(self.__class__.FILE_ROOT, self.slug)
+        return os.path.join(self.files.file_root,
+                            self.FILE_STORAGE_SUBDIR,
+                            self.slug)
 
     def bucket(self):
         """
         Object storage bucket name
         """
-        return self.__class__.FILE_ROOT
+        return os.path.join(self.files.file_root,
+                            self.FILE_STORAGE_SUBDIR)
 
     def get_storage_info(self, force_calculate=True):
         """

--- a/physionet-django/project/projectfiles/__init__.py
+++ b/physionet-django/project/projectfiles/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 from physionet.settings.base import StorageTypes
 from project.projectfiles.gcs import GCSProjectFiles
@@ -6,6 +8,8 @@ from project.projectfiles.local import LocalProjectFiles
 
 class ProjectFiles:
     def __new__(cls):
+        warnings.warn("use project.files instead of ProjectFiles()",
+                      DeprecationWarning, stacklevel=2)
         if settings.STORAGE_TYPE == StorageTypes.LOCAL:
             return LocalProjectFiles()
         elif settings.STORAGE_TYPE == StorageTypes.GCP:

--- a/physionet-django/project/test_projectfiles.py
+++ b/physionet-django/project/test_projectfiles.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from django.test import override_settings
 from physionet.settings.base import StorageTypes
-from project.projectfiles import ProjectFiles
+from project.models import ActiveProject
 from project.projectfiles.gcs import GCSProjectFiles
 from project.projectfiles.local import LocalProjectFiles
 
@@ -10,8 +10,10 @@ from project.projectfiles.local import LocalProjectFiles
 class TestProjectFiles(TestCase):
     @override_settings(STORAGE_TYPE=StorageTypes.LOCAL)
     def test_project_files_if_local_storage_type(self):
-        self.assertIsInstance(ProjectFiles(), LocalProjectFiles)
+        project = ActiveProject()
+        self.assertIsInstance(project.files, LocalProjectFiles)
 
     @override_settings(STORAGE_TYPE=StorageTypes.GCP)
     def test_project_files_if_google_cloud_storage_type(self):
-        self.assertIsInstance(ProjectFiles(), GCSProjectFiles)
+        project = ActiveProject()
+        self.assertIsInstance(project.files, GCSProjectFiles)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1096,7 +1096,7 @@ def project_files(request, project_slug, subdir='', **kwargs):
             'file_warning': file_warning,
             'files_editable': files_editable,
             'maintenance_message': maintenance_message,
-            'is_lightwave_supported': ProjectFiles().is_lightwave_supported(),
+            'is_lightwave_supported': project.files.is_lightwave_supported(),
             'storage_type': settings.STORAGE_TYPE,
         },
     )
@@ -1221,7 +1221,7 @@ def project_preview(request, project_slug, subdir='', **kwargs):
             'platform_citations': platform_citations,
             'parent_projects': parent_projects,
             'has_passphrase': has_passphrase,
-            'is_lightwave_supported': ProjectFiles().is_lightwave_supported(),
+            'is_lightwave_supported': project.files.is_lightwave_supported(),
             'show_platform_wide_citation': show_platform_wide_citation,
             'main_platform_citation': main_platform_citation,
         },
@@ -1851,8 +1851,8 @@ def published_project(request, project_slug, version, subdir=''):
         'data_access': data_access,
         'messages': messages.get_messages(request),
         'platform_citations': platform_citations,
-        'is_lightwave_supported': ProjectFiles().is_lightwave_supported(),
-        'is_wget_supported': ProjectFiles().is_wget_supported(),
+        'is_lightwave_supported': project.files.is_lightwave_supported(),
+        'is_wget_supported': project.files.is_wget_supported(),
         'show_platform_wide_citation': show_platform_wide_citation,
         'main_platform_citation': main_platform_citation,
     }

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -27,7 +27,7 @@
     </p>
     <p class="pub-details">Published: {{ published_project.publish_datetime|date }}.
       Version: {{ published_project.version }}</p>
-    {% if is_lightwave_supported %}
+    {% if published_project.files.is_lightwave_supported %}
       {% can_view_project_files published_project request.user as user_can_view_project_files %}
       {% if published_project.has_wfdb and user_can_view_project_files %}
         <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -11,7 +11,6 @@ from django.shortcuts import redirect, render, reverse
 from django.templatetags.static import static
 from physionet.utility import paginate
 from project.models import PublishedProject, PublishedTopic
-from project.projectfiles import ProjectFiles
 from search import forms
 
 
@@ -223,7 +222,6 @@ def content_index(request, resource_type=None):
             'form_type': form_type,
             'form_topic': form_topic,
             'querystring': querystring,
-            'is_lightwave_supported': ProjectFiles().is_lightwave_supported(),
         },
     )
 

--- a/physionet-django/user/migrations/0036_training_2.py
+++ b/physionet-django/user/migrations/0036_training_2.py
@@ -5,8 +5,6 @@ from django.conf import settings
 from django.core.management import call_command
 from django.db import migrations
 
-from project.projectfiles import ProjectFiles
-
 
 def migrate_forward(apps, schema_editor):
     CredentialReview = apps.get_model('user', 'CredentialReview')


### PR DESCRIPTION
Currently, project file storage is (mostly[*]) managed by the "ProjectFiles" classes: when you want to read or write or rename or delete a file, you call the appropriate ProjectFiles method rather than calling built-in `os` functions.  This works great!

However, in the long term we'd like to be able to support multiple project storage backends (which might mean distributing files across multiple local servers, and/or keeping some files entirely on remote servers.)  Details are very much TBD.

This means, however, we can't assume every project uses the same backend; although there will probably always be a single default backend used for new ActiveProjects, code will have to assume that each each existing project might use a different backend.

So, new code should not be calling the global `ProjectFiles` function, which will eventually go away; instead, assuming you have an existing project object, use `project.files` to access that project's files.  And don't assume that one project's files backend can be used to manipulate a different project.


[*] things I noticed:
- lightwave doesn't use ProjectFiles.
- PublishedProject.remove_zip is weird and should probably be rewritten.
- Some asymmetry with UploadedDocument.  I still don't understand the workings there, see issue #2051.
