### PR TITLE
Feature: Add server side cursors option

### DIFF
--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -18,7 +18,7 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT', default=''),
-        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False),
+        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False, cast=bool),
     }
 }
 

--- a/physionet-django/physionet/settings/production.py
+++ b/physionet-django/physionet/settings/production.py
@@ -18,6 +18,7 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT', default=''),
+        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False),
     }
 }
 

--- a/physionet-django/physionet/settings/settings.py
+++ b/physionet-django/physionet/settings/settings.py
@@ -17,6 +17,7 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT', default=''),
+        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False),
         'TEST': {
             'MIRROR': 'default'
         },

--- a/physionet-django/physionet/settings/settings.py
+++ b/physionet-django/physionet/settings/settings.py
@@ -17,7 +17,7 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT', default=''),
-        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False),
+        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False, cast=bool),
         'TEST': {
             'MIRROR': 'default'
         },

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -18,7 +18,7 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT', default=''),
-        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False),
+        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False, cast=bool),
     }
 }
 

--- a/physionet-django/physionet/settings/staging.py
+++ b/physionet-django/physionet/settings/staging.py
@@ -18,6 +18,7 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT', default=''),
+        'DISABLE_SERVER_SIDE_CURSORS': config('DISABLE_SERVER_SIDE_CURSORS', default=False),
     }
 }
 


### PR DESCRIPTION
This option is responsible for a specific django behaviour about querying the database, if enabled the database calls will be sectioned and fetched in a few smaller calls, to which we need constant database connection. We would like to change our database management tool(pgbouncer) to transaction mode and to do that we would need to disable that default django behaviour. The implementation only adds an option to change it which defaults to the same behaviour as it is now. We will change that on our side by env variables