### PR TITLE
Default reference emails to lowercase when comparing to user's email addresses

### DIFF
--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -542,7 +542,7 @@ class ReferenceCAF(forms.ModelForm):
     def clean_reference_email(self):
         reference_email = self.cleaned_data.get('reference_email')
         if reference_email:
-            if reference_email in self.user.get_emails():
+            if reference_email.lower() in [email.lower() for email in self.user.get_emails()]:
                 raise forms.ValidationError("""You can not put yourself
                     as a reference.""")
             else:


### PR DESCRIPTION
This PR fixes the bug that was found in #2147. Since `self.user.get_emails()` is a list, we go through the list to check that the reference's email does not match any of the potential emails that the user has.