### PR TITLE
Add `public_user_uuid` field to User model

### DIFF
--- a/physionet-django/user/migrations/0064_user_public_user_uuid.py
+++ b/physionet-django/user/migrations/0064_user_public_user_uuid.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("user", "0063_alter_training_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="public_user_uuid",
+            field=models.UUIDField(
+                null=True,
+                editable=False,
+                db_index=True,
+                help_text="Persistent, public identifier for user accounts.",
+            ),
+        ),
+    ]

--- a/physionet-django/user/migrations/0065_backfill_public_user_uuid.py
+++ b/physionet-django/user/migrations/0065_backfill_public_user_uuid.py
@@ -1,0 +1,22 @@
+# 0065_backfill_public_user_uuid.py
+
+from django.db import migrations
+import uuid
+
+
+def backfill_uuids(apps, schema_editor):
+    User = apps.get_model("user", "User")
+    for user in User.objects.filter(public_user_uuid__isnull=True):
+        user.public_user_uuid = uuid.uuid4()
+        user.save(update_fields=["public_user_uuid"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("user", "0064_user_public_user_uuid"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_uuids, reverse_code=migrations.RunPython.noop),
+    ]

--- a/physionet-django/user/migrations/0066_enforce_public_user_uuid_constraint.py
+++ b/physionet-django/user/migrations/0066_enforce_public_user_uuid_constraint.py
@@ -1,0 +1,26 @@
+# 0066_enforce_public_user_uuid_constraints.py
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("user", "0065_backfill_public_user_uuid"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="user",
+            name="public_user_uuid",
+            field=models.UUIDField(
+                unique=True,
+                default=uuid.uuid4,
+                null=False,
+                editable=False,
+                db_index=True,
+                help_text="Persistent, public identifier for user accounts.",
+            ),
+        ),
+    ]

--- a/physionet-django/user/migrations/0066_enforce_public_user_uuid_constraint.py
+++ b/physionet-django/user/migrations/0066_enforce_public_user_uuid_constraint.py
@@ -6,6 +6,8 @@ import uuid
 
 class Migration(migrations.Migration):
 
+    MIGRATE_AFTER_INSTALL = True
+
     dependencies = [
         ("user", "0065_backfill_public_user_uuid"),
     ]

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from datetime import timedelta
+import uuid
 
 from django.utils.crypto import get_random_string
 from django.conf import settings
@@ -350,6 +351,14 @@ class User(AbstractBaseUser, PermissionsMixin):
     sso_id = models.CharField(max_length=256, unique=True, null=True, blank=False)
     join_date = models.DateField(auto_now_add=True)
     last_login = models.DateTimeField(null=True, blank=True)
+
+    public_user_uuid = models.UUIDField(
+        default=uuid.uuid4,
+        unique=True,
+        editable=False,
+        db_index=True,
+        help_text="Persistent, public identifier for user accounts.",
+    )
 
     # IP address used when account was registered
     registration_ip = models.CharField(max_length=40, db_index=True,


### PR DESCRIPTION
It would be helpful to have a unique field to identify user accounts. One use case for this ID is for our project to allow PhysioNet users to login to the NSTRI platform (see: https://github.com/MIT-LCP/physionet-build/issues/2383).

The unique ID would allow the NSTRI platform to maintain a persistent link between logins and PhysioNet users (see: https://github.com/MIT-LCP/physionet-build/issues/2383).

PhysioNet users can update their email, username, etc, so these fields do not meet this need. It seems weird to be sharing the primary key in our database, so instead we are creating a new `public_user_uuid` field.

This pull request:

- Adds a `public_user_uuid` to the User model
- Adds a 3-step migration:
    1. create the field, first nullable;
    2. backfill existing user data
    3. add the non-null constraint.
  