### PR TITLE
Allow submitting author status to be transferred to a co-author. Ref #2128

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_submitting_author.html
+++ b/physionet-django/notification/templates/notification/email/notify_submitting_author.html
@@ -1,0 +1,11 @@
+{% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
+Dear {{ name }},
+
+You have been made submitting author of the project entitled "{{ project.title }}" on {{ SITE_NAME }}.
+
+You can view and edit the project on your project homepage: {{ url_prefix }}{% url "project_home" %}.
+
+{{ signature }}
+
+{{ footer }}
+{% endfilter %}{% endautoescape %}

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -1023,3 +1023,22 @@ def notify_event_participant_application(request, user, registered_user, event):
     body = loader.render_to_string('events/email/event_registration.html', context)
     # Not resend the email if there was an integrity error
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)
+
+
+def notify_submitting_author(request, project):
+    """
+    Notify a user that they have been made submitting author for a project.
+    """
+    author = project.authors.get(is_submitting=True)
+    subject = f"{settings.SITE_NAME}: You are now a submitting author"
+    context = {
+        'name': author.get_full_name(),
+        'project': project,
+        'url_prefix': get_url_prefix(request),
+        'SITE_NAME': settings.SITE_NAME,
+        'signature': settings.EMAIL_SIGNATURE,
+        'footer': email_footer()
+    }
+    body = loader.render_to_string('notification/email/notify_submitting_author.html', context)
+    # Not resend the email if there was an integrity error
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [author.user.email], fail_silently=False)

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -73,6 +73,31 @@ class CorrespondingAuthorForm(forms.Form):
             new_c.save()
 
 
+class TransferAuthorForm(forms.Form):
+    """
+    Transfer submitting author.
+    """
+    transfer_author = forms.ModelChoiceField(queryset=None, required=True,
+                                             widget=forms.Select(attrs={'onchange': 'set_transfer_author()',
+                                                                        'id': 'transfer_author_id'}),
+                                             empty_label="Select an author")
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+        # Exclude the current submitting author from the queryset
+        authors = project.authors.exclude(is_submitting=True).order_by('display_order')
+        self.fields['transfer_author'].queryset = authors
+
+    def transfer(self):
+        new_author = self.cleaned_data['transfer_author']
+
+        # Assign the new submitting author
+        self.project.authors.update(is_submitting=False)
+        new_author.is_submitting = True
+        new_author.save()
+
+
 class ActiveProjectFilesForm(forms.Form):
     """
     Inherited form for manipulating project files/directories. Upload

--- a/physionet-django/project/static/project/js/transfer-author.js
+++ b/physionet-django/project/static/project/js/transfer-author.js
@@ -1,0 +1,22 @@
+$(document).ready(function() {
+  // Function to update the displayed author name when a new author is selected
+  function set_transfer_author() {
+    var selectedAuthorName = $("#transfer_author_id option:selected").text();
+    $('#project_author').text(selectedAuthorName);
+  }
+
+  // Attach the change event to the author select dropdown to update the name on change
+  $("#transfer_author_id").change(set_transfer_author);
+
+  // Prevent the default form submission and show the confirmation modal
+  $('#authorTransferForm').on('submit', function(e) {
+    e.preventDefault();
+    $('#transfer_author_modal').modal('show');
+  });
+
+  // When the confirmation button is clicked, submit the form
+  $('#confirmAuthorTransfer').on('click', function() {
+    $('#authorTransferForm').off('submit').submit();
+  });
+});
+

--- a/physionet-django/project/templates/project/project_authors.html
+++ b/physionet-django/project/templates/project/project_authors.html
@@ -170,6 +170,46 @@
   <button class="btn btn-primary btn-rsp" name="edit_affiliations" type="submit">Set Affiliations</button>
 </form>
 <hr>
+<br>
+
+{# Transfer project to a new submitting author #}
+{% if is_submitting %}
+  <h3>Submitting Author</h3>
+  <p>Only the submitting author of a project is able to edit content.
+     You may transfer the role of submitting author to a co-author.
+     Choose one of the co-authors below to make them the submitting author for this project.
+     Transferring authorship will remove your ability to edit content!</p>
+
+  <form id="authorTransferForm" action="{% url 'project_authors' project.slug %}" method="post" class="no-pd">
+    {% csrf_token %}
+    {% include "inline_form_snippet.html" with form=transfer_author_form %}
+    <button class="btn btn-primary btn-rsp" name="transfer_author" type="submit">Transfer</button>
+  </form>
+  <hr>
+{% endif %}
+
+<!-- Modal for confirming author transfer -->
+<div class="modal fade" id="transfer_author_modal" tabindex="-1" role="dialog" aria-labelledby="transferAuthorshipModalTitle" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="transferAuthorshipModalTitle">Transfer Authorship</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p id="confirmationText">Please confirm that you would like to assign '<span id="project_author"></span>' as the new submitting author.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" id="confirmAuthorTransfer">Transfer</button>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- End Modal -->
+
 {% endblock %}
 
 {% block local_js_bottom %}
@@ -177,8 +217,14 @@
 <script>
   disableAddButtons();
 </script>
+
 {# Disable submission if not currently editable #}
 {% if not project.author_editable %}
   <script src="{% static 'custom/js/disable-input.js' %}"></script>
 {% endif %}
+
+{% if is_submitting %}
+  <script src="{% static 'project/js/transfer-author.js' %}"></script>
+{% endif %}
+
 {% endblock %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -607,15 +607,23 @@ def project_authors(request, project_slug, **kwargs):
     authors = project.get_author_info()
     invitations = project.authorinvitations.filter(is_active=True)
     edit_affiliations_url = reverse('edit_affiliation', args=[project.slug])
-    return render(request, 'project/project_authors.html', {'project':project,
-        'authors':authors, 'invitations':invitations,
-        'affiliation_formset':affiliation_formset,
-        'invite_author_form':invite_author_form,
-        'corresponding_author_form':corresponding_author_form,
-        'corresponding_email_form':corresponding_email_form,
-        'transfer_author_form': transfer_author_form,
-        'add_item_url':edit_affiliations_url, 'remove_item_url':edit_affiliations_url,
-        'is_submitting':is_submitting})
+    return render(
+        request,
+        "project/project_authors.html",
+        {
+            "project": project,
+            "authors": authors,
+            "invitations": invitations,
+            "affiliation_formset": affiliation_formset,
+            "invite_author_form": invite_author_form,
+            "corresponding_author_form": corresponding_author_form,
+            "corresponding_email_form": corresponding_email_form,
+            "transfer_author_form": transfer_author_form,
+            "add_item_url": edit_affiliations_url,
+            "remove_item_url": edit_affiliations_url,
+            "is_submitting": is_submitting,
+        },
+    )
 
 
 def edit_content_item(request, project_slug):


### PR DESCRIPTION
As discussed in #2128, currently the submitting author of a project cannot be changed. There are times when it would be helpful to allow submitting authors to transfer this status to co-authors. e.g. when:

- A co-author would like to take responsibility for editing content or uploading files.
- A project requires updating and the original submitting author is no longer available.

This change adds a 'transfer project' button to the author page of the project submission system.