### PR TITLE
Fix section order in /projects/X/content/ for model projects

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -564,7 +564,7 @@ class ContentForm(forms.ModelForm):
          'conflicts_of_interest',
          ),
         # 3: Model
-        ('title', 'abstract', 'background', 'methods', 'content_description',
+        ('title', 'abstract', 'background', 'content_description', 'methods',
          'installation', 'usage_notes', 'release_notes',
          'acknowledgements', 'conflicts_of_interest',
          ),

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -589,7 +589,7 @@ class ContentForm(forms.ModelForm):
          'content_description': '* Describe the model and any supporting data and software.',
          'installation': '* Instructions on how to set up a software environment for using the model.',
          'usage_notes': '* Describe how you intend others to (re)use the model.',
-         'methods': 'Details on the technical implementation. ie. the development process, and the underlying algorithms.',
+         'methods': '* Details on the technical implementation. ie. the development process, and the underlying algorithms.',
          'usage_notes': '* How the software is to be used. List some example function calls or specify the demo file(s).'},
     )
 

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -589,7 +589,10 @@ class ContentForm(forms.ModelForm):
          'content_description': '* Describe the model and any supporting data and software.',
          'installation': '* Instructions on how to set up a software environment for using the model.',
          'usage_notes': '* Describe how you intend others to (re)use the model.',
-         'methods': '* Details on the technical implementation. ie. the development process, and the underlying algorithms.',
+         'methods': (
+             '* Details on the technical implementation. '
+             'ie. the development process, and the underlying algorithms.'
+         ),
          'usage_notes': '* How the software is to be used. List some example function calls or specify the demo file(s).'},
     )
 


### PR DESCRIPTION
Different resource types have different sets of optional and required sections - some sections are only required for certain resource types, and the section titles don't match the database field names.

For Model projects (resource type 3), the "Model Description" section (`project.content_description`) appears third, before "Technical Implementation" (`project.methods`).  For example, see http://localhost:8000/projects/AGlSZa5VTv5Dg09CSpoh/preview/.

However, in the Project Content page (http://localhost:8000/projects/AGlSZa5VTv5Dg09CSpoh/content/), "Technical Implementation" is currently shown before "Model Description".  This inconsistency is confusing.

Also, there should be a red star next to "Technical Implementation", to indicate that this section is required for Model projects.
