### PR TITLE
Prevent a file embargo from being carried forward to new project versions

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -429,7 +429,7 @@ class NewProjectVersionForm(forms.ModelForm):
 
         # Direct copy over fields
         for field in (field.name for field in Metadata._meta.fields):
-            if field not in ['slug', 'version', 'creation_datetime']:
+            if field not in ['slug', 'version', 'creation_datetime', 'embargo_files_days']:
                 setattr(project, field, getattr(self.latest_project, field))
 
         # Set new fields


### PR DESCRIPTION
In #1759 and #2076 we highlight what will happen if a restricted / credentialed project is published with an embargo and then subsequently a new version is created and the access policy is changed to open and published. When this is done the embargo will be carried forward from the previous version and the editor will not realize this (since we don't allow an embargo on an open project the console messaging indicates that no embargo will be put in place even though it will). Upon publication the projects files will be under embargo which shouldn't happen for an open access project as described in #1759.

This PR prevents carrying an embargo forward when a new project version is created. This will prevent a hidden embargo from being carried forward should a project with an embargo be switched to open in a new version. This is really the ideal behavior even for projects which don't change their access policy to open upon submitting a new version. We really want the editor to explicitly set an embargo for a given version instead of using the embargo setting for the previous version of the project. 