### PR TITLE
Change the sorting of training applications in the admin console

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1789,11 +1789,11 @@ def training_list(request, status):
     """
     List all training applications.
     """
-    trainings = Training.objects.select_related(
-            'user__profile', 'training_type'
-    ).annotate(
-            application_date = TruncDate('application_datetime')
-    ).order_by('application_date', '-user__is_credentialed', 'application_datetime')
+    trainings = (
+        Training.objects.select_related("user__profile", "training_type")
+        .annotate(application_date=TruncDate("application_datetime"))
+        .order_by("application_date", "-user__is_credentialed", "application_datetime")
+    )
 
     training_types = TrainingType.objects.values_list("name", flat=True)
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -18,7 +18,7 @@ from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.redirects.models import Redirect
 from django.db.models import Count, DurationField, F, Q
-from django.db.models.functions import Cast
+from django.db.models.functions import Cast, TruncDate
 from django.forms import Select, Textarea, modelformset_factory
 from django.forms.models import model_to_dict
 from django.http import Http404, HttpResponse, JsonResponse, HttpResponseRedirect
@@ -1790,7 +1790,10 @@ def training_list(request, status):
     List all training applications.
     """
     trainings = Training.objects.select_related(
-        'user__profile', 'training_type').order_by('application_datetime', '-user__is_credentialed')
+            'user__profile', 'training_type'
+    ).annotate(
+            application_date = TruncDate('application_datetime')
+    ).order_by('application_date', '-user__is_credentialed', 'application_datetime')
 
     training_types = TrainingType.objects.values_list("name", flat=True)
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1790,7 +1790,7 @@ def training_list(request, status):
     List all training applications.
     """
     trainings = Training.objects.select_related(
-        'user__profile', 'training_type').order_by('-user__is_credentialed', 'application_datetime')
+        'user__profile', 'training_type').order_by('application_datetime', '-user__is_credentialed')
 
     training_types = TrainingType.objects.values_list("name", flat=True)
 


### PR DESCRIPTION
As outlined in #2263, the list of training applications is currently sorted first by credentialing status and then by the timestamp of the application submission. This makes it difficult to handle the applications in the order they came in.

I propose to order the training applications by the keys (and order):

1. Date
2. Credentialed Status
3. Time

Like this, the applications can be handled by the day they came in, while still handling applications of credentialed users first (as these are the ones where an accepted training is immediately useful).  Within these groups, the applications are ordered by their exact timestamp.