### PR TITLE
Use title being shown in project preview for new publications

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -571,14 +571,13 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                     previous_published_projects = self.core_project.publishedprojects.all()
 
                     slug = previous_published_projects.first().slug
-                    title = previous_published_projects.first().title
                     if slug != published_project.slug:
                         raise ValueError(
                             {"message": "The published project has different slugs."})
 
                 # Set the slug if specified
                 published_project.slug = slug or self.slug
-                published_project.title = title or self.title
+                published_project.title = self.title
                 published_project.doi = self.doi
 
                 # Change internal links (that point to files within

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -537,7 +537,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         self.files.rmtree(self.file_root())
 
-    def publish(self, slug=None, make_zip=True, title=None):
+    def publish(self, slug=None, make_zip=True):
         """
         Create a published version of this project and update the
         submission status.


### PR DESCRIPTION
As discussed in #2072 , the project title being shown in the project preview isn't used in the publication step for a new version. As @bemoody mentioned we should always use the version being displayed by the project preview (i.e. `self.title`). This updates the code to always use `self.title` for the publication of a new project version and removes the request to get the original title version since it is not needed in `publish`. 