### PR TITLE
Fix CSS kludge that breaks JavaScript modal boxes

### DIFF
--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -1,6 +1,3 @@
-html,body{height:100%; width: 100%;}
-html{ overflow: overlay; }
-
 /* Open in new window icon */
 a[target='_blank']::after {
   content: '\29C9';

--- a/physionet-django/static/custom/scss/_home.scss
+++ b/physionet-django/static/custom/scss/_home.scss
@@ -41,7 +41,7 @@ html {
 	url("../../images/background.jpg");
 	background-size: cover;
 	background-attachment: fixed;
-	height: calc(100% - 65px);
+	height: calc(100vh - 65px);
 	position: relative;
 	.float {
 		display: inline-block;


### PR DESCRIPTION
An old kludge by Lucas Bulgarelli (to make the splash-screen fill the browser window) currently interferes with CKEditor modal boxes and will interfere with TinyMCE modal boxes.

For example, open one of your "Project Content" pages, scroll to the bottom and in the CKEditor toolbar, click the "equation" button.  The equation editor modal box pops up, as expected - but in the background, "behind" the modal box, the page has scrolled back to the top.

The same problem and worse problems occur with TinyMCE.

I don't know why this is, and don't really care to debug it further.  It's likely to be browser-dependent.

But I think the best thing is not to mess around with the dimensions and overflow behavior of the html and body elements.  On current browsers, we can use `100vh` to get Lucas's desired effect, and it doesn't really hurt anything if the effect doesn't work on outdated browsers.
