### PR TITLE
Configurable production database name and credentials

### DIFF
--- a/deploy/test-server/install-pn-test-server
+++ b/deploy/test-server/install-pn-test-server
@@ -132,9 +132,9 @@ su pn -c '
    cp -p /physionet/physionet-build/deploy/post-receive hooks/post-receive
 
    cd /physionet/physionet-build
-   grep -v ^SECRET_KEY= < .env.example > .env
+   grep -v -e ^SECRET_KEY= -e ^DB_PASSWORD= < .env.example > .env
    printf SECRET_KEY=%s\\n "$SECRET_KEY" >> .env
-   printf DATABASES_PASSWORD=%s\\n "$DBPASSWORD" >> .env
+   printf DB_PASSWORD=%s\\n "$DBPASSWORD" >> .env
    chgrp www-data .env
    chmod 640 .env
 

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -13,10 +13,10 @@ SITE_ID = 3
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'physionet',
-        'USER': 'physionet',
-        'PASSWORD': config('DATABASES_PASSWORD'),
-        'HOST': 'localhost',
+        'NAME': config('DB_NAME'),
+        'USER': config('DB_USER'),
+        'PASSWORD': config('DB_PASSWORD'),
+        'HOST': config('DB_HOST'),
         'PORT': '',
     }
 }

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -13,10 +13,10 @@ SITE_ID = 2
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'physionet',
-        'USER': 'physionet',
-        'PASSWORD': config('DATABASES_PASSWORD'),
-        'HOST': 'localhost',
+        'NAME': config('DB_NAME'),
+        'USER': config('DB_USER'),
+        'PASSWORD': config('DB_PASSWORD'),
+        'HOST': config('DB_HOST'),
         'PORT': '',
     }
 }


### PR DESCRIPTION
Allow configuring the production database name (and username and hostname) by bringing these old settings modules in line with the new style config variables used by physionet.settings.settings.

(All these variables *should* already be set correctly on all our servers, but of course we should check before deploying.)
