### PR TITLE
Add separate ORCiD activate user view

### DIFF
--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -1000,13 +1000,13 @@ def task_rescheduled_notify(name, attempts, last_error, date_time, task_name, ta
     mail_admins(subject, body, settings.DEFAULT_FROM_EMAIL)
 
 
-def notify_account_registration(request, user, uidb64, token, sso=False, orcid=False):
+def notify_account_registration(request, user, uidb64, token, activation_type):
     """
     Send the registration email.
     """
     # Send an email with the activation link
     subject = f"{settings.SITE_NAME} Account Activation"
-    activation_link = _get_activation_link(request, uidb64, token, sso, orcid)
+    activation_link = _get_activation_link(request, uidb64, token, activation_type)
     context = {
         'name': user.get_full_name(),
         'domain': get_current_site(request),
@@ -1020,17 +1020,10 @@ def notify_account_registration(request, user, uidb64, token, sso=False, orcid=F
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)
 
 
-def _get_activation_link(request, uidb64, token, sso, orcid):
+def _get_activation_link(request, uidb64, token, activation_type):
     url_prefix = get_url_prefix(request)
-    activate_user_view_name = 'activate_user'
 
-    if sso:
-        activate_user_view_name = 'sso_activate_user'
-
-    if orcid:
-        activate_user_view_name = 'orcid_activate_user'
-
-    return f"{url_prefix}{reverse(activate_user_view_name, kwargs={'uidb64': uidb64, 'token': token})}"
+    return f"{url_prefix}{reverse(activation_type.value, kwargs={'uidb64': uidb64, 'token': token})}"
 
 
 def notify_participant_event_waitlist(request, user, event):

--- a/physionet-django/notification/utility.py
+++ b/physionet-django/notification/utility.py
@@ -1000,24 +1000,37 @@ def task_rescheduled_notify(name, attempts, last_error, date_time, task_name, ta
     mail_admins(subject, body, settings.DEFAULT_FROM_EMAIL)
 
 
-def notify_account_registration(request, user, uidb64, token, sso=False):
+def notify_account_registration(request, user, uidb64, token, sso=False, orcid=False):
     """
     Send the registration email.
     """
     # Send an email with the activation link
     subject = f"{settings.SITE_NAME} Account Activation"
+    activation_link = _get_activation_link(request, uidb64, token, sso, orcid)
     context = {
         'name': user.get_full_name(),
         'domain': get_current_site(request),
-        'url_prefix': get_url_prefix(request),
         'uidb64': uidb64,
         'token': token,
-        'sso': sso,
+        'activation_link': activation_link,
         'SITE_NAME': settings.SITE_NAME,
     }
     body = loader.render_to_string('user/email/register_email.html', context)
     # Not resend the email if there was an integrity error
     send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)
+
+
+def _get_activation_link(request, uidb64, token, sso, orcid):
+    url_prefix = get_url_prefix(request)
+    activate_user_view_name = 'activate_user'
+
+    if sso:
+        activate_user_view_name = 'sso_activate_user'
+
+    if orcid:
+        activate_user_view_name = 'orcid_activate_user'
+
+    return f"{url_prefix}{reverse(activate_user_view_name, kwargs={'uidb64': uidb64, 'token': token})}"
 
 
 def notify_participant_event_waitlist(request, user, event):

--- a/physionet-django/sso/views.py
+++ b/physionet-django/sso/views.py
@@ -14,6 +14,7 @@ from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from notification.utility import notify_account_registration
 from physionet.middleware.maintenance import disallow_during_maintenance
 from sso import forms
+from user.enums import ActivateUserType
 from user.models import User
 
 logger = logging.getLogger(__name__)
@@ -83,7 +84,7 @@ def sso_register(request):
             user = form.save()
             uidb64 = force_str(urlsafe_base64_encode(force_bytes(user.pk)))
             token = default_token_generator.make_token(user)
-            notify_account_registration(request, user, uidb64, token, sso=True)
+            notify_account_registration(request, user, uidb64, token, activation_type=ActivateUserType.SSO)
             return render(request, 'user/register_done.html', {'email': user.email, 'sso': True})
     else:
         try:

--- a/physionet-django/user/enums.py
+++ b/physionet-django/user/enums.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import IntEnum, Enum
 
 from django.db import models
 
@@ -19,6 +19,16 @@ class RequiredField(IntEnum):
     DOCUMENT = 0
     URL = 1
     PLATFORM = 2
+
+    @classmethod
+    def choices(cls):
+        return tuple((option.value, option.name) for option in cls)
+
+
+class ActivateUserType(Enum):
+    DEFAULT = 'activate_user'
+    SSO = 'sso_activate_user'
+    ORCID = 'orcid_activate_user'
 
     @classmethod
     def choices(cls):

--- a/physionet-django/user/templates/user/email/register_email.html
+++ b/physionet-django/user/templates/user/email/register_email.html
@@ -3,7 +3,7 @@ Dear {{ name }},
 
 Thanks for registering for an account on {{ domain }}. Please activate your account by clicking the following activation link or by copying and pasting the link into your web browser:
 
-{{ url_prefix }}{% url sso|yesno:"sso_activate_user,activate_user" uidb64=uidb64 token=token %}
+{{ activation_link }}
 
 This link will expire in 3 days or after the account has been activated.
 

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -122,6 +122,11 @@ if settings.ORCID_LOGIN_ENABLED:
             path("authorcid_login/", views.auth_orcid_login, name="auth_orcid_login"),
             path("orcid_init_login", views.orcid_init_login, name="orcid_init_login"),
             path("orcid_register/", views.orcid_register, name="orcid_register"),
+            re_path(
+                r"^orcid_activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$",
+                views.activate_orcid_user,
+                name="orcid_activate_user"
+            ),
         ]
     )
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -63,7 +63,7 @@ from user.models import (
     TrainingType,
 )
 from user.userfiles import UserFiles
-from user.enums import RequiredField
+from user.enums import RequiredField, ActivateUserType
 from physionet.models import StaticPage
 from django.db.models import F
 
@@ -601,7 +601,7 @@ def orcid_register(request):
             user = form.save()
             uidb64 = force_str(urlsafe_base64_encode(force_bytes(user.pk)))
             token = default_token_generator.make_token(user)
-            notify_account_registration(request, user, uidb64, token, sso=False, orcid=True)
+            notify_account_registration(request, user, uidb64, token, activation_type=ActivateUserType.ORCID)
 
             return render(
                 request, 'user/register_done.html', {'email': user.email, 'sso': settings.ENABLE_SSO}
@@ -733,7 +733,7 @@ def register(request):
                 uidb64 = force_str(urlsafe_base64_encode(force_bytes(
                     user.pk)))
                 token = default_token_generator.make_token(user)
-                notify_account_registration(request, user, uidb64, token)
+                notify_account_registration(request, user, uidb64, token, activation_type=ActivateUserType.DEFAULT)
 
             return render(request, 'user/register_done.html', {
                 'email': user.email})

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -601,7 +601,7 @@ def orcid_register(request):
             user = form.save()
             uidb64 = force_str(urlsafe_base64_encode(force_bytes(user.pk)))
             token = default_token_generator.make_token(user)
-            notify_account_registration(request, user, uidb64, token, sso=settings.ENABLE_SSO)
+            notify_account_registration(request, user, uidb64, token, sso=False, orcid=True)
 
             return render(
                 request, 'user/register_done.html', {'email': user.email, 'sso': settings.ENABLE_SSO}
@@ -629,6 +629,42 @@ def orcid_init_login(request):
         f'{auth_url}?response_type=code&redirect_uri={redirect_uri}&client_id={client_id}&scope={scope}'
     )
 
+
+@disallow_during_maintenance
+def activate_orcid_user(request, uidb64, token):
+    """Orcid Registration view
+
+    This view activates user and initiate orcid log in flow automatically.
+    """
+    if not settings.ORCID_LOGIN_ENABLED:
+        return redirect('home')
+
+    context = {'title': 'Invalid Activation Link', 'isvalid': False}
+
+    try:
+        uid = force_str(urlsafe_base64_decode(uidb64))
+        user = User.objects.get(pk=uid)
+    except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+        user = None
+
+    if user and user.is_active:
+        messages.success(request, 'The account is active.')
+        return redirect('sso_login')
+
+    if default_token_generator.check_token(user, token):
+        with transaction.atomic():
+            user.is_active = True
+            user.save()
+            email = user.associated_emails.first()
+            email.verification_date = timezone.now()
+            email.is_verified = True
+            email.save()
+            logger.info('User activated - {0}'.format(user.email))
+            messages.success(request, 'The account has been activated.')
+
+        return redirect('orcid_init_login')
+
+    return render(request, 'user/activate_user_complete.html', context)
 
 
 @login_required


### PR DESCRIPTION
After we deployed the ORCiD log-in to Healthdata Nexus, we discovered a bug with SSO (eduGain) registration. To fix that, we need to introduce a separate activation path for the ORCiD flow so that it does not interfere with the SSO log-in.