### PR TITLE
Install and start rsyslog. Closes #2208.

### DIFF
--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -49,6 +49,8 @@ apt-get install -y \
         virtualenv python3-dev libpq-dev libffi-dev \
         `# Requirements for building LightWAVE` \
         build-essential libcap-dev libflac-dev libseccomp-dev \
+        `# Logging system` \
+        rsyslog \
         `# Other tools required by PhysioNet` \
         zip unzip xfsprogs \
         `# Development and administration tools` \
@@ -229,6 +231,9 @@ systemctl restart postfix
 # Disable network time so that we can play with the clock
 systemctl disable systemd-timesyncd
 systemctl stop systemd-timesyncd
+
+systemctl enable rsyslog
+systemctl restart rsyslog
 
 systemctl daemon-reload
 systemctl enable emperor.uwsgi


### PR DESCRIPTION
As discussed in #2208, we are using rsyslog for logging, but rsyslog is not installed on the test server. This pull request:

- Installs rsyslog on the test server
- Starts it running.