### PR TITLE
Remove "no_phi" from "quality assurance results"

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -179,7 +179,8 @@ class EditSubmissionForm(forms.ModelForm):
             self.initial['auto_doi'] = False
 
         # This will be used in clean
-        self.quality_assurance_fields = EditLog.QUALITY_ASSURANCE_FIELDS[resource_type.id]
+        self.quality_assurance_fields = [*EditLog.QUALITY_ASSURANCE_FIELDS[resource_type.id],
+                                         *EditLog.INTERNAL_QUALITY_ASSURANCE_FIELDS]
 
         rm_fields = set(self.base_fields) - set(self.quality_assurance_fields) - set(EditLog.EDITOR_FIELDS)
         for f in rm_fields:

--- a/physionet-django/project/modelcomponents/submission.py
+++ b/physionet-django/project/modelcomponents/submission.py
@@ -23,7 +23,6 @@ class EditLog(models.Model):
             'open_format',
             'data_machine_readable',
             'reusable',
-            'no_phi',
             'pn_suitable',
             'ethics_included',
         ),
@@ -32,7 +31,6 @@ class EditLog(models.Model):
             'soundly_produced',
             'well_described',
             'open_format',
-            'no_phi',
             'reusable',
             'pn_suitable',
             'ethics_included',
@@ -44,7 +42,6 @@ class EditLog(models.Model):
             'open_format',
             'data_machine_readable',
             'reusable',
-            'no_phi',
             'pn_suitable',
             'ethics_included',
         ),
@@ -55,11 +52,14 @@ class EditLog(models.Model):
             'open_format',
             'data_machine_readable',
             'reusable',
-            'no_phi',
             'pn_suitable',
             'ethics_included',
         ),
     )
+    # Internal quality assurance fields (required but not displayed)
+    INTERNAL_QUALITY_ASSURANCE_FIELDS = [
+        'no_phi',
+    ]
     # The editor's free input fields
     EDITOR_FIELDS = ('editor_comments', 'decision', 'auto_doi')
 


### PR DESCRIPTION
When a project is submitted, the editor is asked "Is the project free of protected health information?"

We don't want to give anyone the false impression that we have performed an exhaustive review or that this constitutes an "expert determination".  *That is the author's job, not ours.*

With this change, the question is still shown in the "Edit Submission" page (http://127.0.0.1:8000/console/submitted-projects/SHuKI1APLrwWCqxSQnSk/edit/).  The editor is still required to answer "Yes" before the project can be accepted.

However, to reduce the possibilities for confusion, we won't include the question in the "standard quality assurance results", which are displayed in a few places:
- Submission timeline:
   - http://127.0.0.1:8000/console/submitted-projects/SHuKI1APLrwWCqxSQnSk/copyedit/#timeline
   - http://127.0.0.1:8000/projects/SHuKI1APLrwWCqxSQnSk/submission/
   - http://127.0.0.1:8000/projects/published/demobsn/1.0/submission-history/
- Notification email:
   - accept_submission_notify.html
   - reject_submission_notify.html
   - revise_submission_notify.html

Fixes issue #2218.
