### PR TITLE
Add option to download a published authors CSV from the console

### DIFF
--- a/physionet-django/console/templates/console/downloads.html
+++ b/physionet-django/console/templates/console/downloads.html
@@ -29,6 +29,14 @@
         </a>
       </div>
 
+      <div class="mb-4">
+        <h6>Published authors</h6>
+        <p>Download a complete list of published authors, including their names, email addresses, and affiliations.</p>
+        <a href="{% url 'download_published_authors' %}" class="btn btn-primary">
+          Download published authors
+        </a>
+      </div>
+
     </div>
   </div>
 </div>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -108,6 +108,7 @@ urlpatterns = [
     path('downloads/', views.downloads, name='downloads'),
     path('download/users/', views.download_users, name='download_users'),
     path('download/projects/', views.download_projects, name='download_projects'),
+    path('download/published_authors/', views.download_published_authors, name='download_published_authors'),
 
     # redirects
     path('redirects/', views.view_redirects, name='redirects'),

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2587,7 +2587,7 @@ def get_published_authors(authors):
                author.last_name,
                author.corresponding_email,
                ', '.join(author.user.get_emails()),
-               ', '.join([a.name for a in author.affiliations.all()]),
+               '; '.join([a.name for a in author.affiliations.all()]),
                author.approval_datetime,
                author.is_corresponding,
                author.is_submitting,

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2575,7 +2575,7 @@ def get_published_authors(authors):
                   "is_submitting",
                   "display_order",
                   "primary_key"
-    ]
+                  ]
     yield csv_header
 
     for author in authors:
@@ -2593,7 +2593,7 @@ def get_published_authors(authors):
                author.is_submitting,
                author.display_order,
                author.pk
-        ]
+               ]
 
 
 @console_permission_required('project.can_view_access_logs')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2573,8 +2573,7 @@ def get_published_authors(authors):
                   "approval_datetime",
                   "is_corresponding",
                   "is_submitting",
-                  "display_order",
-                  "primary_key"
+                  "display_order"
                   ]
     yield csv_header
 
@@ -2591,8 +2590,7 @@ def get_published_authors(authors):
                author.approval_datetime,
                author.is_corresponding,
                author.is_submitting,
-               author.display_order,
-               author.pk
+               author.display_order
                ]
 
 


### PR DESCRIPTION
This adds another download option on top of what was introduced in #2270 . It gives the option to download all of the published author objects and related data. 

I've included all the base `PublishedAuthor` fields and have linked to a couple of other relevant fields (`user_id`, `project_id`, etc.). I'm happy to add / remove fields as desired. 