### PR TITLE
docker-compose -> docker compose

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -4,9 +4,9 @@
 # All published images are also tagged with corresponding git commit sha.
 #
 # To run the tests locally in a similar environment to GitHub Actions you can use:
-# $ docker-compose -f docker/docker-compose.test.yml build
-# $ docker-compose -f docker/docker-compose.test.yml run --rm test
-# $ docker-compose -f docker/docker-compose.test.yml down
+# $ docker compose -f docker/docker-compose.test.yml build
+# $ docker compose -f docker/docker-compose.test.yml run --rm test
+# $ docker compose -f docker/docker-compose.test.yml down
 
 name: Docker / Build, Test and Publish
 
@@ -42,10 +42,10 @@ jobs:
           load: true
 
       - name: Run tests
-        run: docker-compose -f docker/docker-compose.test.yml run --rm test
+        run: docker compose -f docker/docker-compose.test.yml run --rm test
 
       - name: Stop and remove containers
-        run: docker-compose -f docker/docker-compose.test.yml down
+        run: docker compose -f docker/docker-compose.test.yml down
 
       - name: Save physionet image
         if: github.ref == 'refs/heads/dev' || github.event.inputs.publish_tag

--- a/GuideForNewDevelopers.md
+++ b/GuideForNewDevelopers.md
@@ -766,7 +766,7 @@ cp .env.example .env
 ##### 3.1.6.3 Build the physionet image
     
 ```sh
-docker-compose build 
+docker compose build 
 ```
 
 That should take care of all the setup for you, now let's go ahead start our server and load the demo data on our database.
@@ -776,7 +776,7 @@ That should take care of all the setup for you, now let's go ahead start our ser
 To start our server, we can do it with a single command.
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
 This will start our development server on [http://localhost:8000](http://localhost:8000), run the postgres database, development and test containers. Before you go ahead and play around with the project, we need to load the demo data on our test and development database (Note: we only need to load the demo data when doing the setup for the first time). 
@@ -793,7 +793,7 @@ cd physionet-build
 Enter the development container shell and navigate inside `physionet-django` directory.
 
 ```sh
-docker-compose exec dev /bin/bash
+docker compose exec dev /bin/bash
 ```
 ```sh
 cd physionet-django
@@ -811,7 +811,7 @@ Run the following commands to set up the database
 In a new Terminal, enter the test container shell and navigate inside `physionet-django` directory.
 
 ```sh
-docker-compose exec test /bin/bash
+docker compose exec test /bin/bash
 ```
 ```sh
 cd physionet-django
@@ -895,7 +895,7 @@ copy .env.example .env
 ##### 3.2.5.3 Build the physionet image
     
 ```cmd
-docker-compose build
+docker compose build
 ```
 
 That should take care of all the setup for you, now let's go ahead start our server and load the demo data on our database.
@@ -905,7 +905,7 @@ That should take care of all the setup for you, now let's go ahead start our ser
 To start our server, we can do it with a single command.
 
 ```cmd
-docker-compose up
+docker compose up
 ```
 
 This will start our development server on [http://localhost:8000](http://localhost:8000), run the postgres database, development and test containers. Before you go ahead and play around with the project, we need to load the demo data on our test and development database (Note: we only need to load the demo data when doing the setup for the first time). 
@@ -922,7 +922,7 @@ cd physionet-build
 Enter the development container shell and navigate inside `physionet-django` directory.
 
 ```cmd
-docker-compose exec dev /bin/bash
+docker compose exec dev /bin/bash
 ```
 
 ```sh
@@ -941,7 +941,7 @@ Run the following commands to set up the database
 In a new CMD, enter the test container shell and navigate inside `physionet-django` directory.
 
 ```cmd
-docker-compose exec test /bin/bash
+docker compose exec test /bin/bash
 ```
 ```sh
 cd physionet-django
@@ -1036,7 +1036,7 @@ cp .env.example .env
 ##### 3.3.5.3 Build the physionet image
     
 ```sh
-docker-compose build 
+docker compose build 
 ```
 
 That should take care of all the setup for you, now let's go ahead start our server and load the demo data on our database.
@@ -1046,7 +1046,7 @@ That should take care of all the setup for you, now let's go ahead start our ser
 To start our server, we can do it with a single command.
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
 This will start our development server on [http://localhost:8000](http://localhost:8000), run the postgres database, development and test containers. Before you go ahead and play around with the project, we need to load the demo data on our test and development database (Note: we only need to load the demo data when doing the setup for the first time). 
@@ -1063,7 +1063,7 @@ cd physionet-build
 Enter the development container shell and navigate inside `physionet-django` directory.
 
 ```sh
-docker-compose exec dev /bin/bash
+docker compose exec dev /bin/bash
 ```
 ```sh
 cd physionet-django
@@ -1081,7 +1081,7 @@ Run the following commands to set up the database
 In a new terminal, enter the test container shell and navigate inside `physionet-django` directory.
 
 ```sh
-docker-compose exec test /bin/bash
+docker compose exec test /bin/bash
 ```
 ```sh
 cd physionet-django

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ The local development server will be available at [http://localhost:8000](http:/
 
 - Install docker: [https://docs.docker.com/engine/install/](https://docs.docker.com/engine/install/).
 - Copy the example config: `cp .env.example .env`.
-- Build the physionet image: `docker-compose build`.
-- Run `docker-compose up` to run the postgres database, development and test containers.
+- Build the physionet image: `docker compose build`.
+- Run `docker compose up` to run the postgres database, development and test containers.
 - In a separate shell:
-  - Run: `docker-compose exec dev /bin/bash` to enter the development container shell.
+  - Run: `docker compose exec dev /bin/bash` to enter the development container shell.
   - Within the `physionet-django` directory:
     - Run: `python manage.py resetdb` to reset the database.
     - Run: `python manage.py loaddemo` to load the demo fixtures set up example files.
-  - Run: `docker-compose exec test /bin/bash` to enter the test container shell.
+  - Run: `docker compose exec test /bin/bash` to enter the test container shell.
   - Within the `physionet-django` directory:
     - Run: `python manage.py resetdb` to reset the database.
     - Run: `python manage.py loaddemo` to load the demo fixtures set up example files.
@@ -35,11 +35,11 @@ The local development server will be available at [http://localhost:8000](http:/
 
 The local development server will be available at [http://localhost:8000](http://localhost:8000).
 
-All the management commands should be executed inside the desired container (with `docker-compose exec dev /bin/bash/` or `docker-compose exec test /bin/bash`).
+All the management commands should be executed inside the desired container (with `docker compose exec dev /bin/bash/` or `docker compose exec test /bin/bash`).
 
-The code should dynamically reload in development, however, if there are any issues you can stop the `docker-compose up` command and run `docker-compose up --build` which will rebuild the physionet image.
+The code should dynamically reload in development, however, if there are any issues you can stop the `docker compose up` command and run `docker compose up --build` which will rebuild the physionet image.
 
-Docker-compose uses volumes to persist the database contents and data directories (media and static files). To clean up the created containers, networks and volumes stop `docker-compose up` and run `docker-compose down -v`. Do not run `docker-compose down -v` if you want to retain current database contents.
+Docker compose uses volumes to persist the database contents and data directories (media and static files). To clean up the created containers, networks and volumes stop `docker compose up` and run `docker compose down -v`. Do not run `docker compose down -v` if you want to retain current database contents.
 
 ## Background tasks
 
@@ -69,7 +69,7 @@ The debugger should now be available in the new shell.
 
 ## Testing
 
-If using docker, all of the commands should run inside the test container (`docker-compose exec test /bin/bash`). You may need to `pip install coverage` beforehand if not using docker.
+If using docker, all of the commands should run inside the test container (`docker compose exec test /bin/bash`). You may need to `pip install coverage` beforehand if not using docker.
 
 - Unit tests for each app are kept in their `test*.py` files.
 - To run the unit tests, change to the `physionet-django` directory and run `python manage.py test`.


### PR DESCRIPTION
We are seeing a new "`docker-compose: command not found`" error on the [docker-build-test.yml github workflow](https://github.com/MIT-LCP/physionet-build/blob/dev/.github/workflows/docker-build-test.yml). See: https://github.com/MIT-LCP/physionet-build/issues/2268

It looks like "`docker-compose`" is being phased out, in favour of "`docker compose`": 
https://docs.docker.com/compose/migrate/. This pull request switches all mentions to `docker-compose` to `docker compose`.

Merging this pull request should fix the error in: https://github.com/MIT-LCP/physionet-build/pull/1951