### PR TITLE
Add "legacy" parameter to PublishedProject.zip_name

### DIFF
--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -123,11 +123,21 @@ class PublishedProject(Metadata, SubmissionInfo):
         """
         return '-'.join((slugify(self.title), self.version.replace(' ', '-')))
 
-    def zip_name(self, full=False):
+    def zip_name(self, full=False, legacy=True):
         """
         Name of the zip file. Either base name or full path name.
+
+        If legacy is true, use the project title to generate the file
+        name (e.g. "demo-ecg-signal-toolbox-10.5.24.zip").
+
+        If false, use the project slug (e.g. "demoecg-10.5.24.zip").
+
+        Eventually the old style will be replaced with the new style.
         """
-        name = '{}.zip'.format(self.slugged_label())
+        if legacy:
+            name = '{}.zip'.format(self.slugged_label())
+        else:
+            name = '{}-{}.zip'.format(self.slug, self.version)
         if full:
             name = os.path.join(self.project_file_root(), name)
         return name


### PR DESCRIPTION
We would like to avoid including the project title in zip file names as well as in the zip file contents, in favor of the project slug, which is more stable and machine-readable.  (See issue #1674 for more background.)

Eventually, therefore, the behavior of the zip_name function should be changed; as a first step in that direction, add an optional argument so callers can specify whether they want the old or new style.

Existing code continues to use the old style for now, but when we upload zip files to S3 I'd like to rename the zip files to the new style (see issue #2122).  Adding the code in PublishedProject should make that easier and cleaner, and allow the rest of the site to be migrated eventually.
