### PR TITLE
Allow admin to be a project editor

### DIFF
--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -14380,6 +14380,11 @@
         "activeproject"
       ],
       [
+        "can_edit_activeprojects",
+        "project",
+        "activeproject"
+      ],
+      [
         "change_activeproject",
         "project",
         "activeproject"


### PR DESCRIPTION
For convenience in testing, the demo "admin" user should be
allowed both to assign editors to projects, and to serve as an
editor (i.e., they should be able to assign a project to
themselves.)
