### PR TITLE
Quota manager for GCS

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -220,7 +220,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         versions of this CoreProject.  (The QuotaManager should ensure
         that the same file is not counted twice in this total.)
         """
-        current = self.files.active_project_storage_used(self)
+        current = self.quota_manager().bytes_used
         published = self.core_project.total_published_size
 
         return current + published

--- a/physionet-django/project/modelcomponents/submission.py
+++ b/physionet-django/project/modelcomponents/submission.py
@@ -3,7 +3,6 @@ import functools
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from project.quota import DemoQuotaManager
 from django.conf import settings
 
 from physionet.settings.base import StorageTypes
@@ -245,19 +244,7 @@ class SubmissionInfo(models.Model):
         (represented by the bytes_used and inodes_used properties of
         the QuotaManager object.)
         """
-        allowance = self.core_project.storage_allowance
-        published = self.core_project.total_published_size
-        limit = allowance - published
-
-        # DemoQuotaManager needs to know the project's toplevel
-        # directory as well as its creation time (so that files
-        # present in multiple versions can be correctly attributed to
-        # the version where they first appeared.)
-        quota_manager = DemoQuotaManager(
-            project_path=self.file_root(),
-            creation_time=self.creation_datetime)
-        quota_manager.set_limits(bytes_hard=limit, bytes_soft=limit)
-        return quota_manager
+        return self.files.project_quota_manager(self)
 
     @functools.cached_property
     def files(self):

--- a/physionet-django/project/projectfiles/base.py
+++ b/physionet-django/project/projectfiles/base.py
@@ -115,11 +115,6 @@ class BaseProjectFiles(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def active_project_storage_used(self, project):
-        """Total storage used in bytes - active project."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def published_project_storage_used(self, project):
         """Total storage used in bytes - published project."""
         raise NotImplementedError

--- a/physionet-django/project/projectfiles/base.py
+++ b/physionet-django/project/projectfiles/base.py
@@ -110,6 +110,11 @@ class BaseProjectFiles(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def project_quota_manager(self, project):
+        """Create a quota manager for a project."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def active_project_storage_used(self, project):
         """Total storage used in bytes - active project."""
         raise NotImplementedError

--- a/physionet-django/project/projectfiles/gcs.py
+++ b/physionet-django/project/projectfiles/gcs.py
@@ -137,9 +137,6 @@ class GCSProjectFiles(BaseProjectFiles):
         quota_manager.set_limits(bytes_hard=limit, bytes_soft=limit)
         return quota_manager
 
-    def active_project_storage_used(self, project):
-        return self._storage_used(project)
-
     def published_project_storage_used(self, project):
         return self._storage_used(project)
 

--- a/physionet-django/project/projectfiles/local.py
+++ b/physionet-django/project/projectfiles/local.py
@@ -147,9 +147,6 @@ class LocalProjectFiles(BaseProjectFiles):
         quota_manager.set_limits(bytes_hard=limit, bytes_soft=limit)
         return quota_manager
 
-    def active_project_storage_used(self, project):
-        return project.quota_manager().bytes_used
-
     def published_project_storage_used(self, project):
         return get_tree_size(project.file_root())
 

--- a/physionet-django/project/projectfiles/local.py
+++ b/physionet-django/project/projectfiles/local.py
@@ -5,6 +5,7 @@ import shutil
 from django.conf import settings
 from physionet.utility import serve_file, sorted_tree_files, zip_dir
 from project.projectfiles.base import BaseProjectFiles
+from project.quota import DemoQuotaManager
 from project.utility import (
     clear_directory,
     get_directory_info,
@@ -130,6 +131,21 @@ class LocalProjectFiles(BaseProjectFiles):
 
     def get_file_root(self, slug, version, access_policy, klass):
         return os.path.join(self.get_project_file_root(slug, version, access_policy, klass), version)
+
+    def project_quota_manager(self, project):
+        allowance = project.core_project.storage_allowance
+        published = project.core_project.total_published_size
+        limit = allowance - published
+
+        # DemoQuotaManager needs to know the project's toplevel
+        # directory as well as its creation time (so that files
+        # present in multiple versions can be correctly attributed to
+        # the version where they first appeared.)
+        quota_manager = DemoQuotaManager(
+            project_path=project.file_root(),
+            creation_time=project.creation_datetime)
+        quota_manager.set_limits(bytes_hard=limit, bytes_soft=limit)
+        return quota_manager
 
     def active_project_storage_used(self, project):
         return project.quota_manager().bytes_used


### PR DESCRIPTION
Today's yak-shaving has brought me to the fact that the GCS storage backend never properly implemented the `SubmissionInfo.quota_manager` method.

(Want to know what `quota_manager` is about?  See https://github.com/MIT-LCP/physionet-build/pull/1003#issuecomment-624179553 and issue #518)

This pull request rearranges logic a bit but shouldn't have any functional changes - storage usage is still measured by calling `GCSObject.size`.

This is necessary for exciting and wonderful things in the future.
