### PR TITLE
Disallow assigning a project author as the editor

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -105,6 +105,20 @@ class AssignEditorForm(forms.Form):
             raise forms.ValidationError("Incorrect project selected.")
         return pid
 
+    def clean(self):
+        project = ActiveProject.objects.get(id=self.cleaned_data["project"])
+        editor = self.cleaned_data["editor"]
+        if project.authors.filter(user=editor).exists():
+            raise forms.ValidationError(
+                '%(name)s is an author of "%(project)s". '
+                'Select an editor who is not one of the project authors.',
+                code='assign_own_project',
+                params={
+                    'name': editor.get_full_name(),
+                    'project': project.title,
+                },
+            )
+
 
 class ReassignEditorForm(forms.Form):
     """

--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -126,14 +126,17 @@ class ReassignEditorForm(forms.Form):
     """
     editor = forms.ModelChoiceField(queryset=None, widget=forms.Select(attrs={'onchange': 'set_editor_text()'}))
 
-    def __init__(self, user, *args, **kwargs):
+    def __init__(self, *args, project, **kwargs):
         """
         Set the appropriate queryset
         """
         super().__init__(*args, **kwargs)
         users = User.get_users_with_permission('project', 'can_edit_activeprojects') \
                     .order_by('username')
-        users = users.exclude(username=user.username)
+        if project.editor:
+            users = users.exclude(id=project.editor.id)
+        author_ids = project.authors.values_list('user__id', flat=True)
+        users = users.exclude(id__in=author_ids)
         self.fields['editor'].queryset = users
 
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -337,15 +337,16 @@ def submission_info(request, project_slug):
     elif 'remove_passphrase' in request.POST:
         project.anonymous.all().delete()
         anonymous_url, passphrase = '', 'revoked'
-    elif ('reassign_editor' in request.POST
-              and user == project.editor
-              and reassign_editor_form.is_valid()):
-        project.reassign_editor(reassign_editor_form.cleaned_data['editor'])
-        notification.editor_notify_new_project(project, user, reassigned=True)
-        messages.success(request, 'The editor has been reassigned')
-        LOGGER.info("The editor for the project {0} has been reassigned from "
-                    "{1} to {2}".format(project, user,
-                                        reassign_editor_form.cleaned_data['editor']))
+    elif 'reassign_editor' in request.POST and user == project.editor:
+        if reassign_editor_form.is_valid():
+            project.reassign_editor(reassign_editor_form.cleaned_data['editor'])
+            notification.editor_notify_new_project(project, user, reassigned=True)
+            messages.success(request, 'The editor has been reassigned')
+            LOGGER.info("The editor for the project {0} has been reassigned from "
+                        "{1} to {2}".format(project, user,
+                                            reassign_editor_form.cleaned_data['editor']))
+        else:
+            messages.error(request, 'Invalid submission. See errors below.')
     elif 'embargo_files' in request.POST:
         embargo_form = forms.EmbargoFilesDaysForm(data=request.POST)
         if settings.SYSTEM_MAINTENANCE_NO_UPLOAD:

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -173,6 +173,10 @@ def submitted_projects(request):
             notification.assign_editor_notify(project)
             notification.editor_notify_new_project(project, user)
             messages.success(request, 'The editor has been assigned')
+        else:
+            for _, errors in assign_editor_form.errors.items():
+                for error in errors:
+                    messages.error(request, error)
 
     # Submitted projects
     projects = ActiveProject.objects.filter(submission_status__gt=SubmissionStatus.ARCHIVED).order_by(

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -333,7 +333,9 @@ def submission_info(request, project_slug):
     elif 'remove_passphrase' in request.POST:
         project.anonymous.all().delete()
         anonymous_url, passphrase = '', 'revoked'
-    elif 'reassign_editor' in request.POST and reassign_editor_form.is_valid():
+    elif ('reassign_editor' in request.POST
+              and user == project.editor
+              and reassign_editor_form.is_valid()):
         project.reassign_editor(reassign_editor_form.cleaned_data['editor'])
         notification.editor_notify_new_project(project, user, reassigned=True)
         messages.success(request, 'The editor has been reassigned')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -322,7 +322,7 @@ def submission_info(request, project_slug):
     copyedit_logs = project.copyedit_log_history()
 
     data = request.POST or None
-    reassign_editor_form = forms.ReassignEditorForm(user, data=data)
+    reassign_editor_form = forms.ReassignEditorForm(project=project, data=data)
     internal_note_form = forms.InternalNoteForm(data)
     embargo_form = forms.EmbargoFilesDaysForm()
     passphrase = ''
@@ -405,7 +405,7 @@ def edit_submission(request, project_slug, *args, **kwargs):
     except EditLog.DoesNotExist:
         return redirect('editor_home')
 
-    reassign_editor_form = forms.ReassignEditorForm(request.user)
+    reassign_editor_form = forms.ReassignEditorForm(project=project)
     embargo_form = forms.EmbargoFilesDaysForm()
     internal_note_form = forms.InternalNoteForm()
 
@@ -466,7 +466,7 @@ def copyedit_submission(request, project_slug, *args, **kwargs):
         return redirect('editor_home')
 
     copyedit_log = project.copyedit_logs.get(complete_datetime=None)
-    reassign_editor_form = forms.ReassignEditorForm(request.user)
+    reassign_editor_form = forms.ReassignEditorForm(project=project)
     embargo_form = forms.EmbargoFilesDaysForm()
     internal_note_form = forms.InternalNoteForm()
 
@@ -646,7 +646,7 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
 
     outstanding_emails = ';'.join([a.user.email for a in authors.filter(
         approval_datetime=None)])
-    reassign_editor_form = forms.ReassignEditorForm(request.user)
+    reassign_editor_form = forms.ReassignEditorForm(project=project)
     embargo_form = forms.EmbargoFilesDaysForm()
     internal_note_form = forms.InternalNoteForm()
 
@@ -713,7 +713,7 @@ def publish_submission(request, project_slug, *args, **kwargs):
     if settings.SYSTEM_MAINTENANCE_NO_UPLOAD:
         raise ServiceUnavailable()
 
-    reassign_editor_form = forms.ReassignEditorForm(request.user)
+    reassign_editor_form = forms.ReassignEditorForm(project=project)
     embargo_form = forms.EmbargoFilesDaysForm()
     internal_note_form = forms.InternalNoteForm()
 

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -1032,8 +1032,17 @@ class InvitationResponseForm(forms.ModelForm):
             raise forms.ValidationError(
                   'You are not invited.')
 
-        if cleaned_data['response'] and not cleaned_data.get('affiliation'):
-            raise forms.ValidationError('You must specify your affiliation.')
+        if cleaned_data['response']:
+            if self.user == self.instance.project.editor:
+                raise forms.ValidationError(
+                    'You must reassign this project to another editor '
+                    'before accepting an authorship invitation.'
+                )
+
+            if not cleaned_data.get('affiliation'):
+                raise forms.ValidationError(
+                    'You must specify your affiliation.'
+                )
 
         return cleaned_data
 


### PR DESCRIPTION
We want to avoid assigning a project author as the editor, to avoid the appearance of a conflict of interest, and to ensure that there's always another set of eyes on the project before it's published.

I think these changes should cover all the possibilities, but it's been a couple of months since I wrote this, so take a careful look. :)

- When project is "awaiting editor assignment", trying to assign it to one of the authors should give an error.

- When project is "awaiting decision", trying to reassign it to one of the authors should give an error.

- When project is "awaiting author revisions", if the submitting author sends an author invitation to the editor, and they try to accept that invitation, that should give an error.  (They should be able to reassign to another editor and then accept the invitation.)
