### PR TITLE
files_panel dynamic navigation fixes

### DIFF
--- a/physionet-django/project/static/project/js/dynamic-files-panel.js
+++ b/physionet-django/project/static/project/js/dynamic-files-panel.js
@@ -1,0 +1,38 @@
+(function() {
+    'use strict';
+
+    var panel = $('#files-panel');
+    var cur_dir = panel.find('[data-dfp-cur-dir]').data('dfp-cur-dir');
+    var panel_url = panel.find('[data-dfp-panel-url]').data('dfp-panel-url');
+
+    function navigateDir(subdir, page_url, push_history) {
+        $.ajax({
+            type: 'GET',
+            url: panel_url,
+            data: {'subdir': subdir, 'v': '2'},
+            success: function(result) {
+                if (push_history)
+                    history.pushState(subdir, '', page_url);
+                else
+                    history.replaceState(subdir, '', page_url);
+                panel.html(result);
+                setClickHandlers();
+            },
+        });
+    }
+
+    function setClickHandlers() {
+        panel.find('a[data-dfp-dir]').click(function(event) {
+            navigateDir($(this).data('dfp-dir'), this.href, true);
+            event.preventDefault();
+        });
+    }
+    setClickHandlers();
+
+    window.onpopstate = function(event) {
+        if (event.state !== null) {
+            navigateDir(event.state, window.location, false);
+        }
+    };
+    history.replaceState(cur_dir, '');
+})();

--- a/physionet-django/project/templates/project/files_panel.html
+++ b/physionet-django/project/templates/project/files_panel.html
@@ -43,14 +43,14 @@
   <tbody>
   {% if subdir %}
     <tr class="parentdir">
-      <td><a href="../#files-panel" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></td>
+      <td><a href="../#files-panel" onclick="return navigateDir('{{ parent_dir|escapejs }}')">Parent Directory</a></td>
       <td></td>
       <td></td>
     </tr>
   {% endif %}
   {% for dir in display_dirs %}
     <tr class="subdir">
-      <td><a href="{{ dir.name }}/#files-panel" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></td>
+      <td><a href="{{ dir.name }}/#files-panel" onclick="return navigateDir('{{ dir.full_subdir|escapejs }}')">{{ dir.name }}</a></td>
       <td></td>
       <td></td>
     </tr>
@@ -77,7 +77,7 @@
   function navigateDir(subdir){
     $.ajax({
             type: "GET",
-            url: "{{ files_panel_url }}",
+            url: "{{ files_panel_url|escapejs }}",
             data: {'subdir':subdir
             },
             success: function reloadSection(result){

--- a/physionet-django/project/templates/project/files_panel_v2.html
+++ b/physionet-django/project/templates/project/files_panel_v2.html
@@ -1,5 +1,7 @@
-{# Note: This template is obsolescent. Use files_panel_v2 instead. #}
-<div class="card-header">
+{# Note: This template is used together with dynamic-files-panel.js. #}
+<div class="card-header"
+     data-dfp-panel-url="{{ files_panel_url }}"
+     data-dfp-cur-dir="{{ subdir }}">
   Folder Navigation:
   {% spaceless %}
     <span class="dir-breadcrumbs">
@@ -8,7 +10,7 @@
           <span class="dir-breadcrumb-self">{{ breadcrumb.name }}</span>
         {% else %}
           <a href="{{ breadcrumb.rel_path }}#files-panel"
-             onclick="return navigateDir('{{ breadcrumb.full_subdir }}')"
+             data-dfp-dir="{{ breadcrumb.full_subdir }}"
              class="dir-breadcrumb-up">{{ breadcrumb.name }}</a>
           <span class="dir-breadcrumb-sep">/</span>
         {% endif %}
@@ -44,21 +46,21 @@
   <tbody>
   {% if subdir %}
     <tr class="parentdir">
-      <td><a href="../#files-panel" onclick="return navigateDir('{{ parent_dir|escapejs }}')">Parent Directory</a></td>
+      <td><a href="../#files-panel" data-dfp-dir="{{ parent_dir }}">Parent Directory</a></td>
       <td></td>
       <td></td>
     </tr>
   {% endif %}
   {% for dir in display_dirs %}
     <tr class="subdir">
-      <td><a href="{{ dir.name }}/#files-panel" onclick="return navigateDir('{{ dir.full_subdir|escapejs }}')">{{ dir.name }}</a></td>
+      <td><a href="{{ dir.name }}/#files-panel" data-dfp-dir="{{ dir.full_subdir }}">{{ dir.name }}</a></td>
       <td></td>
       <td></td>
     </tr>
   {% endfor %}
   {% for file in display_files %}
     <tr>
-      <td><a href="{{ file.url }}">{{ file.name }}</a>
+      <td><a href="{{ file.name }}">{{ file.name }}</a>
         <a class="download" href="{{ file.download_url }}"
            title="Download {{ file.name }}">
           <span class="visually-hidden">(download)</span>
@@ -71,20 +73,3 @@
   </tbody>
 </table>
 {% endif %}
-
-<script>
-  // Navigate to another file directory and reload the file panel
-  // subdir is the full subdirectory
-  function navigateDir(subdir){
-    $.ajax({
-            type: "GET",
-            url: "{{ files_panel_url|escapejs }}",
-            data: {'subdir':subdir
-            },
-            success: function reloadSection(result){
-                $("#files-panel").html(result);
-            },
-    });
-    return false
-  }
-</script>

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -236,7 +236,7 @@
     {% endif %}
   {% endif %}
   <div id="files-panel" class="card">
-    {% include "project/files_panel.html" %}
+    {% include "project/files_panel_v2.html" %}
   </div>
   <br>
 
@@ -244,6 +244,7 @@
 {% endblock %}
 
 {% block local_js_bottom %}
+<script src="{% static 'project/js/dynamic-files-panel.js' %}"></script>
 <script src="{% static 'custom/js/enable-popover.js' %}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endblock %}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -442,7 +442,7 @@
         {% endif %}
 
         <div id="files-panel" class="card">
-          {% include "project/files_panel.html" %}
+          {% include "project/files_panel_v2.html" %}
         </div>
       {% else %}
         {% include "project/published_project_denied_downloads.html" %}
@@ -472,6 +472,7 @@
 {% endblock %}
 
 {% block local_js_bottom %}
+  <script src="{% static 'project/js/dynamic-files-panel.js' %}"></script>
   <script src="{% static 'custom/js/enable-popover.js' %}"></script>
   <script>hljs.initHighlightingOnLoad();</script>
 {% endblock %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1151,7 +1151,12 @@ def preview_files_panel(request, project_slug, **kwargs):
     file_warning = get_project_file_warning(display_files, display_dirs,
                                               subdir)
 
-    return render(request, 'project/files_panel.html',
+    if request.GET.get('v', '1') == '1':
+        template = 'project/files_panel.html'
+    else:
+        template = 'project/files_panel_v2.html'
+
+    return render(request, template,
         {'project':project, 'subdir':subdir, 'file_error':file_error,
          'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
          'display_files':display_files, 'display_dirs':display_dirs,
@@ -1574,7 +1579,12 @@ def published_files_panel(request, project_slug, version):
         files_panel_url = reverse('published_files_panel',
             args=(project.slug, project.version))
 
-        return render(request, 'project/files_panel.html',
+        if request.GET.get('v', '1') == '1':
+            template = 'project/files_panel.html'
+        else:
+            template = 'project/files_panel_v2.html'
+
+        return render(request, template,
             {'project':project, 'subdir':subdir,
              'dir_breadcrumbs':dir_breadcrumbs, 'parent_dir':parent_dir,
              'display_files':display_files, 'display_dirs':display_dirs,


### PR DESCRIPTION
When you go to the "Files" section of a preview or published project, and click on a link to a subdirectory (with javascript enabled), then instead of reloading the entire page, a script will load just the files section for that directory.

I think this is generally a convenient thing, but there are a bunch of significant problems with the current implementation:

- After you navigate to a subdirectory in this way, the page URL is not modified (so you can't bookmark it.)

- After you navigate to a subdirectory, the back button doesn't take you back to where you were.

- After you navigate to a file within a subdirectory, the back button might or might not take you back to where you were.

- After you navigate to a subdirectory, other subdirectory links (if you right-click on one and say "copy link") are broken.

- The current implementation has theoretical XSS vulnerabilities.

- Inline scripts are a bad idea and should never be used.

The first three issues are variously fixed by calling `history.replaceState` or `history.pushState` before loading the new HTML.  The other issues are fixed by putting the logic in a separate, static, script file.

For example, if you go to `https://localhost:8000/content/demoecg/10.5.24/#files-panel`:

- If you click on "app", the page URL should change to `https://localhost:8000/content/demoecg/10.5.24/app/#files-panel`.

- If you then right-click on "Parent Directory" and click "Copy Link", the copied text should be `https://localhost:8000/content/demoecg/10.5.24/#files-panel` (not `https://localhost:8000/content/demoecg/#files-panel`.)

- If you then click on "12lead.pro", it should display the file; then, clicking the Back button should take you back to the "app" subdirectory (not to the toplevel directory of the project.)

- If you click the Back button again, it should return you to the toplevel directory (not back to some other page.)

It would be quite complicated to make this change in a truly backward-compatible way (i.e., returning the correct URLs and loading the new script when somebody invokes the *old* `navigateDir` function), and I thought this wasn't worth the effort.  So this is set up as a parallel template; old clients can still use the old one.  After a while the old template can be removed.
