### PR TITLE
Bump `hdn-research-environment` to `2.3.8`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -754,12 +754,12 @@ protobuf = ">=3.12.0"
 
 [[package]]
 name = "hdn-research-environment"
-version = "2.3.6"
+version = "2.3.8"
 description = "A Django app for supporting cloud-native research environments"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "hdn-research-environment-2.3.6.tar.gz", hash = "sha256:b28d67db8ba4cf82e1362aefde47d483b549e8f7b96d1d4f56baebe0b76dfc31"},
+    {file = "hdn-research-environment-2.3.8.tar.gz", hash = "sha256:371b33950e3c1598b650edefd42fa19a3532d2ca815dd42f495f0460c57df97f"},
 ]
 
 [package.dependencies]
@@ -1453,4 +1453,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2297d8c676de9b2ac1455227f408f5a45f51a249993c1f72ea56221882937464"
+content-hash = "68860ca96b3262f70f6624a0504b6f9509464a66b8cc0fe087fba6a15f97e14c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ zxcvbn = "^4.4.28"
 certifi = "^2023.7.22"
 setuptools = "65.5.1"
 django-js-asset = "2.0.0"
-hdn-research-environment = "2.3.6"
+hdn-research-environment = "2.3.8"
 django-oauth-toolkit = "^2.2.0"
 django-cors-headers = "^3.14.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -297,8 +297,8 @@ grpcio==1.53.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:f3e837d29f0e1b9d6e7b29d569e2e9b0da61889e41879832ea15569c251c303a \
     --hash=sha256:fa8eaac75d3107e3f5465f2c9e3bbd13db21790c6e45b7de1756eba16b050aca \
     --hash=sha256:fdc6191587de410a184550d4143e2b24a14df495c86ca15e59508710681690ac
-hdn-research-environment==2.3.6 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:b28d67db8ba4cf82e1362aefde47d483b549e8f7b96d1d4f56baebe0b76dfc31
+hdn-research-environment==2.3.8 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:371b33950e3c1598b650edefd42fa19a3532d2ca815dd42f495f0460c57df97f
 html2text==2018.1.9 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662 \
     --hash=sha256:627514fb30e7566b37be6900df26c2c78a030cc9e6211bda604d8181233bcdd4


### PR DESCRIPTION
Just a bugfix version bump of our internal package.

PS: We'll pin it some other way later (like `^x.y.z`), but for now we are just using specific versions `x.y.z` in the Poetry spec.