### PR TITLE
Better handling of .gitkeep in demo-files

### DIFF
--- a/physionet-django/user/management/commands/loaddemo.py
+++ b/physionet-django/user/management/commands/loaddemo.py
@@ -105,7 +105,8 @@ def copy_demo_media():
             if os.path.isdir(path):
                 shutil.copytree(os.path.join(demo_subdir, item),
                                 os.path.join(target_subdir, item),
-                                ignore=shutil.ignore_patterns('.gitkeep'))
+                                ignore=shutil.ignore_patterns('.gitkeep'),
+                                dirs_exist_ok=True)
             else:
                 shutil.copy(os.path.join(demo_subdir, item),
                             os.path.join(target_subdir, item))
@@ -138,7 +139,8 @@ def copy_demo_static():
         for item in [i for i in os.listdir(demo_subdir) if i != '.gitkeep']:
             shutil.copytree(os.path.join(demo_subdir, item),
                             os.path.join(target_subdir, item),
-                            ignore=shutil.ignore_patterns('.gitkeep'))
+                            ignore=shutil.ignore_patterns('.gitkeep'),
+                            dirs_exist_ok=True)
 
     # Published project files should have been made read-only at
     # the time of publication

--- a/physionet-django/user/management/commands/loaddemo.py
+++ b/physionet-django/user/management/commands/loaddemo.py
@@ -104,7 +104,8 @@ def copy_demo_media():
             path = os.path.join(demo_subdir, item)
             if os.path.isdir(path):
                 shutil.copytree(os.path.join(demo_subdir, item),
-                                os.path.join(target_subdir, item))
+                                os.path.join(target_subdir, item),
+                                ignore=shutil.ignore_patterns('.gitkeep'))
             else:
                 shutil.copy(os.path.join(demo_subdir, item),
                             os.path.join(target_subdir, item))
@@ -136,7 +137,8 @@ def copy_demo_static():
 
         for item in [i for i in os.listdir(demo_subdir) if i != '.gitkeep']:
             shutil.copytree(os.path.join(demo_subdir, item),
-                            os.path.join(target_subdir, item))
+                            os.path.join(target_subdir, item),
+                            ignore=shutil.ignore_patterns('.gitkeep'))
 
     # Published project files should have been made read-only at
     # the time of publication

--- a/physionet-django/user/test_views.py
+++ b/physionet-django/user/test_views.py
@@ -140,12 +140,14 @@ class TestMixin(TestCase):
         """
         _force_delete_tree(settings.MEDIA_ROOT)
         shutil.copytree(os.path.abspath(os.path.join(settings.DEMO_FILE_ROOT, 'media')),
-            settings.MEDIA_ROOT)
+                        settings.MEDIA_ROOT,
+                        ignore=shutil.ignore_patterns('.gitkeep'))
 
         self.test_static_root = settings.STATIC_ROOT if settings.STATIC_ROOT else settings.STATICFILES_DIRS[0]
         _force_delete_tree(self.test_static_root)
         shutil.copytree(os.path.abspath(os.path.join(settings.DEMO_FILE_ROOT, 'static')),
-            self.test_static_root)
+                        self.test_static_root,
+                        ignore=shutil.ignore_patterns('.gitkeep'))
 
         if os.path.exists(ORIGINAL_DBCAL_FILE):
             os.symlink(ORIGINAL_DBCAL_FILE, DBCAL_FILE)


### PR DESCRIPTION
We use `.gitkeep` files as placeholders for "empty" directories.  For example we have two demo active projects that don't contain any files, and we want the `loaddemo` command to create project directories for them.  However, `loaddemo` (or `TestMixin`, which loads the demo files for the test suite) shouldn't create an actual `.gitkeep` file in the project directory.

Additionally, `loaddemo` shouldn't fail if the demo project directory already exists.

Should fix problems with `test-upgrade.sh` as seen in #2303.
