### PR TITLE
Migrate ArchivedProject content to ActiveProject

### DIFF
--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -340,6 +340,26 @@
   }
 },
 {
+  "model": "project.author",
+  "pk": 14,
+  "fields": {
+    "user": [
+      "admin"
+    ],
+    "display_order": 1,
+    "is_submitting": true,
+    "is_corresponding": true,
+    "approval_datetime": null,
+    "content_type": [
+      "project",
+      "activeproject"
+    ],
+    "object_id": 9,
+    "corresponding_email": 209,
+    "creation_date": "2020-04-10T16:08:49.337Z"
+  }
+},
+{
   "model": "project.publishedauthor",
   "pk": 1,
   "fields": {

--- a/physionet-django/project/migrations/0074_migrate_archived_to_active.py
+++ b/physionet-django/project/migrations/0074_migrate_archived_to_active.py
@@ -1,0 +1,69 @@
+from django.db import migrations
+from django.contrib.contenttypes.models import ContentType
+from project.models import SubmissionStatus
+
+
+def migrate_archived_to_active(apps, schema_editor):
+    """
+    Copy all ArchivedProject data to the ActiveProject model.
+    """
+    AnonymousAccess = apps.get_model("project", "AnonymousAccess")
+    ActiveProject = apps.get_model("project", "ActiveProject")
+    ArchivedProject = apps.get_model("project", "ArchivedProject")
+    Author = apps.get_model("project", "Author")
+    CopyeditLog = apps.get_model("project", "CopyeditLog")
+    EditLog = apps.get_model("project", "EditLog")
+    Log = apps.get_model("project", "Log")
+    Publication = apps.get_model("project", "Publication")
+    Reference = apps.get_model("project", "Reference")
+    Topic = apps.get_model("project", "Topic")
+    UploadedDocument = apps.get_model("project", "UploadedDocument")
+
+    # Get content types for both models
+    archived_project_type = ContentType.objects.get_for_model(ArchivedProject)
+    active_project_type = ContentType.objects.get_for_model(ActiveProject)
+
+    for archived_project in ArchivedProject.objects.all():
+        # Create a new ActiveProject instance
+        active_project = ActiveProject(
+            submission_status=SubmissionStatus.ARCHIVED.value,
+        )
+        for attr in [f.name for f in ArchivedProject._meta.fields]:
+            if attr != 'id':
+                setattr(active_project, attr, getattr(archived_project, attr))
+        active_project.save()
+
+        # Migrate references, authors, logs, etc from ArchivedProject to ActiveProject
+        for model in [Reference,
+                      Author,
+                      Log,
+                      AnonymousAccess,
+                      Topic,
+                      Publication,
+                      UploadedDocument,
+                      EditLog,
+                      CopyeditLog]:
+            items = model.objects.filter(
+                content_type_id=archived_project_type.id, object_id=archived_project.id
+            )
+            for item in items:
+                item.content_type_id = active_project_type.id
+                item.object_id = active_project.id
+                item.save()
+
+        # Delete the archived project
+        archived_project.delete()
+
+
+def migrate_backward(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("project", "0073_activeproject_archive_datetime"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_archived_to_active, migrate_backward),
+    ]


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/2166, we would like to migrate content from the (now deprecated) `ArchivedProject` model to the `ActiveProject` model.

This pull request:

1) Adds an Author to the "Failed demo software for parsing clinical notes" (`slug="t2ASGLbIBoWaTJvPrM2A"`) fixture.
2) Creates a migration that migrates ArchivedProjects (and associated objects, like authors, references, logs, etc) to ActiveProjects with SubmissionStatus=ARCHIVED.

I have tested this fairly comprehensively and have not found any issues. 

Note that files are **not** migrated. Files for archived projects will remain in the `pn-media/archived-projects` subfolder. We should migrate them to `pn-media/active-projects` later. 

One way of testing is to:

1 . Reset to `c49b2a1c640a0a6c07ee135f3ff84d45e2baa4e3` (e.g. `with git reset c49b2a1c640a0a6c07ee135f3ff84d45e2baa4e3 --hard`) which is the pull request prior to the archived status being added to the ActiveProject object.
2. Create a bunch of interesting ArchivedProjects using the console. Add references, co-authors, copyediting history, etc.
3. Pull down the latest version of this branch.
4. Run the migrations to migrate ArchivedProjects to ActiveProjects.
5. Try viewing archived projects in the console, author project page, etc.
6. Change the submission status of the archived projects to unsubmitted (`p.submission_status = 0`) and save the change.
7. Check whether the now-active projects are correctly populated in the author submission system. You should find that all pages work correctly, except `http://localhost:8000/projects/SLUG/files/`, which will raise a `FileNotFoundError` as expected.