### PR TITLE
Hide "total uncompressed size" if unknown

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -372,8 +372,9 @@
     {% else %}
       {% if is_authorized %}
         {% if project.allow_file_downloads %}
-        {#  refactored code goes here            #}
-        <p>Total uncompressed size: {{ main_size }}.</p>
+          {% if project.main_storage_size %}
+            <p>Total uncompressed size: {{ main_size }}.</p>
+          {% endif %}
         {# ZIP START #}
         <h5>Access the files</h5>
         {% if project.access_policy == AccessPolicy.CONTRIBUTOR_REVIEW %}


### PR DESCRIPTION
If a published project's download size is not yet known, the site displays "Total uncompressed size: 0 B."

This is obviously wrong and makes it look like the server is broken.  But in fact, it is *expected* that the size is unknown when the project is first published.

This fixes issue #2362.
