### PR TITLE
Show a count of the internal notes.

### DIFF
--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -1,4 +1,5 @@
 {% load project_templatetags %}
+{% load console_templatetags %}
 <div class="card mb-3">
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
@@ -28,7 +29,9 @@
       </li>
       {% endif %}
       <li class="nav-item">
-        <a class="nav-link" id="notes-tab" data-toggle="tab" href="#notes" role="tab" aria-controls="notes" aria-selected="false">Internal notes</a>
+        <a class="nav-link" id="notes-tab" data-toggle="tab" href="#notes" role="tab" aria-controls="notes" aria-selected="false">Internal notes
+          {{ notes|task_count_badge|safe }}
+        </a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This is a minor change to add a count of the number of internal notes on an active project. See the screenshot below, for example, which has 2 notes:

![Screenshot 2024-07-12 at 11 59 51 AM](https://github.com/user-attachments/assets/86ef29c5-8a11-4454-b41f-d1aa64488a02)
