### PR TITLE
Use the --no-sign-request argument to avoid loading AWS credentials

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -433,7 +433,7 @@
           {% if has_s3_credentials and project.aws.sent_files %}
             <li>
               Download the files using AWS command line tools:
-              <pre class="shell-command">aws s3 sync {{ project.aws.s3_uri }} DESTINATION</pre>
+              <pre class="shell-command">aws s3 sync --no-sign-request {{ project.aws.s3_uri }} DESTINATION</pre>
             </li>
           {% endif %}  
 


### PR DESCRIPTION
This PR modifies the current AWS sync command for downloading open-access projects. 

Adding the --no-sign-request argument will avoid loading AWS credentials, as they are not required to access these datasets.