### PR TITLE
Adds an `/oauth/userinfo` endpoint with updated OAuth scopes

### DIFF
--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -46,7 +46,7 @@ class BaseTest(TestCase):
 
         self.access_token = AccessToken.objects.create(
             user=self.test_user,
-            scope="read write",
+            scope="profile:read email:read public_id:read",
             expires=timezone.now() + timedelta(seconds=300),
             token="secret-access-token-key",
             application=self.application,
@@ -113,7 +113,7 @@ class BaseAuthorizationCodeTokenView(BaseTest):
         authcode_data = {
             "client_id": self.application.client_id,
             "state": "random_state_string",
-            "scope": "read write",
+            "scope": "profile:read email:read public_id:read",
             "redirect_uri": "http://example.org",
             "response_type": "code",
             "allow": True,
@@ -132,7 +132,7 @@ class BaseAuthorizationCodeTokenView(BaseTest):
         authcode_data = {
             "client_id": self.application.client_id,
             "state": "random_state_string",
-            "scope": "read write",
+            "scope": "profile:read email:read public_id:read",
             "redirect_uri": "http://example.org",
             "response_type": "code",
             "allow": True,
@@ -217,3 +217,29 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         auth = self._create_authorization_header(token)
         response = self.client.get("/oauth/hello", HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, 200)
+
+
+class TestOAuth2Scopes(BaseTest):
+    def test_userinfo_scopes(self):
+        auth = self._create_authorization_header(self.access_token.token)
+        response = self.client.get("/oauth/userinfo", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(data["username"], self.test_user.username)
+        self.assertEqual(data["full_name"], self.test_user.profile.get_full_name())
+        self.assertEqual(data["email"], self.test_user.email)
+        self.assertEqual(str(data["public_user_uuid"]), str(self.test_user.public_user_uuid))
+
+    def test_userinfo_missing_scope(self):
+        # Set only profile:read
+        self.access_token.scope = "profile:read"
+        self.access_token.save()
+
+        auth = self._create_authorization_header(self.access_token.token)
+        response = self.client.get("/oauth/userinfo", HTTP_AUTHORIZATION=auth)
+        data = response.json()
+
+        self.assertIn("username", data)
+        self.assertNotIn("email", data)
+        self.assertNotIn("public_user_uuid", data)

--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -11,6 +11,8 @@ from django.urls import reverse
 from urllib.parse import parse_qs, urlparse
 from oauth2_provider.settings import oauth2_settings
 from django.utils.crypto import get_random_string
+from oauth.views import SCOPES_MAPPING
+
 
 Application = get_application_model()
 AccessToken = get_access_token_model()
@@ -32,6 +34,11 @@ class BaseTest(TestCase):
         self.dev_user = User.objects.create_user(
             username="oauth_dev_user", email="oauth_dev@example.com", password="123456"
         )
+
+        self.test_user.profile.first_names = "OAuth"
+        self.test_user.profile.last_name = "User"
+        self.test_user.profile.affiliation = "MIT"
+        self.test_user.profile.save()
 
         self.oauth2_settings = oauth2_settings
 
@@ -243,3 +250,23 @@ class TestOAuth2Scopes(BaseTest):
         self.assertIn("username", data)
         self.assertNotIn("email", data)
         self.assertNotIn("public_user_uuid", data)
+
+
+class TestUserInfoScopeValidation(BaseTest):
+    def test_scope_fields_are_accessible(self):
+        """
+        Check that each field defined in SCOPES_MAPPING is present in the
+        returned dictionary and corresponds to a valid attribute/method
+        on the User or related objects.
+        """
+        for scope, builder in SCOPES_MAPPING.items():
+            self.assertTrue(callable(builder), f"Scope '{scope}' does not map to a callable")
+
+            try:
+                result = builder(self.test_user)
+            except Exception as e:
+                self.fail(f"Callable for scope '{scope}' raised an exception: {e}")
+
+            self.assertIsInstance(result, dict, f"Scope '{scope}' did not return a dictionary")
+            for field, value in result.items():
+                self.assertIsNotNone(field, f"Field name in scope '{scope}' is None")

--- a/physionet-django/oauth/urls.py
+++ b/physionet-django/oauth/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 import oauth2_provider.views as oauth2_views
 from django.conf import settings
-from .views import hello
+from oauth.views import hello, UserInfoView
 
 # OAuth2 provider endpoints
 oauth2_endpoint_views = [
@@ -59,4 +59,5 @@ urlpatterns = [
         ),
     ),
     path("hello", hello.as_view(), name="hello"),  # an example resource endpoint
+    path("userinfo", UserInfoView.as_view(), name="userinfo"),
 ]

--- a/physionet-django/oauth/views.py
+++ b/physionet-django/oauth/views.py
@@ -1,5 +1,58 @@
-from django.http import HttpResponse
-from oauth2_provider.views.generic import ProtectedResourceView
+from django.http import HttpResponse, JsonResponse
+from oauth2_provider.views.generic import ProtectedResourceView, ScopedProtectedResourceView
+from oauth2_provider.oauth2_backends import get_oauthlib_core
+
+
+class UserInfoView(ScopedProtectedResourceView):
+    """
+    Returns selected user profile information based on the scopes associated
+    with the provided OAuth2 token.
+
+    This view supports the following scopes:
+    - 'profile:read': returns `username` and `full_name`
+    - 'email:read': returns `email`
+    - 'institution:read': returns `institution`
+    - 'credentialing:read': returns `training_status` and `credentialing_status`
+    - 'orcid:read': returns `orcid`
+    - 'public_id:read': returns `public_user_uuid`
+
+    Only fields corresponding to granted scopes are included in the response.
+    """
+    required_scopes = []
+
+    def get(self, request, *args, **kwargs):
+
+        valid, r = get_oauthlib_core().verify_request(request, scopes=[])
+        if not valid:
+            return JsonResponse({"error": "Invalid or missing token"}, status=403)
+
+        token = r.access_token
+        scopes = token.scope.split()
+
+        user = token.user
+        data = {}
+
+        if "profile:read" in scopes:
+            data["username"] = user.username
+            data["full_name"] = user.profile.get_full_name()
+
+        if "email:read" in scopes:
+            data["email"] = user.email
+
+        if "institution:read" in scopes:
+            data["institution"] = user.institution
+
+        if "credentialing:read" in scopes:
+            data["training_status"] = user.training_status
+            data["credentialing_status"] = user.credentialing_status
+
+        if "orcid:read" in scopes:
+            data["orcid"] = user.orcid
+
+        if "public_id:read" in scopes:
+            data["public_user_uuid"] = str(user.public_user_uuid)
+
+        return JsonResponse(data)
 
 
 class hello(ProtectedResourceView):

--- a/physionet-django/oauth/views.py
+++ b/physionet-django/oauth/views.py
@@ -11,8 +11,8 @@ class UserInfoView(ScopedProtectedResourceView):
     This view supports the following scopes:
     - 'profile:read': returns `username` and `full_name`
     - 'email:read': returns `email`
-    - 'institution:read': returns `institution`
-    - 'credentialing:read': returns `training_status` and `credentialing_status`
+    - 'institution:read': returns `affiliation`
+    - 'credentialing:read': returns `credentialing_status`
     - 'orcid:read': returns `orcid`
     - 'public_id:read': returns `public_user_uuid`
 
@@ -37,17 +37,17 @@ class UserInfoView(ScopedProtectedResourceView):
             data["full_name"] = user.profile.get_full_name()
 
         if "email:read" in scopes:
-            data["email"] = user.email
+            primary_email = user.get_primary_email()
+            data["email"] = primary_email.email
 
         if "institution:read" in scopes:
-            data["institution"] = user.institution
+            data["affiliation"] = user.profile.affiliation
 
         if "credentialing:read" in scopes:
-            data["training_status"] = user.training_status
-            data["credentialing_status"] = user.credentialing_status
+            data["credentialing_status"] = user.is_credentialed
 
         if "orcid:read" in scopes:
-            data["orcid"] = user.orcid
+            data["orcid"] = user.get_orcid_id()
 
         if "public_id:read" in scopes:
             data["public_user_uuid"] = str(user.public_user_uuid)

--- a/physionet-django/oauth/views.py
+++ b/physionet-django/oauth/views.py
@@ -3,54 +3,52 @@ from oauth2_provider.views.generic import ProtectedResourceView, ScopedProtected
 from oauth2_provider.oauth2_backends import get_oauthlib_core
 
 
+SCOPES_MAPPING = {
+    "profile:read": lambda user: {
+        "username": user.username,
+        "full_name": user.get_full_name(),
+    },
+    "email:read": lambda user: {
+        "email": user.get_primary_email().email if user.get_primary_email() else None,
+    },
+    "institution:read": lambda user: {
+        "affiliation": user.profile.affiliation,
+    },
+    "credentialing:read": lambda user: {
+        "credentialing_status": user.is_credentialed,
+    },
+    "orcid:read": lambda user: {
+        "orcid": user.get_orcid_id(),
+    },
+    "public_id:read": lambda user: {
+        "public_user_uuid": str(user.public_user_uuid),
+    },
+}
+
+
 class UserInfoView(ScopedProtectedResourceView):
     """
     Returns selected user profile information based on the scopes associated
     with the provided OAuth2 token.
 
-    This view supports the following scopes:
-    - 'profile:read': returns `username` and `full_name`
-    - 'email:read': returns `email`
-    - 'institution:read': returns `affiliation`
-    - 'credentialing:read': returns `credentialing_status`
-    - 'orcid:read': returns `orcid`
-    - 'public_id:read': returns `public_user_uuid`
-
-    Only fields corresponding to granted scopes are included in the response.
+    Requires at minimum the "profile:read" scope.
     """
-    required_scopes = []
+    required_scopes = ["profile:read"]
 
     def get(self, request, *args, **kwargs):
 
-        valid, r = get_oauthlib_core().verify_request(request, scopes=[])
+        valid, r = get_oauthlib_core().verify_request(request, scopes=self.required_scopes)
         if not valid:
             return JsonResponse({"error": "Invalid or missing token"}, status=403)
 
         token = r.access_token
         scopes = token.scope.split()
-
         user = token.user
         data = {}
 
-        if "profile:read" in scopes:
-            data["username"] = user.username
-            data["full_name"] = user.profile.get_full_name()
-
-        if "email:read" in scopes:
-            primary_email = user.get_primary_email()
-            data["email"] = primary_email.email
-
-        if "institution:read" in scopes:
-            data["affiliation"] = user.profile.affiliation
-
-        if "credentialing:read" in scopes:
-            data["credentialing_status"] = user.is_credentialed
-
-        if "orcid:read" in scopes:
-            data["orcid"] = user.get_orcid_id()
-
-        if "public_id:read" in scopes:
-            data["public_user_uuid"] = str(user.public_user_uuid)
+        for scope, builder in SCOPES_MAPPING.items():
+            if scope in scopes:
+                data.update(builder(user))
 
         return JsonResponse(data)
 

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -754,3 +754,15 @@ ALLOWED_ACCESS_POLICIES = config(
     'ALLOWED_ACCESS_POLICIES',
     default='OPEN,RESTRICTED,CREDENTIALED,CONTRIBUTOR_REVIEW'
 ).split(',')
+
+# OAUTH PROVIDER SCOPES
+OAUTH2_PROVIDER = {
+    "SCOPES": {
+        "profile:read": "Read access to user's profile (username, full name)",
+        "email:read": "Read access to user's email address",
+        "institution:read": "Read access to user's institutional affiliation",
+        "credentialing:read": "Read access to user's credentialing and training status",
+        "orcid:read": "Read access to user's ORCID iD",
+        "public_id:read": "Read access to the user's persistent public ID",
+    }
+}


### PR DESCRIPTION
This pull request introduces the following updates to support OAuth2 access to data (ref https://github.com/MIT-LCP/physionet-build/issues/2383):

1. Adds the following read only OAuth2 scopes:

  - profile:read – username and full name
  - email:read – email address
  - institution:read – institutional affiliation
  - credentialing:read – credentialing
  - orcid:read – ORCID iD
  - public_id:read – persistent public user UUID

2. Adds an `/oauth/userinfo` endpoint that returns selected user profile information depending on the scopes granted to the access token.

3. Adds/updates tests for the new scopes and endpoint.
