### PR TITLE
Make new versions clearer in the submission system #2282

### DIFF
--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -45,8 +45,8 @@
           Authors: {% for author in authors %}{{ author|show_all_author_info|safe }} {% endfor %}<br>
           Created: {{ project.creation_datetime|date }}. Submitted: {{ project.submission_datetime|date }}.<br>
           Storage Used: {{ storage_info.readable_used }} / {{ storage_info.readable_allowance }}<br>
-          Version: {{ project.version }}
-          {% if project.is_new_version %}<br>Latest Published Version: <a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>{% endif %}
+          Version: {{ project.version }} {% if project.is_new_version %}<em>(this is an update to a published project)</em>{% endif %}<br>
+          Latest Published Version: {% if project.is_new_version %}<a href="{% url 'published_project' latest_version.slug latest_version.version %}" target="_blank">{{ latest_version.version }}</a>{% else %} No published version available.{% endif %}
           {% if project.latest_reminder %}
             <br>Latest reminder email sent on: {{ project.latest_reminder }}
           {% endif %}


### PR DESCRIPTION
On the Project Submission Info page, when there is a new version of a published project, a message is displayed alongside the version number stating, 'This is an update of the latest published version'. Otherwise, a message stating 'No latest version available' is displayed. #2282 closed.