### PR TITLE
Notify user of secondary email address. Fixes #1291.

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -1023,3 +1023,19 @@ def notify_event_participant_application(request, user, registered_user, event):
     body = loader.render_to_string('events/email/event_registration.html', context)
     # Not resend the email if there was an integrity error
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)
+
+
+def notify_primary_email(associated_email):
+    """
+    Inform a user of the primary email address linked to their account.
+    Must only be used when the email address is verified.
+    """
+    if associated_email.is_verified:
+        subject = f"Primary email address on {settings.SITE_NAME}"
+        context = {
+            'name': associated_email.user.get_full_name(),
+            'primary_email': associated_email.user.email,
+            'SITE_NAME': settings.SITE_NAME,
+        }
+        body = loader.render_to_string('user/email/notify_primary_email.html', context)
+        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [associated_email.email], fail_silently=False)

--- a/physionet-django/user/templates/user/email/notify_primary_email.html
+++ b/physionet-django/user/templates/user/email/notify_primary_email.html
@@ -1,0 +1,8 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+You are receiving this email because you requested a password reset for your account at {{ SITE_NAME }}.
+
+Only your primary email address can be used for resetting your password. Your primary email address is {{ primary_email }}.
+
+Regards
+The {{ SITE_NAME }} Team
+{% endfilter %}{% endautoescape %}


### PR DESCRIPTION
As discussed in #1291, the ResetPassword form only works for primary email addresses. This is confusing for users who try to reset their password using a non-primary email address (i.e. they do not receive a password reset email, and they are unable to register because the registration form rejects the email address).

This update addresses the issue by informing the user of the primary email address linked to their account. Now, when a user tries to reset their password using a secondary email address, they receive the following email:

```
Subject: Primary email address on DataShare
From: PhysioNet Automated System <noreply@dev.physionet.org>
To: tpollard@fake-gmail.com
Date: Sun, 12 Nov 2023 11:27:57 -0000

You are receiving this email because you requested a password reset
for your account at DataShare.

Only your primary email address can be used for resetting your
password. Your primary email address is tpollard@primary.com.

Regards
The DataShare Team
```
