### PR TITLE
[WIP] Bump minimum version of Python to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM python:3.10-bullseye
 
 RUN apt-get update -y \
     && apt-get upgrade -y \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The new PhysioNet platform built using Django. The new site is currently hosted 
 ## Running Local Instance Using Django Server
 
 - Install sqlite3: `sudo apt-get install sqlite3`.
-- Create python environment with >=python 3.8.
+- Create python environment with >=python 3.10.
 - Activate virtual python environment.
 - Install python packages in `requirements.txt`.
 - Copy `.env.example` file to `.env`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 bleach = "^3.3.0"
 boto3 = "^1.28.53"
 botocore = "^1.31.53"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
-asgiref==3.5.2 ; python_version >= "3.9" and python_version < "4.0" \
+asgiref==3.5.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4 \
     --hash=sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424
-bleach==3.3.0 ; python_version >= "3.9" and python_version < "4.0" \
+bleach==3.3.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125 \
     --hash=sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433
-boto3==1.28.53 ; python_version >= "3.9" and python_version < "4.0" \
+boto3==1.28.53 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:b95b0cc39f08402029c3a2bb141e1775cfa46576ebe9f9916f79bde90e27f53f \
     --hash=sha256:dc2da9aff7de359774030a243a09b74568664117e2afb77c6e4b90572ae3a6c3
-botocore==1.31.53 ; python_version >= "3.9" and python_version < "4.0" \
+botocore==1.31.53 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:905580ea724d74f11652bab63fcec6bf0d32f1cf8b2963f7388efc0ea406b69b \
     --hash=sha256:aa647f94039d21de97c969df21ce8c5186b68234eb5c53148f0d8bbd708e375d
-cachetools==4.2.2 ; python_version >= "3.9" and python_version < "4.0" \
+cachetools==4.2.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001 \
     --hash=sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff
-certifi==2023.7.22 ; python_version >= "3.9" and python_version < "4.0" \
+certifi==2023.7.22 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
-cffi==1.15.1 ; python_version >= "3.9" and python_version < "4.0" \
+cffi==1.15.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \
     --hash=sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef \
     --hash=sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104 \
@@ -81,13 +81,13 @@ cffi==1.15.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b \
     --hash=sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01 \
     --hash=sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0
-chardet==3.0.4 ; python_version >= "3.9" and python_version < "4.0" \
+chardet==3.0.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-charset-normalizer==2.0.12 ; python_version >= "3.9" and python_version < "4.0" \
+charset-normalizer==2.0.12 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
     --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
-coverage==7.2.3 ; python_version >= "3.9" and python_version < "4.0" \
+coverage==7.2.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:06ddd9c0249a0546997fdda5a30fbcb40f23926df0a874a60a8a185bc3a87d93 \
     --hash=sha256:0743b0035d4b0e32bc1df5de70fba3059662ace5b9a2a86a9f894cfe66569013 \
     --hash=sha256:0f3736a5d34e091b0a611964c6262fd68ca4363df56185902528f0b75dbb9c1f \
@@ -139,7 +139,7 @@ coverage==7.2.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:fa546d66639d69aa967bf08156eb8c9d0cd6f6de84be9e8c9819f52ad499c910 \
     --hash=sha256:fd214917cabdd6f673a29d708574e9fbdb892cb77eb426d0eae3490d95ca7859 \
     --hash=sha256:fff5aaa6becf2c6a1699ae6a39e2e6fb0672c2d42eca8eb0cafa91cf2e9bd312
-cryptography==41.0.6 ; python_version >= "3.9" and python_version < "4.0" \
+cryptography==41.0.6 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:068bc551698c234742c40049e46840843f3d98ad7ce265fd2bd4ec0d11306596 \
     --hash=sha256:0f27acb55a4e77b9be8d550d762b0513ef3fc658cd3eb15110ebbcbd626db12c \
     --hash=sha256:2132d5865eea673fe6712c2ed5fb4fa49dba10768bb4cc798345748380ee3660 \
@@ -163,69 +163,69 @@ cryptography==41.0.6 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:da46e2b5df770070412c46f87bac0849b8d685c5f2679771de277a422c7d0b86 \
     --hash=sha256:f39812f70fc5c71a15aa3c97b2bbe213c3f2a460b79bd21c40d033bb34a9bf36 \
     --hash=sha256:ff369dd19e8fe0528b02e8df9f2aeb2479f89b1270d90f96a63500afe9af5cae
-deprecated==1.2.13 ; python_version >= "3.9" and python_version < "4.0" \
+deprecated==1.2.13 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
     --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
-django-autocomplete-light==3.9.4 ; python_version >= "3.9" and python_version < "4.0" \
+django-autocomplete-light==3.9.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0f6da75c1c7186698b867a467a8cdb359f0513fdd8e09288a0c2fb018ae3d94e
-django-background-tasks-updated==1.2.7 ; python_version >= "3.9" and python_version < "4.0" \
+django-background-tasks-updated==1.2.7 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:b8cdb115350e7c4706dd1ae8061df7d9d7827906c8563c6228abbf0867236954 \
     --hash=sha256:d137c095e174c28e85aceb9c5071af22572d41f134a85ead22eb102b33027625
-django-ckeditor==6.5.1 ; python_version >= "3.9" and python_version < "4.0" \
+django-ckeditor==6.5.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1321f24df392f30698513930ce5c9f6d899f9bd0ef734c3b64fe936d809e11b3 \
     --hash=sha256:57cd8fb7cd150adca354cd4e5c35a743fadaab7073f957d2b7167f0d9fe1fcaf
-django-cors-headers==3.14.0 ; python_version >= "3.9" and python_version < "4.0" \
+django-cors-headers==3.14.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739 \
     --hash=sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e
-django-coverage-plugin==3.1.0 ; python_version >= "3.9" and python_version < "4.0" \
+django-coverage-plugin==3.1.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:223d34bf92bebadcb8b7b89932480e41c7bd98b44a8156934488fbe7f4a71f99 \
     --hash=sha256:eb0ea8ffdb0db11a02994fc99be6500550efb496c350d709f418ff3d8e553a67
-django-debug-toolbar==3.2.4 ; python_version >= "3.9" and python_version < "4.0" \
+django-debug-toolbar==3.2.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:644bbd5c428d3283aa9115722471769cac1bec189edf3a0c855fd8ff870375a9 \
     --hash=sha256:6b633b6cfee24f232d73569870f19aa86c819d750e7f3e833f2344a9eb4b4409
-django-js-asset==2.0.0 ; python_version >= "3.9" and python_version < "4.0" \
+django-js-asset==2.0.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:86f9f300d682537ddaf0487dc2ab356581b8f50c069bdba91d334a46e449f923 \
     --hash=sha256:adc1ee1efa853fad42054b540c02205344bb406c9bddf87c9e5377a41b7db90f
-django-oauth-toolkit==2.2.0 ; python_version >= "3.9" and python_version < "4.0" \
+django-oauth-toolkit==2.2.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:46890decb24a34e2a5382debeaf7752e50d90b7a11716cf2a9fd067097ec0963 \
     --hash=sha256:abd85c74af525a62365ec2049113e73a2ff8b46ef906e7104a7ba968ef02a11d
-django-sass==1.1.0 ; python_version >= "3.9" and python_version < "4.0" \
+django-sass==1.1.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:992f39d97a7b2d7d891255e5f99512ffd616b2e0aae1ca9b76983c5ecd603342 \
     --hash=sha256:da163cd7ad7b9c2f1f10f2ec8b76939640d5b32d21ee74a240ca50a059c5fe7a
-django-storages[google]==1.12.3 ; python_version >= "3.9" and python_version < "4.0" \
+django-storages[google]==1.12.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:204a99f218b747c46edbfeeb1310d357f83f90fa6a6024d8d0a3f422570cee84 \
     --hash=sha256:a475edb2f0f04c4f7e548919a751ecd50117270833956ed5bd585c0575d2a5e7
-django==4.1.13 ; python_version >= "3.9" and python_version < "4.0" \
+django==4.1.13 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:04ab3f6f46d084a0bba5a2c9a93a3a2eb3fe81589512367a75f79ee8acf790ce \
     --hash=sha256:94a3f471e833c8f124ee7a2de11e92f633991d975e3fa5bdd91e8abd66426318
-djangorestframework==3.14.0 ; python_version >= "3.9" and python_version < "4.0" \
+djangorestframework==3.14.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8 \
     --hash=sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08
-google-api-core==1.34.0 ; python_version >= "3.9" and python_version < "4.0" \
+google-api-core==1.34.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:6fb380f49d19ee1d09a9722d0379042b7edb06c0112e4796c7a395078a043e71 \
     --hash=sha256:7421474c39d396a74dfa317dddbc69188f2336835f526087c7648f91105e32ff
-google-api-core[grpc]==1.34.0 ; python_version >= "3.9" and python_version < "4.0" \
+google-api-core[grpc]==1.34.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:6fb380f49d19ee1d09a9722d0379042b7edb06c0112e4796c7a395078a043e71 \
     --hash=sha256:7421474c39d396a74dfa317dddbc69188f2336835f526087c7648f91105e32ff
-google-api-python-client==1.12.8 ; python_version >= "3.9" and python_version < "4.0" \
+google-api-python-client==1.12.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:3c4c4ca46b5c21196bec7ee93453443e477d82cbfa79234d1ce0645f81170eaf \
     --hash=sha256:f3b9684442eec2cfe9f9bb48e796ef919456b82142c7528c5fd527e5224f08bb
-google-auth-httplib2==0.1.0 ; python_version >= "3.9" and python_version < "4.0" \
+google-auth-httplib2==0.1.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10 \
     --hash=sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac
-google-auth==1.32.0 ; python_version >= "3.9" and python_version < "4.0" \
+google-auth==1.32.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:b3a67fa9ba5b768861dacf374c2135eb09fa14a0e40c851c3b8ea7abe6fc8fef \
     --hash=sha256:e34e5f5de5610b202f9b40ebd9f8b27571d5c5537db9afed3a72b2db5a345039
-google-cloud-core==1.7.0 ; python_version >= "3.9" and python_version < "4.0" \
+google-cloud-core==1.7.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2ab0cf260c11d0cc334573301970419abb6a1f3909c6cd136e4be996616372fe \
     --hash=sha256:9bd528810423aeaa428a9a178e7320883bbb690a8b0bb38297b794dc319c415a
-google-cloud-storage==1.42.3 ; python_version >= "3.9" and python_version < "4.0" \
+google-cloud-storage==1.42.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:71ee3a0dcf2c139f034a054181cd7658f1ec8f12837d2769c450a8a00fcd4c6d \
     --hash=sha256:7754d4dcaa45975514b404ece0da2bb4292acbc67ca559a69e12a19d54fcdb06
-google-cloud-workflows==1.9.1 ; python_version >= "3.9" and python_version < "4.0" \
+google-cloud-workflows==1.9.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:3267373a5caa51d84eaeb2f3aa847e4cb7688f97faa67a879c3d89cefbdd7c8c \
     --hash=sha256:e4b7fb22387caf45a5f4a25780911f71af9faa53093e0b020b8f46fa8cfe0578
-google-crc32c==1.1.2 ; python_version >= "3.9" and python_version < "4.0" \
+google-crc32c==1.1.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0ae3cf54e0d4d83c8af1afe96fc0970fbf32f1b29275f3bfd44ce25c4b622a2b \
     --hash=sha256:0dd9b61d0c63043b013349c9ec8a83ec2b05c96410c5bc257da5d0de743fc171 \
     --hash=sha256:110157fb19ab5db15603debfaf5fcfbac9627576787d9caf8618ff96821a7a1f \
@@ -255,16 +255,16 @@ google-crc32c==1.1.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:e6458c41236d37cb982120b070ebcc115687c852bee24cdd18792da2640cf44d \
     --hash=sha256:ea170341a4a9078a067b431044cd56c73553425833a7c2bb81734777a230ad4b \
     --hash=sha256:ef2ed6d0ac4de4ac602903e203eccd25ec8e37f1446fe1a3d2953a658035e0a5
-google-resumable-media==1.3.1 ; python_version >= "3.9" and python_version < "4.0" \
+google-resumable-media==1.3.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:106db689574283a7d9d154d5a97ab384153c55a1195cecb8c01cad9e6e827628 \
     --hash=sha256:1a1eb743d13f782d1405437c266b2c815ef13c2b141ba40835c74a3317539d01
-googleapis-common-protos==1.58.0 ; python_version >= "3.9" and python_version < "4.0" \
+googleapis-common-protos==1.58.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
-grpcio-status==1.48.2 ; python_version >= "3.9" and python_version < "4.0" \
+grpcio-status==1.48.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2c33bbdbe20188b2953f46f31af669263b6ee2a9b2d38fa0d36ee091532e21bf \
     --hash=sha256:53695f45da07437b7c344ee4ef60d370fd2850179f5a28bb26d8e2aa1102ec11
-grpcio==1.53.2 ; python_version >= "3.9" and python_version < "4.0" \
+grpcio==1.53.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:07b83c06e7d113044cf3da15ca52f578c5f3dca299af711e9a589c1b71eb8be5 \
     --hash=sha256:0c9e42f2499c8603af1d88771dc97e2c6b0310c278337058fd7fd1ddb35ab853 \
     --hash=sha256:0e92dc6a85cd1de42527812ef1276095e62169d002d86c888b6e889fcda1dd29 \
@@ -310,26 +310,26 @@ grpcio==1.53.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:f3761f9a6817e32898eaa5aecd0b0ad69d0c68ab45ea7bf206e8dc4548f025f0 \
     --hash=sha256:f7e66d8b31ef2bada7029275debbe12c97397ec7ac70a659837a7b8a6a9dc916 \
     --hash=sha256:f9f7c0dd17f24e1774cc3a8df738246772994e853c28b28ed6ba7711ccf0abb4
-hdn-research-environment==2.3.8 ; python_version >= "3.9" and python_version < "4.0" \
+hdn-research-environment==2.3.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:371b33950e3c1598b650edefd42fa19a3532d2ca815dd42f495f0460c57df97f
-html2text==2018.1.9 ; python_version >= "3.9" and python_version < "4.0" \
+html2text==2018.1.9 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:490db40fe5b2cd79c461cf56be4d39eb8ca68191ae41ba3ba79f6cb05b7dd662 \
     --hash=sha256:627514fb30e7566b37be6900df26c2c78a030cc9e6211bda604d8181233bcdd4
-httplib2==0.19.1 ; python_version >= "3.9" and python_version < "4.0" \
+httplib2==0.19.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d \
     --hash=sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4
-idna==2.10 ; python_version >= "3.9" and python_version < "4.0" \
+idna==2.10 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
-jinja2==3.1.3 ; python_version >= "3.9" and python_version < "4.0" \
+jinja2==3.1.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa \
     --hash=sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90
-jmespath==1.0.1 ; python_version >= "3.9" and python_version < "4.0" \
+jmespath==1.0.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
-jwcrypto==1.5.1 ; python_version >= "3.9" and python_version < "4.0" \
+jwcrypto==1.5.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:48bb9bf433777136253579e52b75ffe0f9a4a721d133d01f45a0b91ed5f4f1ae
-libsass==0.21.0 ; python_version >= "3.9" and python_version < "4.0" \
+libsass==0.21.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:06c8776417fe930714bdc930a3d7e795ae3d72be6ac883ff72a1b8f7c49e5ffb \
     --hash=sha256:12f39712de38689a8b785b7db41d3ba2ea1d46f9379d81ea4595802d91fa6529 \
     --hash=sha256:1e25dd9047a9392d3c59a0b869e0404f2b325a03871ee45285ee33b3664f5613 \
@@ -340,7 +340,7 @@ libsass==0.21.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:c9ec490609752c1d81ff6290da33485aa7cb6d7365ac665b74464c1b7d97f7da \
     --hash=sha256:d5ba529d9ce668be9380563279f3ffe988f27bc5b299c5a28453df2e0b0fbaf2 \
     --hash=sha256:e2b1a7d093f2e76dc694c17c0c285e846d0b0deb0e8b21dc852ba1a3a4e2f1d6
-markupsafe==2.1.3 ; python_version >= "3.9" and python_version < "4.0" \
+markupsafe==2.1.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e \
     --hash=sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e \
     --hash=sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431 \
@@ -401,19 +401,19 @@ markupsafe==2.1.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc \
     --hash=sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2 \
     --hash=sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11
-moto==4.2.10 ; python_version >= "3.9" and python_version < "4.0" \
+moto==4.2.10 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:5cf0736d1f43cb887498d00b00ae522774bfddb7db1f4994fedea65b290b9f0e \
     --hash=sha256:92595fe287474a31ac3ef847941ebb097e8ffb0c3d6c106e47cf573db06933b2
-oauthlib==3.2.2 ; python_version >= "3.9" and python_version < "4.0" \
+oauthlib==3.2.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca \
     --hash=sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918
-packaging==20.9 ; python_version >= "3.9" and python_version < "4.0" \
+packaging==20.9 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5 \
     --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
-pdfminer-six==20211012 ; python_version >= "3.9" and python_version < "4.0" \
+pdfminer-six==20211012 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0351f17d362ee2d48b158be52bcde6576d96460efd038a3e89a043fba6d634d7 \
     --hash=sha256:d3efb75c0249b51c1bf795e3a8bddf1726b276c77bf75fb136adea471ee2825b
-pillow==10.2.0 ; python_version >= "3.9" and python_version < "4.0" \
+pillow==10.2.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0304004f8067386b477d20a518b50f3fa658a28d44e4116970abfcd94fac34a8 \
     --hash=sha256:0689b5a8c5288bc0504d9fcee48f61a6a586b9b98514d7d29b840143d6734f39 \
     --hash=sha256:0eae2073305f451d8ecacb5474997c08569fb4eb4ac231ffa4ad7d342fdc25ac \
@@ -482,10 +482,10 @@ pillow==10.2.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:edca80cbfb2b68d7b56930b84a0e45ae1694aeba0541f798e908a49d66b837f1 \
     --hash=sha256:f379abd2f1e3dddb2b61bc67977a6b5a0a3f7485538bcc6f39ec76163891ee48 \
     --hash=sha256:fe4c15f6c9285dc54ce6553a3ce908ed37c8f3825b5a51a15c91442bb955b868
-proto-plus==1.22.2 ; python_version >= "3.9" and python_version < "4.0" \
+proto-plus==1.22.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165 \
     --hash=sha256:de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d
-protobuf==3.20.3 ; python_version >= "3.9" and python_version < "4.0" \
+protobuf==3.20.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7 \
     --hash=sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c \
     --hash=sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2 \
@@ -508,7 +508,7 @@ protobuf==3.20.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:e64857f395505ebf3d2569935506ae0dfc4a15cb80dc25261176c784662cdcc4 \
     --hash=sha256:f4bd856d702e5b0d96a00ec6b307b0f51c1982c2bf9c0052cf9019e9a544ba99 \
     --hash=sha256:f4c42102bc82a51108e449cbb32b19b180022941c727bac0cfd50170341f16ee
-psycopg2==2.9.5 ; python_version >= "3.9" and python_version < "4.0" \
+psycopg2==2.9.5 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:093e3894d2d3c592ab0945d9eba9d139c139664dcf83a1c440b8a7aa9bb21955 \
     --hash=sha256:190d51e8c1b25a47484e52a79638a8182451d6f6dff99f26ad9bd81e5359a0fa \
     --hash=sha256:1a5c7d7d577e0eabfcf15eb87d1e19314c8c4f0e722a301f98e0e3a65e238b4e \
@@ -522,34 +522,34 @@ psycopg2==2.9.5 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f \
     --hash=sha256:f5b6320dbc3cf6cfb9f25308286f9f7ab464e65cfb105b64cc9c52831748ced2 \
     --hash=sha256:fc04dd5189b90d825509caa510f20d1d504761e78b8dfb95a0ede180f71d50e5
-pyasn1-modules==0.2.8 ; python_version >= "3.9" and python_version < "4.0" \
+pyasn1-modules==0.2.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e \
     --hash=sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74
-pyasn1==0.4.8 ; python_version >= "3.9" and python_version < "4.0" \
+pyasn1==0.4.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
-pycparser==2.20 ; python_version >= "3.9" and python_version < "4.0" \
+pycparser==2.20 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0 \
     --hash=sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705
-pyopenssl==23.2.0 ; python_version >= "3.9" and python_version < "4.0" \
+pyopenssl==23.2.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:24f0dc5227396b3e831f4c7f602b950a5e9833d292c8e4a2e06b709292806ae2 \
     --hash=sha256:276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac
-pyparsing==2.4.7 ; python_version >= "3.9" and python_version < "4.0" \
+pyparsing==2.4.7 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
-python-dateutil==2.8.2 ; python_version >= "3.9" and python_version < "4.0" \
+python-dateutil==2.8.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-python-decouple==3.4 ; python_version >= "3.9" and python_version < "4.0" \
+python-decouple==3.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2e5adb0263a4f963b58d7407c4760a2465d464ee212d733e2a2c179e54c08d8f \
     --hash=sha256:a8268466e6389a639a20deab9d880faee186eb1eb6a05e54375bdf158d691981
-python-json-logger==2.0.2 ; python_version >= "3.9" and python_version < "4.0" \
+python-json-logger==2.0.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:202a4f29901a4b8002a6d1b958407eeb2dd1d83c18b18b816f5b64476dde9096 \
     --hash=sha256:99310d148f054e858cd5f4258794ed6777e7ad2c3fd7e1c1b527f1cba4d08420
-pytz==2022.1 ; python_version >= "3.9" and python_version < "4.0" \
+pytz==2022.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
     --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
-pyyaml==6.0.1 ; python_version >= "3.9" and python_version < "4.0" \
+pyyaml==6.0.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5 \
     --hash=sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc \
     --hash=sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df \
@@ -601,57 +601,57 @@ pyyaml==6.0.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585 \
     --hash=sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d \
     --hash=sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f
-requests-mock==1.9.3 ; python_version >= "3.9" and python_version < "4.0" \
+requests-mock==1.9.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970 \
     --hash=sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba
-requests-oauthlib==1.3.0 ; python_version >= "3.9" and python_version < "4.0" \
+requests-oauthlib==1.3.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d \
     --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a
-requests==2.31.0 ; python_version >= "3.9" and python_version < "4.0" \
+requests==2.31.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
     --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
-responses==0.24.1 ; python_version >= "3.9" and python_version < "4.0" \
+responses==0.24.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:a2b43f4c08bfb9c9bd242568328c65a34b318741d3fab884ac843c5ceeb543f9 \
     --hash=sha256:b127c6ca3f8df0eb9cc82fd93109a3007a86acb24871834c47b77765152ecf8c
-rsa==4.7.2 ; python_version >= "3.9" and python_version < "4" \
+rsa==4.7.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
-s3transfer==0.6.2 ; python_version >= "3.9" and python_version < "4.0" \
+s3transfer==0.6.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084 \
     --hash=sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861
-selenium==3.141.0 ; python_version >= "3.9" and python_version < "4.0" \
+selenium==3.141.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
     --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
-sentry-sdk==1.14.0 ; python_version >= "3.9" and python_version < "4.0" \
+sentry-sdk==1.14.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:273fe05adf052b40fd19f6d4b9a5556316807246bd817e5e3482930730726bb0 \
     --hash=sha256:72c00322217d813cf493fe76590b23a757e063ff62fec59299f4af7201dd4448
-setuptools==65.5.1 ; python_version >= "3.9" and python_version < "4.0" \
+setuptools==65.5.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31 \
     --hash=sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f
-six==1.16.0 ; python_version >= "3.9" and python_version < "4.0" \
+six==1.16.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-sqlparse==0.4.4 ; python_version >= "3.9" and python_version < "4.0" \
+sqlparse==0.4.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
     --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
-tzdata==2022.7 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32" \
+tzdata==2022.7 ; python_version >= "3.10" and python_version < "4.0" and sys_platform == "win32" \
     --hash=sha256:2b88858b0e3120792a3c0635c23daf36a7d7eeeca657c323da299d2094402a0d \
     --hash=sha256:fe5f866eddd8b96e9fcba978f8e503c909b19ea7efda11e52e39494bad3a7bfa
-uritemplate==3.0.1 ; python_version >= "3.9" and python_version < "4.0" \
+uritemplate==3.0.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f \
     --hash=sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae
-urllib3==1.26.18 ; python_version >= "3.9" and python_version < "4.0" \
+urllib3==1.26.18 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07 \
     --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
-uwsgi==2.0.22 ; python_version >= "3.9" and python_version < "4.0" \
+uwsgi==2.0.22 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:4cc4727258671ac5fa17ab422155e9aaef8a2008ebb86e4404b66deaae965db2
-webencodings==0.5.1 ; python_version >= "3.9" and python_version < "4.0" \
+webencodings==0.5.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-werkzeug==3.0.1 ; python_version >= "3.9" and python_version < "4.0" \
+werkzeug==3.0.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc \
     --hash=sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10
-wrapt==1.15.0 ; python_version >= "3.9" and python_version < "4.0" \
+wrapt==1.15.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0 \
     --hash=sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420 \
     --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a \
@@ -727,8 +727,8 @@ wrapt==1.15.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09 \
     --hash=sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559 \
     --hash=sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639
-xmltodict==0.13.0 ; python_version >= "3.9" and python_version < "4.0" \
+xmltodict==0.13.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56 \
     --hash=sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852
-zxcvbn==4.4.28 ; python_version >= "3.9" and python_version < "4.0" \
+zxcvbn==4.4.28 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1


### PR DESCRIPTION
This pull request bumps the minimum supported version of Python to 3.10, in preparation for upgrading to Django 5 (see: https://github.com/MIT-LCP/physionet-build/issues/2196). Alongside bumping the version here, we'll need to make sure that our servers are running Python 3.10 or greater.