### PR TITLE
Allow users to generate personal OAuth access tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,3 +230,14 @@ CITI_SOAP_URL="https://webservices.citiprogram.org/SOAP/CITISOAPService.asmx"
 # See https://docs.djangoproject.com/en/4.2/ref/settings/
 DATA_UPLOAD_MAX_NUMBER_FILES=1000
 DATA_UPLOAD_MAX_MEMORY_SIZE=2621440
+
+# OAUTH_CLIENT_APP_NAME is the name of the default OAuth application used
+# when programmatically generating access tokens (e.g., via the /settings/tokens
+# interface or other internal APIs).
+#
+# This should match the 'name' field of a registered OAuth Application in the
+# django-oauth-toolkit Application model.
+#
+# It is used to associate new access tokens with a known, trusted client
+# (typically representing the main web interface or API client).
+OAUTH_CLIENT_APP_NAME=local_web_client

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -755,6 +755,10 @@ ALLOWED_ACCESS_POLICIES = config(
     default='OPEN,RESTRICTED,CREDENTIALED,CONTRIBUTOR_REVIEW'
 ).split(',')
 
+# OAUTH_CLIENT_APP_NAME is the name of the default OAuth application used
+# when programmatically generating access tokens (e.g., via the /settings/tokens).
+OAUTH_CLIENT_APP_NAME = config('OAUTH_CLIENT_APP_NAME', default='')
+
 # OAUTH PROVIDER SCOPES
 OAUTH2_PROVIDER = {
     "SCOPES": {
@@ -764,5 +768,6 @@ OAUTH2_PROVIDER = {
         "credentialing:read": "Read access to user's credentialing and training status",
         "orcid:read": "Read access to user's ORCID iD",
         "public_id:read": "Read access to the user's persistent public ID",
+        "data:download": "Download project data if token-holder is approved for access (training, DUA, etc).",
     }
 }

--- a/physionet-django/user/management/commands/create_default_oauth_app.py
+++ b/physionet-django/user/management/commands/create_default_oauth_app.py
@@ -1,44 +1,64 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from oauth2_provider.models import get_application_model
+from django.contrib.auth import get_user_model
+
+
+def create_default_oauth_application(user=None, stdout=None):
+    app_name = getattr(settings, "OAUTH_CLIENT_APP_NAME", "PhysioNet Client")
+    Application = get_application_model()
+    User = get_user_model()
+
+    if not user:
+        user = User.objects.filter(is_superuser=True).first()
+        if not user:
+            msg = "No superuser found; skipping OAuth application creation."
+            if stdout:
+                stdout.write(msg)
+            else:
+                print(msg)
+            return
+
+    app, created = Application.objects.get_or_create(
+        name=app_name,
+        defaults={
+            'user': user,
+            'client_type': Application.CLIENT_CONFIDENTIAL,
+            'authorization_grant_type': Application.GRANT_PASSWORD,
+            'skip_authorization': True,
+        }
+    )
+
+    msg = (
+        f"Created OAuth application: {app.name}"
+        if created else
+        f'OAuth application "{app.name}" already exists.'
+    )
+    if stdout:
+        stdout.write(msg)
+    else:
+        print(msg)
 
 
 class Command(BaseCommand):
-    help = 'Creates the default OAuth application for the given superuser.'
+    help = 'Creates the default OAuth application.'
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'username',
+            '--username',
             type=str,
-            help='The username of the superuser who will own the OAuth application.'
+            help='Optional superuser username to assign as the application owner.',
         )
 
     def handle(self, *args, **options):
-        Application = get_application_model()
         User = get_user_model()
+        username = options.get("username")
 
-        username = options['username']
-        try:
-            user = User.objects.get(username=username, is_superuser=True)
-        except User.DoesNotExist:
-            raise CommandError(f'Superuser with username "{username}" does not exist.')
+        user = None
+        if username:
+            try:
+                user = User.objects.get(username=username, is_superuser=True)
+            except User.DoesNotExist:
+                raise CommandError(f'Superuser with username "{username}" does not exist.')
 
-        app_name = getattr(settings, 'OAUTH_CLIENT_APP_NAME', 'Default OAuth Application')
-        client_type = Application.CLIENT_CONFIDENTIAL
-        authorization_grant_type = Application.GRANT_PASSWORD
-
-        app, created = Application.objects.get_or_create(
-            name=app_name,
-            defaults={
-                'user': user,
-                'client_type': client_type,
-                'authorization_grant_type': authorization_grant_type,
-                'skip_authorization': True,
-            }
-        )
-
-        if created:
-            self.stdout.write(self.style.SUCCESS(f'Created OAuth application: {app.name}'))
-        else:
-            self.stdout.write(self.style.WARNING(f'OAuth application "{app.name}" already exists.'))
+        create_default_oauth_application(user=user, stdout=self.stdout)

--- a/physionet-django/user/management/commands/create_default_oauth_app.py
+++ b/physionet-django/user/management/commands/create_default_oauth_app.py
@@ -1,0 +1,44 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from oauth2_provider.models import get_application_model
+
+
+class Command(BaseCommand):
+    help = 'Creates the default OAuth application for the given superuser.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'username',
+            type=str,
+            help='The username of the superuser who will own the OAuth application.'
+        )
+
+    def handle(self, *args, **options):
+        Application = get_application_model()
+        User = get_user_model()
+
+        username = options['username']
+        try:
+            user = User.objects.get(username=username, is_superuser=True)
+        except User.DoesNotExist:
+            raise CommandError(f'Superuser with username "{username}" does not exist.')
+
+        app_name = getattr(settings, 'OAUTH_CLIENT_APP_NAME', 'Default OAuth Application')
+        client_type = Application.CLIENT_CONFIDENTIAL
+        authorization_grant_type = Application.GRANT_PASSWORD
+
+        app, created = Application.objects.get_or_create(
+            name=app_name,
+            defaults={
+                'user': user,
+                'client_type': client_type,
+                'authorization_grant_type': authorization_grant_type,
+                'skip_authorization': True,
+            }
+        )
+
+        if created:
+            self.stdout.write(self.style.SUCCESS(f'Created OAuth application: {app.name}'))
+        else:
+            self.stdout.write(self.style.WARNING(f'OAuth application "{app.name}" already exists.'))

--- a/physionet-django/user/management/commands/loaddemo.py
+++ b/physionet-django/user/management/commands/loaddemo.py
@@ -19,6 +19,7 @@ from physionet.utility import get_project_apps
 
 from user.models import Training, TrainingType, TrainingQuestion, CredentialApplication
 from user.enums import TrainingStatus
+from user.management.commands import create_default_oauth_app
 
 
 class Command(BaseCommand):
@@ -71,6 +72,10 @@ class Command(BaseCommand):
         # Make symlink of wfdbcal for lightwave
         if os.path.exists(ORIGINAL_DBCAL_FILE):
             os.symlink(ORIGINAL_DBCAL_FILE, DBCAL_FILE)
+
+        # Add OAuth application for managing user-generated OAuth tokens
+        create_default_oauth_app.create_default_oauth_application()
+
 
 def find_demo_fixtures(project_apps):
     """

--- a/physionet-django/user/templates/user/edit_tokens.html
+++ b/physionet-django/user/templates/user/edit_tokens.html
@@ -1,0 +1,45 @@
+{% extends "user/settings.html" %}
+{% load static %}
+
+{% block title %}Access Tokens{% endblock %}
+
+{% block main_content %}
+<h1 class="form-signin-heading">API Access Tokens</h1>
+<hr>
+
+<p>
+  Access tokens allow you to authenticate with the {{ SITE_NAME }} API (e.g. using our Python package) without logging in.
+  Tokens expire automatically after <strong>60 days</strong>. Keep these tokens secret — they act like passwords. You can revoke them at any time.
+</p>
+
+<form action="" method="post" class="form-inline mt-3">
+  {% csrf_token %}
+  <div class="form-group">
+    <label for="token-name">Create new token:</label>&nbsp;
+    <input type="text" class="form-control" id="token-name" name="name" placeholder="e.g. My Laptop" required>
+    <button class="btn btn-primary ml-2" type="submit">Generate</button>
+  </div>
+</form>
+
+{% if tokens %}
+  <h3 class="mt-4">Your Tokens</h3>
+  <ul class="list-group mt-2">
+    {% for token in tokens %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+      <div>
+        <code>{{ token.token }}</code>
+        <br>
+        <small>
+        Created {{ token.created|date:"Y-m-d H:i" }} —
+        Expires {{ token.expires|date:"Y-m-d H:i" }}
+        {% if token.is_expired %}<span class="badge badge-danger">Expired</span>{% endif %}
+        </small>
+      </div>
+      <a class="btn btn-sm btn-danger" href="?delete={{ token.id }}">Revoke</a>
+      </li>
+    {% endfor %}  
+  </ul>
+{% else %}
+  <p class="mt-4">You don’t have any tokens yet.</p>
+{% endif %}
+{% endblock %}

--- a/physionet-django/user/test_tokens.py
+++ b/physionet-django/user/test_tokens.py
@@ -1,0 +1,101 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+from oauth2_provider.models import get_access_token_model, get_application_model
+
+from django.utils.crypto import get_random_string
+
+AccessToken = get_access_token_model()
+Application = get_application_model()
+User = get_user_model()
+
+
+class TestAccessTokens(TestCase):
+    def setUp(self):
+        self.user = User.objects.get(email="admin@mit.edu")
+        self.client.login(username="admin@mit.edu", password="Tester11!")
+
+        Application = get_application_model()
+        self.application = Application.objects.get(name=settings.OAUTH_CLIENT_APP_NAME)
+
+    def test_token_settings_page_renders(self):
+        response = self.client.get(reverse("edit_tokens"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "API Access Tokens")
+
+    def test_create_token_with_fixed_60_day_expiration(self):
+        response = self.client.post(reverse("edit_tokens"), data={"name": "Fixed Expiry Token"})
+        self.assertRedirects(response, reverse("edit_tokens"))
+
+        token = AccessToken.objects.filter(user=self.user, application=self.application).latest("created")
+        self.assertIsNotNone(token.expires)
+
+        expected_expiration = token.created + timedelta(days=60)
+        delta = abs(token.expires - expected_expiration)
+        self.assertLess(delta.total_seconds(), 5)
+
+    def test_token_expiration_logic(self):
+        expired_token = AccessToken.objects.create(
+            user=self.user,
+            application=self.application,
+            token=get_random_string(40),
+            expires=timezone.now() - timedelta(days=1),
+            scope="read",
+        )
+        self.assertTrue(expired_token.is_expired())
+
+    def test_token_deletion(self):
+        token = AccessToken.objects.create(
+            user=self.user,
+            application=self.application,
+            token=get_random_string(40),
+            expires=timezone.now() + timedelta(days=60),
+            scope="read",
+        )
+        response = self.client.get(reverse("edit_tokens") + f"?delete={token.id}")
+        self.assertRedirects(response, reverse("edit_tokens"))
+        self.assertFalse(AccessToken.objects.filter(id=token.id).exists())
+
+    def test_token_generation(self):
+        # Reset tokens
+        AccessToken.objects.filter(user=self.user, application=self.application).delete()
+
+        self.client.login(username='admin@mit.edu', password='Tester11!')
+        user = User.objects.get(email='admin@mit.edu')
+
+        # Visit the token settings page (GET)
+        response = self.client.get(reverse('edit_tokens'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "API Access Tokens")
+
+        # Create a new token (POST)
+        response = self.client.post(reverse('edit_tokens'), data={'name': 'Test Token'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], reverse('edit_tokens'))
+
+        # Verify that token exists in DB
+        tokens = AccessToken.objects.filter(user=user)
+        self.assertEqual(tokens.count(), 1)
+        self.assertTrue(len(tokens.first().token) >= 32)
+
+    def test_token_limit_enforced(self):
+        """
+        Users are limited to 3 tokens at a time.
+        """
+        AccessToken.objects.filter(user=self.user, application=self.application).delete()
+        for i in range(3):
+            AccessToken.objects.create(
+                user=self.user,
+                application=self.application,
+                token=f"token-{i}",
+                expires=timezone.now() + timedelta(days=60),
+                scope="data:download",
+            )
+
+        response = self.client.post(reverse("edit_tokens"),
+                                    data={"name": "Should Fail"}, follow=True)
+        self.assertContains(response, "You can only have up to 3 tokens")

--- a/physionet-django/user/urls.py
+++ b/physionet-django/user/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path("settings/cloud/", views.edit_cloud, name="edit_cloud"),
     path("settings/cloud/aws/", views.edit_cloud_aws, name="edit_cloud_aws"),
     path("settings/orcid/", views.edit_orcid, name="edit_orcid"),
+    path("settings/tokens/", views.edit_tokens, name="edit_tokens"),
     path("authorcid/", views.auth_orcid, name="auth_orcid"),
     path(
         "settings/credentialing/", views.edit_credentialing, name="edit_credentialing"

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -36,6 +36,8 @@ from notification.utility import (
     training_application_request,
 )
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from oauth2_provider.models import get_application_model, AccessToken
+
 from physionet import utility
 from physionet.middleware.maintenance import (
     ServiceUnavailable,
@@ -255,6 +257,7 @@ def check_legacy_credentials(user, email):
         legacy_credential.save()
         user.save()
 
+
 def remove_email(request, email_id):
     "Remove a non-primary email associated with a user"
     user = request.user
@@ -308,6 +311,7 @@ def set_public_email(request, public_email_form):
             else:
                 messages.success(request, 'Your email: {0} has been set to private.'.format(current_public_email.email))
 
+
 def add_email(request, add_email_form):
     user = request.user
     # noinspection GrazieInspection
@@ -332,6 +336,7 @@ def add_email(request, add_email_form):
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
             [add_email_form.cleaned_data['email']], fail_silently=False)
         messages.success(request, 'A verification link has been sent to: {0}'.format(associated_email.email))
+
 
 @login_required
 def edit_emails(request):
@@ -423,6 +428,52 @@ def edit_profile(request):
             form = forms.ProfileForm(instance=profile)
 
     return render(request, 'user/edit_profile.html', {'form':form})
+
+
+@login_required
+def edit_tokens(request):
+    """
+    View for users to manage their personal API access tokens.
+
+    - POST: Creates a new access token with default read scopes.
+    - GET with `?delete=<id>`: Deletes an access token.
+    - GET: Lists current active tokens.
+    """
+    Application = get_application_model()
+
+    # Creating tokens requires a local OAUTH client to exist.
+    app_name = getattr(settings, "OAUTH_CLIENT_APP_NAME", None)
+    if not app_name:
+        raise Exception("OAUTH_CLIENT_APP_NAME is not defined in settings.")
+
+    try:
+        application = Application.objects.get(name=app_name)
+    except Application.DoesNotExist:
+        raise Exception(f"OAuth application named '{app_name}' not found.")
+
+    if request.method == "POST":
+
+        if AccessToken.objects.filter(user=request.user, application=application).count() >= 3:
+            messages.error(request, "You can only have up to 3 tokens. Please delete one first.")
+            return redirect("edit_tokens")
+
+        expires_at = timezone.now() + timedelta(days=60)
+        token = AccessToken.objects.create(
+            user=request.user,
+            application=application,
+            token=get_random_string(40),
+            expires=expires_at,
+            scope="data:download",
+        )
+        return redirect("edit_tokens")
+
+    if request.GET.get("delete"):
+        AccessToken.objects.filter(user=request.user, id=request.GET["delete"]).delete()
+        return redirect("edit_tokens")
+
+    tokens = AccessToken.objects.filter(user=request.user)
+    return render(request, "user/edit_tokens.html", {"tokens": tokens})
+
 
 @login_required
 def edit_orcid(request):

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -458,7 +458,7 @@ def edit_tokens(request):
             return redirect("edit_tokens")
 
         expires_at = timezone.now() + timedelta(days=60)
-        token = AccessToken.objects.create(
+        AccessToken.objects.create(
             user=request.user,
             application=application,
             token=get_random_string(40),


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/2380, we would like to add support for tokens to enable secure, programmatic use of protected API endpoints (e.g. downloading credentialed datasets or querying metadata), without prompting for login credentials.

This pull request is part 1 of the implementation plan. It adds an interface for users to create up to 3 personal (OAuth) tokens. Each token: is tied to a user; expires after 60 days; and is revocable via the UI. For now, the interface is hidden from users.

Important notes:

- The tokens require a local OAuth Application to be created. This can be done using the management command `python manage.py create_default_oauth_app  --username <username>`
- The tokens are currently given a single `data:download` scope. This scope has no function right now, but later it could allow users to request files.
- The tokens do not support a "name". This can be later, if needed.
- For now, the settings page is hidden from users.