### PR TITLE
Skip LightWAVE URL tests if sandboxed-lightwave is not installed

### DIFF
--- a/physionet-django/lightwave/urls.py
+++ b/physionet-django/lightwave/urls.py
@@ -1,3 +1,5 @@
+import shutil
+
 from django.urls import path
 
 from lightwave import views
@@ -16,4 +18,12 @@ urlpatterns = [
 TEST_DEFAULTS = {
     'project_slug': 'SHuKI1APLrwWCqxSQnSk',
     '_user_': 'rgmark',
+}
+TEST_CASES = {
+    'lightwave_server': {
+        '_skip_': lambda: (shutil.which('sandboxed-lightwave') is None),
+    },
+    'lightwave_project_server': {
+        '_skip_': lambda: (shutil.which('sandboxed-lightwave') is None),
+    },
 }


### PR DESCRIPTION
If sandboxed-lightwave isn't installed, but `ENABLE_LIGHTWAVE=True` (as it is by default) then TestURLs will fail:
```
ERROR: test_urls (physionet.test_urls.TestURLs) [/lightwave/server] (project_slug='SHuKI1APLrwWCqxSQnSk', _user_='rgmark')
...
TypeError: expected str, bytes or os.PathLike object, not NoneType

ERROR: test_urls (physionet.test_urls.TestURLs) [/lightwave/projects/%(project_slug)s/server] (project_slug='SHuKI1APLrwWCqxSQnSk', _user_='rgmark')
...
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

I want to have lightwave enabled in the standard demo configuration (sandboxed-lightwave is installed both in the github workflows and in install-pn-test-server) but not having it installed shouldn't get in the way of testing.
