### PR TITLE
Display DOI for current version and latest version.

### DIFF
--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -84,7 +84,7 @@
     {% if project.version_clash %}
       <a style="color:red"><strong>{{ project.version}} * Clashing Version</strong></a>
     {% else %}
-      {{ project.version}}
+      {{ project.version }}
     {% endif %}
   {% else %}
     <a style="color:red"><strong>* Required field missing</strong></a>
@@ -177,7 +177,11 @@
       <div class="card my-4">
         <h5 class="card-header">Discovery</h5>
         <div class="card-body">
-          <p><strong>DOI:</strong><br>
+          <p><strong>DOI (version {{ project.version }}):</strong><br>
+            https://doi.org/10.13026/*****
+          </p>
+
+          <p><strong>DOI (latest version):</strong><br>
             https://doi.org/10.13026/*****
           </p>
 

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -280,9 +280,16 @@
           <h5 class="card-header">Discovery</h5>
           <div class="card-body">
             {% if project.doi %}
-              <p><strong>DOI:</strong>
+              <p><strong>DOI (version {{ project.version }}):</strong>
                 <br>
                 <a href="https://doi.org/{{ project.doi }}">https://doi.org/{{ project.doi }}</a>
+              </p>
+            {% endif %}
+
+            {% if project.core_project.doi %}
+              <p><strong>DOI (latest version):</strong>
+                <br>
+                <a href="https://doi.org/{{ project.core_project.doi }}">https://doi.org/{{ project.core_project.doi }}</a>
               </p>
             {% endif %}
 


### PR DESCRIPTION
When a new version of a project is published, it is assigned a version-specific DOI. We also assign a “canonical DOI”, which represents all versions of the project (and which always resolves to the latest version).

Currently, we only display the version-specific DOI on the project landing page. For example: https://physionet.org/content/icehg-ds/ only displays https://doi.org/10.13026/rfts-nv79.

The canonical DOI is sometimes what people want to know, so we should clearly display it too (for the project above, the canonical DOI is https://doi.org/10.13026/vrvd-mf28).

This pull request updates the Discovery box to display both DOIs, e.g.:

![Screenshot 2023-09-23 at 12 20 25 AM](https://github.com/MIT-LCP/physionet-build/assets/822601/85c40703-498c-4005-bae9-f585af926160)

For the DataCite guidelines on versioning, see:
https://support.datacite.org/docs/versioning

Note: All projects should be assigned DOIs, so the if clauses in the template shouldn't be necessary. They are there for published projects because some legacy content may still be missing DOIs.