### PR TITLE
Configure workflows to allow use of merge queue

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -17,6 +17,9 @@ on:
   pull_request:
     branches:
       - dev
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
     inputs:
       publish_tag:

--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - dev
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   test:

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - dev
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   testupgrade:


### PR DESCRIPTION
GitHub's "merge queue" provides a way to run tests at the time a
branch is merged (i.e. tests run on the exact tree that is pushed to
dev; if the tests fail it doesn't get pushed.)

I don't know how well this will work, but it seems like it's worth
trying.

In order to do this, both the workflows and the repository settings
need updating.  Documentation is here:
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group
