### PR TITLE
Set new Google Cloud buckets as requester-pays

### DIFF
--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -55,7 +55,8 @@ def create_bucket(project, version, title, protected=True):
     bucket_name, email = bucket_info(project, version)
     storage_client.create_bucket(bucket_name)
     bucket = storage_client.bucket(bucket_name)
-    bucket.iam_configuration.bucket_policy_only_enabled = True
+    # Only bucket-level permissions are enforced; there are no per-file ACLs.
+    bucket.iam_configuration.uniform_bucket_level_access_enabled = True
     bucket.patch()
     LOGGER.info("Created bucket {0} for project {1}".format(
         bucket_name.lower(), project))

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -57,6 +57,8 @@ def create_bucket(project, version, title, protected=True):
     bucket = storage_client.bucket(bucket_name)
     # Only bucket-level permissions are enforced; there are no per-file ACLs.
     bucket.iam_configuration.uniform_bucket_level_access_enabled = True
+    # Clients accessing this bucket will be billed for download costs.
+    bucket.requester_pays = True
     storage_client.create_bucket(bucket)
 
     LOGGER.info("Created bucket {0} for project {1}".format(

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -53,11 +53,12 @@ def create_bucket(project, version, title, protected=True):
     """
     storage_client = storage.Client()
     bucket_name, email = bucket_info(project, version)
-    storage_client.create_bucket(bucket_name)
+
     bucket = storage_client.bucket(bucket_name)
     # Only bucket-level permissions are enforced; there are no per-file ACLs.
     bucket.iam_configuration.uniform_bucket_level_access_enabled = True
-    bucket.patch()
+    storage_client.create_bucket(bucket)
+
     LOGGER.info("Created bucket {0} for project {1}".format(
         bucket_name.lower(), project))
     if protected:


### PR DESCRIPTION
GCS buckets may be either "requester-pays" (the client accessing the data must specify a "project" that will be billed for egress costs), or "non-requester-pays" (any authorized client can access the data and the bucket's owner will be billed for egress costs.)

This option can be switched on or off at any time, and it would be nice to have a way to do so in the PhysioNet console.  For the time being, we want to set all newly created buckets as "requester-pays" by default.

This pull also cleans up the logic to create the bucket in a single API request rather than two.

**I don't anticipate any problems with this, but it hasn't been tested.  I'd suggest we push this to the live server and test with one or two small projects - check that it works and the resulting bucket settings are correct.  Please don't publish any big projects to GCP until we've tested this.**  We can wait to merge this if that's a problem.

Fixes #2079
