### PR TITLE
Make training an optional field

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -42,6 +42,7 @@ from project.models import (
 )
 from user.models import User, TrainingType
 from user.validators import validate_affiliation
+from django.forms import ModelMultipleChoiceField
 
 INVITATION_CHOICES = (
     (1, 'Accept'),
@@ -924,11 +925,24 @@ class AccessMetadataForm(forms.ModelForm):
             access_policy=self.access_policy
         )
 
-        if self.access_policy not in {AccessPolicy.CREDENTIALED, AccessPolicy.CONTRIBUTOR_REVIEW}:
+        if self.access_policy in {AccessPolicy.OPEN, AccessPolicy.RESTRICTED}:
             self.fields['required_trainings'].disabled = True
             self.fields['required_trainings'].required = False
             self.fields['required_trainings'].widget = forms.HiddenInput()
             self.initial['required_trainings'] = ''
+
+        if self.access_policy == AccessPolicy.CREDENTIALED:
+            self.fields['required_trainings'].disabled = False
+            self.fields['required_trainings'].required = True
+
+            # Replace the original field with a custom version
+            original_field = self.fields['required_trainings']
+            custom_field = CustomModelMultipleChoiceField(
+                queryset=original_field.queryset.order_by('name'),
+                required=True,
+                widget=original_field.widget
+            )
+            self.fields['required_trainings'] = custom_field
 
         if self.access_policy == AccessPolicy.OPEN:
             self.fields['dua'].disabled = True
@@ -939,6 +953,26 @@ class AccessMetadataForm(forms.ModelForm):
         if not self.editable:
             for field in self.fields.values():
                 field.disabled = True
+
+
+class CustomModelMultipleChoiceField(ModelMultipleChoiceField):
+    def clean(self, value):
+        # If 'No training required' is explicitly selected, return an empty list
+        if value == ['']:
+            return []
+
+        # If no selection is made, raise a validation error
+        if not value:
+            raise forms.ValidationError('Please select at least one training')
+
+        return super().clean(value)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add empty option to the widget
+        self.widget.choices = list(self.widget.choices)
+        if ('', 'No training required') not in self.widget.choices:
+            self.widget.choices.append(('', 'No training required'))
 
 
 class AuthorCommentsForm(forms.Form):

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -924,18 +924,15 @@ class AccessMetadataForm(forms.ModelForm):
             project_types=self.instance.resource_type,
             access_policy=self.access_policy
         )
-
+        # Open and restricted projects do not require training
         if self.access_policy in {AccessPolicy.OPEN, AccessPolicy.RESTRICTED}:
             self.fields['required_trainings'].disabled = True
             self.fields['required_trainings'].required = False
             self.fields['required_trainings'].widget = forms.HiddenInput()
             self.initial['required_trainings'] = ''
 
-        if self.access_policy == AccessPolicy.CREDENTIALED:
-            self.fields['required_trainings'].disabled = False
-            self.fields['required_trainings'].required = True
-
-            # Replace the original field with a custom version
+        # Credentialed and Contributor Review projects may or may not require training
+        if self.access_policy in {AccessPolicy.CREDENTIALED, AccessPolicy.CONTRIBUTOR_REVIEW}:
             original_field = self.fields['required_trainings']
             custom_field = CustomModelMultipleChoiceField(
                 queryset=original_field.queryset.order_by('name'),
@@ -956,23 +953,31 @@ class AccessMetadataForm(forms.ModelForm):
 
 
 class CustomModelMultipleChoiceField(ModelMultipleChoiceField):
-    def clean(self, value):
-        # If 'No training required' is explicitly selected, return an empty list
-        if value == ['']:
-            return []
-
-        # If no selection is made, raise a validation error
-        if not value:
-            raise forms.ValidationError('Please select at least one training')
-
-        return super().clean(value)
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Add empty option to the widget
         self.widget.choices = list(self.widget.choices)
         if ('', 'No training required') not in self.widget.choices:
             self.widget.choices.append(('', 'No training required'))
+
+    def clean(self, value):
+        # If 'No training required' is selected, return an empty list
+        if value == ['']:
+            return []
+
+        # If no selection is made or value is None, return an empty list
+        # (equivalent to 'No training required')
+        if not value:
+            return []
+
+        return super().clean(value)
+
+    def prepare_value(self, value):
+        # If the value is None or an empty list, return ['']
+        # to preselect 'No training required'
+        if value is None or value == []:
+            return ['']
+        return super().prepare_value(value)
 
 
 class AuthorCommentsForm(forms.Form):

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -165,10 +165,14 @@
           {% if project.access_policy == AccessPolicy.CREDENTIALED or project.access_policy == AccessPolicy.CONTRIBUTOR_REVIEW %}
             <p>
               <strong>Required training:</strong>
-              {% for training in project.required_trainings.all %}
-                <br>
-                <a href="{% url 'project_required_trainings_preview' project.slug %}#{{ training.id }}">{{ training }}</a>
-              {% endfor%}
+              {% if project.required_trainings.all|length > 0 %}
+                {% for training in project.required_trainings.all %}
+                  <br>
+                  <a href="{% url 'project_required_trainings_preview' project.slug %}#{{ training.id }}">{{ training }}</a>
+                {% endfor %}
+              {% else %}
+                <br>No training required
+              {% endif %}
             </p>
           {% endif %}
         </div>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -268,10 +268,14 @@
             {% if project.access_policy == AccessPolicy.CREDENTIALED or project.access_policy == AccessPolicy.CONTRIBUTOR_REVIEW %}
               <p>
                 <strong>Required training:</strong>
-                {% for training in project.required_trainings.all %}
-                  <br>
-                  <a href="{% url 'published_project_required_training' project.slug project.version %}#{{ training.id }}"{{ training }}>{{ training }}</a>
-                {% endfor %}
+                {% if project.required_trainings.all|length > 0 %}
+                  {% for training in project.required_trainings.all %}
+                    <br>
+                    <a href="{% url 'project_required_trainings_preview' project.slug %}#{{ training.id }}">{{ training }}</a>
+                  {% endfor %}
+                {% else %}
+                  <br>No training required
+                {% endif %}
               </p>
             {% endif %}
           </div>


### PR DESCRIPTION
This PR allows the waiving of training submissions for credentialed access type. This modification has been implemented to support the release of the Bridge2AI project.

The PR modifies the handling of required trainings for credentialed access policy in the `AccessMetadataForm`.

The empty_field option doesn't work for the current AccessMetadataForm as it triggers the error "" is not a valid value (see image below):

<img width="958" alt="Issue_PR" src="https://github.com/user-attachments/assets/4db719cb-f698-43f7-9c1c-7e7bc2d1ac15" />

To fix that issue, we needed to add a custom `CustomModelMultipleChoiceField` to allow 'No training required' as a valid option to be selected by the authors when no training is required.  

All the following tests passed:

1. Creation and publication of a new project P1 with credentialed access type with no training required, and testing the access with different types of users: 
   - User 1 with **credentialing = False** and **training = False**
   - User 2 with **credentialing = True** and **training = True**
   - User 3 with **credentialing = True** and **training = False**
   - User 4 with **credentialing = False** and **training = True**

2. Creation and publication of a new project P2 with credentialed access type with CITI training required, and testing the access with different types of users: 
   - User 1 with **credentialing = False** and **training = False**
   - User 2 with **credentialing = True** and **training = True**
   - User 3 with **credentialing = True** and **training = False**
   - User 4 with **credentialing = False** and **training = True**

3. Creation and publication of a new version of project P1 keeping the same information as the previous version, and testing the access with different types of users: 
   - User 2 with **credentialing = True** and **training = True**
   - User 3 with **credentialing = False** and **training = False**

4. Creation and publication of a new version of project P2 keeping the same information as the previous version, and testing the access with different types of users:  
   - User 2 with **credentialing = True** and **training = True**
   - User 3 with **credentialing = False** and **training = False**

5. Creation and publication of a new version of project P1 changing the information of the previous version (i.e., required training information), and testing the access with different types of users: 
   - User 2 with **credentialing = True** and **training = True**
   - User 3 with **credentialing = False** and **training = False**

6. Creation and publication of a new version of project P2 changing the information of the previous version (i.e., required training information), and testing the access with different types of users:  
   - User 2 with **credentialing = True** and **training = True**
   - User 3 with **credentialing = False** and **training = False**