### PR TITLE
Add "downloads" page to console with link to CSV files

### DIFF
--- a/physionet-django/console/navbar.py
+++ b/physionet-django/console/navbar.py
@@ -204,7 +204,7 @@ CONSOLE_NAV_MENU = NavMenu([
         NavLink(_('Project review'), 'guidelines_review'),
     ]),
 
-    NavSubmenu(_('Usage Stats'), 'stats', 'chart-area', [
+    NavSubmenu(_('Metrics'), 'stats', 'chart-area', [
         NavLink(_('Editorial'), 'editorial_stats'),
         NavLink(_('Credentialing'), 'credentialing_stats'),
         NavLink(_('Submissions'), 'submission_stats'),

--- a/physionet-django/console/navbar.py
+++ b/physionet-django/console/navbar.py
@@ -208,6 +208,7 @@ CONSOLE_NAV_MENU = NavMenu([
         NavLink(_('Editorial'), 'editorial_stats'),
         NavLink(_('Credentialing'), 'credentialing_stats'),
         NavLink(_('Submissions'), 'submission_stats'),
+        NavLink(_('Download data'), 'downloads'),
     ]),
 
     NavSubmenu(_('Pages'), 'pages', 'window-maximize', [

--- a/physionet-django/console/templates/console/credentialing_stats.html
+++ b/physionet-django/console/templates/console/credentialing_stats.html
@@ -2,13 +2,13 @@
 
 {% load static %}
 
-{% block title %}Identity checks{% endblock %}
+{% block title %}Credentialing metrics{% endblock %}
 
 {% block content %}
 
 <div class="card mb-3">
   <div class="card-header">
-    Time to check identity
+    Credentialing metrics
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/console/templates/console/credentialing_stats.html
+++ b/physionet-django/console/templates/console/credentialing_stats.html
@@ -2,13 +2,13 @@
 
 {% load static %}
 
-{% block title %}Credentialing metrics{% endblock %}
+{% block title %}Identity checks{% endblock %}
 
 {% block content %}
 
 <div class="card mb-3">
   <div class="card-header">
-    Credentialing metrics
+    Time to check identity
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/console/templates/console/downloads.html
+++ b/physionet-django/console/templates/console/downloads.html
@@ -1,0 +1,36 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}Download data{% endblock %}
+
+{% block content %}
+
+<div class="card mb-3">
+  <div class="card-header">
+    Download data
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+        
+      <div class="mb-4">
+        <h6>Users</h6>
+        <p>Download a complete list of users, including their names, email addresses, and registration dates.</p>
+        <a href="{% url 'download_users' %}" class="btn btn-primary">
+          Download users
+        </a>
+      </div>
+      
+      <div class="mb-4">
+        <h6>Projects</h6>
+        <p>Download a complete list of published projects, including project names, descriptions, and timelines.</p>
+        <a href="{% url 'download_projects' %}" class="btn btn-primary">
+          Download projects
+        </a>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/physionet-django/console/templates/console/editorial_stats.html
+++ b/physionet-django/console/templates/console/editorial_stats.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">
-    Usage stats for reviewers
+    Time to review
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/console/templates/console/submission_stats.html
+++ b/physionet-django/console/templates/console/submission_stats.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="card mb-3">
   <div class="card-header">
-    Project statistics over previous 18 months
+    New projects (past 18 months)
   </div>
   <div class="card-body">
     <div class="table-responsive">
@@ -13,10 +13,10 @@
         <tr>
           <th>Year</th>
           <th>Month</th>
-          <th>Projects Created</th>
-          <th>New Submissions</th>
-          <th>Resubmissions</th>
-          <th>Publications</th>
+          <th>Created</th>
+          <th>Submitted</th>
+          <th>Resubmitted</th>
+          <th>Published</th>
         </tr>
         {% for year, month_list in stats.items%}
           {% for month, val in month_list.items%}

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -105,6 +105,9 @@ urlpatterns = [
     path('usage/editorial/stats/', views.editorial_stats, name='editorial_stats'),
     path('usage/credentialing/stats/', views.credentialing_stats, name='credentialing_stats'),
     path('usage/submission/stats/', views.submission_stats, name='submission_stats'),
+    path('downloads/', views.downloads, name='downloads'),
+    path('download/users/', views.download_users, name='download_users'),
+    path('download/projects/', views.download_projects, name='download_projects'),
 
     # redirects
     path('redirects/', views.view_redirects, name='redirects'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2363,7 +2363,7 @@ def download_users(request):
     Delivers a CSV file containing data on users.
     """
     users = User.objects.select_related('profile').prefetch_related(
-        Prefetch('credential_applications', 
+        Prefetch('credential_applications',
                  queryset=CredentialApplication.objects.filter(
                      status=CredentialApplication.Status.ACCEPTED
                  ).order_by('decision_datetime'),
@@ -2445,6 +2445,7 @@ def generate_user_csv_data(users):
                credentials.reference_response_text if credentials else None,
                credentials.research_summary if credentials else None,
                ]
+
 
 @console_permission_required('project.can_view_stats')
 def download_projects(request):

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2357,7 +2357,7 @@ class Echo:
         return value
 
 
-@console_permission_required('project.can_view_stats')
+@console_permission_required('user.change_credentialapplication')
 def download_users(request):
     """
     Delivers a CSV file containing data on users.
@@ -2447,7 +2447,7 @@ def generate_user_csv_data(users):
                ]
 
 
-@console_permission_required('project.can_view_stats')
+@console_permission_required('user.change_credentialapplication')
 def download_projects(request):
     """
     Delivers a CSV file containing data on published projects.

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -28,6 +28,7 @@ from django.utils import timezone
 from django.core.exceptions import PermissionDenied
 from events.forms import EventAgreementForm, EventDatasetForm
 from events.models import Event, EventAgreement, EventDataset, EventApplication
+from html2text import html2text
 from notification.models import News
 from physionet.forms import set_saved_fields_cookie
 from physionet.middleware.maintenance import ServiceUnavailable
@@ -2467,6 +2468,12 @@ def download_projects(request):
 
     projects = PublishedProject.objects.all()
 
+    # Function to process and sanitize HTML content
+    def clean_html(html_content):
+        text = html2text(html_content)
+        text = text.replace('\n', ' ').replace('"', '""')
+        return text.strip()
+
     for project in projects:
         authors = project.authors.all().order_by('display_order')
         publication = project.publications.first()
@@ -2481,24 +2488,24 @@ def download_projects(request):
                         project.is_latest_version,
                         project.doi,
                         project.core_project.doi,
-                        project.full_description,
+                        clean_html(project.full_description),
                         ', '.join(str(author.id) for author in authors if author.is_submitting),
                         project.title,
-                        project.abstract,
-                        project.background,
-                        project.methods,
-                        project.content_description,
-                        project.usage_notes,
-                        project.installation,
-                        project.acknowledgements,
-                        project.conflicts_of_interest,
-                        project.release_notes,
+                        clean_html(project.abstract),
+                        clean_html(project.background),
+                        clean_html(project.methods),
+                        clean_html(project.content_description),
+                        clean_html(project.usage_notes),
+                        clean_html(project.installation),
+                        clean_html(project.acknowledgements),
+                        clean_html(project.conflicts_of_interest),
+                        clean_html(project.release_notes),
                         project.short_description,
                         project.access_policy,
                         project.license,
                         project.dua,
                         project.project_home_page,
-                        project.ethics_statement,
+                        clean_html(project.ethics_statement),
                         ', '.join(str(author.id) for author in authors if author.is_corresponding),
                         ', '.join(str(author.id) for author in authors),
                         publication.citation if publication else None,

--- a/physionet-django/physionet/test_urls.py
+++ b/physionet-django/physionet/test_urls.py
@@ -5,6 +5,7 @@ import urllib.parse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.redirects.models import Redirect
+from django.http import StreamingHttpResponse
 from django.test import TestCase
 from django.urls import URLPattern, URLResolver, get_resolver
 from django.utils.regex_helper import normalize
@@ -204,7 +205,11 @@ class TestURLs(TestMixin):
             path = os.path.join(self._dump_dir, path)
             os.makedirs(os.path.dirname(path), exist_ok=True)
             with open(path, 'wb') as f:
-                f.write(response.content)
+                if isinstance(response, StreamingHttpResponse):
+                    for chunk in response.streaming_content:
+                        f.write(chunk)
+                else:
+                    f.write(response.content)
 
     def _output_filename(self, url, query, response):
         path = url


### PR DESCRIPTION
This pull request adds a new page at "/console/downloads/" that allows administrators (`@console_permission_required('project.can_view_stats')`) to download the following CSV files:

- "Users": Contains information on all active users.  Example: [users_example.csv](https://github.com/user-attachments/files/16530731/users_example.csv)
- "Projects": Contains information on all published projects. Example: [projects_example.csv](https://github.com/user-attachments/files/16530736/projects_example.csv)

Some additional notes:

- I sneaked in a change to the the menu item from "Usage stats" to "Metrics".
- We may want to introduce a new permission for these tools later (preferably in a new pull request).
- We will want to introduce new variables and datasets later.
- This pull request is needed to generate metrics for our U24 proposal, so a quick review/merge would be appreciated!

