### PR TITLE
Allow creating a new version after previous submission is archived

### DIFF
--- a/physionet-django/project/modelcomponents/coreproject.py
+++ b/physionet-django/project/modelcomponents/coreproject.py
@@ -3,7 +3,10 @@ import uuid
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from project.modelcomponents.activeproject import ActiveProject
+from project.modelcomponents.activeproject import (
+    ActiveProject,
+    SubmissionStatus,
+)
 from project.modelcomponents.publishedproject import PublishedProject
 
 
@@ -27,7 +30,9 @@ class CoreProject(models.Model):
 
     def active_new_version(self):
         "Whether there is a new version being worked on"
-        return bool(self.activeprojects.filter())
+        return self.activeprojects.exclude(
+            submission_status=SubmissionStatus.ARCHIVED
+        ).exists()
 
     def get_published_versions(self):
         """


### PR DESCRIPTION
If you are the submitting author of a published project:

- Go to your Project Home.
- Click "New Version" and create a new version.
- Go to the overview page for the new version.
- Click "Delete Project" and confirm.
- Return to your Project Home.
- You are now incapable of creating another new version.

Likewise, if you create a new version and submit it, and it is rejected, you will be incapable of creating another new version.

This was an unintended consequence of adding ARCHIVED as a submission status and removing ArchivedProjects (see pull #2149 and #2170).
