### PR TITLE
Fix Principal in AWS verification bucket policy

### DIFF
--- a/physionet-django/user/awsverification.py
+++ b/physionet-django/user/awsverification.py
@@ -273,7 +273,7 @@ def configure_aws_verification_bucket(bucket_name):
 
     # This must match the set of allowed principals
     # (see parse_aws_user_arn above).
-    principal = "arn:aws:iam::*:user/*"
+    principal = "*"
 
     # This must match the required verification key
     # (see get_aws_verification_key above).


### PR DESCRIPTION
In testing the new AWS user verification feature (see #2121), we found that the bucket policy written in the code didn't match the policy I had actually set for the `bm-uverify-test1` demo bucket.  (Sorry, I guess I never tested the final version of that code.)

We need to allow *any* principal, not only principals matching a pattern.

This new version of the policy has been tested on my personal AWS account, so hopefully it should work when we do the same on the PhysioNet account.
