### PR TITLE
Modify order of references in the "When using this resource" box

### DIFF
--- a/physionet-django/project/templates/project/citation_box.html
+++ b/physionet-django/project/templates/project/citation_box.html
@@ -1,6 +1,6 @@
 <div class="alert alert-secondary">
 
-  {% if "The PhysioNet/Computing in Cardiology Challenge" in project.title %}
+  {% if "The PhysioNet/Computing in Cardiology Challenge" in project.title or "George B. Moody PhysioNet Challenge" in project.title %}
     {% if publication %}
       <strong>When using this resource, please cite the original publication:</strong>
       {% if publication.url %}


### PR DESCRIPTION
This is a minor change to keep the seas calm by modifying the order of references in the "When using this resource, please cite:" box at the top of the landing pages for the annual CinC challenges. 