### PR TITLE
Enforce academic email requirements for students, postdocs, and academic researchers

### DIFF
--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -89,7 +89,7 @@
   "pk": 6,
   "fields": {
     "password": "pbkdf2_sha256$150000$6e8RyzxeUEDC$XjhKiSVwTTucKJIvpC2gYWL/6jCeSBWuZQRMSe8bm3g=",
-    "email": "eula_easley@fake_gmail.com",
+    "email": "eula_easley@mit.edu",
     "username": "eulaeasley",
     "join_date": "2020-03-29",
     "last_login": null,
@@ -3438,7 +3438,7 @@
     "user": [
       "eulaeasley"
     ],
-    "email": "eula_easley@fake_gmail.com",
+    "email": "eula_easley@mit.edu",
     "is_primary_email": true,
     "added_date": "2020-03-29T21:51:08.458Z",
     "verification_date": "2020-03-29T21:51:08.458Z",

--- a/physionet-django/user/forms.py
+++ b/physionet-django/user/forms.py
@@ -624,7 +624,7 @@ class CredentialApplicationForm(forms.ModelForm):
         if (not self.instance and CredentialApplication.objects
                 .filter(user=self.user, status=CredentialApplication.Status.PENDING)):
             raise forms.ValidationError('Outstanding application exists.')
-        
+
         # If the user is a student, postdoc, or academic researcher, an associated email should be provided
         if category in [0, 1, 2, 7]:
             has_institutional_email = False

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -257,7 +257,8 @@ def validate_institutional_email(value):
     Validate that the email address is from an institutional domain.
     """
     validate_email(value)
-    domains = ["yahoo.com", "163.com", "126.com", "outlook.com", "gmail.com", "qq.com", "foxmail.com"]
+    domains = ["yahoo.com", "163.com", "126.com", "outlook.com", "gmail.com", "qq.com",
+               "foxmail.com", "hotmail.com", "168.com"]
     if value.split('@')[-1].lower() in domains:
         raise ValidationError('Please provide an academic or institutional email address.')
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -43,7 +43,7 @@ from physionet.models import Section
 from physionet.settings.base import StorageTypes
 from project.models import Author, DUASignature, DUA, PublishedProject
 from requests_oauthlib import OAuth2Session
-from user import forms
+from user import forms, validators
 from user.models import (
     AssociatedEmail,
     CodeOfConduct,

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -43,7 +43,7 @@ from physionet.models import Section
 from physionet.settings.base import StorageTypes
 from project.models import Author, DUASignature, DUA, PublishedProject
 from requests_oauthlib import OAuth2Session
-from user import forms, validators
+from user import forms
 from user.models import (
     AssociatedEmail,
     CodeOfConduct,


### PR DESCRIPTION
This PR addresses #2129 by adding checks to credential applications to ensure users who select 'student, graduate student, postdoc, academic researcher' as their research category have their email address verified.

- I added a "new" validator, which was a previously used one but adjusted the text to fit the email criteria. It also briefly explains how to change your primary email.

One final thing that needs to be added is including the error banner at the top of the page instead of having it linger at the bottom of `class PersonalCAF(forms.ModelForm)`