### PR TITLE
Added 'Archive Events' Page to filter events in the admin console

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -123,14 +123,16 @@
               <span class="nav-link-text">Events</span>
             </a>
             <!-- submenu -->
-          {% if events_nav %}
+          {% if events_nav or archive_event_nav %}
             <ul class="sidenav-second-level collapse show" id="events">
           {% else  %}
             <ul class="sidenav-second-level collapse" id="events">
           {% endif %}
               <li class="nav-item {% if events_nav %}active{% endif %}">
                 <a id="nav_events" class="nav-link" href="{% url 'event' %}">Event List</a>
-                <a id="nav_events" class="nav-link" href="{% url 'archive_event' %}">Archived Events</a>
+              </li>
+              <li class="nav-item {% if archive_event_nav %}active{% endif %}">
+                <a id="nav_archive_event" class="nav-link" href="{% url 'archive_event' %}">Archived Events</a>
               </li>
             </ul>
         </li>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -130,6 +130,7 @@
           {% endif %}
               <li class="nav-item {% if events_nav %}active{% endif %}">
                 <a id="nav_events" class="nav-link" href="{% url 'event' %}">Event List</a>
+                <a id="nav_events" class="nav-link" href="{% url 'archive_event' %}">Archived Events</a>
               </li>
             </ul>
         </li>

--- a/physionet-django/console/templates/console/event_archive_event.html
+++ b/physionet-django/console/templates/console/event_archive_event.html
@@ -13,7 +13,7 @@
 {% block content %}
 <div class="card mb-3">
     <div class="card-header">
-        Archived Events <span class="badge badge-pill badge-info">{{ events.paginator.count }}</span> 
+        Archived Events <span class="badge badge-pill badge-info">{{ archive_event.paginator.count }}</span> 
     </div>
     <div class="card-body">
         <div class="table-responsive">
@@ -32,9 +32,9 @@
                 </tr>
               </thead>
               <tbody>
-              {% for event in events %}
+              {% for event in archive_event %}
                 <tr>
-                    <td><a href="{% url 'archive_event_detail' event.slug %}">{{ event.title }}</a></td>
+                    <td><a href="{% url 'event_detail' event.slug %}">{{ event.title }}</a></td>
                     <td>{{ event.get_category_display|title }}</td>
                     <td>{{ event.host }}</td>
                     <td>{{ event.added_datetime|date }}</td>

--- a/physionet-django/console/templates/console/event_archive_event.html
+++ b/physionet-django/console/templates/console/event_archive_event.html
@@ -1,0 +1,55 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}Archived Events{% endblock %}
+
+{% block local_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
+{% endblock %}
+
+{% load console_templatetags %}
+
+{% block content %}
+<div class="card mb-3">
+    <div class="card-header">
+        Archived Events <span class="badge badge-pill badge-info">{{ events.paginator.count }}</span> 
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-bordered">
+              <thead>
+                <tr>
+                  <th>Event</th>
+                  <th>Event Type</th>
+                  <th>Host</th>
+                  <th>Created</th>
+                  <th>Started</th>
+                  <th>Ended</th>
+                  <th>Credentialing</th>
+                  <th>Training</th>
+                  <th>Manage</th>
+                </tr>
+              </thead>
+              <tbody>
+              {% for event in events %}
+                <tr>
+                    <td><a href="{% url 'archive_event_detail' event.slug %}">{{ event.title }}</a></td>
+                    <td>{{ event.get_category_display|title }}</td>
+                    <td>{{ event.host }}</td>
+                    <td>{{ event.added_datetime|date }}</td>
+                    <td>{{ event.start_date }}</td>
+                    <td>{{ event.end_date }}</td>
+                    <td><a href = "{% url 'credential_processing' %}?event={{ event.slug }}">View list</a></td>
+                    <td><a href = "{% url 'training_list' status='review' %}?event={{ event.slug }}">View list</a></td>
+                    <td><a href="{% url 'event_management' event.slug %}" class="btn btn-sm btn-primary" role="button">Manage</a></td>
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+            {% include "console/pagination.html" with pagination=events %}
+          </div>           
+    </div>
+</div>
+{% endblock %}
+

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -148,6 +148,8 @@ urlpatterns = [
     # Lists of event components
     path('event/', views.event,
          name='event'),
+    path('archive_event/', views.archive_event,
+         name='archive_event'),
     path('event/manage/<event_slug>', views.event_management, name='event_management'),
     path('event_agreements/', views.event_agreement_list, name='event_agreement_list'),
     path('event_agreements/<int:pk>/', views.event_agreement_detail, name='event_agreement_detail'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2952,6 +2952,20 @@ def event(request):
                    })
 
 
+@permission_required('user.view_archive_event', raise_exception=True)
+def archive_event(request):
+    """
+    List of archived events
+    """
+    archive_event = Event.objects.filter(all).order_by('archive_datetime')
+    archive_event = paginate(request, archive_event, 50)
+
+    return render(request, 'console/event_archive_event.html',
+                  {'event_archive_event': archive_event,
+                   'events_nav': True
+                   })
+
+
 @permission_required('user.view_all_events', raise_exception=True)
 def event_management(request, event_slug):
     """

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2952,17 +2952,18 @@ def event(request):
                    })
 
 
-@permission_required('user.view_archive_event', raise_exception=True)
+@permission_required('user.view_all_events', raise_exception=True)
 def archive_event(request):
     """
     List of archived events
     """
-    archive_event = Event.objects.filter(all).order_by('archive_datetime')
+    now = timezone.now()
+    archive_event = Event.objects.filter(end_date__lte=now)
     archive_event = paginate(request, archive_event, 50)
 
     return render(request, 'console/event_archive_event.html',
-                  {'event_archive_event': archive_event,
-                   'events_nav': True
+                  {'archive_event': archive_event,
+                   'archive_event_nav': True
                    })
 
 


### PR DESCRIPTION
This PR addresses #2026 by adding an "Archived Events" page to eliminate event clutter that will eventually occur over time as we add new events. 

EDIT: We will eventually need to change the normal events page to only include events that haven't been archived yet (active/future events). This can be done in a separate PR, though.