### PR TITLE
Refactor console_navbar for maintainability

### DIFF
--- a/physionet-django/console/navbar.py
+++ b/physionet-django/console/navbar.py
@@ -1,0 +1,214 @@
+import functools
+
+from django.conf import settings
+from django.urls import get_resolver, reverse
+from django.utils.translation import gettext_lazy as _
+
+from physionet.settings.base import StorageTypes
+
+
+class NavLink:
+    """
+    A link to be displayed in the navigation menu.
+
+    The exact URL of the link is determined by reversing the view
+    name.
+
+    The use of view_args is deprecated, and provided for compatibility
+    with existing views that require a static URL argument.  Don't use
+    view_args for newly added items.
+
+    The link will only be displayed in the menu if the logged-in user
+    has permission to access that URL.  This means that the
+    corresponding view function must be decorated with the
+    console_permission_required decorator.
+
+    The link will appear as "active" if the request URL matches the
+    link URL or a descendant.
+    """
+    def __init__(self, title, view_name, icon=None, *,
+                 enabled=True, view_args=()):
+        self.title = title
+        self.icon = icon
+        self.enabled = enabled
+        self.view_name = view_name
+        self.view_args = view_args
+        if self.view_args:
+            self.name = self.view_name + '__' + '_'.join(self.view_args)
+        else:
+            self.name = self.view_name
+
+    @functools.cached_property
+    def url(self):
+        return reverse(self.view_name, args=self.view_args)
+
+    @functools.cached_property
+    def required_permission(self):
+        view = get_resolver().resolve(self.url).func
+        return view.required_permission
+
+    def is_visible(self, request):
+        return self.enabled and request.user.has_perm(self.required_permission)
+
+    def is_active(self, request):
+        return request.path.startswith(self.url)
+
+
+class NavHomeLink(NavLink):
+    """
+    Variant of NavLink that does not include sub-pages.
+    """
+    def is_active(self, request):
+        return request.path == self.url
+
+
+class NavSubmenu:
+    """
+    A collection of links to be displayed as a submenu.
+    """
+    def __init__(self, title, name, icon=None, items=[]):
+        self.title = title
+        self.name = name
+        self.icon = icon
+        self.items = items
+
+
+class NavMenu:
+    """
+    A collection of links and submenus for navigation.
+    """
+    def __init__(self, items):
+        self.items = items
+
+    def get_menu_items(self, request):
+        """
+        Return the navigation menu items for an HTTP request.
+
+        This returns a list of dictionaries, each of which represents
+        either a page link or a submenu.
+
+        For a page link, the dictionary contains:
+         - 'title': human readable title
+         - 'name': unique name (corresponding to the view name)
+         - 'icon': icon name
+         - 'url': page URL
+         - 'active': true if this page is currently active
+
+        For a submenu, the dictionary contains:
+         - 'title': human readable title
+         - 'name': unique name
+         - 'icon': icon name
+         - 'subitems': list of page links
+         - 'active': true if this submenu is currently active
+        """
+        visible_items = []
+
+        for item in self.items:
+            if isinstance(item, NavSubmenu):
+                subitems = item.items
+            elif isinstance(item, NavLink):
+                subitems = [item]
+            else:
+                raise TypeError(item)
+
+            visible_subitems = []
+            active = False
+            for subitem in subitems:
+                if subitem.is_visible(request):
+                    subitem_active = subitem.is_active(request)
+                    active = active or subitem_active
+                    visible_subitems.append({
+                        'title': subitem.title,
+                        'name': subitem.name,
+                        'icon': subitem.icon,
+                        'url': subitem.url,
+                        'active': subitem_active,
+                    })
+
+            if visible_subitems:
+                if isinstance(item, NavSubmenu):
+                    visible_items.append({
+                        'title': item.title,
+                        'name': item.name,
+                        'icon': item.icon,
+                        'subitems': visible_subitems,
+                        'active': active,
+                    })
+                else:
+                    visible_items += visible_subitems
+
+        return visible_items
+
+
+CONSOLE_NAV_MENU = NavMenu([
+    NavHomeLink(_('Home'), 'console_home', 'book-open'),
+
+    NavLink(_('Editor Home'), 'editor_home', 'book-open'),
+
+    NavSubmenu(_('Projects'), 'projects', 'clipboard-list', [
+        NavLink(_('Unsubmitted'), 'unsubmitted_projects'),
+        NavLink(_('Submitted'), 'submitted_projects'),
+        NavLink(_('Published'), 'published_projects'),
+        NavLink(_('Archived'), 'archived_submissions'),
+    ]),
+
+    NavLink(_('Storage'), 'storage_requests', 'cube'),
+
+    NavSubmenu(_('Identity check'), 'identity', 'hand-paper', [
+        NavLink(_('Processing'), 'credential_processing'),
+        NavLink(_('All Applications'), 'credential_applications',
+                view_args=['successful']),
+        NavLink(_('Known References'), 'known_references'),
+    ]),
+
+    NavLink(_('Training check'), 'training_list', 'school',
+            view_args=['review']),
+
+    NavSubmenu(_('Events'), 'events', 'clipboard-list', [
+        NavLink(_('Active'), 'event_active'),
+        NavLink(_('Archived'), 'event_archive'),
+    ]),
+
+    NavSubmenu(_('Legal'), 'legal', 'handshake', [
+        NavLink(_('Licenses'), 'license_list'),
+        NavLink(_('DUAs'), 'dua_list'),
+        NavLink(_('Code of Conduct'), 'code_of_conduct_list'),
+        NavLink(_('Event Agreements'), 'event_agreement_list'),
+    ]),
+
+    NavSubmenu(_('Logs'), 'logs', 'fingerprint', [
+        NavLink(_('Project Logs'), 'project_access_logs'),
+        NavLink(_('Access Requests'), 'project_access_requests_list'),
+        NavLink(_('User Logs'), 'user_access_logs'),
+        NavLink(_('GCP Logs'), 'gcp_signed_urls_logs',
+                enabled=(settings.STORAGE_TYPE == StorageTypes.GCP)),
+    ]),
+
+    NavSubmenu(_('Users'), 'users', 'user-check', [
+        NavLink(_('Active Users'), 'users', view_args=['active']),
+        NavLink(_('Inactive Users'), 'users', view_args=['inactive']),
+        NavLink(_('All Users'), 'users', view_args=['all']),
+        NavLink(_('User Groups'), 'user_groups'),
+        NavLink(_('Administrators'), 'users', view_args=['admin']),
+    ]),
+
+    NavLink(_('Featured Content'), 'featured_content', 'star'),
+
+    NavSubmenu(_('Guidelines'), 'guidelines', 'book', [
+        NavLink(_('Project review'), 'guidelines_review'),
+    ]),
+
+    NavSubmenu(_('Usage Stats'), 'stats', 'chart-area', [
+        NavLink(_('Editorial'), 'editorial_stats'),
+        NavLink(_('Credentialing'), 'credentialing_stats'),
+        NavLink(_('Submissions'), 'submission_stats'),
+    ]),
+
+    NavSubmenu(_('Pages'), 'pages', 'window-maximize', [
+        NavLink(_('Static Pages'), 'static_pages'),
+        NavLink(_('Frontpage Buttons'), 'frontpage_buttons'),
+        NavLink(_('Redirects'), 'redirects'),
+    ]),
+
+    NavLink(_('News'), 'news_console', 'newspaper'),
+])

--- a/physionet-django/console/static/console/css/console-noscript.css
+++ b/physionet-django/console/static/console/css/console-noscript.css
@@ -1,0 +1,8 @@
+.navbar-sidenav .nav-item:focus-within .collapse,
+.navbar-sidenav .nav-link-collapse:focus + .collapse {
+  display: block;
+}
+
+#mainNav .navbar-collapse .navbar-sidenav .nav-item:focus-within .nav-link-collapse.collapsed::after {
+  content: "\f107"; /* angle-down */
+}

--- a/physionet-django/console/templates/console/base_console.html
+++ b/physionet-django/console/templates/console/base_console.html
@@ -7,6 +7,7 @@
     {% include "base_css.html" %}
     <link rel="stylesheet" type="text/css" href="{% static 'console/css/console.css' %}"/>
     <link rel="stylesheet" type="text/css" href="{% static 'custom/css/form-control-input.css' %}"/>
+    <noscript><link rel="stylesheet" type="text/css" href="{% static 'console/css/console-noscript.css' %}"/></noscript>
     {% block local_css %}{% endblock %}
     {% include "base_js_top.html" %}
     {% block local_js_top %}{% endblock %}

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -15,14 +15,23 @@
       {% for item in nav_menu_items %}
         {% if item.subitems %}
           <li class="nav-item">
-            <a id="nav_{{ item.name }}_dropdown" class="nav-link nav-link-collapse drop{{ item.active|yesno:', collapsed' }}" data-toggle="collapse" href="#nav_{{ item.name }}_components" data-parent="#sideAccordion" aria-expanded="{{ item.active|yesno:'true,false' }}">
-              {% if item.icon %}<i class="fa fa-fw fa-{{ item.icon }}"></i>{% endif %}
+            <a id="nav_{{ item.name }}_dropdown"
+               class="nav-link nav-link-collapse drop {{ item.active|yesno:',collapsed' }}"
+               data-toggle="collapse"
+               href="#nav_{{ item.name }}_components"
+               data-parent="#sideAccordion"
+               aria-expanded="{{ item.active|yesno:'true,false' }}">
+              {% if item.icon %}
+                <i class="fa fa-fw fa-{{ item.icon }}"></i>
+              {% endif %}
               <span class="nav-link-text">{{ item.title }}</span>
             </a>
-            <ul class="sidenav-second-level collapse{{ item.active|yesno:' show,' }}" id="nav_{{ item.name }}_components">
+            <ul class="sidenav-second-level collapse {{ item.active|yesno:'show,' }}"
+                id="nav_{{ item.name }}_components">
               {% for subitem in item.subitems %}
                 <li class="nav-item {{ subitem.active|yesno:'active,' }}">
-                  <a id="nav_{{ subitem.name }}" class="nav-link" href="{{ subitem.url }}">{{ subitem.title }}</a>
+                  <a id="nav_{{ subitem.name }}" class="nav-link"
+                     href="{{ subitem.url }}">{{ subitem.title }}</a>
                 </li>
               {% endfor %}
             </ul>
@@ -30,7 +39,9 @@
         {% else %}
           <li class="nav-item {{ item.active|yesno:'active,' }}">
             <a id="nav_{{ item.name }}" class="nav-link" href="{{ item.url }}">
-              {% if item.icon %}<i class="fa fa-fw fa-{{ item.icon }}"></i>{% endif %}
+              {% if item.icon %}
+                <i class="fa fa-fw fa-{{ item.icon }}"></i>
+              {% endif %}
               <span class="nav-link-text">{{ item.title }}</span>
             </a>
           </li>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -11,7 +11,6 @@
   <div class="collapse navbar-collapse" id="navbarResponsive">
     <ul class="navbar-nav navbar-sidenav" id="sideAccordion">
 
-      <!-- console home page -->
       <li class="nav-item {% if console_home_nav %}active{% endif %}">
         <a id="nav_console_home" class="nav-link" href="{% url 'console_home' %}">
           <i class="fa fa-fw fa-book-open"></i>
@@ -19,7 +18,6 @@
         </a>
       </li>
 
-      <!-- editor home -->
       {% if perms.project.change_activeproject or perms.project.change_publishedproject %}
         <li class="nav-item {% if editor_home %}active{% endif %}">
           <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
@@ -29,7 +27,6 @@
         </li>
       {% endif %}
 
-      <!-- projects -->
       {% if perms.project.change_publishedproject %}
         <li class="nav-item">
         {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
@@ -40,7 +37,6 @@
             <i class="fa fa-fw fa-clipboard-list"></i>
             <span class="nav-link-text">Projects</span>
           </a>
-          <!-- submenu -->
         {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_projects_components" style="">
         {% else %}
@@ -61,7 +57,7 @@
           </ul>
         </li>
       {% endif %}
-      <!-- storage requests -->
+
       {% if perms.project.change_storagerequest %}
         <li class="nav-item {% if storage_requests_nav %}active{% endif %}">
           <a id="nav_storage_requests" class="nav-link" href="{% url 'storage_requests' %}">
@@ -71,7 +67,6 @@
         </li>
       {% endif %}
 
-      <!-- credentialing -->
       {% if perms.user.change_credentialapplication %}
         <li class="nav-item">
         {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
@@ -82,7 +77,6 @@
             <i class="fa fa-fw fa-hand-paper"></i>
             <span class="nav-link-text">Identity check</span>
           </a>
-          <!-- submenu -->
         {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_identity_components">
         {% else %}
@@ -102,7 +96,6 @@
       {% endif %}
 
       {% if perms.user.can_review_training %}
-        <!-- training -->
         <li class="nav-item {% if training_nav %}active{% endif %}">
           <a id="nav_training_list__review" class="nav-link" href="{% url 'training_list' 'review' %}">
             <i class="fa fa-fw fa-school"></i>
@@ -111,7 +104,6 @@
         </li>
       {% endif %}
 
-      <!-- events -->
       {% if perms.user.view_all_events %}
         <li class="nav-item">
           {% if events_nav %}
@@ -122,7 +114,6 @@
               <i class="fa fa-fw fa-clipboard-list"></i>
               <span class="nav-link-text">Events</span>
             </a>
-            <!-- submenu -->
           {% if nav_event_active or nav_event_archive %}
             <ul class="sidenav-second-level collapse show" id="nav_events_components">
           {% else  %}
@@ -138,7 +129,6 @@
         </li>
       {% endif %}
 
-      <!-- legal -->
       {% if perms.project.add_dua or perms.project.add_codeofconduct or perms.project.add_license or perms.events.add_eventagreement %}
         <li class="nav-item">
           {% if license_nav or dua_nav or code_of_conduct_nav %}
@@ -149,7 +139,6 @@
               <i class="fa fa-fw fa-handshake"></i>
               <span class="nav-link-text">Legal</span>
             </a>
-            <!-- submenu -->
           {% if license_nav or dua_nav or code_of_conduct_nav or event_agreement_nav %}
             <ul class="sidenav-second-level collapse show" id="nav_legal_components">
           {% else  %}
@@ -179,7 +168,6 @@
         </li>
       {% endif %}
       
-      <!-- logs -->
       {% if perms.project.can_view_access_logs %}
         <li class="nav-item">
         {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
@@ -190,7 +178,6 @@
             <i class="fa fa-fw fa-fingerprint"></i>
             <span class="nav-link-text">Logs</span>
           </a>
-          <!-- submenu -->
         {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_logs_components" style="">
         {% else %}
@@ -213,9 +200,7 @@
           </ul>
         </li>
       {% endif %}
-      
 
-      <!-- users -->
       {% if perms.user.view_user %}
         <li class="nav-item">
         {% if user_nav %}
@@ -226,7 +211,6 @@
             <i class="fa fa-fw fa-user-check"></i>
             <span class="nav-link-text">Users</span>
           </a>
-          <!-- submenu -->
         {% if user_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_users_components">
         {% else  %}
@@ -251,7 +235,6 @@
         </li>
       {% endif %}
 
-      <!-- featured content -->
       {% if perms.project.can_edit_featured_content %}
         <li class="nav-item {% if featured_content_nav %}active{% endif %}">
           <a id="nav_featured_content" class="nav-link" href="{% url 'featured_content' %}">
@@ -261,7 +244,6 @@
         </li>
       {% endif %}
 
-      <!-- guidelines and documentation -->
       {% if perms.project.can_view_project_guidelines %}
         <li class="nav-item">
         {% if guidelines_review_nav %}
@@ -272,7 +254,6 @@
             <i class="fa fa-fw fa-book"></i>
             <span class="nav-link-text">Guidelines</span>
           </a>
-          <!-- submenu -->
         {% if guidelines_review_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_guidelines_components">
         {% else  %}
@@ -285,7 +266,6 @@
         </li>
       {% endif %}
 
-      <!-- usage stats -->
       {% if perms.project.can_view_stats %}
         <li class="nav-item">
         {% if stats_nav %}
@@ -296,7 +276,6 @@
             <i class="fa fa-fw fa-chart-area"></i>
             <span class="nav-link-text">Usage Stats</span>
           </a>
-          <!-- submenu -->
           {% if stats_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_stats_components">
           {% else  %}
@@ -315,7 +294,6 @@
         </li>
       {% endif %}
 
-      <!-- Pages -->
       {% if perms.physionet.change_staticpage or perms.physionet.change_frontpagebutton or perms.redirect.view_redirect %}
       <li class="nav-item">
         {% if frontpage_buttons_nav or static_pages_nav %}
@@ -326,7 +304,6 @@
             <i class="fa fa-fw fa-window-maximize"></i>
             <span class="nav-link-text">Pages</span>
           </a>
-          <!-- submenu -->
         {% if frontpage_buttons_nav or static_pages_nav or redirects_nav %}
           <ul class="sidenav-second-level collapse show" id="nav_pages_components" style="">
         {% else %}
@@ -345,7 +322,6 @@
       </li>
       {% endif %}
 
-      <!-- news -->
       {% if perms.notification.change_news %}
         <li class="nav-item {% if news_nav %}active{% endif %}">
           <a id="nav_news_console" class="nav-link" href="{% url 'news_console' %}">

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -245,7 +245,7 @@
               <a id="nav_user_groups" class="nav-link" href="{% url 'user_groups' %}">User Groups</a>
             </li>
             <li class="nav-item {% if group == 'admin' %}active{% endif %}">
-              <a id="nav_all_users" class="nav-link" href="{% url 'users' 'admin' %}"> {{admin}}Administrators</a>
+              <a id="nav_all_users" class="nav-link" href="{% url 'users' 'admin' %}">Administrators</a>
             </li>
           </ul>
         </li>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -22,7 +22,7 @@
                data-parent="#sideAccordion"
                aria-expanded="{{ item.active|yesno:'true,false' }}">
               {% if item.icon %}
-                <i class="fa fa-fw fa-{{ item.icon }}"></i>
+                <span class="nav-link-icon fa fa-fw fa-{{ item.icon }}"></span>
               {% endif %}
               <span class="nav-link-text">{{ item.title }}</span>
             </a>
@@ -40,7 +40,7 @@
           <li class="nav-item {{ item.active|yesno:'active,' }}">
             <a id="nav_{{ item.name }}" class="nav-link" href="{{ item.url }}">
               {% if item.icon %}
-                <i class="fa fa-fw fa-{{ item.icon }}"></i>
+                <span class="nav-link-icon fa fa-fw fa-{{ item.icon }}"></span>
               {% endif %}
               <span class="nav-link-text">{{ item.title }}</span>
             </a>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -12,7 +12,7 @@
     <ul class="navbar-nav navbar-sidenav" id="sideAccordion">
 
       <!-- console home page -->
-      <li class="nav-item {% if console_home_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+      <li class="nav-item {% if console_home_nav %}active{% endif %}">
         <a id="nav_console_home" class="nav-link" href="{% url 'console_home' %}">
           <i class="fa fa-fw fa-book-open"></i>
           <span class="nav-link-text">Home</span>
@@ -21,7 +21,7 @@
 
       <!-- editor home -->
       {% if perms.project.change_activeproject or perms.project.change_publishedproject %}
-        <li class="nav-item {% if editor_home %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item {% if editor_home %}active{% endif %}">
           <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
             <i class="fa fa-fw fa-book-open"></i>
             <span class="nav-link-text">Editor Home</span>
@@ -31,7 +31,7 @@
 
       <!-- projects -->
       {% if perms.project.change_publishedproject %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
         {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
           <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_projects_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -63,7 +63,7 @@
       {% endif %}
       <!-- storage requests -->
       {% if perms.project.change_storagerequest %}
-        <li class="nav-item {% if storage_requests_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item {% if storage_requests_nav %}active{% endif %}">
           <a id="nav_storage_requests" class="nav-link" href="{% url 'storage_requests' %}">
             <i class="fa fa-fw fa-cube"></i>
             <span class="nav-link-text">Storage</span>
@@ -73,7 +73,7 @@
 
       <!-- credentialing -->
       {% if perms.user.change_credentialapplication %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
         {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
           <a id="nav_identity_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_identity_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -103,7 +103,7 @@
 
       {% if perms.user.can_review_training %}
         <!-- training -->
-        <li class="nav-item {% if training_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item {% if training_nav %}active{% endif %}">
           <a id="nav_training_list__review" class="nav-link" href="{% url 'training_list' 'review' %}">
             <i class="fa fa-fw fa-school"></i>
             <span class="nav-link-text">Training check</span>
@@ -113,7 +113,7 @@
 
       <!-- events -->
       {% if perms.user.view_all_events %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
           {% if events_nav %}
             <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_events_components" data-parent="#sideAccordion" aria-expanded="true">
           {% else %}
@@ -140,7 +140,7 @@
 
       <!-- legal -->
       {% if perms.project.add_dua or perms.project.add_codeofconduct or perms.project.add_license or perms.events.add_eventagreement %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
           {% if license_nav or dua_nav or code_of_conduct_nav %}
             <a id="nav_legal_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_legal_components" data-parent="#sideAccordion" aria-expanded="true">
           {% else %}
@@ -181,7 +181,7 @@
       
       <!-- logs -->
       {% if perms.project.can_view_access_logs %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
         {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
           <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_logs_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -217,7 +217,7 @@
 
       <!-- users -->
       {% if perms.user.view_user %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
         {% if user_nav %}
           <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_users_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -253,7 +253,7 @@
 
       <!-- featured content -->
       {% if perms.project.can_edit_featured_content %}
-        <li class="nav-item {% if featured_content_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item {% if featured_content_nav %}active{% endif %}">
           <a id="nav_featured_content" class="nav-link" href="{% url 'featured_content' %}">
             <i class="fa fa-fw fa-star"></i>
             <span class="nav-link-text">Featured Content</span>
@@ -263,7 +263,7 @@
 
       <!-- guidelines and documentation -->
       {% if perms.project.can_view_project_guidelines %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
         {% if guidelines_review_nav %}
           <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_guidelines_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -287,7 +287,7 @@
 
       <!-- usage stats -->
       {% if perms.project.can_view_stats %}
-        <li class="nav-item" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item">
         {% if stats_nav %}
           <a id="nav_stats_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -318,7 +318,7 @@
 
       <!-- Pages -->
       {% if perms.physionet.change_staticpage or perms.physionet.change_frontpagebutton or perms.redirect.view_redirect %}
-      <li class="nav-item" data-toggle="tooltip" data-placement="right">
+      <li class="nav-item">
         {% if frontpage_buttons_nav or static_pages_nav %}
           <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_pages_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
@@ -348,7 +348,7 @@
 
       <!-- news -->
       {% if perms.notification.change_news %}
-        <li class="nav-item {% if news_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
+        <li class="nav-item {% if news_nav %}active{% endif %}">
           <a id="nav_news_console" class="nav-link" href="{% url 'news_console' %}">
             <i class="fa fa-fw fa-newspaper"></i>
             <span class="nav-link-text">News</span>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -38,7 +38,7 @@
             <span class="nav-link-text">Projects</span>
           </a>
         {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_projects_components" style="">
+          <ul class="sidenav-second-level collapse show" id="nav_projects_components">
         {% else %}
           <ul class="sidenav-second-level collapse" id="nav_projects_components">
         {% endif %}
@@ -85,10 +85,10 @@
             <li class="nav-item {% if processing_credentials_nav %}active{% endif %}">
               <a id="nav_credential_processing" class="nav-link" href="{% url 'credential_processing' %}">Processing</a>
             </li>
-            <li class="nav-item {% if past_credentials_nav %}active{% endif %} ">
+            <li class="nav-item {% if past_credentials_nav %}active{% endif %}">
               <a id="nav_credential_applications__successful" class="nav-link" href="{% url 'credential_applications' 'successful' %}">All Applications</a>
             </li>
-            <li class="nav-item {% if known_ref_nav %}active{% endif %} ">
+            <li class="nav-item {% if known_ref_nav %}active{% endif %}">
               <a id="nav_known_references" class="nav-link" href="{% url 'known_references' %}">Known References</a>
             </li>
           </ul>
@@ -179,7 +179,7 @@
             <span class="nav-link-text">Logs</span>
           </a>
         {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_logs_components" style="">
+          <ul class="sidenav-second-level collapse show" id="nav_logs_components">
         {% else %}
           <ul class="sidenav-second-level collapse" id="nav_logs_components">
         {% endif %}
@@ -271,7 +271,7 @@
         {% if stats_nav %}
           <a id="nav_stats_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="False">
+          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-chart-area"></i>
             <span class="nav-link-text">Usage Stats</span>
@@ -305,7 +305,7 @@
             <span class="nav-link-text">Pages</span>
           </a>
         {% if frontpage_buttons_nav or static_pages_nav or redirects_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_pages_components" style="">
+          <ul class="sidenav-second-level collapse show" id="nav_pages_components">
         {% else %}
           <ul class="sidenav-second-level collapse" id="nav_pages_components">
         {% endif %}

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load console_templatetags %}
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top d-flex justify-content-between" id="mainNav">
   <label for="navicon" class="navbar-icon">&#9776;</label>
   <input type="checkbox" id="navicon" class="navbar-check">
@@ -10,327 +11,31 @@
   <!-- start of menu items -->
   <div class="collapse navbar-collapse" id="navbarResponsive">
     <ul class="navbar-nav navbar-sidenav" id="sideAccordion">
-
-      <li class="nav-item {% if console_home_nav %}active{% endif %}">
-        <a id="nav_console_home" class="nav-link" href="{% url 'console_home' %}">
-          <i class="fa fa-fw fa-book-open"></i>
-          <span class="nav-link-text">Home</span>
-        </a>
-      </li>
-
-      {% if perms.project.change_activeproject or perms.project.change_publishedproject %}
-        <li class="nav-item {% if editor_home %}active{% endif %}">
-          <a id="nav_editor_home" class="nav-link" href="{% url 'editor_home' %}">
-            <i class="fa fa-fw fa-book-open"></i>
-            <span class="nav-link-text">Editor Home</span>
-          </a>
-        </li>
-      {% endif %}
-
-      {% if perms.project.change_publishedproject %}
-        <li class="nav-item">
-        {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
-          <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_projects_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_projects_components" data-parent="#sideAccordion" aria-expanded="false">
-        {% endif %}
-            <i class="fa fa-fw fa-clipboard-list"></i>
-            <span class="nav-link-text">Projects</span>
-          </a>
-        {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_projects_components">
-        {% else %}
-          <ul class="sidenav-second-level collapse" id="nav_projects_components">
-        {% endif %}
-            <li class="nav-item {% if unsubmitted_projects_nav %}active{% endif %}">
-              <a id="nav_unsubmitted_projects" class="nav-link" href="{% url 'unsubmitted_projects' %}">Unsubmitted</a>
-            </li>
-            <li class="nav-item {% if submitted_projects_nav %}active{% endif %}">
-              <a id="nav_submitted_projects" class="nav-link" href="{% url 'submitted_projects' %}">Submitted</a>
-            </li>
-            <li class="nav-item {% if published_projects_nav %}active{% endif %}">
-              <a id="nav_published_projects" class="nav-link" href="{% url 'published_projects' %}">Published</a>
-            </li>
-            <li class="nav-item {% if archived_projects_nav %}active{% endif %}">
-              <a id="nav_archived_submissions" class="nav-link" href="{% url 'archived_submissions' %}">Archived</a>
-            </li>          
-          </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.project.change_storagerequest %}
-        <li class="nav-item {% if storage_requests_nav %}active{% endif %}">
-          <a id="nav_storage_requests" class="nav-link" href="{% url 'storage_requests' %}">
-            <i class="fa fa-fw fa-cube"></i>
-            <span class="nav-link-text">Storage</span>
-          </a>
-        </li>
-      {% endif %}
-
-      {% if perms.user.change_credentialapplication %}
-        <li class="nav-item">
-        {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
-          <a id="nav_identity_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_identity_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_identity_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_identity_components" data-parent="#sideAccordion" aria-expanded="false">
-        {% endif %}
-            <i class="fa fa-fw fa-hand-paper"></i>
-            <span class="nav-link-text">Identity check</span>
-          </a>
-        {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_identity_components">
-        {% else %}
-          <ul class="sidenav-second-level collapse" id="nav_identity_components">
-        {% endif %}
-            <li class="nav-item {% if processing_credentials_nav %}active{% endif %}">
-              <a id="nav_credential_processing" class="nav-link" href="{% url 'credential_processing' %}">Processing</a>
-            </li>
-            <li class="nav-item {% if past_credentials_nav %}active{% endif %}">
-              <a id="nav_credential_applications__successful" class="nav-link" href="{% url 'credential_applications' 'successful' %}">All Applications</a>
-            </li>
-            <li class="nav-item {% if known_ref_nav %}active{% endif %}">
-              <a id="nav_known_references" class="nav-link" href="{% url 'known_references' %}">Known References</a>
-            </li>
-          </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.user.can_review_training %}
-        <li class="nav-item {% if training_nav %}active{% endif %}">
-          <a id="nav_training_list__review" class="nav-link" href="{% url 'training_list' 'review' %}">
-            <i class="fa fa-fw fa-school"></i>
-            <span class="nav-link-text">Training check</span>
-          </a>
-        </li>
-      {% endif %}
-
-      {% if perms.user.view_all_events %}
-        <li class="nav-item">
-          {% if events_nav %}
-            <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_events_components" data-parent="#sideAccordion" aria-expanded="true">
-          {% else %}
-            <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_events_components" data-parent="#sideAccordion" aria-expanded="false">
-          {% endif %}
-              <i class="fa fa-fw fa-clipboard-list"></i>
-              <span class="nav-link-text">Events</span>
+      {% console_nav_menu_items request as nav_menu_items %}
+      {% for item in nav_menu_items %}
+        {% if item.subitems %}
+          <li class="nav-item">
+            <a id="nav_{{ item.name }}_dropdown" class="nav-link nav-link-collapse drop{{ item.active|yesno:', collapsed' }}" data-toggle="collapse" href="#nav_{{ item.name }}_components" data-parent="#sideAccordion" aria-expanded="{{ item.active|yesno:'true,false' }}">
+              {% if item.icon %}<i class="fa fa-fw fa-{{ item.icon }}"></i>{% endif %}
+              <span class="nav-link-text">{{ item.title }}</span>
             </a>
-          {% if nav_event_active or nav_event_archive %}
-            <ul class="sidenav-second-level collapse show" id="nav_events_components">
-          {% else  %}
-            <ul class="sidenav-second-level collapse" id="nav_events_components">
-          {% endif %}
-              <li class="nav-item {% if nav_event_active %}active{% endif %}">
-                <a id="nav_event_active" class="nav-link" href="{% url 'event_active' %}">Active</a>
-              </li>
-              <li class="nav-item {% if nav_event_archive %}active{% endif %}">
-                <a id="nav_event_archive" class="nav-link" href="{% url 'event_archive' %}">Archived</a>
-              </li>
+            <ul class="sidenav-second-level collapse{{ item.active|yesno:' show,' }}" id="nav_{{ item.name }}_components">
+              {% for subitem in item.subitems %}
+                <li class="nav-item {{ subitem.active|yesno:'active,' }}">
+                  <a id="nav_{{ subitem.name }}" class="nav-link" href="{{ subitem.url }}">{{ subitem.title }}</a>
+                </li>
+              {% endfor %}
             </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.project.add_dua or perms.project.add_codeofconduct or perms.project.add_license or perms.events.add_eventagreement %}
-        <li class="nav-item">
-          {% if license_nav or dua_nav or code_of_conduct_nav %}
-            <a id="nav_legal_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_legal_components" data-parent="#sideAccordion" aria-expanded="true">
-          {% else %}
-            <a id="nav_legal_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_legal_components" data-parent="#sideAccordion" aria-expanded="false">
-          {% endif %}
-              <i class="fa fa-fw fa-handshake"></i>
-              <span class="nav-link-text">Legal</span>
+          </li>
+        {% else %}
+          <li class="nav-item {{ item.active|yesno:'active,' }}">
+            <a id="nav_{{ item.name }}" class="nav-link" href="{{ item.url }}">
+              {% if item.icon %}<i class="fa fa-fw fa-{{ item.icon }}"></i>{% endif %}
+              <span class="nav-link-text">{{ item.title }}</span>
             </a>
-          {% if license_nav or dua_nav or code_of_conduct_nav or event_agreement_nav %}
-            <ul class="sidenav-second-level collapse show" id="nav_legal_components">
-          {% else  %}
-            <ul class="sidenav-second-level collapse" id="nav_legal_components">
-          {% endif %}
-              {% if perms.project.add_license %}
-                <li class="nav-item {% if license_nav %}active{% endif %}">
-                  <a id="nav_license_list" class="nav-link" href="{% url 'license_list' %}">Licenses</a>
-                </li>
-              {% endif %}
-              {% if perms.project.add_dua %}
-                <li class="nav-item {% if dua_nav %}active{% endif %}">
-                  <a id="nav_dua_list" class="nav-link" href="{% url 'dua_list' %}">DUAs</a>
-                </li>
-              {% endif %}
-              {% if perms.project.add_codeofconduct %}
-                <li class="nav-item {% if code_of_conduct_nav %}active{% endif %}">
-                  <a id="nav_code_of_conduct_list" class="nav-link" href="{% url 'code_of_conduct_list' %}">Code of Conduct</a>
-                </li>
-              {% endif %}
-              {% if perms.events.add_eventagreement %}
-                <li class="nav-item {% if event_agreement_nav %}active{% endif %}">
-                  <a id="nav_event_agreement_list" class="nav-link" href="{% url 'event_agreement_list' %}">Event Agreements</a>
-                </li>
-              {% endif %}
-            </ul>
-        </li>
-      {% endif %}
-      
-      {% if perms.project.can_view_access_logs %}
-        <li class="nav-item">
-        {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
-          <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_logs_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_logs_components" data-parent="#sideAccordion" aria-expanded="false">
+          </li>
         {% endif %}
-            <i class="fa fa-fw fa-fingerprint"></i>
-            <span class="nav-link-text">Logs</span>
-          </a>
-        {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_logs_components">
-        {% else %}
-          <ul class="sidenav-second-level collapse" id="nav_logs_components">
-        {% endif %}
-            <li class="nav-item {% if project_access_logs_nav %}active{% endif %}">
-              <a id="nav_project_access_logs" class="nav-link" href="{% url 'project_access_logs' %}">Project Logs</a>
-            </li>
-            <li class="nav-item {% if access_requests_nav %}active{% endif %}">
-              <a id="nav_project_access_requests_list" class="nav-link" href="{% url 'project_access_requests_list' %}">Access Requests</a>
-            </li>
-            <li class="nav-item {% if user_access_logs_nav %}active{% endif %}">
-              <a id="nav_user_access_logs" class="nav-link" href="{% url 'user_access_logs' %}">User Logs</a>
-            </li>
-            {% if storage_type == 'GCP' %}
-              <li class="nav-item {% if gcp_logs_nav %}active{% endif %}">
-                <a id="nav_gcp_signed_urls_logs" class="nav-link" href="{% url 'gcp_signed_urls_logs' %}">GCP Logs</a>
-              </li>
-            {% endif %}
-          </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.user.view_user %}
-        <li class="nav-item">
-        {% if user_nav %}
-          <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_users_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_users_components" data-parent="#sideAccordion" aria-expanded="false">
-        {% endif %}
-            <i class="fa fa-fw fa-user-check"></i>
-            <span class="nav-link-text">Users</span>
-          </a>
-        {% if user_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_users_components">
-        {% else  %}
-          <ul class="sidenav-second-level collapse" id="nav_users_components">
-        {% endif %}
-            <li class="nav-item {% if group == 'active' %}active{% endif %}">
-              <a id="nav_users__active" class="nav-link" href="{% url 'users' 'active' %}">Active Users</a>
-            </li>
-            <li class="nav-item {% if group == 'inactive' %}active{% endif %}">
-              <a id="nav_users__inactive" class="nav-link" href="{% url 'users' 'inactive' %}">Inactive Users</a>
-            </li>
-            <li class="nav-item {% if group == 'all' %}active{% endif %}">
-              <a id="nav_users__all" class="nav-link" href="{% url 'users' 'all' %}">All Users</a>
-            </li>
-            <li class="nav-item {% if user_groups_nav%}active{% endif %}">
-              <a id="nav_user_groups" class="nav-link" href="{% url 'user_groups' %}">User Groups</a>
-            </li>
-            <li class="nav-item {% if group == 'admin' %}active{% endif %}">
-              <a id="nav_users__admin" class="nav-link" href="{% url 'users' 'admin' %}">Administrators</a>
-            </li>
-          </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.project.can_edit_featured_content %}
-        <li class="nav-item {% if featured_content_nav %}active{% endif %}">
-          <a id="nav_featured_content" class="nav-link" href="{% url 'featured_content' %}">
-            <i class="fa fa-fw fa-star"></i>
-            <span class="nav-link-text">Featured Content</span>
-          </a>
-        </li>
-      {% endif %}
-
-      {% if perms.project.can_view_project_guidelines %}
-        <li class="nav-item">
-        {% if guidelines_review_nav %}
-          <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_guidelines_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_guidelines_components" data-parent="#sideAccordion" aria-expanded="false">
-        {% endif %}
-            <i class="fa fa-fw fa-book"></i>
-            <span class="nav-link-text">Guidelines</span>
-          </a>
-        {% if guidelines_review_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_guidelines_components">
-        {% else  %}
-          <ul class="sidenav-second-level collapse" id="nav_guidelines_components">
-        {% endif %}
-            <li class="nav-item {% if guidelines_review_nav %}active{% endif %}">
-              <a id="nav_guidelines_review" class="nav-link" href="{% url 'guidelines_review' %}">Project review</a>
-            </li>
-          </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.project.can_view_stats %}
-        <li class="nav-item">
-        {% if stats_nav %}
-          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="false">
-        {% endif %}
-            <i class="fa fa-fw fa-chart-area"></i>
-            <span class="nav-link-text">Usage Stats</span>
-          </a>
-          {% if stats_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_stats_components">
-          {% else  %}
-          <ul class="sidenav-second-level collapse" id="nav_stats_components">
-          {% endif %}
-            <li class="nav-item {% if submenu == 'editorial' %}active{% endif %}">
-              <a id="nav_editorial_stats" class="nav-link" href="{% url 'editorial_stats' %}">Editorial</a>
-            </li>
-            <li class="nav-item {% if submenu == 'credential' %}active{% endif %}">
-              <a id="nav_credentialing_stats" class="nav-link" href="{% url 'credentialing_stats' %}">Credentialing</a>
-            </li>
-            <li class="nav-item {% if submenu == 'submissions' %}active{% endif %}">
-              <a id="nav_submission_stats" class="nav-link" href="{% url 'submission_stats' %}">Submissions</a>
-            </li>
-          </ul>
-        </li>
-      {% endif %}
-
-      {% if perms.physionet.change_staticpage or perms.physionet.change_frontpagebutton or perms.redirect.view_redirect %}
-      <li class="nav-item">
-        {% if frontpage_buttons_nav or static_pages_nav %}
-          <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_pages_components" data-parent="#sideAccordion" aria-expanded="true">
-        {% else %}
-          <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_pages_components" data-parent="#sideAccordion" aria-expanded="false">
-        {% endif %}
-            <i class="fa fa-fw fa-window-maximize"></i>
-            <span class="nav-link-text">Pages</span>
-          </a>
-        {% if frontpage_buttons_nav or static_pages_nav or redirects_nav %}
-          <ul class="sidenav-second-level collapse show" id="nav_pages_components">
-        {% else %}
-          <ul class="sidenav-second-level collapse" id="nav_pages_components">
-        {% endif %}
-            <li class="nav-item {% if static_pages_nav %}active{% endif %}">
-              <a id="nav_static_pages" class="nav-link" href="{% url 'static_pages' %}">Static Pages</a>
-            </li>
-            <li class="nav-item {% if frontpage_buttons_nav %}active{% endif %}">
-              <a id="nav_frontpage_buttons" class="nav-link" href="{% url 'frontpage_buttons' %}">Frontpage Buttons</a>
-            </li>
-            <li class="nav-item {% if redirects_nav %}active{% endif %}">
-              <a id="nav_redirects" class="nav-link" href="{% url 'redirects' %}">Redirects</a>
-            </li>
-          </ul>
-      </li>
-      {% endif %}
-
-      {% if perms.notification.change_news %}
-        <li class="nav-item {% if news_nav %}active{% endif %}">
-          <a id="nav_news_console" class="nav-link" href="{% url 'news_console' %}">
-            <i class="fa fa-fw fa-newspaper"></i>
-            <span class="nav-link-text">News</span>
-          </a>
-        </li>
-      {% endif %}
-
+      {% endfor %}
     <!-- end of menu items -->
     </ul>
 

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -33,18 +33,18 @@
       {% if perms.project.change_publishedproject %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
-          <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#projectComponents" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_projects_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#projectComponents" data-parent="#sideAccordion" aria-expanded="false">
+          <a id="nav_projects_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_projects_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-clipboard-list"></i>
             <span class="nav-link-text">Projects</span>
           </a>
           <!-- submenu -->
         {% if project_info_nav or submitted_projects_nav or unsubmitted_projects_nav or published_projects_nav or archived_projects_nav %}
-          <ul class="sidenav-second-level collapse show" id="projectComponents" style="">
+          <ul class="sidenav-second-level collapse show" id="nav_projects_components" style="">
         {% else %}
-          <ul class="sidenav-second-level collapse" id="projectComponents">
+          <ul class="sidenav-second-level collapse" id="nav_projects_components">
         {% endif %}
             <li class="nav-item {% if unsubmitted_projects_nav %}active{% endif %}">
               <a id="nav_unsubmitted_projects" class="nav-link" href="{% url 'unsubmitted_projects' %}">Unsubmitted</a>
@@ -75,27 +75,27 @@
       {% if perms.user.change_credentialapplication %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
-          <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_identity_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_identity_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#credentialComponents" data-parent="#sideAccordion" aria-expanded="false">
+          <a id="nav_identity_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_identity_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-hand-paper"></i>
             <span class="nav-link-text">Identity check</span>
           </a>
           <!-- submenu -->
         {% if credentials_nav or past_credentials_nav or known_ref_nav or processing_credentials_nav %}
-          <ul class="sidenav-second-level collapse show" id="credentialComponents">
+          <ul class="sidenav-second-level collapse show" id="nav_identity_components">
         {% else %}
-          <ul class="sidenav-second-level collapse" id="credentialComponents">
+          <ul class="sidenav-second-level collapse" id="nav_identity_components">
         {% endif %}
             <li class="nav-item {% if processing_credentials_nav %}active{% endif %}">
-              <a id="nav_credential_applications" href="{% url 'credential_processing' %}">Processing</a>
+              <a id="nav_credential_processing" href="{% url 'credential_processing' %}">Processing</a>
             </li>
             <li class="nav-item {% if past_credentials_nav %}active{% endif %} ">
-              <a id="nav_all_credential_applications" href="{% url 'credential_applications' 'successful' %}">All Applications</a>
+              <a id="nav_credential_applications__successful" href="{% url 'credential_applications' 'successful' %}">All Applications</a>
             </li>
             <li class="nav-item {% if known_ref_nav %}active{% endif %} ">
-              <a id="nav_known_ref" href="{% url 'known_references' %}">Known References</a>
+              <a id="nav_known_references" href="{% url 'known_references' %}">Known References</a>
             </li>
           </ul>
         </li>
@@ -104,7 +104,7 @@
       {% if perms.user.can_review_training %}
         <!-- training -->
         <li class="nav-item {% if training_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
-          <a id="nav_storage_requests" class="nav-link" href="{% url 'training_list' 'review' %}">
+          <a id="nav_training_list__review" class="nav-link" href="{% url 'training_list' 'review' %}">
             <i class="fa fa-fw fa-school"></i>
             <span class="nav-link-text">Training check</span>
           </a>
@@ -115,18 +115,18 @@
       {% if perms.user.view_all_events %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
           {% if events_nav %}
-            <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#events" data-parent="#sideAccordion" aria-expanded="true">
+            <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_events_components" data-parent="#sideAccordion" aria-expanded="true">
           {% else %}
-            <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#events" data-parent="#sideAccordion" aria-expanded="false">
+            <a id="nav_events_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_events_components" data-parent="#sideAccordion" aria-expanded="false">
           {% endif %}
               <i class="fa fa-fw fa-clipboard-list"></i>
               <span class="nav-link-text">Events</span>
             </a>
             <!-- submenu -->
           {% if nav_event_active or nav_event_archive %}
-            <ul class="sidenav-second-level collapse show" id="events">
+            <ul class="sidenav-second-level collapse show" id="nav_events_components">
           {% else  %}
-            <ul class="sidenav-second-level collapse" id="events">
+            <ul class="sidenav-second-level collapse" id="nav_events_components">
           {% endif %}
               <li class="nav-item {% if nav_event_active %}active{% endif %}">
                 <a id="nav_event_active" class="nav-link" href="{% url 'event_active' %}">Active</a>
@@ -142,37 +142,37 @@
       {% if perms.project.add_dua or perms.project.add_codeofconduct or perms.project.add_license or perms.events.add_eventagreement %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
           {% if license_nav or dua_nav or code_of_conduct_nav %}
-            <a id="nav_credentialing_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#license" data-parent="#sideAccordion" aria-expanded="true">
+            <a id="nav_legal_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_legal_components" data-parent="#sideAccordion" aria-expanded="true">
           {% else %}
-            <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#license" data-parent="#sideAccordion" aria-expanded="false">
+            <a id="nav_legal_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_legal_components" data-parent="#sideAccordion" aria-expanded="false">
           {% endif %}
               <i class="fa fa-fw fa-handshake"></i>
               <span class="nav-link-text">Legal</span>
             </a>
             <!-- submenu -->
           {% if license_nav or dua_nav or code_of_conduct_nav or event_agreement_nav %}
-            <ul class="sidenav-second-level collapse show" id="license">
+            <ul class="sidenav-second-level collapse show" id="nav_legal_components">
           {% else  %}
-            <ul class="sidenav-second-level collapse" id="license">
+            <ul class="sidenav-second-level collapse" id="nav_legal_components">
           {% endif %}
               {% if perms.project.add_license %}
                 <li class="nav-item {% if license_nav %}active{% endif %}">
-                  <a id="nav_license" class="nav-link" href="{% url 'license_list' %}">Licenses</a>
+                  <a id="nav_license_list" class="nav-link" href="{% url 'license_list' %}">Licenses</a>
                 </li>
               {% endif %}
               {% if perms.project.add_dua %}
                 <li class="nav-item {% if dua_nav %}active{% endif %}">
-                  <a id="nav_dua" class="nav-link" href="{% url 'dua_list' %}">DUAs</a>
+                  <a id="nav_dua_list" class="nav-link" href="{% url 'dua_list' %}">DUAs</a>
                 </li>
               {% endif %}
               {% if perms.project.add_codeofconduct %}
                 <li class="nav-item {% if code_of_conduct_nav %}active{% endif %}">
-                  <a id="nav_code_of_conduct" class="nav-link" href="{% url 'code_of_conduct_list' %}">Code of Conduct</a>
+                  <a id="nav_code_of_conduct_list" class="nav-link" href="{% url 'code_of_conduct_list' %}">Code of Conduct</a>
                 </li>
               {% endif %}
               {% if perms.events.add_eventagreement %}
                 <li class="nav-item {% if event_agreement_nav %}active{% endif %}">
-                  <a id="nav_event_agreement" class="nav-link" href="{% url 'event_agreement_list' %}">Event Agreements</a>
+                  <a id="nav_event_agreement_list" class="nav-link" href="{% url 'event_agreement_list' %}">Event Agreements</a>
                 </li>
               {% endif %}
             </ul>
@@ -183,31 +183,31 @@
       {% if perms.project.can_view_access_logs %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
-          <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#logsComponent" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_logs_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#logsComponent" data-parent="#sideAccordion" aria-expanded="false">
+          <a id="nav_logs_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_logs_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-fingerprint"></i>
             <span class="nav-link-text">Logs</span>
           </a>
           <!-- submenu -->
         {% if project_access_logs_nav or user_access_logs_nav or gcp_logs_nav or access_requests_nav %}
-          <ul class="sidenav-second-level collapse show" id="logsComponent" style="">
+          <ul class="sidenav-second-level collapse show" id="nav_logs_components" style="">
         {% else %}
-          <ul class="sidenav-second-level collapse" id="logsComponent">
+          <ul class="sidenav-second-level collapse" id="nav_logs_components">
         {% endif %}
             <li class="nav-item {% if project_access_logs_nav %}active{% endif %}">
               <a id="nav_project_access_logs" class="nav-link" href="{% url 'project_access_logs' %}">Project Logs</a>
             </li>
             <li class="nav-item {% if access_requests_nav %}active{% endif %}">
-              <a id="nav_all_users" class="nav-link" href="{% url 'project_access_requests_list' %}">Access Requests</a>
+              <a id="nav_project_access_requests_list" class="nav-link" href="{% url 'project_access_requests_list' %}">Access Requests</a>
             </li>
             <li class="nav-item {% if user_access_logs_nav %}active{% endif %}">
               <a id="nav_user_access_logs" class="nav-link" href="{% url 'user_access_logs' %}">User Logs</a>
             </li>
             {% if storage_type == 'GCP' %}
               <li class="nav-item {% if gcp_logs_nav %}active{% endif %}">
-                <a id="nav_gcp_logs" class="nav-link" href="{% url 'gcp_signed_urls_logs' %}">GCP Logs</a>
+                <a id="nav_gcp_signed_urls_logs" class="nav-link" href="{% url 'gcp_signed_urls_logs' %}">GCP Logs</a>
               </li>
             {% endif %}
           </ul>
@@ -219,33 +219,33 @@
       {% if perms.user.view_user %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if user_nav %}
-          <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#userComponents" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_users_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#userComponents" data-parent="#sideAccordion" aria-expanded="false">
+          <a id="nav_users_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_users_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-user-check"></i>
             <span class="nav-link-text">Users</span>
           </a>
           <!-- submenu -->
         {% if user_nav %}
-          <ul class="sidenav-second-level collapse show" id="userComponents">
+          <ul class="sidenav-second-level collapse show" id="nav_users_components">
         {% else  %}
-          <ul class="sidenav-second-level collapse" id="userComponents">
+          <ul class="sidenav-second-level collapse" id="nav_users_components">
         {% endif %}
             <li class="nav-item {% if group == 'active' %}active{% endif %}">
-              <a id="nav_active_users" class="nav-link" href="{% url 'users' 'active' %}">Active Users</a>
+              <a id="nav_users__active" class="nav-link" href="{% url 'users' 'active' %}">Active Users</a>
             </li>
             <li class="nav-item {% if group == 'inactive' %}active{% endif %}">
-              <a id="nav_inactive_users" class="nav-link" href="{% url 'users' 'inactive' %}">Inactive Users</a>
+              <a id="nav_users__inactive" class="nav-link" href="{% url 'users' 'inactive' %}">Inactive Users</a>
             </li>
             <li class="nav-item {% if group == 'all' %}active{% endif %}">
-              <a id="nav_all_users" class="nav-link" href="{% url 'users' 'all' %}">All Users</a>
+              <a id="nav_users__all" class="nav-link" href="{% url 'users' 'all' %}">All Users</a>
             </li>
             <li class="nav-item {% if user_groups_nav%}active{% endif %}">
               <a id="nav_user_groups" class="nav-link" href="{% url 'user_groups' %}">User Groups</a>
             </li>
             <li class="nav-item {% if group == 'admin' %}active{% endif %}">
-              <a id="nav_all_users" class="nav-link" href="{% url 'users' 'admin' %}">Administrators</a>
+              <a id="nav_users__admin" class="nav-link" href="{% url 'users' 'admin' %}">Administrators</a>
             </li>
           </ul>
         </li>
@@ -254,7 +254,7 @@
       <!-- featured content -->
       {% if perms.project.can_edit_featured_content %}
         <li class="nav-item {% if featured_content_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
-          <a id="nav_console_featured" class="nav-link" href="{% url 'featured_content' %}">
+          <a id="nav_featured_content" class="nav-link" href="{% url 'featured_content' %}">
             <i class="fa fa-fw fa-star"></i>
             <span class="nav-link-text">Featured Content</span>
           </a>
@@ -265,21 +265,21 @@
       {% if perms.project.can_view_project_guidelines %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if guidelines_review_nav %}
-          <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#guidelinesComponents" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_guidelines_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#guidelinesComponents" data-parent="#sideAccordion" aria-expanded="false">
+          <a id="nav_guidelines_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_guidelines_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-book"></i>
             <span class="nav-link-text">Guidelines</span>
           </a>
           <!-- submenu -->
         {% if guidelines_review_nav %}
-          <ul class="sidenav-second-level collapse show" id="guidelinesComponents">
+          <ul class="sidenav-second-level collapse show" id="nav_guidelines_components">
         {% else  %}
-          <ul class="sidenav-second-level collapse" id="guidelinesComponents">
+          <ul class="sidenav-second-level collapse" id="nav_guidelines_components">
         {% endif %}
             <li class="nav-item {% if guidelines_review_nav %}active{% endif %}">
-              <a href="{% url 'guidelines_review' %}">Project review</a>
+              <a id="nav_guidelines_review" href="{% url 'guidelines_review' %}">Project review</a>
             </li>
           </ul>
         </li>
@@ -289,28 +289,28 @@
       {% if perms.project.can_view_stats %}
         <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if stats_nav %}
-          <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_usage_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#statsComponents" data-parent="#sideAccordion" aria-expanded="False">
+          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="False">
         {% endif %}
             <i class="fa fa-fw fa-chart-area"></i>
             <span class="nav-link-text">Usage Stats</span>
           </a>
           <!-- submenu -->
           {% if stats_nav %}
-          <ul class="sidenav-second-level collapse show" id="statsComponents">
+          <ul class="sidenav-second-level collapse show" id="nav_stats_components">
           {% else  %}
-          <ul class="sidenav-second-level collapse" id="statsComponents">
+          <ul class="sidenav-second-level collapse" id="nav_stats_components">
           {% endif %}
             <li>
             <li class="nav-item {% if submenu == 'editorial' %}active{% endif %}">
-              <a href="{% url 'editorial_stats' %}">Editorial</a>
+              <a id="nav_editorial_stats" href="{% url 'editorial_stats' %}">Editorial</a>
             </li>
             <li class="nav-item {% if submenu == 'credential' %}active{% endif %}">
-              <a href="{% url 'credentialing_stats' %}">Credentialing</a>
+              <a id="nav_credentialing_stats" href="{% url 'credentialing_stats' %}">Credentialing</a>
             </li>
             <li class="nav-item {% if submenu == 'submissions' %}active{% endif %}">
-              <a href="{% url 'submission_stats' %}">Submissions</a>
+              <a id="nav_submission_stats" href="{% url 'submission_stats' %}">Submissions</a>
             </li>
           </ul>
         </li>
@@ -320,27 +320,27 @@
       {% if perms.physionet.change_staticpage or perms.physionet.change_frontpagebutton or perms.redirect.view_redirect %}
       <li class="nav-item" data-toggle="tooltip" data-placement="right">
         {% if frontpage_buttons_nav or static_pages_nav %}
-          <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#pagesComponent" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_pages_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
-          <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#pagesComponent" data-parent="#sideAccordion" aria-expanded="false">
+          <a id="nav_pages_dropdown" class="nav-link nav-link-collapse drop collapsed" data-toggle="collapse" href="#nav_pages_components" data-parent="#sideAccordion" aria-expanded="false">
         {% endif %}
             <i class="fa fa-fw fa-window-maximize"></i>
             <span class="nav-link-text">Pages</span>
           </a>
           <!-- submenu -->
         {% if frontpage_buttons_nav or static_pages_nav or redirects_nav %}
-          <ul class="sidenav-second-level collapse show" id="pagesComponent" style="">
+          <ul class="sidenav-second-level collapse show" id="nav_pages_components" style="">
         {% else %}
-          <ul class="sidenav-second-level collapse" id="pagesComponent">
+          <ul class="sidenav-second-level collapse" id="nav_pages_components">
         {% endif %}
             <li class="nav-item {% if static_pages_nav %}active{% endif %}">
-              <a id="nav_pages_dropdown" class="nav-link" href="{% url 'static_pages' %}">Static Pages</a>
+              <a id="nav_static_pages" class="nav-link" href="{% url 'static_pages' %}">Static Pages</a>
             </li>
             <li class="nav-item {% if frontpage_buttons_nav %}active{% endif %}">
-              <a id="nav_pages_dropdown" class="nav-link" href="{% url 'frontpage_buttons' %}">Frontpage Buttons</a>
+              <a id="nav_frontpage_buttons" class="nav-link" href="{% url 'frontpage_buttons' %}">Frontpage Buttons</a>
             </li>
             <li class="nav-item {% if redirects_nav %}active{% endif %}">
-              <a id="nav_pages_dropdown" class="nav-link" href="{% url 'redirects' %}">Redirects</a>
+              <a id="nav_redirects" class="nav-link" href="{% url 'redirects' %}">Redirects</a>
             </li>
           </ul>
       </li>
@@ -349,7 +349,7 @@
       <!-- news -->
       {% if perms.notification.change_news %}
         <li class="nav-item {% if news_nav %}active{% endif %}" data-toggle="tooltip" data-placement="right">
-          <a id="nav_console_news" class="nav-link" href="{% url 'news_console' %}">
+          <a id="nav_news_console" class="nav-link" href="{% url 'news_console' %}">
             <i class="fa fa-fw fa-newspaper"></i>
             <span class="nav-link-text">News</span>
           </a>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -289,7 +289,7 @@
       {% if perms.project.can_view_stats %}
         <li class="nav-item">
         {% if stats_nav %}
-          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="true">
+          <a id="nav_stats_dropdown" class="nav-link nav-link-collapse drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="true">
         {% else %}
           <a id="nav_stats_dropdown" class="nav-link nav-link-collapse collapsed drop" data-toggle="collapse" href="#nav_stats_components" data-parent="#sideAccordion" aria-expanded="False">
         {% endif %}
@@ -302,7 +302,6 @@
           {% else  %}
           <ul class="sidenav-second-level collapse" id="nav_stats_components">
           {% endif %}
-            <li>
             <li class="nav-item {% if submenu == 'editorial' %}active{% endif %}">
               <a id="nav_editorial_stats" class="nav-link" href="{% url 'editorial_stats' %}">Editorial</a>
             </li>

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -18,9 +18,10 @@
             <a id="nav_{{ item.name }}_dropdown"
                class="nav-link nav-link-collapse drop {{ item.active|yesno:',collapsed' }}"
                data-toggle="collapse"
-               href="#nav_{{ item.name }}_components"
+               data-target="#nav_{{ item.name }}_components"
                data-parent="#sideAccordion"
-               aria-expanded="{{ item.active|yesno:'true,false' }}">
+               aria-expanded="{{ item.active|yesno:'true,false' }}"
+               href="#">
               {% if item.icon %}
                 <span class="nav-link-icon fa fa-fw fa-{{ item.icon }}"></span>
               {% endif %}

--- a/physionet-django/console/templates/console/console_navbar.html
+++ b/physionet-django/console/templates/console/console_navbar.html
@@ -89,13 +89,13 @@
           <ul class="sidenav-second-level collapse" id="nav_identity_components">
         {% endif %}
             <li class="nav-item {% if processing_credentials_nav %}active{% endif %}">
-              <a id="nav_credential_processing" href="{% url 'credential_processing' %}">Processing</a>
+              <a id="nav_credential_processing" class="nav-link" href="{% url 'credential_processing' %}">Processing</a>
             </li>
             <li class="nav-item {% if past_credentials_nav %}active{% endif %} ">
-              <a id="nav_credential_applications__successful" href="{% url 'credential_applications' 'successful' %}">All Applications</a>
+              <a id="nav_credential_applications__successful" class="nav-link" href="{% url 'credential_applications' 'successful' %}">All Applications</a>
             </li>
             <li class="nav-item {% if known_ref_nav %}active{% endif %} ">
-              <a id="nav_known_references" href="{% url 'known_references' %}">Known References</a>
+              <a id="nav_known_references" class="nav-link" href="{% url 'known_references' %}">Known References</a>
             </li>
           </ul>
         </li>
@@ -279,7 +279,7 @@
           <ul class="sidenav-second-level collapse" id="nav_guidelines_components">
         {% endif %}
             <li class="nav-item {% if guidelines_review_nav %}active{% endif %}">
-              <a id="nav_guidelines_review" href="{% url 'guidelines_review' %}">Project review</a>
+              <a id="nav_guidelines_review" class="nav-link" href="{% url 'guidelines_review' %}">Project review</a>
             </li>
           </ul>
         </li>
@@ -304,13 +304,13 @@
           {% endif %}
             <li>
             <li class="nav-item {% if submenu == 'editorial' %}active{% endif %}">
-              <a id="nav_editorial_stats" href="{% url 'editorial_stats' %}">Editorial</a>
+              <a id="nav_editorial_stats" class="nav-link" href="{% url 'editorial_stats' %}">Editorial</a>
             </li>
             <li class="nav-item {% if submenu == 'credential' %}active{% endif %}">
-              <a id="nav_credentialing_stats" href="{% url 'credentialing_stats' %}">Credentialing</a>
+              <a id="nav_credentialing_stats" class="nav-link" href="{% url 'credentialing_stats' %}">Credentialing</a>
             </li>
             <li class="nav-item {% if submenu == 'submissions' %}active{% endif %}">
-              <a id="nav_submission_stats" href="{% url 'submission_stats' %}">Submissions</a>
+              <a id="nav_submission_stats" class="nav-link" href="{% url 'submission_stats' %}">Submissions</a>
             </li>
           </ul>
         </li>

--- a/physionet-django/console/templatetags/console_templatetags.py
+++ b/physionet-django/console/templatetags/console_templatetags.py
@@ -1,8 +1,31 @@
 from django import template
 
+from console.navbar import CONSOLE_NAV_MENU
 import notification.utility as notification
 
 register = template.Library()
+
+
+@register.simple_tag
+def console_nav_menu_items(request):
+    """
+    Get a list of menu items to be shown in the navigation bar.
+
+    Each menu item is a dictionary, representing either a link or a
+    submenu that contains one or more links.  The argument should be
+    the original HTTP request object; request.user determines which
+    menu items are visible, and request.path determines which menu
+    items are marked as "active".
+
+    Typically the return value of this tag will be assigned to a
+    template variable, e.g.:
+
+        {% console_nav_menu_items request as nav_menu_items %}
+        {% for item in nav_menu_items %}
+            ...
+        {% endfor %}
+    """
+    return CONSOLE_NAV_MENU.get_menu_items(request)
 
 
 @register.filter(name='task_count_badge')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -153,7 +153,7 @@ def console_permission_required(perm):
 def console_home(request):
     if not request.user.is_authenticated or not request.user.has_access_to_admin_console():
         raise PermissionDenied
-    return render(request, 'console/console_home.html', {'console_home_nav': True})
+    return render(request, 'console/console_home.html')
 
 
 @console_permission_required('project.change_activeproject')
@@ -222,7 +222,6 @@ def submitted_projects(request):
                    'copyedit_projects': copyedit_projects,
                    'approval_projects': approval_projects,
                    'publish_projects': publish_projects,
-                   'submitted_projects_nav': True,
                    'yesterday': yesterday})
 
 
@@ -326,8 +325,7 @@ def submission_info(request, project_slug):
                    'anonymous_url': anonymous_url, 'url_prefix': url_prefix,
                    'bulk_url_prefix': bulk_url_prefix,
                    'reassign_editor_form': reassign_editor_form,
-                   'embargo_form': embargo_form,
-                   'project_info_nav': True})
+                   'embargo_form': embargo_form})
 
 
 @handling_editor
@@ -745,8 +743,7 @@ def storage_requests(request):
         queryset=StorageRequest.objects.filter(is_active=True))
 
     return render(request, 'console/storage_requests.html',
-                  {'storage_response_formset': storage_response_formset,
-                   'storage_requests_nav': True})
+                  {'storage_response_formset': storage_response_formset})
 
 
 @console_permission_required('project.change_activeproject')
@@ -758,7 +755,7 @@ def unsubmitted_projects(request):
         'creation_datetime')
     projects = paginate(request, projects, 50)
     return render(request, 'console/unsubmitted_projects.html',
-                  {'projects': projects, 'unsubmitted_projects_nav': True})
+                  {'projects': projects})
 
 
 @console_permission_required('project.change_publishedproject')
@@ -769,7 +766,7 @@ def published_projects(request):
     projects = PublishedProject.objects.all().order_by('-publish_datetime')
     projects = paginate(request, projects, 50)
     return render(request, 'console/published_projects.html',
-                  {'projects': projects, 'published_projects_nav': True})
+                  {'projects': projects})
 
 
 @associated_task(PublishedProject, 'pid', read_only=True)
@@ -1061,7 +1058,6 @@ def manage_published_project(request, project_slug, version):
             'ro_tasks': ro_tasks,
             'anonymous_url': anonymous_url,
             'passphrase': passphrase,
-            'published_projects_nav': True,
             'url_prefix': url_prefix,
             'bulk_url_prefix': bulk_url_prefix,
             'contact_form': contact_form,
@@ -1159,7 +1155,7 @@ def archived_submissions(request):
                                             ).order_by('creation_datetime')
     projects = paginate(request, projects, 50)
     return render(request, 'console/archived_submissions.html',
-                  {'projects': projects, 'archived_projects_nav': True})
+                  {'projects': projects})
 
 
 @console_permission_required('user.view_user')
@@ -1175,7 +1171,6 @@ def users(request, group='all'):
         return render(request, 'console/users_admin.html', {
             'admin_users': admin_users,
             'group': group,
-            'user_nav': True,
         })
     elif group == 'active':
         user_list = user_list.filter(is_active=True)
@@ -1184,7 +1179,7 @@ def users(request, group='all'):
 
     users = paginate(request, user_list, 50)
 
-    return render(request, 'console/users.html', {'users': users, 'group': group, 'user_nav': True})
+    return render(request, 'console/users.html', {'users': users, 'group': group})
 
 
 @console_permission_required('user.view_user')
@@ -1195,7 +1190,7 @@ def user_groups(request):
     groups = Group.objects.all().order_by('name')
     for group in groups:
         group.user_count = User.objects.filter(groups=group).count()
-    return render(request, 'console/user_groups.html', {'groups': groups, 'user_nav': True, 'user_groups_nav': True})
+    return render(request, 'console/user_groups.html', {'groups': groups})
 
 
 @console_permission_required('user.view_user')
@@ -1209,7 +1204,7 @@ def user_group(request, group):
     return render(
         request,
         'console/user_group.html',
-        {'group': group, 'users': users, 'permissions': permissions, 'user_nav': True, 'user_groups_nav': True}
+        {'group': group, 'users': users, 'permissions': permissions}
     )
 
 
@@ -1526,7 +1521,7 @@ def process_credential_application(request, application_slug):
                   {'application': application, 'app_user': application.user,
                    'intermediate_credential_form': intermediate_credential_form,
                    'credential_review_form': credential_review_form,
-                   'processing_credentials_nav': True, 'page_title': page_title,
+                   'page_title': page_title,
                    'contact_cred_ref_form': contact_cred_ref_form,
                    'training_list': training})
 
@@ -1575,8 +1570,7 @@ def credential_processing(request):
                    'personal_applications': personal_applications,
                    'reference_applications': reference_applications,
                    'response_applications': response_applications,
-                   'final_applications': final_applications,
-                   'processing_credentials_nav': True})
+                   'final_applications': final_applications})
 
 
 @console_permission_required('user.change_credentialapplication')
@@ -1599,7 +1593,7 @@ def view_credential_application(request, application_slug):
 
     return render(request, 'console/view_credential_application.html',
                   {'application': application, 'app_user': application.user,
-                   'form': form, 'past_credentials_nav': True, 'CredentialApplication': CredentialApplication})
+                   'form': form, 'CredentialApplication': CredentialApplication})
 
 
 @console_permission_required('user.change_credentialapplication')
@@ -1676,7 +1670,7 @@ def credential_applications(request, status):
     pending_apps = paginate(request, pending_apps, 50)
 
     return render(request, 'console/credential_applications.html',
-                  {'applications': all_successful_apps, 'past_credentials_nav': True,
+                  {'applications': all_successful_apps,
                    'u_applications': unsuccessful_apps,
                    'p_applications': pending_apps})
 
@@ -1797,7 +1791,6 @@ def training_list(request, status):
             'valid_count': valid_training.count(),
             'expired_count': expired_training.count(),
             'rejected_count': rejected_training.count(),
-            'training_nav': True,
         },
     )
 
@@ -1916,7 +1909,7 @@ def news_console(request):
     news_items = News.objects.all().order_by('-publish_datetime')
     news_items = paginate(request, news_items, 50)
     return render(request, 'console/news_console.html',
-                  {'news_items': news_items, 'news_nav': True})
+                  {'news_items': news_items})
 
 
 @console_permission_required('notification.change_news')
@@ -1931,8 +1924,7 @@ def news_add(request):
     else:
         form = forms.NewsForm()
 
-    return render(request, 'console/news_add.html', {'form': form,
-                                                     'news_nav': True})
+    return render(request, 'console/news_add.html', {'form': form})
 
 
 @console_permission_required('notification.change_news')
@@ -1972,7 +1964,7 @@ def news_edit(request, news_slug):
         form = forms.NewsForm(instance=news)
 
     response = render(request, 'console/news_edit.html', {'news': news,
-                                                          'form': form, 'news_nav': True})
+                                                          'form': form})
     if saved:
         set_saved_fields_cookie(form, request.path, response)
     return response
@@ -2022,7 +2014,7 @@ def featured_content(request):
     ).order_by('featured')
 
     return render(request, 'console/featured_content.html',
-                  {'featured_content': featured_content, 'featured_content_nav': True})
+                  {'featured_content': featured_content})
 
 
 @console_permission_required('project.can_edit_featured_content')
@@ -2054,8 +2046,7 @@ def add_featured(request):
     return render(request, 'console/add_featured.html', {'title': title,
                                                          'projects': projects,
                                                          'form': form,
-                                                         'valid_search': valid_search,
-                                                         'featured_content_nav': True})
+                                                         'valid_search': valid_search})
 
 
 @console_permission_required('project.can_view_project_guidelines')
@@ -2063,8 +2054,7 @@ def guidelines_review(request):
     """
     Guidelines for reviewers.
     """
-    return render(request, 'console/guidelines_review.html',
-                  {'guidelines_review_nav': True})
+    return render(request, 'console/guidelines_review.html')
 
 
 @console_permission_required('project.can_view_stats')
@@ -2106,7 +2096,7 @@ def editorial_stats(request):
         except StatisticsError:
             stats[y].append(None)
 
-    return render(request, 'console/editorial_stats.html', {'stats_nav': True,
+    return render(request, 'console/editorial_stats.html', {
                   'submenu': 'editorial', 'stats': stats})
 
 
@@ -2173,7 +2163,7 @@ def credentialing_stats(request):
             stats[y]['time_to_decision'] = None
 
     return render(request, 'console/credentialing_stats.html',
-                  {'stats_nav': True, 'submenu': 'credential',
+                  {'submenu': 'credential',
                    'stats': stats})
 
 
@@ -2227,7 +2217,7 @@ def submission_stats(request):
                 pass
 
     return render(request, 'console/submission_stats.html',
-                  {'stats_nav': True, 'submenu': 'submission', 'stats': stats})
+                  {'submenu': 'submission', 'stats': stats})
 
 
 @console_permission_required('project.can_view_access_logs')
@@ -2299,7 +2289,7 @@ def project_access_manage(request, pid):
 
     return render(request, 'console/project_access_manage.html', {
         'c_project': c_project, 'project_members': c_project.duasignature_set.all(),
-        'project_access_logs_nav': True})
+    })
 
 
 @console_permission_required('project.can_view_access_logs')
@@ -2315,7 +2305,7 @@ def project_access_requests_list(request):
     projects = paginate(request, projects, 50)
 
     return render(request, 'console/project_access_requests_list.html', {
-        'access_requests_nav': True, 'projects': projects
+        'projects': projects
     })
 
 
@@ -2332,7 +2322,7 @@ def project_access_requests_detail(request, pk):
     access_requests = paginate(request, access_requests, 50)
 
     return render(request, 'console/project_access_requests_detail.html', {
-        'access_requests_nav': True, 'project': project, 'access_requests': access_requests
+        'project': project, 'access_requests': access_requests
     })
 
 
@@ -2359,7 +2349,7 @@ def project_access_logs(request):
     c_projects = paginate(request, c_projects, 50)
 
     return render(request, 'console/project_access_logs.html', {
-        'c_projects': c_projects, 'project_access_logs_nav': True,
+        'c_projects': c_projects,
     })
 
 
@@ -2388,7 +2378,7 @@ def project_access_logs_detail(request, pid):
 
     return render(request, 'console/project_access_logs_detail.html', {
         'c_project': c_project, 'logs': logs,
-        'project_access_logs_nav': True, 'user_filter_form': user_filter_form
+        'user_filter_form': user_filter_form
     })
 
 
@@ -2443,7 +2433,7 @@ def user_access_logs(request):
     users = paginate(request, users, 50)
 
     return render(request, 'console/user_access_logs.html', {
-        'users': users, 'user_access_logs_nav': True,
+        'users': users,
     })
 
 
@@ -2471,7 +2461,7 @@ def user_access_logs_detail(request, pid):
     project_filter_form = ProjectFilterForm()
 
     return render(request, 'console/user_access_logs_detail.html', {
-        'user': user, 'logs': logs, 'user_access_logs_nav': True,
+        'user': user, 'logs': logs,
         'project_filter_form': project_filter_form
     })
 
@@ -2515,7 +2505,7 @@ def gcp_signed_urls_logs(request):
     projects = paginate(request, projects, 50)
 
     return render(request, 'console/gcp_logs.html', {
-        'projects': projects, 'gcp_logs_nav': True,
+        'projects': projects,
     })
 
 
@@ -2529,7 +2519,6 @@ def gcp_signed_urls_logs_detail(request, pk):
 
     return render(request, 'console/gcp_logs_detail.html', {
         'project': project, 'logs': logs,
-        'gcp_logs_nav': True,
     })
 
 
@@ -2623,7 +2612,8 @@ def known_references(request):
     all_known_ref = paginate(request, all_known_ref, 50)
 
     return render(request, 'console/known_references.html', {
-        'all_known_ref': all_known_ref, 'known_ref_nav': True})
+        'all_known_ref': all_known_ref,
+    })
 
 
 @console_permission_required('redirects.view_redirect')
@@ -2635,7 +2625,7 @@ def view_redirects(request):
     return render(
         request,
         'console/redirects.html',
-        {'redirects': redirects, 'redirects_nav': True})
+        {'redirects': redirects})
 
 
 @console_permission_required('physionet.change_frontpagebutton')
@@ -2657,7 +2647,7 @@ def frontpage_buttons(request):
     return render(
         request,
         'console/frontpage_button/index.html',
-        {'frontpage_buttons': frontpage_buttons, 'frontpage_buttons_nav': True})
+        {'frontpage_buttons': frontpage_buttons})
 
 
 @console_permission_required('physionet.change_frontpagebutton')
@@ -2729,7 +2719,7 @@ def static_pages(request):
     return render(
         request,
         'console/static_page/index.html',
-        {'pages': pages, 'static_pages_nav': True})
+        {'pages': pages})
 
 
 @console_permission_required('physionet.change_staticpage')
@@ -2805,7 +2795,7 @@ def static_page_sections(request, page_pk):
     return render(
         request,
         'console/static_page_sections.html',
-        {'sections': sections, 'page': static_page, 'section_form': section_form, 'static_pages_nav': True},
+        {'sections': sections, 'page': static_page, 'section_form': section_form},
     )
 
 
@@ -2835,7 +2825,7 @@ def static_page_sections_edit(request, page_pk, section_pk):
     return render(
         request,
         'console/static_page_sections_edit.html',
-        {'section_form': section_form, 'static_pages_nav': True, 'page': static_page, 'section': section},
+        {'section_form': section_form, 'page': static_page, 'section': section},
     )
 
 
@@ -2858,7 +2848,7 @@ def license_list(request):
     return render(
         request,
         'console/license_list.html',
-        {'license_nav': True, 'licenses': licenses, 'license_form': license_form}
+        {'licenses': licenses, 'license_form': license_form}
     )
 
 
@@ -2880,7 +2870,7 @@ def license_detail(request, pk):
     return render(
         request,
         'console/license_detail.html',
-        {'license_nav': True, 'license': license, 'license_form': license_form}
+        {'license': license, 'license_form': license_form}
     )
 
 
@@ -2914,7 +2904,7 @@ def license_new_version(request, pk):
     return render(
         request,
         'console/license_new_version.html',
-        {'license_nav': True, 'license': license, 'license_form': license_form}
+        {'license': license, 'license_form': license_form}
     )
 
 
@@ -2934,7 +2924,7 @@ def dua_list(request):
     duas = DUA.objects.order_by('access_policy', 'name')
     duas = paginate(request, duas, 20)
 
-    return render(request, 'console/dua_list.html', {'dua_nav': True, 'duas': duas, 'dua_form': dua_form})
+    return render(request, 'console/dua_list.html', {'duas': duas, 'dua_form': dua_form})
 
 
 @console_permission_required('project.add_dua')
@@ -2952,7 +2942,7 @@ def dua_detail(request, pk):
     else:
         dua_form = forms.DUAForm(instance=dua)
 
-    return render(request, 'console/dua_detail.html', {'dua_nav': True, 'dua': dua, 'dua_form': dua_form})
+    return render(request, 'console/dua_detail.html', {'dua': dua, 'dua_form': dua_form})
 
 
 @console_permission_required('project.add_dua')
@@ -2982,7 +2972,7 @@ def dua_new_version(request, pk):
         dua_data['version'] = None
         dua_form = forms.DUAForm(initial=dua_data)
 
-    return render(request, 'console/dua_new_version.html', {'dua_nav': True, 'dua': dua, 'dua_form': dua_form})
+    return render(request, 'console/dua_new_version.html', {'dua': dua, 'dua_form': dua_form})
 
 
 @console_permission_required('project.add_codeofconduct')
@@ -3005,7 +2995,6 @@ def code_of_conduct_list(request):
         request,
         'console/code_of_conduct_list.html',
         {
-            'code_of_conduct_nav': True,
             'code_of_conducts': code_of_conducts,
             'code_of_conduct_form': code_of_conduct_form,
         },
@@ -3030,7 +3019,6 @@ def code_of_conduct_detail(request, pk):
         request,
         'console/code_of_conduct_detail.html',
         {
-            'code_of_conduct_nav': True,
             'code_of_conduct': code_of_conduct,
             'code_of_conduct_form': code_of_conduct_form,
         },
@@ -3067,7 +3055,6 @@ def code_of_conduct_new_version(request, pk):
         request,
         'console/code_of_conduct_new_version.html',
         {
-            'code_of_conduct_nav': True,
             'code_of_conduct': code_of_conduct,
             'code_of_conduct_form': code_of_conduct_form,
         },
@@ -3228,7 +3215,6 @@ def event_agreement_list(request):
         request,
         'console/event_agreement_list.html',
         {
-            'event_agreement_nav': True,
             'event_agreements': event_agreements,
             'event_agreement_form': event_agreement_form
         }
@@ -3258,7 +3244,6 @@ def event_agreement_new_version(request, pk):
         request,
         'console/event_agreement_new_version.html',
         {
-            'event_agreement_nav': True,
             'event_agreement': event_agreement,
             'event_agreement_form': event_agreement_form
         }
@@ -3284,7 +3269,6 @@ def event_agreement_detail(request, pk):
         request,
         'console/event_agreement_detail.html',
         {
-            'event_agreement_nav': True,
             'event_agreement': event_agreement,
             'event_agreement_form': event_agreement_form
         }

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -149,6 +149,7 @@ def console_permission_required(perm):
 # ------------------------- Views begin ------------------------- #
 
 
+@console_permission_required('user.can_view_admin_console')
 def console_home(request):
     if not request.user.is_authenticated or not request.user.has_access_to_admin_console():
         raise PermissionDenied

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -128,6 +128,24 @@ def handling_editor(base_view):
         raise Http404('Unable to access page')
     return handling_view
 
+
+def console_permission_required(perm):
+    """
+    Decorator for a view that requires user permissions.
+
+    If the client is not logged in, or the user doesn't have the
+    specified permission, the view raises PermissionDenied.
+
+    The required permission name is also stored as an attribute for
+    introspection purposes.
+    """
+    def wrapper(view):
+        view = permission_required(perm, raise_exception=True)(view)
+        view.required_permission = perm
+        return view
+    return wrapper
+
+
 # ------------------------- Views begin ------------------------- #
 
 
@@ -137,7 +155,7 @@ def console_home(request):
     return render(request, 'console/console_home.html', {'console_home_nav': True})
 
 
-@permission_required('project.change_activeproject', raise_exception=True)
+@console_permission_required('project.change_activeproject')
 def submitted_projects(request):
     """
     List of active submissions. Editors are assigned here.
@@ -207,7 +225,7 @@ def submitted_projects(request):
                    'yesterday': yesterday})
 
 
-@permission_required('project.change_activeproject', raise_exception=True)
+@console_permission_required('project.change_activeproject')
 def editor_home(request):
     """
     List of submissions the editor is responsible for
@@ -253,7 +271,7 @@ def submission_info_redirect(request, project_slug):
     return redirect('submission_info', project_slug=project_slug)
 
 
-@permission_required('project.change_activeproject', raise_exception=True)
+@console_permission_required('project.change_activeproject')
 def submission_info(request, project_slug):
     """
     View information about a project under submission
@@ -678,7 +696,7 @@ def publish_submission(request, project_slug, *args, **kwargs):
                    'embargo_form': embargo_form})
 
 
-@permission_required('project.change_storagerequest', raise_exception=True)
+@console_permission_required('project.change_storagerequest')
 def process_storage_response(request, storage_response_formset):
     """
     Implement the response to a storage request.
@@ -707,7 +725,7 @@ def process_storage_response(request, storage_response_formset):
                                   f"{notification.RESPONSE_ACTIONS[storage_request.response]}"))
 
 
-@permission_required('project.change_storagerequest', raise_exception=True)
+@console_permission_required('project.change_storagerequest')
 def storage_requests(request):
     """
     Page for listing and responding to project storage requests
@@ -730,7 +748,7 @@ def storage_requests(request):
                    'storage_requests_nav': True})
 
 
-@permission_required('project.change_activeproject', raise_exception=True)
+@console_permission_required('project.change_activeproject')
 def unsubmitted_projects(request):
     """
     List of unsubmitted projects
@@ -742,7 +760,7 @@ def unsubmitted_projects(request):
                   {'projects': projects, 'unsubmitted_projects_nav': True})
 
 
-@permission_required('project.change_publishedproject', raise_exception=True)
+@console_permission_required('project.change_publishedproject')
 def published_projects(request):
     """
     List of published projects
@@ -839,7 +857,7 @@ def update_aws_bucket_policy(pid):
     return updated_policy
 
 
-@permission_required('project.change_publishedproject', raise_exception=True)
+@console_permission_required('project.change_publishedproject')
 def manage_doi_request(request, project):
     """
     Manage a request to register or update a Digital Object Identifier (DOI).
@@ -884,7 +902,7 @@ def manage_doi_request(request, project):
     return message
 
 
-@permission_required('project.change_publishedproject', raise_exception=True)
+@console_permission_required('project.change_publishedproject')
 def manage_published_project(request, project_slug, version):
     """
     Manage a published project
@@ -1054,7 +1072,7 @@ def manage_published_project(request, project_slug, version):
     )
 
 
-@permission_required('project.change_publishedproject', raise_exception=True)
+@console_permission_required('project.change_publishedproject')
 def gcp_bucket_management(request, project, user):
     """
     Create the database object and cloud bucket if they do not exist, and send
@@ -1096,7 +1114,7 @@ def gcp_bucket_management(request, project, user):
     send_files_to_gcp(project.id, verbose_name='GCP - {}'.format(project), creator=user)
 
 
-@permission_required("project.change_publishedproject", raise_exception=True)
+@console_permission_required('project.change_publishedproject')
 def aws_bucket_management(request, project, user):
     """
     Manage AWS S3 bucket for a project.
@@ -1131,7 +1149,7 @@ def aws_bucket_management(request, project, user):
     send_files_to_aws(project.id, verbose_name='AWS - {}'.format(project), creator=user)
 
 
-@permission_required('project.change_activeproject', raise_exception=True)
+@console_permission_required('project.change_activeproject')
 def archived_submissions(request):
     """
     List of archived submissions
@@ -1143,7 +1161,7 @@ def archived_submissions(request):
                   {'projects': projects, 'archived_projects_nav': True})
 
 
-@permission_required('user.view_user', raise_exception=True)
+@console_permission_required('user.view_user')
 def users(request, group='all'):
     """
     List of users
@@ -1168,7 +1186,7 @@ def users(request, group='all'):
     return render(request, 'console/users.html', {'users': users, 'group': group, 'user_nav': True})
 
 
-@permission_required('user.view_user', raise_exception=True)
+@console_permission_required('user.view_user')
 def user_groups(request):
     """
     List of all user groups
@@ -1179,7 +1197,7 @@ def user_groups(request):
     return render(request, 'console/user_groups.html', {'groups': groups, 'user_nav': True, 'user_groups_nav': True})
 
 
-@permission_required('user.view_user', raise_exception=True)
+@console_permission_required('user.view_user')
 def user_group(request, group):
     """
     Shows details of a user group, lists users in the group, lists permissions for the group
@@ -1194,7 +1212,7 @@ def user_group(request, group):
     )
 
 
-@permission_required('user.view_user', raise_exception=True)
+@console_permission_required('user.view_user')
 def user_management(request, username):
     """
     Admin page for managing an individual user account.
@@ -1254,7 +1272,7 @@ def user_management(request, username):
                                                             'gcp_info': gcp_info})
 
 
-@permission_required('user.view_user', raise_exception=True)
+@console_permission_required('user.view_user')
 def users_search(request, group):
     """
     Search user list.
@@ -1290,7 +1308,7 @@ def users_search(request, group):
     raise Http404()
 
 
-@permission_required('user.view_user', raise_exception=True)
+@console_permission_required('user.view_user')
 def users_aws_access_list_json(request):
     """
     Generate JSON list of currently authorized AWS accounts.
@@ -1322,7 +1340,7 @@ def users_aws_access_list_json(request):
     return JsonResponse(datasets)
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def known_references_search(request):
     """
     Search credential applications and user list.
@@ -1350,7 +1368,7 @@ def known_references_search(request):
     raise Http404()
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def complete_credential_applications(request):
     """
     Legacy page for processing credentialing applications.
@@ -1358,7 +1376,7 @@ def complete_credential_applications(request):
     return redirect(credential_processing)
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def complete_list_credentialed_people(request):
     """
     Legacy page that displayed a list of all approved MIMIC users.
@@ -1366,7 +1384,7 @@ def complete_list_credentialed_people(request):
     return redirect(credential_applications, "successful")
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def process_credential_application(request, application_slug):
     """
     Process a credential application. View details, advance to next stage,
@@ -1512,7 +1530,7 @@ def process_credential_application(request, application_slug):
                    'training_list': training})
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def credential_processing(request):
     """
     Process applications for credentialed access.
@@ -1560,7 +1578,7 @@ def credential_processing(request):
                    'processing_credentials_nav': True})
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def view_credential_application(request, application_slug):
     """
     View a credential application in any status.
@@ -1583,7 +1601,7 @@ def view_credential_application(request, application_slug):
                    'form': form, 'past_credentials_nav': True, 'CredentialApplication': CredentialApplication})
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def credential_applications(request, status):
     """
     Inactive credential applications. Split into successful and
@@ -1662,7 +1680,7 @@ def credential_applications(request, status):
                    'p_applications': pending_apps})
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def search_credential_applications(request):
     """
     Search past credentialing applications.
@@ -1714,7 +1732,7 @@ def search_credential_applications(request):
         return all_successful_apps, unsuccessful_apps, pending_apps
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def credentialed_user_info(request, username):
     try:
         c_user = User.objects.get(username__iexact=username)
@@ -1726,7 +1744,7 @@ def credentialed_user_info(request, username):
                                                                    'CredentialApplication': CredentialApplication})
 
 
-@permission_required('user.can_review_training', raise_exception=True)
+@console_permission_required('user.can_review_training')
 def training_list(request, status):
     """
     List all training applications.
@@ -1806,7 +1824,7 @@ def search_training_applications(request, display_training):
     return display_training
 
 
-@permission_required('user.can_review_training', raise_exception=True)
+@console_permission_required('user.can_review_training')
 def training_process(request, pk):
     training = get_object_or_404(Training.objects.select_related('training_type', 'user__profile').get_review(), pk=pk)
 
@@ -1882,14 +1900,14 @@ def training_process(request, pk):
     )
 
 
-@permission_required('user.can_review_training', raise_exception=True)
+@console_permission_required('user.can_review_training')
 def training_detail(request, pk):
     training = get_object_or_404(Training.objects.prefetch_related('training_type'), pk=pk)
 
     return render(request, 'console/training_detail.html', {'training': training})
 
 
-@permission_required('notification.change_news', raise_exception=True)
+@console_permission_required('notification.change_news')
 def news_console(request):
     """
     List of news items
@@ -1900,7 +1918,7 @@ def news_console(request):
                   {'news_items': news_items, 'news_nav': True})
 
 
-@permission_required('notification.change_news', raise_exception=True)
+@console_permission_required('notification.change_news')
 def news_add(request):
     if request.method == 'POST':
         form = forms.NewsForm(data=request.POST)
@@ -1916,7 +1934,7 @@ def news_add(request):
                                                      'news_nav': True})
 
 
-@permission_required('notification.change_news', raise_exception=True)
+@console_permission_required('notification.change_news')
 def news_search(request):
     """
     Filtered list of news items
@@ -1931,7 +1949,7 @@ def news_search(request):
     raise Http404()
 
 
-@permission_required('notification.change_news', raise_exception=True)
+@console_permission_required('notification.change_news')
 def news_edit(request, news_slug):
     try:
         news = News.objects.get(slug=news_slug)
@@ -1959,7 +1977,7 @@ def news_edit(request, news_slug):
     return response
 
 
-@permission_required('project.can_edit_featured_content', raise_exception=True)
+@console_permission_required('project.can_edit_featured_content')
 def featured_content(request):
     """
     List of news items
@@ -2006,7 +2024,7 @@ def featured_content(request):
                   {'featured_content': featured_content, 'featured_content_nav': True})
 
 
-@permission_required('project.can_edit_featured_content', raise_exception=True)
+@console_permission_required('project.can_edit_featured_content')
 def add_featured(request):
     """
     List of news items
@@ -2039,7 +2057,7 @@ def add_featured(request):
                                                          'featured_content_nav': True})
 
 
-@permission_required('project.can_view_project_guidelines', raise_exception=True)
+@console_permission_required('project.can_view_project_guidelines')
 def guidelines_review(request):
     """
     Guidelines for reviewers.
@@ -2048,7 +2066,7 @@ def guidelines_review(request):
                   {'guidelines_review_nav': True})
 
 
-@permission_required('project.can_view_stats', raise_exception=True)
+@console_permission_required('project.can_view_stats')
 def editorial_stats(request):
     """
     Editorial stats for reviewers.
@@ -2091,7 +2109,7 @@ def editorial_stats(request):
                   'submenu': 'editorial', 'stats': stats})
 
 
-@permission_required('project.can_view_stats', raise_exception=True)
+@console_permission_required('project.can_view_stats')
 def credentialing_stats(request):
     """
     Credentialing metrics.
@@ -2158,7 +2176,7 @@ def credentialing_stats(request):
                    'stats': stats})
 
 
-@permission_required('project.can_view_stats', raise_exception=True)
+@console_permission_required('project.can_view_stats')
 def submission_stats(request):
     stats = OrderedDict()
     todays_date = datetime.today()
@@ -2211,7 +2229,7 @@ def submission_stats(request):
                   {'stats_nav': True, 'submenu': 'submission', 'stats': stats})
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def download_credentialed_users(request):
     """
     CSV create and download for database access.
@@ -2273,7 +2291,7 @@ def download_credentialed_users(request):
     return response
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def project_access_manage(request, pid):
     projects = PublishedProject.objects.prefetch_related('duasignature_set__user__profile')
     c_project = get_object_or_404(projects, id=pid, access_policy=AccessPolicy.CREDENTIALED)
@@ -2283,7 +2301,7 @@ def project_access_manage(request, pid):
         'project_access_logs_nav': True})
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def project_access_requests_list(request):
     projects = PublishedProject.objects.filter(access_policy=AccessPolicy.CONTRIBUTOR_REVIEW).annotate(
         access_requests_count=Count('data_access_requests')
@@ -2300,7 +2318,7 @@ def project_access_requests_list(request):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def project_access_requests_detail(request, pk):
     project = get_object_or_404(PublishedProject, access_policy=AccessPolicy.CONTRIBUTOR_REVIEW, pk=pk)
     access_requests = DataAccessRequest.objects.filter(project=project)
@@ -2317,14 +2335,14 @@ def project_access_requests_detail(request, pk):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def access_request(request, pk):
     access_request = get_object_or_404(DataAccessRequest, pk=pk)
 
     return render(request, 'console/access_request.html', {'access_request': access_request})
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def project_access_logs(request):
     c_projects = PublishedProject.objects.annotate(
         log_count=Count('logs', filter=Q(logs__category=LogCategory.ACCESS)))
@@ -2344,7 +2362,7 @@ def project_access_logs(request):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def project_access_logs_detail(request, pid):
     c_project = get_object_or_404(PublishedProject, id=pid)
     logs = (
@@ -2373,7 +2391,7 @@ def project_access_logs_detail(request, pid):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def download_project_accesses(request, pk):
     headers = ['User', 'Email address', 'First access', 'Last access', 'Duration', 'Count']
 
@@ -2404,7 +2422,7 @@ def download_project_accesses(request, pk):
     return response
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def user_access_logs(request):
     users = (
         User.objects.filter(is_active=True)
@@ -2428,7 +2446,7 @@ def user_access_logs(request):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def user_access_logs_detail(request, pid):
     user = get_object_or_404(User, id=pid, is_active=True)
     logs = (
@@ -2457,7 +2475,7 @@ def user_access_logs_detail(request, pid):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def download_user_accesses(request, pk):
     headers = ['Project name', 'First access', 'Last access', 'Duration', 'Count']
 
@@ -2484,7 +2502,7 @@ def download_user_accesses(request, pk):
     return response
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def gcp_signed_urls_logs(request):
     projects = ActiveProject.objects.annotate(
         log_count=Count('logs', filter=Q(logs__category=LogCategory.GCP)))
@@ -2500,7 +2518,7 @@ def gcp_signed_urls_logs(request):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def gcp_signed_urls_logs_detail(request, pk):
     project = get_object_or_404(ActiveProject, pk=pk)
     logs = project.logs.order_by('-creation_datetime').prefetch_related('project').annotate(
@@ -2514,7 +2532,7 @@ def gcp_signed_urls_logs_detail(request, pk):
     })
 
 
-@permission_required('project.can_view_access_logs', raise_exception=True)
+@console_permission_required('project.can_view_access_logs')
 def download_signed_urls_logs(request, pk):
     headers = ['User', 'Email address', 'First access', 'Last access', 'Duration', 'Data', 'Count']
 
@@ -2578,7 +2596,7 @@ class ProjectAutocomplete(autocomplete.Select2QuerySetView):
         return qs
 
 
-@permission_required('user.change_credentialapplication', raise_exception=True)
+@console_permission_required('user.change_credentialapplication')
 def known_references(request):
     """
     List all known references witht he option of removing the contact date
@@ -2607,7 +2625,7 @@ def known_references(request):
         'all_known_ref': all_known_ref, 'known_ref_nav': True})
 
 
-@permission_required('redirects.view_redirect', raise_exception=True)
+@console_permission_required('redirects.view_redirect')
 def view_redirects(request):
     """
     Display a list of redirected URLs.
@@ -2619,7 +2637,7 @@ def view_redirects(request):
         {'redirects': redirects, 'redirects_nav': True})
 
 
-@permission_required('physionet.change_frontpagebutton', raise_exception=True)
+@console_permission_required('physionet.change_frontpagebutton')
 def frontpage_buttons(request):
 
     if request.method == 'POST':
@@ -2641,7 +2659,7 @@ def frontpage_buttons(request):
         {'frontpage_buttons': frontpage_buttons, 'frontpage_buttons_nav': True})
 
 
-@permission_required('physionet.change_frontpagebutton', raise_exception=True)
+@console_permission_required('physionet.change_frontpagebutton')
 def frontpage_button_add(request):
     if request.method == 'POST':
         frontpage_button_form = forms.FrontPageButtonForm(data=request.POST)
@@ -2659,7 +2677,7 @@ def frontpage_button_add(request):
     )
 
 
-@permission_required('physionet.change_frontpagebutton', raise_exception=True)
+@console_permission_required('physionet.change_frontpagebutton')
 def frontpage_button_edit(request, button_pk):
 
     frontpage_button = get_object_or_404(FrontPageButton, pk=button_pk)
@@ -2682,7 +2700,7 @@ def frontpage_button_edit(request, button_pk):
     )
 
 
-@permission_required('physionet.change_frontpagebutton', raise_exception=True)
+@console_permission_required('physionet.change_frontpagebutton')
 def frontpage_button_delete(request, button_pk):
     frontpage_button = get_object_or_404(FrontPageButton, pk=button_pk)
     if request.method == 'POST':
@@ -2692,7 +2710,7 @@ def frontpage_button_delete(request, button_pk):
     return HttpResponseRedirect(reverse('frontpage_buttons'))
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_pages(request):
     if request.method == 'POST':
         up = request.POST.get('up')
@@ -2713,7 +2731,7 @@ def static_pages(request):
         {'pages': pages, 'static_pages_nav': True})
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_page_add(request):
     if request.method == 'POST':
         static_page_form = forms.StaticPageForm(data=request.POST)
@@ -2731,7 +2749,7 @@ def static_page_add(request):
     )
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_page_edit(request, page_pk):
 
     static_page = get_object_or_404(StaticPage, pk=page_pk)
@@ -2751,7 +2769,7 @@ def static_page_edit(request, page_pk):
     )
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_page_delete(request, page_pk):
     static_page = get_object_or_404(StaticPage, pk=page_pk)
     if request.method == 'POST':
@@ -2761,7 +2779,7 @@ def static_page_delete(request, page_pk):
     return HttpResponseRedirect(reverse('static_pages'))
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_page_sections(request, page_pk):
     static_page = get_object_or_404(StaticPage, pk=page_pk)
     if request.method == 'POST':
@@ -2790,7 +2808,7 @@ def static_page_sections(request, page_pk):
     )
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_page_sections_delete(request, page_pk, section_pk):
     static_page = get_object_or_404(StaticPage, pk=page_pk)
     if request.method == 'POST':
@@ -2801,7 +2819,7 @@ def static_page_sections_delete(request, page_pk, section_pk):
     return redirect('static_page_sections', page_pk=static_page.pk)
 
 
-@permission_required('physionet.change_staticpage', raise_exception=True)
+@console_permission_required('physionet.change_staticpage')
 def static_page_sections_edit(request, page_pk, section_pk):
     static_page = get_object_or_404(StaticPage, pk=page_pk)
     section = get_object_or_404(Section, static_page=static_page, pk=section_pk)
@@ -2820,7 +2838,7 @@ def static_page_sections_edit(request, page_pk, section_pk):
     )
 
 
-@permission_required('project.add_license', raise_exception=True)
+@console_permission_required('project.add_license')
 def license_list(request):
     if request.method == 'POST':
         license_form = forms.LicenseForm(data=request.POST)
@@ -2843,7 +2861,7 @@ def license_list(request):
     )
 
 
-@permission_required('project.add_license', raise_exception=True)
+@console_permission_required('project.add_license')
 def license_detail(request, pk):
     license = get_object_or_404(License, pk=pk)
 
@@ -2865,7 +2883,7 @@ def license_detail(request, pk):
     )
 
 
-@permission_required('project.add_license', raise_exception=True)
+@console_permission_required('project.add_license')
 def license_delete(request, pk):
     if request.method == 'POST':
         license = get_object_or_404(License, pk=pk)
@@ -2874,7 +2892,7 @@ def license_delete(request, pk):
     return redirect('license_list')
 
 
-@permission_required('project.add_license', raise_exception=True)
+@console_permission_required('project.add_license')
 def license_new_version(request, pk):
     license = get_object_or_404(License, pk=pk)
 
@@ -2899,7 +2917,7 @@ def license_new_version(request, pk):
     )
 
 
-@permission_required('project.add_dua', raise_exception=True)
+@console_permission_required('project.add_dua')
 def dua_list(request):
     if request.method == 'POST':
         dua_form = forms.DUAForm(data=request.POST)
@@ -2918,7 +2936,7 @@ def dua_list(request):
     return render(request, 'console/dua_list.html', {'dua_nav': True, 'duas': duas, 'dua_form': dua_form})
 
 
-@permission_required('project.add_dua', raise_exception=True)
+@console_permission_required('project.add_dua')
 def dua_detail(request, pk):
     dua = get_object_or_404(DUA, pk=pk)
 
@@ -2936,7 +2954,7 @@ def dua_detail(request, pk):
     return render(request, 'console/dua_detail.html', {'dua_nav': True, 'dua': dua, 'dua_form': dua_form})
 
 
-@permission_required('project.add_dua', raise_exception=True)
+@console_permission_required('project.add_dua')
 def dua_delete(request, pk):
     if request.method == 'POST':
         dua = get_object_or_404(DUA, pk=pk)
@@ -2945,7 +2963,7 @@ def dua_delete(request, pk):
     return redirect("dua_list")
 
 
-@permission_required('project.add_dua', raise_exception=True)
+@console_permission_required('project.add_dua')
 def dua_new_version(request, pk):
     dua = get_object_or_404(DUA, pk=pk)
 
@@ -2966,7 +2984,7 @@ def dua_new_version(request, pk):
     return render(request, 'console/dua_new_version.html', {'dua_nav': True, 'dua': dua, 'dua_form': dua_form})
 
 
-@permission_required('project.add_codeofconduct', raise_exception=True)
+@console_permission_required('project.add_codeofconduct')
 def code_of_conduct_list(request):
     if request.method == 'POST':
         code_of_conduct_form = forms.CodeOfConductForm(data=request.POST)
@@ -2993,7 +3011,7 @@ def code_of_conduct_list(request):
     )
 
 
-@permission_required('project.add_codeofconduct', raise_exception=True)
+@console_permission_required('project.add_codeofconduct')
 def code_of_conduct_detail(request, pk):
     code_of_conduct = get_object_or_404(CodeOfConduct, pk=pk)
     if request.method == 'POST':
@@ -3018,7 +3036,7 @@ def code_of_conduct_detail(request, pk):
     )
 
 
-@permission_required('project.add_codeofconduct', raise_exception=True)
+@console_permission_required('project.add_codeofconduct')
 def code_of_conduct_delete(request, pk):
     if request.method == 'POST':
         code_of_conduct = get_object_or_404(CodeOfConduct, pk=pk)
@@ -3027,7 +3045,7 @@ def code_of_conduct_delete(request, pk):
     return redirect("code_of_conduct_list")
 
 
-@permission_required('project.add_codeofconduct', raise_exception=True)
+@console_permission_required('project.add_codeofconduct')
 def code_of_conduct_new_version(request, pk):
     code_of_conduct = get_object_or_404(CodeOfConduct, pk=pk)
     if request.method == 'POST':
@@ -3055,7 +3073,7 @@ def code_of_conduct_new_version(request, pk):
     )
 
 
-@permission_required('project.add_codeofconduct', raise_exception=True)
+@console_permission_required('project.add_codeofconduct')
 def code_of_conduct_activate(request, pk):
     CodeOfConduct.objects.filter(is_active=True).update(is_active=False)
 
@@ -3068,7 +3086,7 @@ def code_of_conduct_activate(request, pk):
     return redirect("code_of_conduct_list")
 
 
-@permission_required('user.view_all_events', raise_exception=True)
+@console_permission_required('user.view_all_events')
 def event_active(request):
     """
     List of events
@@ -3082,7 +3100,7 @@ def event_active(request):
                    })
 
 
-@permission_required('user.view_all_events', raise_exception=True)
+@console_permission_required('user.view_all_events')
 def event_archive(request):
     """
     List of archived events
@@ -3096,7 +3114,7 @@ def event_archive(request):
                    })
 
 
-@permission_required("user.view_all_events", raise_exception=True)
+@console_permission_required('user.view_all_events')
 def event_management(request, event_slug):
     """
     Admin page for managing an individual Event.
@@ -3188,8 +3206,7 @@ def event_management(request, event_slug):
     )
 
 
-
-@permission_required('events.add_eventagreement', raise_exception=True)
+@console_permission_required('events.add_eventagreement')
 def event_agreement_list(request):
     if request.method == 'POST':
         event_agreement_form = EventAgreementForm(data=request.POST)
@@ -3217,7 +3234,7 @@ def event_agreement_list(request):
     )
 
 
-@permission_required('events.add_eventagreement', raise_exception=True)
+@console_permission_required('events.add_eventagreement')
 def event_agreement_new_version(request, pk):
     event_agreement = get_object_or_404(EventAgreement, pk=pk)
 
@@ -3247,7 +3264,7 @@ def event_agreement_new_version(request, pk):
     )
 
 
-@permission_required('events.add_eventagreement', raise_exception=True)
+@console_permission_required('events.add_eventagreement')
 def event_agreement_detail(request, pk):
     event_agreement = get_object_or_404(EventAgreement, pk=pk)
 
@@ -3273,7 +3290,7 @@ def event_agreement_detail(request, pk):
     )
 
 
-@permission_required('events.add_eventagreement', raise_exception=True)
+@console_permission_required('events.add_eventagreement')
 def event_agreement_delete(request, pk):
     if request.method == 'POST':
         event_agreement = get_object_or_404(EventAgreement, pk=pk)


### PR DESCRIPTION
`console/templates/console/console_navbar.html` defines the structure of the navigation sidebar/popup for the Admin Console.

Currently this file contains a huge amount of boilerplate code, some of which is useless, some of which is buggy; it's full of logic that needs to be kept in sync with views.py, and that can't easily be tested by the test suite.  The UI design is good, but the complicated implementation makes it needlessly difficult to add new features to the console.

With a bit of magic, this pull request removes the logic from the template and defines the menu structure in Python instead - replacing 300-ish lines of messy template code with 70-ish lines of Python (see the bottom of `console/navbar.py`).

This fixes some small bugs (styling of the stats menu, noscript accessibility) but shouldn't significantly change the appearance or functionality.

A few pages are now longer treated as "children" of their "parent" page, because their URLs don't match.  I intend to fix this by changing the URLs, but I would like to do that in a separate pull request.
