### PR TITLE
TestURLs coverage for project app

### DIFF
--- a/physionet-django/project/urls.py
+++ b/physionet-django/project/urls.py
@@ -95,10 +95,57 @@ urlpatterns = [
     ),
 ]
 
+# Parameters for testing URLs (see physionet/test_urls.py)
+TEST_DEFAULTS = {
+    '_user_': 'rgmark',
+    'project_slug': 'T108xFtYkRAxiRiuOLEJ',
+    'subdir': 'notes',
+    'file_name': 'notes/notes.txt',
+    'full_file_name': 'notes/notes.txt',
+}
 TEST_CASES = {
-    'project_files': {
-        '_user_': 'rgmark',
-        'project_slug': 'T108xFtYkRAxiRiuOLEJ',
-        'subdir': 'notes',
-    }
+    'new_project_version': {
+        'project_slug': 'demoeicu',
+    },
+    'archived_submission_history': {
+        '_user_': 'admin',
+        'project_slug': 't2ASGLbIBoWaTJvPrM2A',
+    },
+    'published_submission_history': {
+        'project_slug': 'demoeicu',
+        'version': '2.0.0',
+    },
+    'edit_affiliation': {
+        '_query_': {'add_first': 1},
+    },
+    'edit_content_item': [
+        {'_query_': {'add_first': 1, 'item': 'reference'}},
+        {'_query_': {'add_first': 1, 'item': 'publication'}},
+        {'_query_': {'add_first': 1, 'item': 'topic'}},
+    ],
+    'edit_ethics': {
+        '_query_': {'add_first': 1},
+    },
+    'project_files_panel': {
+        '_query_': {'subdir': 'notes'},
+    },
+    'preview_files_panel': {
+        '_query_': {'subdir': 'notes'},
+    },
+    'serve_document': {
+        # missing UploadedDocument in demo
+        '_skip_': True,
+        'file_name': 'Ethics_Approval_57e9ba85-eb58-4da5-a86f-2b653ba17cf4.pdf',
+    },
+    'published_project_request_access': {
+        # missing DataAccess in demo
+        '_skip_': True,
+        'project_slug': 'demoeicu',
+        'version': '2.0.0',
+        'access_type': '3',
+    },
+
+    # these views accept only POST
+    'generate_signed_url': {'_skip_': True},
+    'move_author': {'_skip_': True},
 }

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1518,6 +1518,8 @@ def edit_ethics(request, project_slug, **kwargs):
     elif request.method == 'POST' and 'remove_id' in request.POST:
         extra_forms = 0
         UploadedDocument.objects.get(id=int(request.POST['remove_id'])).delete()
+    else:
+        raise Http404()
 
     UploadedSupportingDocumentFormSet = generic_inlineformset_factory(
         UploadedDocument,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1213,7 +1213,10 @@ def preview_files_panel(request, project_slug, **kwargs):
     manipulate them. Called via ajax to navigate directories.
     """
     project = kwargs['project']
-    subdir = request.GET['subdir']
+    try:
+        subdir = request.GET['subdir']
+    except KeyError:
+        raise Http404()
 
     (display_files, display_dirs, dir_breadcrumbs, parent_dir,
      file_error) = get_project_file_info(project=project, subdir=subdir)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -367,6 +367,8 @@ def new_project_version(request, project_slug):
     previous_projects = PublishedProject.objects.filter(
         slug=project_slug).order_by('-version_order')
     latest_project = previous_projects.first()
+    if latest_project is None:
+        raise Http404()
 
     # Only submitting author can make new. Also can only have one new version
     # of this project out at a time.

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -982,7 +982,10 @@ def project_files_panel(request, project_slug, **kwargs):
     """
     project, is_submitting = (kwargs[k] for k in ('project', 'is_submitting'))
     is_editor = request.user == project.editor
-    subdir = request.GET['subdir']
+    try:
+        subdir = request.GET['subdir']
+    except KeyError:
+        raise Http404()
 
     if is_submitting and project.author_editable():
         files_editable = True

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -538,6 +538,8 @@ def edit_affiliation(request, project_slug, **kwargs):
             affiliation.delete()
         else:
             raise Http404()
+    else:
+        raise Http404()
 
     AffiliationFormSet = inlineformset_factory(parent_model=Author,
         model=Affiliation, fields=('name',), extra=extra_forms,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -705,16 +705,24 @@ def edit_content_item(request, project_slug):
 
     # Reload the formset with the first empty form
     if request.method == 'GET' and 'add_first' in request.GET:
-        item = request.GET['item']
-        model = model_dict[item]
+        try:
+            item = request.GET['item']
+            model = model_dict[item]
+        except KeyError:
+            raise Http404()
         extra_forms = 1
     # Remove an object
     elif request.method == 'POST' and 'remove_id' in request.POST:
-        item = request.POST['item']
-        model = model_dict[item]
+        try:
+            item = request.POST['item']
+            model = model_dict[item]
+            item_id = int(request.POST['remove_id'])
+        except (KeyError, ValueError):
+            raise Http404()
         extra_forms = 0
-        item_id = int(request.POST['remove_id'])
         model.objects.filter(id=item_id).delete()
+    else:
+        raise Http404()
 
     # Create the formset
     if is_generic_relation[item]:


### PR DESCRIPTION
This adds test coverage for most of the URLs in the `project` app.

See the previous pull requests #1695, #1922, #2108 for background.

With this change, the bulk of site functionality should now be included in the TestURLs framework.  A few small apps are left to add:
- `oauth` (should be easy)
- `sso` (should be easy but I'm not sure this is enabled in test configs)
- `training` (awaiting pull #1951)

And a number of URLs across the site are skipped due to a lack of fixture data:
- `console`
  - `edit_submission`
  - `copyedit_submission`
  - `awaiting_authors`
  - `publish_submission`
  - `event_agreement_detail`
  - `event_agreement_delete`
  - `event_agreement_new_version`
- `project`
  - `serve_document`
  - `published_project_request_access`
- `search`
  - `redirect_challenge_project`
