### PR TITLE
Add title of news items to the page header

### DIFF
--- a/physionet-django/notification/templates/notification/news_item.html
+++ b/physionet-django/notification/templates/notification/news_item.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block title %}
-{{ year }} News
+News
 {% endblock %}
 
 

--- a/physionet-django/notification/templates/notification/news_item.html
+++ b/physionet-django/notification/templates/notification/news_item.html
@@ -2,10 +2,7 @@
 
 {% load static %}
 
-{% block title %}
-News
-{% endblock %}
-
+{% block title %}{{ news.title }}{% endblock %}
 
 {% block content %}
 <div class="main">


### PR DESCRIPTION
The `<title>` in the `<header>` section of all news items is currently "News" (see: https://github.com/MIT-LCP/physionet-build/issues/1983). This is a minor change that instead displays the title of the news item.

e.g. the `<head>` section of http://localhost:8000/news/post/3 changes from:

```
<head>
    <meta charset="UTF-8">
    <title>News</title>
```

...to: 

```
<head>
    <meta charset="UTF-8">
    <title>Preparing New Challenges</title>
```


