### PR TITLE
Require valid reference order for submission/publication

### DIFF
--- a/physionet-django/console/templates/console/copyedit_submission.html
+++ b/physionet-django/console/templates/console/copyedit_submission.html
@@ -54,6 +54,7 @@
           {% include "project/content_inline_form_snippet.html" with form=description_form %}
           {% include "project/content_inline_form_snippet.html" with form=ethics_form %}
           {% include 'project/item_list.html' with item="reference" item_label=reference_formset.item_label formset=reference_formset form_name=reference_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
+          {% include "project/confirm_reference_order_form.html" %}
           <h3>Access</h3>
           <div id="access">
             {% include "project/content_inline_form_snippet.html" with form=access_form %}

--- a/physionet-django/project/templates/project/confirm_reference_order_form.html
+++ b/physionet-django/project/templates/project/confirm_reference_order_form.html
@@ -1,0 +1,28 @@
+{% comment %}
+Past bugs in the project editing forms can result in references having
+'order' set to None, or the order of 'order' not matching the order
+displayed in the content/copyedit page.  It is impractical to repair
+all existing projects automatically since that requires guessing the
+author's intent.
+
+Therefore, if a project's reference order is undefined or
+inconsistent, the message below should be displayed on the content
+page (when the project is author-editable) or copyedit page (when the
+project is copyeditable.)
+
+The "confirm_reference_order" checkbox will be handled by
+ReferenceFormSet (see project/forms.py).
+{% endcomment %}
+{% if not project.has_valid_reference_order %}
+<div class="alert alert-form alert-warning">
+  <div>
+    The References list may be incorrect due to a server error.
+    Please verify that the list shown above corresponds to the
+    correct numbered citations in the project text.
+  </div>
+  <label>
+    <input type="checkbox" name="confirm_reference_order" value="1">
+    Order of references is correct
+  </label>
+</div>
+{% endif %}

--- a/physionet-django/project/templates/project/project_content.html
+++ b/physionet-django/project/templates/project/project_content.html
@@ -17,7 +17,7 @@
 <p>Please adhere to the standards specified in the helpstrings. Required fields are indicated by a <a style="color:red">*</a>.</p>
 <hr>
 
-<form action="{% url 'project_content' project.slug %}" onsubmit="return validateItems('reference-list', 'description', 'References')" method="post" class="no-pd">
+<form action="{% url 'project_content' project.slug %}" onsubmit="return validateItems('reference-list', 'description', 'References')" method="post">
   {% if not project.author_editable %}
     <div class="alert alert-form alert-warning alert-dismissible">
       <strong>The project cannot be edited right now.</strong>
@@ -32,6 +32,7 @@
   {% include "project/content_inline_form_snippet.html" with form=description_form %}
   {% include 'project/item_list.html' with item="reference" item_label=reference_formset.item_label formset=reference_formset form_name=reference_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
   {% if is_submitting and project.author_editable %}
+  {% include "project/confirm_reference_order_form.html" %}
   <hr>
   <button class="btn btn-primary btn-rsp btn-left" type="submit" name="edit_description">Save Description</button>
   {% endif %}

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -98,7 +98,7 @@ th, td {
   color: white;
 }
 
-.navbar-check{
+input[type=checkbox].navbar-check{
   display: none;
 }
 

--- a/physionet-django/static/custom/css/settings.css
+++ b/physionet-django/static/custom/css/settings.css
@@ -29,6 +29,9 @@ input, select, django-ckeditor-widget, textarea {
   border-radius: 0.25rem;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 }
+input[type=checkbox], input[type=radio] {
+  display: initial;
+}
 
 input::-ms-expand {
   background-color: transparent;


### PR DESCRIPTION
Many existing projects have an invalid order of entries in their References section, due to issue #2137.  "Invalid" means:

(a) One or more references have `order=None`, typically because it was copied from a past published version.

(b) Two references have the same `order` value, typically because a reference was deleted from the middle of the list and then a new one was added.

(c) `order` is distinct but doesn't match `id` order, typically because *two* references were deleted from the middle of the list and then a new one was added.

Whatever the reason for having an invalid order of references, it is *not feasible to fix the order automatically*, so we want to require the author/editor to review and fix it by hand before the project is published.

The demo project "MIMIC-III Clinical Database" currently has `order=None` for its three references.  With these changes, you should see:

- If you open the preview page, there is an error message "Order of references may be incorrect".

- If you open the Project Content page, there is a warning at the bottom of the page.

- If you add or edit references, and click "Save Description" (without checking the checkbox), the references should be saved but the warning should still be present.

- If you check the checkbox and then click "Save Description", the warning should go away.

- Alternatively, if you *delete* all three of the original references and then refresh the page, the warning should go away.
