### PR TITLE
Add small UX adjustment and redirect to `login` page instead of `sso_login`

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -649,7 +649,7 @@ def activate_orcid_user(request, uidb64, token):
 
     if user and user.is_active:
         messages.success(request, 'The account is active.')
-        return redirect('sso_login')
+        return redirect('login')
 
     if default_token_generator.check_token(user, token):
         with transaction.atomic():


### PR DESCRIPTION
When the ORCID user clicks the activate link it is activated and redirected to ORCID login. When the user clicks it again it is already activated and redirected to SSO login (EduGain) which is a bad UX as its account is linked with ORCID, not with EduGain.

This PR changes this behaviour and redirects to the login page.