### PR TITLE
Allow a project's access policy to be changed from credentialed/restricted to open

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -869,11 +869,13 @@ class AccessMetadataForm(forms.ModelForm):
             self.fields['required_trainings'].disabled = True
             self.fields['required_trainings'].required = False
             self.fields['required_trainings'].widget = forms.HiddenInput()
+            self.initial['required_trainings'] = ''
 
         if self.access_policy == AccessPolicy.OPEN:
             self.fields['dua'].disabled = True
             self.fields['dua'].required = False
             self.fields['dua'].widget = forms.HiddenInput()
+            self.initial['dua'] = ''
 
         if not self.editable:
             for field in self.fields.values():

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -355,7 +355,6 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         self.archive(archive_reason=1)
 
-
     def check_integrity(self):
         """
         Run integrity tests on metadata fields and return whether the
@@ -410,6 +409,10 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
 
         if self.access_policy != AccessPolicy.OPEN and self.dua is None:
             self.integrity_errors.append('You have to choose one of the data use agreements.')
+
+        if self.access_policy in {AccessPolicy.CREDENTIALED,
+                                  AccessPolicy.CONTRIBUTOR_REVIEW} and self.required_trainings is None:
+            self.integrity_errors.append('You have to choose a required training.')
 
         if self.integrity_errors:
             return False


### PR DESCRIPTION
As discussed in #1758 attempting to switch a project's access policy from credentialed/restricted to open results in an "Invalid submission. See errors below." message. This underlying error is:
```
self._errors
{'dua': ['This field is required.'], 'required_trainings': ['This field is required.']}
```
These fields shouldn't be required for open projects though. Here I implement the change proposed by @amitupreti in #1758. This does a `del` on the fields which aren't required. 

I've also added a line to `check_integrity` that provides an error message when a credentialed or contributor review project doesn't have `self.required_trainings` set. It is necessary to have a training set for these project types. 