### PR TITLE
Fix deprecated call to  HttpRequest.get_raw_uri. Closes #2296

### DIFF
--- a/physionet-django/templates/404.html
+++ b/physionet-django/templates/404.html
@@ -14,7 +14,7 @@
   <p>If you think this is an error, please email us at: <a href="mailto:{{ ERROR_EMAIL }}?subject=Missing%20URL%20on%20{{ SITE_NAME }}&body={% filter urlencode %}Dear {{ SITE_NAME }} Team,
 
 The following URL is missing from the website:
-{{ request.get_raw_uri }}
+{{ request.build_absolute_uri }}
 {% if request.META.HTTP_REFERER %}
 This URL is linked from:
 {{ request.META.HTTP_REFERER }}


### PR DESCRIPTION
According to the Django Release Notes at https://django.readthedocs.io/en/stable/releases/4.0.html:

> The undocumented HttpRequest.get_raw_uri() method is removed. The [HttpRequest.build_absolute_uri()](https://django.readthedocs.io/en/stable/ref/request-response.html#django.http.HttpRequest.build_absolute_uri) method may be a suitable alternative.

This pull request replaces calls to HttpRequest.get_raw_uri with HttpRequest.build_absolute_uri() on the 404.html page. Closes #2296