### PR TITLE
Don't crash on encountering an encrypted PDF file

### DIFF
--- a/physionet-django/console/services.py
+++ b/physionet-django/console/services.py
@@ -4,7 +4,7 @@ import re
 from typing import Optional
 
 from pdfminer.high_level import extract_text
-from pdfminer.pdfparser import PDFSyntaxError
+from pdfminer.pdfparser import PDFException
 from django.conf import settings
 
 from user.models import Training
@@ -29,7 +29,7 @@ def _get_regex_value_from_text(text: str, regex: str) -> Optional[str]:
 def _parse_pdf_to_string(training_path: str) -> str:
     try:
         text = extract_text(training_path)
-    except PDFSyntaxError:
+    except PDFException:
         text = ''
         logging.error(f'Failed to extract text from {training_path}')
     return ' '.join(text.split())


### PR DESCRIPTION
Some people have submitted PDF training reports to PhysioNet that are encrypted with a password.  I still don't know *why*, but at least three people did so.

We can't read them, so presumably these submissions ought to be rejected.  However, we currently aren't preventing these submissions, and trying to access the console page to view/reject the submission causes an error (PDFPasswordIncorrect, which is not a subclass of PDFSyntaxError).

This pull should treat encrypted PDF files the same as any other file that the server is unable to parse.

For more long-term solutions see issue #2179.
