### PR TITLE
Update 'manage' page in event management UI

### DIFF
--- a/physionet-django/console/templates/console/event_management.html
+++ b/physionet-django/console/templates/console/event_management.html
@@ -56,7 +56,7 @@
 
       <div class="row mb-1">
         <div class="col-md-3">Description:</div>
-        <div class="col-md-9">{{ event.description|safe }}</div>
+        <div class="col-md-9">{{ event.description|escape }}</div>
       </div>
       
     </div>

--- a/physionet-django/console/templates/console/event_management.html
+++ b/physionet-django/console/templates/console/event_management.html
@@ -44,11 +44,10 @@
         <div class="col-md-3">{{ info.title }}</div>
         <div class="col-md-9">
           <div class="row mb-1">
-            <div class="col-md-1">{{ info.count }}</div>
             <div class="col-md-11">
               <button class="btn btn-sm btn-primary"
                       data-toggle="modal"
-                      data-target="#{{ info.id }}">View</button>
+                      data-target="#{{ info.id }}">{{ info.count }} - View</button>
             </div>
           </div>
         </div>
@@ -57,7 +56,7 @@
 
       <div class="row mb-1">
         <div class="col-md-3">Description:</div>
-        <div class="col-md-9">{{ event.description }}</div>
+        <div class="col-md-9">{{ event.description|safe }}</div>
       </div>
       
     </div>

--- a/physionet-django/console/templates/console/event_management.html
+++ b/physionet-django/console/templates/console/event_management.html
@@ -56,7 +56,7 @@
 
       <div class="row mb-1">
         <div class="col-md-3">Description:</div>
-        <div class="col-md-9">{{ event.description|escape }}</div>
+        <div class="col-md-9">{{ event.description|striptags }}</div>
       </div>
       
     </div>


### PR DESCRIPTION
This PR updates the syntax errors that allows html to show in the description of an event on the event management page. 

Also mentioned in #2162, the way we present event participants is a bit off, I decided to merge the `{{ info.count }}` into the button itself, so it cleans up the page a bit. Open to other ways to present the information, but this looks a bit cleaner than before.