### PR TITLE
Add a DB_PORT configuration variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ SITE_ID=4
 DB_USER=physionet
 DB_PASSWORD=password
 DB_HOST=localhost
+DB_PORT=5432
 DB_NAME=physionet
 
 # Emails

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -17,7 +17,7 @@ DATABASES = {
         'USER': config('DB_USER'),
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
-        'PORT': '',
+        'PORT': config('DB_PORT', default=''),
     }
 }
 

--- a/physionet-django/physionet/settings/settings.py
+++ b/physionet-django/physionet/settings/settings.py
@@ -16,7 +16,7 @@ DATABASES = {
         'USER': config('DB_USER'),
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
-        'PORT': '',
+        'PORT': config('DB_PORT', default=''),
         'TEST': {
             'MIRROR': 'default'
         },

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -17,7 +17,7 @@ DATABASES = {
         'USER': config('DB_USER'),
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
-        'PORT': '',
+        'PORT': config('DB_PORT', default=''),
     }
 }
 


### PR DESCRIPTION
Similar to the DB_HOST and DB_NAME variables (see also pull #2219), add a configuration variable to control the port number for PostgreSQL.
