### PR TITLE
Fix security bugs in edit_files_panel

### DIFF
--- a/physionet-django/project/templates/project/edit_files_panel.html
+++ b/physionet-django/project/templates/project/edit_files_panel.html
@@ -26,7 +26,7 @@
                 <span class="dir-breadcrumb-self">{{ breadcrumb.name }}</span>
               {% else %}
                 <a href="{{ breadcrumb.rel_path }}#files-panel"
-                   onclick="return navigateDir('{{ breadcrumb.full_subdir }}')"
+                   onclick="return navigateDir('{{ breadcrumb.full_subdir|escapejs }}')"
                    class="dir-breadcrumb-up">{{ breadcrumb.name }}</a>
                 <span class="dir-breadcrumb-sep">/</span>
               {% endif %}
@@ -64,7 +64,7 @@
         <tbody>
         {% if subdir %}
           <tr class="parentdir">
-            <td><a href="../#files-panel" onclick="return navigateDir('{{ parent_dir }}')">Parent Directory</a></td>
+            <td><a href="../#files-panel" onclick="return navigateDir('{{ parent_dir|escapejs }}')">Parent Directory</a></td>
             <td></td>
             <td></td>
             <td></td>
@@ -72,7 +72,7 @@
         {% endif %}
         {% for dir in display_dirs %}
           <tr class="subdir">
-            <td><a href="{{ dir.name }}/#files-panel" onclick="return navigateDir('{{ dir.full_subdir }}')">{{ dir.name }}</a></td>
+            <td><a href="{{ dir.name }}/#files-panel" onclick="return navigateDir('{{ dir.full_subdir|escapejs }}')">{{ dir.name }}</a></td>
             <td></td>
             <td></td>
             <td>{% if files_editable %}<input type="checkbox" name="items" value="{{ dir.name }}" onchange="countSelected(this)">{% endif %}</td>
@@ -117,7 +117,7 @@
                 };
             },
             accept: (file, done) => {
-                const payload = {size: file.size, filename: `{{ subdir }}/${file.upload.filename}`, csrfmiddlewaretoken: "{{ csrf_token }}"};
+                const payload = {size: file.size, filename: "{{ subdir|escapejs }}/" + file.upload.filename, csrfmiddlewaretoken: "{{ csrf_token }}"};
 
                 $.post("{% url 'generate_signed_url' project_slug=project.slug %}", payload, "json")
                 .done(data => {


### PR DESCRIPTION
As a followup to pull #2111, I noted that the `edit_files_panel` has the same security problem as the old `files_panel`.

(This affects the `project_files` view as well as `copyedit_submission`.)

For example, in `media/active-projects/SHuKI1APLrwWCqxSQnSk`, try renaming `subject-100` to `subject-100'+alert('Hello world')+'` .  Then go to the project files page (not the preview; that bug has now been fixed) and click the corresponding link.
