### PR TITLE
bump actions/upload-artifact from v2 to v4

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload physionet image
         if: github.ref == 'refs/heads/dev' || github.event.inputs.publish_tag
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: physionet
           path: /tmp/physionet.tar.gz


### PR DESCRIPTION
Our Docker build action currently uses `actions/upload-artifact@v2` to upload the PhysioNet image to DockerHub. v2 was deprecated on 30 June 2024: https://github.com/actions/upload-artifact

> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers. 
