### PR TITLE
Don't allow "completing copyedit" with outstanding integrity errors

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -281,6 +281,9 @@ class CopyeditForm(forms.ModelForm):
     def clean(self):
         if self.errors:
             return
+        project = self.instance.project
+        if not project.check_integrity():
+            raise forms.ValidationError(project.integrity_errors)
         if self.cleaned_data['made_changes'] and not self.cleaned_data['changelog_summary']:
             raise forms.ValidationError('Describe the changes you made.')
         if not self.cleaned_data['made_changes'] and self.cleaned_data['changelog_summary']:

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -213,6 +213,27 @@ class TestState(TestMixin):
             data={'reopen_copyedit':''})
         project = ActiveProject.objects.get(id=project.id)
         self.assertTrue(project.copyeditable())
+
+        # Erase a required field
+        project.refresh_from_db()
+        project.abstract = ''
+        project.save()
+
+        # "Complete copyedit" should fail because abstract is missing
+        response = self.client.post(
+            reverse('copyedit_submission', args=(project.slug,)), data={
+                'complete_copyedit': '',
+                'made_changes': 1,
+                'changelog_summary': 'Removed abstract',
+            })
+        project.refresh_from_db()
+        self.assertTrue(project.copyeditable())
+
+        # Restore abstract
+        project.refresh_from_db()
+        project.abstract = '<p>Database of annotated ECGs</p>'
+        project.save()
+
         # Recomplete copyedit
         response = self.client.post(reverse(
             'copyedit_submission', args=(project.slug,)),


### PR DESCRIPTION
There are various requirements that must be satisfied before publishing a project. For example, certain fields cannot be blank.

If a project contains integrity errors, the author is not allowed to submit it.  However, it's possible that integrity errors can be introduced *after* the project is submitted:

- the editor accidentally broke something during the copyedit process
- things that were not treated as errors *at the time the project was submitted* are treated as errors *now*, and should be addressed before publication

If the project is still in its "awaiting copyedit" stage, then the best thing is to require the editor to correct those errors before they can "complete copyedit" and advance the project to "awaiting author approval".

Fixes #2272
