### PR TITLE
Add boto3 1.28.53 and dependencies. Ref #2086

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -33,6 +33,46 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [[package]]
+name = "boto3"
+version = "1.28.53"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "boto3-1.28.53-py3-none-any.whl", hash = "sha256:dc2da9aff7de359774030a243a09b74568664117e2afb77c6e4b90572ae3a6c3"},
+    {file = "boto3-1.28.53.tar.gz", hash = "sha256:b95b0cc39f08402029c3a2bb141e1775cfa46576ebe9f9916f79bde90e27f53f"},
+]
+
+[package.dependencies]
+botocore = ">=1.31.53,<1.32.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.6.0,<0.7.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.31.53"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "botocore-1.31.53-py3-none-any.whl", hash = "sha256:aa647f94039d21de97c969df21ce8c5186b68234eb5c53148f0d8bbd708e375d"},
+    {file = "botocore-1.31.53.tar.gz", hash = "sha256:905580ea724d74f11652bab63fcec6bf0d32f1cf8b2963f7388efc0ea406b69b"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.16.26)"]
+
+[[package]]
 name = "cachetools"
 version = "4.2.2"
 description = "Extensible memoizing collections and decorators"
@@ -845,6 +885,18 @@ files = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
 name = "jwcrypto"
 version = "1.4.2"
 description = "Implementation of JOSE Web standards"
@@ -1176,6 +1228,21 @@ files = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-decouple"
 version = "3.4"
 description = "Strict separation of settings from code."
@@ -1287,6 +1354,24 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "s3transfer"
+version = "0.6.2"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "s3transfer-0.6.2-py3-none-any.whl", hash = "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084"},
+    {file = "s3transfer-0.6.2.tar.gz", hash = "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"},
+]
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "selenium"
@@ -1551,4 +1636,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "da2b20a52af5d1f2b22adb4d2552609c3e764870e009098cca1cebb6244196f7"
+content-hash = "4624cf0a93b4de6190ad28b43fa155522019505f8e7ced5afaa093abe26f895e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ authors = []
 [tool.poetry.dependencies]
 python = "^3.9"
 bleach = "^3.3.0"
+boto3 = "^1.28.53"
+botocore = "^1.31.53"
 chardet = "^3.0.4"
 cryptography = "^41.0.4"
 Django = "4.1.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,12 @@ asgiref==3.5.2 ; python_version >= "3.9" and python_version < "4.0" \
 bleach==3.3.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125 \
     --hash=sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433
+boto3==1.28.53 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:b95b0cc39f08402029c3a2bb141e1775cfa46576ebe9f9916f79bde90e27f53f \
+    --hash=sha256:dc2da9aff7de359774030a243a09b74568664117e2afb77c6e4b90572ae3a6c3
+botocore==1.31.53 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:905580ea724d74f11652bab63fcec6bf0d32f1cf8b2963f7388efc0ea406b69b \
+    --hash=sha256:aa647f94039d21de97c969df21ce8c5186b68234eb5c53148f0d8bbd708e375d
 cachetools==4.2.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001 \
     --hash=sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff
@@ -312,6 +318,9 @@ httplib2==0.19.1 ; python_version >= "3.9" and python_version < "4.0" \
 idna==2.10 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
+jmespath==1.0.1 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
+    --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
 jwcrypto==1.4.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:80a35e9ed1b3b2c43ce03d92c5d48e6d0b6647e2aa2618e4963448923d78a37b
 libsass==0.21.0 ; python_version >= "3.9" and python_version < "4.0" \
@@ -474,6 +483,9 @@ pyopenssl==23.2.0 ; python_version >= "3.9" and python_version < "4.0" \
 pyparsing==2.4.7 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
+python-dateutil==2.8.2 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
+    --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
 python-decouple==3.4 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2e5adb0263a4f963b58d7407c4760a2465d464ee212d733e2a2c179e54c08d8f \
     --hash=sha256:a8268466e6389a639a20deab9d880faee186eb1eb6a05e54375bdf158d691981
@@ -496,6 +508,9 @@ requests==2.31.0 ; python_version >= "3.9" and python_version < "4.0" \
 rsa==4.7.2 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
+s3transfer==0.6.2 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084 \
+    --hash=sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861
 selenium==3.141.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
     --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d


### PR DESCRIPTION
This pull requests adds [boto3](https://pypi.org/project/boto3/) (version 1.28.53) and its dependencies, in preparation for work by @Chrystinne to integrate PhysioNet with the AWS Cloud (see: #2086).

> Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for Python, which allows Python developers to write software that makes use of services like Amazon S3 and Amazon EC2. You can find the latest, most up to date, documentation at our [doc site](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html), including a list of services that are supported. Boto3 is maintained and published by [Amazon Web Services](https://aws.amazon.com/what-is-aws/).

The additional dependencies are:

- [botocore](https://pypi.org/project/botocore/) v1.31.53 - "Low-level" interface to AWS, maintained by AWS.
- [jmespath](https://pypi.org/project/jmespath/) v1.0.1 - Library for extracting elements from a JSON document, maintained by AWS + others.
- [python-dateutil](https://pypi.org/project/python-dateutil/) v2.8.2 - Extension to the standard Python datetime module.
- [s3transfer](https://pypi.org/project/s3transfer/) v0.6.2 - Library for managing Amazon S3 transfers, maintained by AWS.
