### PR TITLE
Update project serializer to include publish_date, doi, version

### DIFF
--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -23,11 +23,20 @@ class DUASerializer(serializers.ModelSerializer):
 class PublishedProjectSerializer(serializers.ModelSerializer):
     license = LicenseSerializer()
     dua = DUASerializer()
+    publish_date = serializers.SerializerMethodField()
+    core_doi = serializers.SerializerMethodField()
+    version_doi = serializers.SerializerMethodField()
 
     class Meta:
         model = PublishedProject
         fields = (
             'slug',
+            'version',
+            'core_doi',
+            'version_doi',
+            'is_latest_version',
+            'short_description',
+            'publish_date',
             'title',
             'abstract',
             'license',
@@ -36,8 +45,19 @@ class PublishedProjectSerializer(serializers.ModelSerializer):
             'compressed_storage_size',
         )
 
+    def get_publish_date(self, obj):
+        return obj.publish_datetime.date() if obj.publish_datetime else None
+
+    def get_core_doi(self, obj):
+        return obj.core_project.doi if hasattr(obj, 'core_project') else None
+
+    def get_version_doi(self, obj):
+        return obj.doi
+
 
 class ProjectVersionsSerializer(serializers.ModelSerializer):
+    citation = serializers.SerializerMethodField()
+
     class Meta:
         model = PublishedProject
         fields = (
@@ -45,7 +65,11 @@ class ProjectVersionsSerializer(serializers.ModelSerializer):
             'title',
             'version',
             'abstract',
+            'citation',
         )
+
+    def get_citation(self, obj):
+        return obj.citation_text(style="Vancouver")
 
 
 class PublishedProjectDetailSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
We have an API at `http://localhost:8000/api/v1/project/published/search` that allows users to export metadata about published projects. 

The API is potentially useful for people who are developing tools that interface with PhysioNet content (e.g. the MEDS project: https://github.com/Medical-Event-Data-Standard.

The metadata returned from queries is defined in `PublishedProjectSerializer`. This pull request updates this serializer to include the following fields:

- `version` (important, because otherwise a search returns what look like duplicate results, one result for each version).
- `core_doi`
- `version_doi` -> (from `doi`)
- `is_latest_version`
- `short_description`
- `publish_date`

Also adds a citation string to the `ProjectVersionsSerializer` method. 