### PR TITLE
Fix notification for background tasks with no verbose_name

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -888,6 +888,7 @@ def task_failed_notify(name, attempts, last_error, date_time, task_name, task_pa
     """
     Notify when a task has failed and not rescheduled
     """
+    name = name or task_name
     body = loader.render_to_string(
         'notification/email/notify_failed_task.html', {
             'name': name,
@@ -906,6 +907,7 @@ def task_rescheduled_notify(name, attempts, last_error, date_time, task_name, ta
     """
     Notify when a task has been rescheduled
     """
+    name = name or task_name
     body = loader.render_to_string(
         'notification/email/notify_rescheduled_task.html', {
             'name': name,


### PR DESCRIPTION
Background tasks can be created with a "verbose name" which provides a human-readable description.  This is what the existing background tasks (mostly implemented by Felipe) all do, and the verbose name is used when sending email notifications.

However, if a task is created without an explicit verbose_name (as is done in pull #2086), the verbose_name is set to None, which causes the email notification functions to crash.

It's best to use a verbose_name, but if we don't do so, we still want the notifications to work. :)
