### PR TITLE
Update challenge naming

### DIFF
--- a/physionet-django/templates/about/moody_challenge_content.html
+++ b/physionet-django/templates/about/moody_challenge_content.html
@@ -15,7 +15,7 @@
 </div>
 
 <section id="moody-challenges">
-  <h1>Moody PhysioNet Challenges</h1>
+  <h1>George B. Moody PhysioNet Challenges</h1>
   <p>Since the turn of the century, PhysioNet has run an annual Challenge in collaboration with Computing in Cardiology.
     More information on these challenges can be found <a href="moody-challenge-overview">here</a>. The
     following is a list of past Challenges, with links to descriptions of the Challenge, associated open access data,

--- a/physionet-django/templates/about/moody_challenge_index.html
+++ b/physionet-django/templates/about/moody_challenge_index.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block title %}
-Moody Challenges
+George B. Moody PhysioNet Challenges
 {% endblock %}
 
 {% block local_css %}
@@ -17,12 +17,12 @@ Moody Challenges
     <div class="main-side">
 
       <div class="card">
-        <h2 class="card-header">Moody PhysioNet Challenges</h2>
+        <h2 class="card-header">George B. Moody PhysioNet Challenges</h2>
         <div class="card-body">
 
             <!-- Challenges -->
             <ul>
-              <li><a href="#moody-challenges">Moody PhysioNet Challenges</a></li>
+              <li><a href="#moody-challenges">George B. Moody PhysioNet Challenges</a></li>
             </ul>
 
         </div>

--- a/physionet-django/templates/about/moody_challenge_overview_content.html
+++ b/physionet-django/templates/about/moody_challenge_overview_content.html
@@ -15,7 +15,7 @@
 </div>
 
 <section id="moody-challenge">
-  <h1>Moody PhysioNet Challenges</h1>
+  <h1>George B. Moody PhysioNet Challenges</h1>
   <p>
     In cooperation with the annual Computing in Cardiology (CinC) conferences, PhysioNet also hosts an annual series of
     biomedical ‘Challenges’ that focus on unsolved problems in clinical and basic science. These Challenges have been
@@ -28,15 +28,15 @@
     the ‘PhysioNet/Computing in Cardiology Challenges’, to the ‘George B. Moody PhysioNet Challenges’ in 2021.
   </p>
   <p>
-    If you are interested in contributing to, or posing a Challenge, please see Organizing a Moody PhysioNet Challenge
-    <a href="/about/challenge/#organizing-moody-challenge">here</a>.
+    If you are interested in contributing to, or posing a Challenge, please see Organizing a George B. Moody PhysioNet
+    Challenge <a href="/about/challenge/#organizing-moody-challenge">here</a>.
   </p>
 </section>
 
 <br>
 
 <section id="past-moody-challenges">
-  <h1>Past Moody PhysioNet Challenges</h1>
+  <h1>Past George B. Moody PhysioNet Challenges</h1>
   <p>
     A list of past Challenges, with links to the descriptions of each Challenge, associated open access data, open
     source code and resultant publications can be found <a href="/about/challenge/moody-challenge">here</a>.

--- a/physionet-django/templates/about/moody_challenge_overview_index.html
+++ b/physionet-django/templates/about/moody_challenge_overview_index.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block title %}
-Moody Challenge Overview
+George B. Moody PhysioNet Challenge Overview
 {% endblock %}
 
 
@@ -19,12 +19,12 @@ Moody Challenge Overview
     <div class="main-side">
 
       <div class="card">
-        <h2 class="card-header">Moody PhysioNet Challenges</h2>
+        <h2 class="card-header">George B. Moody PhysioNet Challenges</h2>
         <div class="card-body">
 
             <!-- Challenges -->
             <ul>
-              <li><a href="#moody-challenge">Moody PhysioNet Challenges</a></li>
+              <li><a href="#moody-challenge">George B. Moody PhysioNet Challenges</a></li>
               <li><a href="#past-moody-challenges">Past Challenges</a></li>
               <li><a href="#support">Support</a></li>
             </ul>


### PR DESCRIPTION
The annual challenge was renamed to the George B. Moody PhysioNet Challenge. In some cases this was being referred to a shorthand version like the Moody Challenge. For clarity, this PR updates the naming to always be George B. Moody PhysioNet Challenge. 