### PR TITLE
Fix resetdb after submitting UploadedDocuments

### DIFF
--- a/physionet-django/user/management/commands/resetdb.py
+++ b/physionet-django/user/management/commands/resetdb.py
@@ -94,13 +94,15 @@ def clear_media_files():
         media_subdir = os.path.join(settings.MEDIA_ROOT, subdir)
         subdir_items = [os.path.join(media_subdir, item) for item in os.listdir(media_subdir) if item != '.gitkeep']
         for item in subdir_items:
-            for root, dirs, files in os.walk(item):
-                for d in dirs:
-                    os.chmod(os.path.join(root, d), 0o755)
-                for f in files:
-                    os.chmod(os.path.join(root, f), 0o755)
-
-            shutil.rmtree(item)
+            if os.path.isdir(item):
+                for root, dirs, files in os.walk(item):
+                    for d in dirs:
+                        os.chmod(os.path.join(root, d), 0o755)
+                    for f in files:
+                        os.chmod(os.path.join(root, f), 0o755)
+                shutil.rmtree(item)
+            else:
+                os.remove(item)
 
 def clear_created_static_files():
     """


### PR DESCRIPTION
The original storage layout, designed by Chen, places all media files (and the dynamic static files) in subdirectories of subdirectories (`media/active-projects/SHuKI1APLrwWCqxSQnSk`, `media/credential-applications/YgqTQmcerj0gLx4MAaZV`, etc.)

Currently the UploadedDocument feature disregards this convention, and stores files in `media/ethics`.

Thus, it breaks the `resetdb` command, which assumes everything is stored in a subdirectory of a subdirectory.
