### PR TITLE
Add license name to published project REST API

### DIFF
--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -52,14 +52,14 @@ class PublishedProjectDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = PublishedProject
         fields = (
+            'slug',
             'title',
-            'abstract',
             'version',
+            'abstract',
             'short_description',
             'project_home_page',
             'publish_datetime',
             'doi',
-            'slug',
             'main_storage_size',
             'compressed_storage_size',
         )

--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -7,13 +7,17 @@ from project.models import PublishedProject, License, DUA
 class LicenseSerializer(serializers.ModelSerializer):
     class Meta:
         model = License
-        fields = ('name',)
+        fields = (
+            'name',
+        )
 
 
 class DUASerializer(serializers.ModelSerializer):
     class Meta:
         model = DUA
-        fields = ('name',)
+        fields = (
+            'name',
+        )
 
 
 class PublishedProjectSerializer(serializers.ModelSerializer):
@@ -22,19 +26,40 @@ class PublishedProjectSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PublishedProject
-        fields = ('slug', 'title', 'abstract', 'license', 'dua', 'main_storage_size',
-                  'compressed_storage_size')
+        fields = (
+            'slug',
+            'title',
+            'abstract',
+            'license',
+            'dua',
+            'main_storage_size',
+            'compressed_storage_size',
+        )
 
 
 class ProjectVersionsSerializer(serializers.ModelSerializer):
     class Meta:
         model = PublishedProject
-        fields = ('slug', 'title', 'version', 'abstract')
+        fields = (
+            'slug',
+            'title',
+            'version',
+            'abstract',
+        )
 
 
 class PublishedProjectDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = PublishedProject
-        fields = ("title", "abstract", "version", "short_description",
-                  "project_home_page", "publish_datetime", "doi", "slug", "main_storage_size",
-                  "compressed_storage_size")
+        fields = (
+            'title',
+            'abstract',
+            'version',
+            'short_description',
+            'project_home_page',
+            'publish_datetime',
+            'doi',
+            'slug',
+            'main_storage_size',
+            'compressed_storage_size',
+        )

--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -49,6 +49,8 @@ class ProjectVersionsSerializer(serializers.ModelSerializer):
 
 
 class PublishedProjectDetailSerializer(serializers.ModelSerializer):
+    license = LicenseSerializer()
+
     class Meta:
         model = PublishedProject
         fields = (
@@ -56,6 +58,7 @@ class PublishedProjectDetailSerializer(serializers.ModelSerializer):
             'title',
             'version',
             'abstract',
+            'license',
             'short_description',
             'project_home_page',
             'publish_datetime',


### PR DESCRIPTION
It's helpful to have information about project licenses in (somewhat) machine readable form.  This is already included in the list of all projects (`/api/v1/project/published/`); add it to the per-project information (`/api/v1/project/published/demoeicu/2.0.0/`) as well.

Example
```
{
   "abstract" : "<p>The eICU Collaborative Research Database is a large multi-center critical care database made available by Philips Healthcare in partnership with the MIT Laboratory for Computational Physiology.</p>",
   "compressed_storage_size" : 3090,
   "doi" : "10.13026/G2F309",
   "license" : {
      "name" : "PhysioNet Credentialed Health Data License 1.5.0"
   },
   "main_storage_size" : 3195,
   "project_home_page" : "https://eicu-crd.mit.edu/",
   "publish_datetime" : "2018-12-17T16:11:17.040000-05:00",
   "short_description" : "",
   "slug" : "demoeicu",
   "title" : "Demo eICU Collaborative Research Database",
   "version" : "2.0.0"
}
```
