### PR TITLE
Handle missing contact address in project_submission

### DIFF
--- a/physionet-django/project/modelcomponents/unpublishedproject.py
+++ b/physionet-django/project/modelcomponents/unpublishedproject.py
@@ -103,6 +103,29 @@ class UnpublishedProject(models.Model):
         """
         return self.files.has_wfdb_files(self)
 
+    @property
+    def editor_contact_email(self):
+        """
+        Email address for contacting the project editor.
+
+        If a site-wide contact address is configured, that address
+        will be used for all projects.  The string PROJECT-SLUG can be
+        included and will be replaced by the active project slug (for
+        example, PROJECT_EDITOR_EMAIL can be set to
+        'editor+PROJECT-SLUG@example.org', if the mail server
+        understands how to handle it.)
+
+        If there is no site-wide contact address, the primary email
+        address of the assigned editor is used.
+        """
+        if not self.editor:
+            return None
+        elif settings.PROJECT_EDITOR_EMAIL:
+            return settings.PROJECT_EDITOR_EMAIL.replace('PROJECT-SLUG',
+                                                         self.slug)
+        else:
+            return self.editor.email
+
     def content_modified(self):
         """
         Update the project's modification timestamp.

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1418,12 +1418,6 @@ def project_submission(request, project_slug, **kwargs):
     else:
         edit_logs, copyedit_logs = None, None
 
-    if settings.PROJECT_EDITOR_EMAIL:
-        contact_email = settings.PROJECT_EDITOR_EMAIL.replace('PROJECT-SLUG',
-                                                              project.slug)
-    else:
-        contact_email = project.editor.email
-
     return render(
         request,
         "project/project_submission.html",
@@ -1435,7 +1429,7 @@ def project_submission(request, project_slug, **kwargs):
             "edit_logs": edit_logs,
             "copyedit_logs": copyedit_logs,
             "awaiting_user_approval": awaiting_user_approval,
-            "contact_email": contact_email,
+            "contact_email": project.editor_contact_email,
         },
     )
 


### PR DESCRIPTION
Pull #2156 introduced the PROJECT_EDITOR_EMAIL setting.

If this setting is not defined (or blank) then we want to fall back to the old behavior of showing the assigned editor's email address.

However, if the project has not yet been assigned to an editor, and PROJECT_EDITOR_EMAIL is blank, it would crash.

(For example, clear the PROJECT_EDITOR_EMAIL setting, then log in as rgmark and try to submit the "MIMIC-III Clinical Database" project.)
