### PR TITLE
[T-CAIREM 1243] Hotfix issue with boolean conversion and use string comparison instead

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -44,7 +44,7 @@ ORCID_TOKEN_URL = config('ORCID_TOKEN_URL', default='https://sandbox.orcid.org/o
 ORCID_CLIENT_ID = config('ORCID_CLIENT_ID', default=False)
 ORCID_CLIENT_SECRET = config('ORCID_CLIENT_SECRET', default=False)
 ORCID_SCOPE = config('ORCID_SCOPE', default=False)
-ORCID_LOGIN_ENABLED = config('ORCID_LOGIN_ENABLED', default=False)
+ORCID_LOGIN_ENABLED = config('ORCID_LOGIN_ENABLED', default=False, cast=bool)
 ORCID_OPEN_ID_JWKS_URL = config('ORCID_OPEN_ID_JWKS_URL', default="https://sandbox.orcid.org/oauth/jwks")
 ORCID_LOGIN_BUTTON_TEXT = config('ORCID_LOGIN_BUTTON_TEXT', default="Log in using ORCID iD")
 

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -238,7 +238,7 @@ def validate_orcid_id_token(token):
 
     rsa_key = public_keys[headers['kid']]
     if rsa_key is None:
-        raise ValidationError('ORCID id_token is invalid.')
+        raise ValidationError('ORCID public RSA key is None.')
 
     try:
         jwt.decode(

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -566,7 +566,8 @@ def _fetch_and_validate_token(request, code, oauth_session):
                 validators.validate_orcid_id_token(token['id_token'])
 
             return True, token
-        except ValidationError:
+        except ValidationError as e:
+            logger.error(f'Validation Error: ORCID token validation failed. Error message: {e.message}')
             messages.error(request, 'Validation Error: ORCID token validation failed.')
     except InvalidGrantError:
         messages.error(


### PR DESCRIPTION
Unfortunately `enable_orcid_login` variable is passed as string and therefore it is evaluated to true showing orcid log in all the time.