### PR TITLE
Fix publicationYear when creating/updating DOIs

### DIFF
--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -183,11 +183,13 @@
     <form action="{% url 'manage_published_project' project.slug project.version %}" method="POST" id="manage_doi_form">
       {% csrf_token %}
       {% if project.core_project.doi %}
-        <button class="btn btn-primary btn-rsp" type="submit" name="update_doi_core">
+        <button class="btn btn-primary btn-rsp" type="submit" name="update_doi_core"
+                {% if not project.is_latest_version %} disabled="disabled" {% endif %}>
           Update metadata (core)
         </button>
       {% else %}
-        <button class="btn btn-primary btn-rsp" type="submit" name="create_doi_core">
+        <button class="btn btn-primary btn-rsp" type="submit" name="create_doi_core"
+                {% if not project.is_latest_version %} disabled="disabled" {% endif %}>
           Create DOI (core)
         </button>  
       {% endif %}

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -6,6 +6,8 @@ import pdb
 
 import requests_mock
 from background_task.tasks import tasks
+from django.contrib.sites.models import Site
+from django.test import TestCase
 from django.test.utils import get_runner
 from django.urls import reverse
 from events.models import EventAgreement
@@ -456,6 +458,86 @@ class TestState(TestMixin):
             self.assertEqual(project.core_project.doi, '10.0000/bbb')
 
         self.assertEqual(mocker.call_count, 4)
+
+
+class TestPublished(TestCase):
+    """
+    Test functions for managing published projects.
+    """
+
+    @requests_mock.Mocker()
+    def test_register_doi(self, mocker):
+        """
+        Test registering new DOIs for a published project.
+        """
+        self.client.login(username='admin', password='Tester11!')
+
+        project = PublishedProject.objects.get(slug='demowave',
+                                               version='1.0.0')
+        self.assertIsNone(project.doi)
+        self.assertIsNone(project.core_project.doi)
+        self.assertTrue(project.is_latest_version)
+
+        site = Site.objects.get_current()
+        site_url = 'https://' + site.domain
+        published_url = site_url + reverse('published_project',
+                                           args=(project.slug,
+                                                 project.version))
+        core_url = site_url + reverse('published_project_latest',
+                                      args=(project.slug,))
+
+        management_url = reverse('manage_published_project',
+                                 args=(project.slug, project.version))
+
+        with self.settings(
+                DATACITE_API_URL='https://api.datacite.example/dois',
+                DATACITE_USER='admin',
+                DATACITE_PASSWORD='letmein',
+                DATACITE_PREFIX='10.0000'):
+
+            # Create new versioned DOI
+            mocker.post('https://api.datacite.example/dois', [
+                {'text': json.dumps(
+                    {'data': {'attributes': {'doi': '10.0000/ccc'}}})},
+            ])
+            response = self.client.post(management_url, data={
+                'create_doi_version': ''
+            })
+            self.assertEqual(response.status_code, 200)
+
+            project.refresh_from_db()
+            self.assertEqual(project.doi, '10.0000/ccc')
+
+            payload = mocker.last_request.json()
+            self.assertEqual(payload['data']['type'], 'dois')
+
+            attributes = payload['data']['attributes']
+            self.assertEqual(attributes['event'], 'publish')
+            self.assertEqual(attributes['publicationYear'],
+                             project.publish_datetime.year)
+            self.assertEqual(attributes['url'], published_url)
+
+            # Create new core DOI
+            mocker.post('https://api.datacite.example/dois', [
+                {'text': json.dumps(
+                    {'data': {'attributes': {'doi': '10.0000/ddd'}}})},
+            ])
+            response = self.client.post(management_url, data={
+                'create_doi_core': ''
+            })
+            self.assertEqual(response.status_code, 200)
+
+            project.core_project.refresh_from_db()
+            self.assertEqual(project.core_project.doi, '10.0000/ddd')
+
+            payload = mocker.last_request.json()
+            self.assertEqual(payload['data']['type'], 'dois')
+
+            attributes = payload['data']['attributes']
+            self.assertEqual(attributes['event'], 'publish')
+            self.assertEqual(attributes['publicationYear'],
+                             project.publish_datetime.year)
+            self.assertEqual(attributes['url'], core_url)
 
 
 class TestStaticPage(TestMixin):

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -456,6 +456,10 @@ def generate_doi_payload(project, core_project=False, event="draft"):
     """
     Generate a payload for registering or updating a DOI.
 
+    If event is "publish", project must be a PublishedProject object.
+    If event is "draft", project may be either a PublishedProject or
+    an ActiveProject.
+
     Args:
         project (obj): Project object.
         core_project (bool): If the metadata relates to the core project
@@ -480,6 +484,13 @@ def generate_doi_payload(project, core_project=False, event="draft"):
         version = "latest"
     else:
         version = project.version
+
+    if event == "publish":
+        publish_datetime = project.publish_datetime
+    elif event == "draft":
+        publish_datetime = timezone.now()
+    else:
+        raise Exception("event must be 'publish' or 'draft'")
 
     authors = []
     if event == "publish":
@@ -548,7 +559,7 @@ def generate_doi_payload(project, core_project=False, event="draft"):
                     "title": project.title
                 }],
                 "publisher": current_site.name,
-                "publicationYear": timezone.now().year,
+                "publicationYear": publish_datetime.year,
                 "types": {
                     "resourceTypeGeneral": resource_type
                 },

--- a/physionet-django/console/utility.py
+++ b/physionet-django/console/utility.py
@@ -472,6 +472,8 @@ def generate_doi_payload(project, core_project=False, event="draft"):
     current_site = Site.objects.get_current()
 
     if event == "publish" and core_project:
+        if not project.is_latest_version:
+            raise Exception("core_project=True requires the latest version")
         project_url = "https://{0}{1}".format(current_site, reverse(
             'published_project_latest', args=(project.slug,)))
     elif event == "publish":

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -878,11 +878,15 @@ def manage_doi_request(request, project):
         return "The DOI was created."
 
     if 'create_doi_core' in request.POST:
+        if not project.is_latest_version:
+            return "This is not the latest project version."
         payload = utility.generate_doi_payload(project, core_project=True,
                                                event="publish")
         utility.register_doi(payload, project.core_project)
         message = "The DOI was created."
     elif 'update_doi_core' in request.POST:
+        if not project.is_latest_version:
+            return "This is not the latest project version."
         payload = utility.generate_doi_payload(project, core_project=True,
                                                event="publish")
         utility.update_doi(project.core_project.doi, payload)


### PR DESCRIPTION
In the management page for a published project, there are buttons to create or update DOIs for the published project and its associated core project.  ("Update" if the project already has a DOI assigned, or "create" if it doesn't.)

The "publicationYear" in the DOI metadata should indicate the year when the resource was published, not the current year or the year the DOI was created.  This corresponds to the project's publish_datetime.

Previously, the page also gave you the option to create/update the core DOI even if you weren't looking at the latest project version.  This was not what you wanted - it would have erroneously applied the metadata of the old version.  This button is now disabled when inapplicable.

Fixes issue #2160.
