### PR TITLE
Add "IsDerivedFrom" to DOI metadata

### DIFF
--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -516,6 +516,24 @@ def generate_doi_payload(project, core_project=False, event="draft"):
     else:
         relation = []
 
+    # projects from which this project is derived
+    for parent_project in project.parent_projects.all():
+        if parent_project.doi:
+            relation.append({
+                "relationType": "IsDerivedFrom",
+                "relatedIdentifier": parent_project.doi,
+                "relatedIdentifierType": "DOI",
+            })
+        else:
+            url = "https://{0}{1}".format(current_site, reverse(
+                'published_project',
+                args=(parent_project.slug, parent_project.version)))
+            relation.append({
+                "relationType": "IsDerivedFrom",
+                "relatedIdentifier": url,
+                "relatedIdentifierType": "URL",
+            })
+
     resource_type = 'Dataset'
     if project.resource_type.name == 'Software':
         resource_type = 'Software'


### PR DESCRIPTION
If a published project is derived from other published projects on the site, include that information in the DOI metadata.

Formally, "IsDerivedFrom indicates B [the related resource] is a source upon which A [the resource being registered] is based. IsDerivedFrom should be used for a resource that is a derivative of an original resource."

https://schema.datacite.org/meta/kernel-4.4/doc/DataCite-MetadataKernel_v4.4.pdf (page 63)

This changes the metadata for newly created DOIs.  We should update the metadata for existing projects too; I don't know if we have a process for doing that.
