### PR TITLE
Don't scramble references when creating a new project version

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -493,10 +493,12 @@ class NewProjectVersionForm(forms.ModelForm):
                     author=author)
 
         # Other related objects
-        for p_reference in self.latest_project.references.all():
+        for p_reference in self.latest_project.references.order_by('order'):
             reference = Reference.objects.create(
                 description=p_reference.description,
-                project=project)
+                order=p_reference.order,
+                project=project,
+            )
 
         for p_publication in self.latest_project.publications.all():
             publication = Publication.objects.create(


### PR DESCRIPTION
When a new project version is created, references are copied from the latest published version.

Copy these references in the order they are displayed on the published project page.

- Reference "id"s must be in sequence (this is what the `order_by('order')` does); this determines the order the references will appear in the Project Content page.

- Reference "order"s must be in sequence (this is what the `order=p_reference.order` does); this determines the order the references will appear in the Project Preview page and ultimately in the published project.

**This pull request does not fix any existing projects.**  This pull request *only* affects what will happen when you click the "new version" button.  Many existing active and published projects have scrambled lists of references.  This pull request does not and cannot fix them.

This pull request also does not fix the fact that for some active projects, the order shown in the Content page doesn't match the Preview page.  If the two pages don't match, that's actually a good sign because in that case we *know* something is wrong.

This pull request also does not fix the lack of database constraints (issue #2137), which we can't fix until we have a way to migrate the broken projects.  Doing nothing is better than doing the wrong thing.
