### PR TITLE
Fix loading/clearing of media files

### DIFF
--- a/physionet-django/user/management/commands/loaddemo.py
+++ b/physionet-django/user/management/commands/loaddemo.py
@@ -99,13 +99,15 @@ def copy_demo_media():
     for subdir in os.listdir(demo_media_root):
         demo_subdir = os.path.join(demo_media_root, subdir)
         target_subdir = os.path.join(settings.MEDIA_ROOT, subdir)
+        os.makedirs(target_subdir, exist_ok=True)
         for item in [i for i in os.listdir(demo_subdir) if i != '.gitkeep']:
             path = os.path.join(demo_subdir, item)
             if os.path.isdir(path):
                 shutil.copytree(os.path.join(demo_subdir, item),
                                 os.path.join(target_subdir, item))
             else:
-                shutil.copy(path, target_subdir)
+                shutil.copy(os.path.join(demo_subdir, item),
+                            os.path.join(target_subdir, item))
 
     # Published project files should have been made read-only at
     # the time of publication

--- a/physionet-django/user/management/commands/resetdb.py
+++ b/physionet-django/user/management/commands/resetdb.py
@@ -87,22 +87,19 @@ def clear_media_files():
     """
     Remove all media files.
 
-    Removes all content in the media root, excluding the immediate
-    subfolders themselves and the .gitkeep files.
+    Remove all content in the media root, except that if a file called
+    ".gitkeep" is found, preserve that file and the subdirectory
+    containing it.
     """
-    for subdir in os.listdir(settings.MEDIA_ROOT):
-        media_subdir = os.path.join(settings.MEDIA_ROOT, subdir)
-        subdir_items = [os.path.join(media_subdir, item) for item in os.listdir(media_subdir) if item != '.gitkeep']
-        for item in subdir_items:
-            if os.path.isdir(item):
-                for root, dirs, files in os.walk(item):
-                    for d in dirs:
-                        os.chmod(os.path.join(root, d), 0o755)
-                    for f in files:
-                        os.chmod(os.path.join(root, f), 0o755)
-                shutil.rmtree(item)
-            else:
-                os.remove(item)
+    for path, subdirs, files in os.walk(settings.MEDIA_ROOT, topdown=False):
+        os.chmod(path, 0o755)
+        for name in files:
+            if name != '.gitkeep':
+                os.remove(os.path.join(path, name))
+        for name in subdirs:
+            if not os.listdir(os.path.join(path, name)):
+                os.rmdir(os.path.join(path, name))
+
 
 def clear_created_static_files():
     """


### PR DESCRIPTION
Currently, `manage.py loaddemo` incorrectly creates a file (not a directory) called `media/ethics`.

Even worse, `manage.py resetdb` currently crashes if that file exists.

Fixes #2247
