### PR TITLE
Added the environment variable in the example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,10 @@ SSO_LOGIN_BUTTON_TEXT="Single Sign-On"
 ENABLE_FILE_DOWNLOADS_OPTION=true
 COPY_FILES_TO_NEW_VERSION=true
 
+# Allowed Access Policies [Optional] - This is a list of access policies that can be assigned to a newly submitted project on the 'Project Access' page.
+# The environment variable is a stringified list of access policies separated by commas
+ALLOWED_ACCESS_POLICIES="OPEN,RESTRICTED,CREDENTIALED,CONTRIBUTOR_REVIEW"
+
 # Used for bucket creation
 GCP_DOMAIN=
 
@@ -214,7 +218,3 @@ CITI_SOAP_URL="https://webservices.citiprogram.org/SOAP/CITISOAPService.asmx"
 # See https://docs.djangoproject.com/en/4.2/ref/settings/
 DATA_UPLOAD_MAX_NUMBER_FILES=1000
 DATA_UPLOAD_MAX_MEMORY_SIZE=2621440
-
-# Allowed Access Policies [Optional] - This is a list of access policies that can be assigned to a project
-# The environment variable is a stringified list of access policies separated by commas
-ALLOWED_ACCESS_POLICIES="RESTRICTED,CREDENTIALED,CONTRIBUTOR_REVIEW"

--- a/.env.example
+++ b/.env.example
@@ -214,3 +214,7 @@ CITI_SOAP_URL="https://webservices.citiprogram.org/SOAP/CITISOAPService.asmx"
 # See https://docs.djangoproject.com/en/4.2/ref/settings/
 DATA_UPLOAD_MAX_NUMBER_FILES=1000
 DATA_UPLOAD_MAX_MEMORY_SIZE=2621440
+
+# Allowed Access Policies [Optional] - This is a list of access policies that can be assigned to a project
+# The environment variable is a stringified list of access policies separated by commas
+ALLOWED_ACCESS_POLICIES="RESTRICTED,CREDENTIALED,CONTRIBUTOR_REVIEW"


### PR DESCRIPTION
This PR is a followup to #2204 where the access policies are getting restricted. This adds the configuration setting to the .env.example with usage instructions and it's effects on the platform. 

