### PR TITLE
Display credentialing status on event management page. Fixes #2163.

### DIFF
--- a/physionet-django/events/templates/events/event_applications.html
+++ b/physionet-django/events/templates/events/event_applications.html
@@ -13,15 +13,15 @@
             </tr>
           </thead>
           <tbody>
-              {% for object in info.objects %}
+              {% for application in info.objects %}
                 <tr>
-                  <td>{{ object.user.username }}</td>
-                  <td>{{ object.user.get_full_name }}</td>
-                  <td>{{ object.user.email }}</td>
-                  <td>{{ object.comment_to_applicant }}</td>
-                  <td>{{ object.decision_datetime | date }}</td>
+                  <td>{{ application.user.username }}</td>
+                  <td>{{ application.user.get_full_name }}</td>
+                  <td>{{ application.user.email }}</td>
+                  <td>{{ application.comment_to_applicant }}</td>
+                  <td>{{ application.decision_datetime | date }}</td>
                   <td>
-                    {% if object.is_cohost %}
+                    {% if application.is_cohost %}
                         <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ object.id }}" disabled checked>
                     {% else %}
                         <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ object.id }}" disabled>

--- a/physionet-django/events/templates/events/event_applications.html
+++ b/physionet-django/events/templates/events/event_applications.html
@@ -9,7 +9,6 @@
               <th>Full name</th>
               <th>Email</th>
               <th>Credentialed</th>
-              <th>Cohost</th>
             </tr>
           </thead>
           <tbody>
@@ -18,15 +17,7 @@
                   <td>{{ application.user.username }}</td>
                   <td>{{ application.user.get_full_name }}</td>
                   <td>{{ application.user.email }}</td>
-                  <td>{{ application.comment_to_applicant }}</td>
-                  <td>{{ application.decision_datetime | date }}</td>
-                  <td>
-                    {% if application.is_cohost %}
-                        <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ object.id }}" disabled checked>
-                    {% else %}
-                        <input type="checkbox" name="toggle-cohost-status"  event-slug="{{ event.slug }}" value="{{ object.id }}" disabled>
-                    {% endif %}
-                </td>
+                  <td>{{ application.user.is_credentialed }}</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/physionet-django/events/templates/events/event_home.html
+++ b/physionet-django/events/templates/events/event_home.html
@@ -102,7 +102,6 @@
     </ul>
   </div>
   <br>
-  {% if events_active %}
   {% for event in events_active %}
     {% for info in event_details|get_applicant_info:event.id %}
       <div class="modal fade" id="{{ info.id }}-modal-{{ event.id }}" tabindex="-1" role="dialog" aria-labelledby="{{ info.id }}-modal" aria-hidden="true">
@@ -120,7 +119,6 @@
         </div>
     {% endfor %}
   {% endfor %}
-  {% endif %}
    
 
 <!-- Past events -->


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/2163, the "credentialed" column on the event management page should display whether or not an event participant is credentialed.

As a result of a bug in the template, the credentialing status is not displayed. This pull request is a minor update to fix the bug. I also remove a couple of unused columns at the same time (e.g. "co-host").