### PR TITLE
Mark move_files_as_readonly as an associated task

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -12,8 +12,8 @@ from django.template import defaultfilters, loader
 from django.utils import timezone
 from django.urls import reverse
 
-from project.models import DataAccessRequest, PublishedProject, AccessPolicy
-from user.models import CredentialApplication
+import project.models
+import user.models
 
 RESPONSE_ACTIONS = {0:'rejected', 1:'accepted'}
 
@@ -211,8 +211,9 @@ def resubmit_notify(project, comments):
 
 @cache
 def example_credentialed_access_project():
-    return PublishedProject.objects.filter(
-        access_policy=AccessPolicy.CREDENTIALED, is_latest_version=True,
+    return project.models.PublishedProject.objects.filter(
+        access_policy=project.models.AccessPolicy.CREDENTIALED,
+        is_latest_version=True,
     ).first()
 
 
@@ -644,7 +645,7 @@ def process_credential_complete(request, application, include_comments=True):
     body = loader.render_to_string(
         'notification/email/process_credential_complete.html', {
             'application': application,
-            'CredentialApplication': CredentialApplication,
+            'CredentialApplication': user.models.CredentialApplication,
             'applicant_name': applicant_name,
             'domain': get_current_site(request),
             'example_project': example_credentialed_access_project(),
@@ -812,7 +813,7 @@ def confirm_user_data_access_request(data_access_request, request_protocol,
     subject = f"{settings.SITE_NAME} Data Access Request"
 
     due_date = timezone.now() + timezone.timedelta(
-        days=DataAccessRequest.DATA_ACCESS_REQUESTS_DAY_LIMIT)
+        days=project.models.DataAccessRequest.DATA_ACCESS_REQUESTS_DAY_LIMIT)
 
     body = loader.render_to_string(
         'notification/email/confirm_user_data_access_request.html', {

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -15,6 +15,8 @@ from django.forms.utils import ErrorList
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import strip_tags
+
+from console.tasks import associated_task
 from physionet.settings.base import StorageTypes
 from project.modelcomponents.access import AccessPolicy
 from project.modelcomponents.archivedproject import ArchivedProject
@@ -34,6 +36,7 @@ from project.validators import validate_subdir
 LOGGER = logging.getLogger(__name__)
 
 
+@associated_task(PublishedProject, 'pid')
 @background()
 def move_files_as_readonly(pid, dir_from, dir_to, make_zip):
     """


### PR DESCRIPTION
When a project is published, we create a SHA256SUMS.txt file which should contain hashes of all the project files (so people who download the files can check that they're all present and haven't been corrupted, etc.)

This can of course take a very long time, so we do it asynchronously.  Really it *ought* to be done long before publication (before or during the author approval stage) but it isn't.

While this task is still pending, admins should *not* be able to trigger other processes to run on the files.  In particular, admins should *not* be able to trigger zip file creation (via the "Make zip" button in the console) nor cloud synchronization (via the "Send files to GCP button") until the server has finished generating the SHA256SUMS.txt file.

For example, if you do the following:
- launch the demo server using `manage.py runserver` (but don't run `process_tasks`)
- log in to the demo server as "rgmark"
- submit "MIT-BIH Arrhythmia Database" for publication
- accept, approve, and publish the project
- go to the published project management page

Because the background-tasks daemon isn't running, you should see the message "Pending task: Read Only Files - MIT-BIH Arrhythmia Database v1.0.0", and the "Make checksum", "Make zip", and "Deprecate files" (and, if applicable, "Send files to GCP") buttons should all be grayed-out.

Then launch the background_tasks daemon (`manage.py process_tasks`), and the task should run (which takes less than a second).  Refresh the page in your browser and the buttons should no longer be grayed-out.
