### PR TITLE
Add author affiliations to DataCite metadata. Ref #2153.

### DIFF
--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -488,6 +488,7 @@ def generate_doi_payload(project, core_project=False, event="draft"):
             author_metadata = {"givenName": author.first_names,
                                "familyName": author.last_name,
                                "name": author.get_full_name(reverse=True)}
+            author_metadata["affiliation"] = [{"name": a.name} for a in author.affiliations.all()]
             if author.user.has_orcid():
                 author_metadata["nameIdentifiers"] = [{
                     "nameIdentifier": f'https://orcid.org/{author.user.get_orcid_id()}',


### PR DESCRIPTION
As discussed in #2153, we do not currently provide author affiliation/s in the metadata that we send to DataCite. This pull request adds affiliations. Example DataCite payloads are shown at: https://support.datacite.org/docs/api-create-dois

e.g.

```
      "creators": [
        {
          "name": "Miller, Elizabeth",
          "nameType": "Personal",
          "givenName": "Elizabeth",
          "familyName": "Miller",
          "affiliation": [
            {
              "affiliationIdentifier": "https://ror.org/04wxnsj81",
              "affiliationIdentifierScheme": "ROR",
              "name": "DataCite",
              "schemeUri": "https://ror.org/"
            },
            {
              "affiliationIdentifier": "https://ror.org/05dxps055",
              "affiliationIdentifierScheme": "ROR",
              "name": "California Institute of Technology",
              "schemeUri": "https://ror.org/"
            }
          ],
          "nameIdentifiers": [
            {
              "schemeUri": "https://orcid.org",
              "nameIdentifier": "https://orcid.org/0000-0001-5000-0007",
              "nameIdentifierScheme": "ORCID"
            }
          ]
        }
      ],
```

In our case, we will only be providing the affiliation name.