### PR TITLE
Conceal the name of the editor during project submission. Ref #2117.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ CONTACT_EMAIL='PhysioNet Contact <contact@dev.physionet.org>'
 SERVER_EMAIL='PhysioNet System <root@dev.physionet.org>'
 ERROR_EMAIL='contact@physionet.org'
 
+# Contact address for project editors. This address may be viewable by authors.
+# Optionally, add "PROJECT-SLUG" to include the project slug.
+PROJECT_EDITOR_EMAIL='editor+PROJECT-SLUG@dev.physionet.org'
+
 # Admins
 ADMINS_NAME=PhysioNet Technical
 ADMINS_MAIL=technical@dev.physionet.org

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -640,3 +640,6 @@ MIN_WORDS_RESEARCH_SUMMARY_CREDENTIALING = config('MIN_WORDS_RESEARCH_SUMMARY_CR
 # Django configuration for file upload (see https://docs.djangoproject.com/en/4.2/ref/settings/)
 DATA_UPLOAD_MAX_NUMBER_FILES = config('DATA_UPLOAD_MAX_NUMBER_FILES', cast=int, default=1000)
 DATA_UPLOAD_MAX_MEMORY_SIZE = config('DATA_UPLOAD_MAX_MEMORY_SIZE', cast=int, default=2621440)
+
+# Emails
+PROJECT_EDITOR_EMAIL = config('PROJECT_EDITOR_EMAIL', default='')

--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -192,7 +192,7 @@
   <li class="list-group-item">
     <div class="row">
       <div class="col-md-2">{{ project.editor_assignment_datetime|date }}</div>
-      <div class="col-md-10">The project was assigned to an editor: {{ project.editor.disp_name_email }}
+      <div class="col-md-10">The project was assigned to an editor. To contact the editor, email:<br />{{ contact_email }}
     </div>
   </li>
   {% endif %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1388,11 +1388,20 @@ def project_submission(request, project_slug, **kwargs):
     else:
         edit_logs, copyedit_logs = None, None
 
-    return render(request, 'project/project_submission.html', {
-        'project':project, 'authors':authors,
-        'is_submitting':is_submitting, 'author_comments_form':author_comments_form,
-        'edit_logs':edit_logs, 'copyedit_logs':copyedit_logs,
-        'awaiting_user_approval':awaiting_user_approval})
+    return render(
+        request,
+        "project/project_submission.html",
+        {
+            "project": project,
+            "authors": authors,
+            "is_submitting": is_submitting,
+            "author_comments_form": author_comments_form,
+            "edit_logs": edit_logs,
+            "copyedit_logs": copyedit_logs,
+            "awaiting_user_approval": awaiting_user_approval,
+            "contact_email": settings.CONTACT_EMAIL,
+        },
+    )
 
 
 @project_auth(auth_mode=0, post_auth_mode=2)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1388,6 +1388,12 @@ def project_submission(request, project_slug, **kwargs):
     else:
         edit_logs, copyedit_logs = None, None
 
+    if settings.PROJECT_EDITOR_EMAIL:
+        contact_email = settings.PROJECT_EDITOR_EMAIL.replace('PROJECT-SLUG',
+                                                              project.slug)
+    else:
+        contact_email = project.editor.email
+
     return render(
         request,
         "project/project_submission.html",
@@ -1399,7 +1405,7 @@ def project_submission(request, project_slug, **kwargs):
             "edit_logs": edit_logs,
             "copyedit_logs": copyedit_logs,
             "awaiting_user_approval": awaiting_user_approval,
-            "contact_email": settings.CONTACT_EMAIL,
+            "contact_email": contact_email,
         },
     )
 


### PR DESCRIPTION
@li-lcp has asked to conceal the name of the editor for projects (see #2117). 

This pull request removes the name of the editor from the submission history page, and add general contact information for the platform.

In #2117, Li-wei asks for an "editor@physionet.org" email address to be listed. This address is not recorded in the config file, so for now I am using the general CONTACT_EMAIL.

Example:

<img width="680" alt="Screenshot 2023-12-02 at 3 25 55 PM" src="https://github.com/MIT-LCP/physionet-build/assets/822601/9e0eb710-f35c-4b0a-a51d-f07593deb618">
