### PR TITLE
Update CITI course instructions page

### DIFF
--- a/physionet-django/templates/about/citi_course.html
+++ b/physionet-django/templates/about/citi_course.html
@@ -12,7 +12,7 @@
   <ol>
     <li>Once you have created an account, go to 'My Courses' on the top of the page. Click "Add affiliation"</li>
     <img src="{% static 'images/about/citi-course-instructions-1.png' %}" alt="Citi Course instructions 1" class="screenshot">
-    <li>Search for "Massachusetts Institute of Technology Affiliates". Click the checkmarks to agree. You are affiliating with MIT for the purpose of accessing data hosted on MIT servers.</li>
+    <li>Search for "Massachusetts Institute of Technology Affiliates". Click the checkmarks to agree. You are affiliating with MIT for the purpose of accessing data hosted on MIT servers. The MIT Affiliation is designated for non-MIT personnel to be able to register on CITI to take the 'Data or Specimens Only Research' course. It is advisable not to register as an independent learner to avoid paying additional fees.</li>
     <img src="{% static 'images/about/citi-course-instructions-2.png' %}" alt="Citi Course instructions 2" class="screenshot"> 
     <li>Fill out the form. Please use your institutional address, not a personal address, where possible (note, you do not require an MIT address).</li>
     <img src="{% static 'images/about/citi-course-instructions-3.png' %}" alt="Citi Course instructions 3" class="screenshot">


### PR DESCRIPTION
This PR follows #2228 by updating the instructions on step 2 to provide more details the MIT Affiliate status. The goal is to hopefully reduce emails with confusion around this affiliation status.