### PR TITLE
Fix permissions for the Pages section of the admin console. Closes #2060.

### DIFF
--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -317,7 +317,7 @@
       {% endif %}
 
       <!-- Pages -->
-      {% if perms.user.change_staticpage or perms.user.change_frontpagebutton or perms.redirect.view_redirect %}
+      {% if perms.physionet.change_staticpage or perms.physionet.change_frontpagebutton or perms.redirect.view_redirect %}
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if frontpage_buttons_nav or static_pages_nav %}
           <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#pagesComponent" data-parent="#sideAccordion" aria-expanded="true">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2487,7 +2487,7 @@ def known_references(request):
         'all_known_ref': all_known_ref, 'known_ref_nav': True})
 
 
-@permission_required('physionet.view_redirect', raise_exception=True)
+@permission_required('redirects.view_redirect', raise_exception=True)
 def view_redirects(request):
     """
     Display a list of redirected URLs.


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/2060, there is a bug the "Pages" permissions. Currently, it is not possible to assign users the correct permissions to view the Pages tabs in the console.

![Screenshot 2023-11-28 at 3 12 41 PM](https://github.com/MIT-LCP/physionet-build/assets/822601/ffe83598-f4f1-482f-95fc-9ee3aefe16f9)

There are two issues:

1. The navbar HTML template is looking for `user.change_staticpage` and `user.change_frontpagebutton` permissions, which don't exist. These permissions belong to the `physionet` app, not `users`.
2. The `view_redirects` view is restricting access to a `physionet.view_redirect` permission, which doesn't exist. The redirect permission belongs to Django's `redirects` app.

Side note, but  it isn't ideal that the navbar logic displays all three subitems {% if perms.physionet.change_staticpage or perms.physionet.change_frontpagebutton or perms.redirect.view_redirect %}, even if the user only has permission to view/edit one of the subitems. I think we can worry about this later.

It might be cleaner to display all tabs/pages admin users, even if the user doesn't have permission to edit/view the page. This way the user knows what functionality exists, and they can request access if needed.