### PR TITLE
Relative image URLs

### DIFF
--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -520,7 +520,10 @@ class TestProjectEditing(TestCase):
         <mfrac><mn>22</mn><mn>7</mn></mfrac></math>,
         some ambiguous characters & < >,
         <form>invalid tags</form>,
-        <span onclick="evil()">invalid attributes</span>
+        <span onclick="evil()">invalid attributes</span>,
+        <img src="http://testserver/foo.jpg" alt="full URL to image">,
+        <img src="/foo.jpg" alt="partial URL to image">,
+        <img src="https://example.com/foo.jpg" alt="cross-domain">
         </p>
         """
 
@@ -532,7 +535,10 @@ class TestProjectEditing(TestCase):
         <mfrac><mn>22</mn><mn>7</mn></mfrac></math>,
         some ambiguous characters &amp; &lt; &gt;,
         &lt;form&gt;invalid tags&lt;/form&gt;,
-        <span>invalid attributes</span>
+        <span>invalid attributes</span>,
+        <img src="/foo.jpg" alt="full URL to image">,
+        <img src="/foo.jpg" alt="partial URL to image">,
+        <img alt="cross-domain">
         </p>
         """
 

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -667,7 +667,7 @@ class LinkFilter:
         if scheme in ('http', 'https') and self.my_netloc_re.fullmatch(netloc):
             url = urllib.parse.urlunparse(('', '', path, params,
                                            query, fragment))
-        elif attr_name == 'src':
+        elif (scheme or netloc) and attr_name == 'src':
             # Discard cross-domain subresources
             return None
 

--- a/physionet-django/project/utility.py
+++ b/physionet-django/project/utility.py
@@ -551,6 +551,8 @@ class LinkFilter:
     >>> f = LinkFilter(my_hostnames=['example.com'])
     >>> f.convert('<img src="https://example.com/foo.jpg">')
     '<img src="/foo.jpg">'
+    >>> f.convert('<img src="/foo.jpg">')
+    '<img src="/foo.jpg">'
     >>> f.convert('<img src="https://unsafe.example.org/bar.jpg">')
     '<img>'
 


### PR DESCRIPTION
The link filter would transform:
```
<img src="https://physionet.org/static/images/background.jpg">
```
into:
```
<img src="/static/images/background.jpg">
```

But it would transform:
```
<img src="/static/images/background.jpg">
```
into:
```
<img>
```

which clearly is not what we want.

(~Amusingly~, it looks like ckeditor or browser (mis)feature would subsequently replace the sourceless image with `&nbsp;`.)

Y'all, I thought this feature was working years ago.  I'm sorry it wasn't.  People may have told me that it was broken and I didn't listen because it didn't come in the form of a bug report.
