### PR TITLE
Stricter version number validation

### DIFF
--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -90,6 +90,9 @@ def validate_version(value):
         raise ValidationError('Version may only contain numbers and dots, and must begin and end with a number.')
     if re.fullmatch(r'[0.]+', value):
         raise ValidationError('Version must not be entirely zeroes.')
+    if re.search(r'\b0[0-9]', value):
+        raise ValidationError('Version must not contain leading zeroes. '
+                              'For example, write "1.0.1" instead of "1.00.01".')
 
 
 def validate_slug(value):

--- a/physionet-django/project/validators.py
+++ b/physionet-django/project/validators.py
@@ -88,6 +88,8 @@ def validate_version(value):
     """
     if not re.fullmatch(r'[0-9]+(\.[0-9]+)+', value) or '..' in value:
         raise ValidationError('Version may only contain numbers and dots, and must begin and end with a number.')
+    if re.fullmatch(r'[0.]+', value):
+        raise ValidationError('Version must not be entirely zeroes.')
 
 
 def validate_slug(value):


### PR DESCRIPTION
Published project versions should follow standard versioning conventions (as used and implemented by a vast range of software.)

In particular, it should be possible to express compatibility between packages in terms of standard version number comparisons.  In order for such comparisons to be unambiguous, leading zeroes cannot be used (is "1.0.1" greater or less than "1.00.01"?)

In some versioning schemes, a version number of "0.0" is nonsensical because it's impossible for it to be compatible with any future version.  Or, to look at it another way, if your project hasn't at least reached version "0.0.1", it is ipso facto not ready to be published.

These changes will impose stricter rules on *newly created projects*; they should not affect existing projects.  (After these changes are applied it should be easy to manually fix up any existing active projects, so I haven't bothered with a migration.  I'm not intending at this point to change any existing *published* projects.)

Fixes #2064
