### PR TITLE
Remove direct link to static zip file

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -305,17 +305,12 @@
         {% endif %}
 
         <ul>
-          {% if project.access_policy %}
-            {% if project.compressed_storage_size %}
+          {% if project.compressed_storage_size %}
             <li><a href="{% url 'serve_published_project_zip' project.slug project.version %}">Download
               the ZIP file</a> ({{ compressed_size }})
             </li>
-            {% endif %}
-          {% else %}
-            {% if project.compressed_storage_size %}
-              <li><a href="{% static project.zip_url %}">Download the ZIP file</a> ({{ compressed_size }})
-              </li>
-            {% endif %}
+          {% endif %}
+          {% if not project.access_policy %}
             {% if project.gcp.sent_files %}
               <li>Access the files using the Google Cloud Storage Browser <a
                 href="https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}/">here</a>.

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -312,21 +312,11 @@
             </li>
             {% endif %}
           {% else %}
+            {% if project.compressed_storage_size %}
+              <li><a href="{% static project.zip_url %}">Download the ZIP file</a> ({{ compressed_size }})
+              </li>
+            {% endif %}
             {% if project.gcp %}
-              {% if project.gcp.sent_zip %}
-                <!-- Temporary fix: Change default location to local servers -->
-                <!--
-                  <li><a href="https://storage.googleapis.com/{{ project.gcp.bucket_name }}/{{ project.zip_name }}">
-                      Download the ZIP file</a> ({{ compressed_size }}).</a></li>
-                  -->
-                <li><a href="{% static project.zip_url %}">Download the ZIP file</a>
-                  ({{ compressed_size }})
-                </li>
-              {% elif project.compressed_storage_size %}
-                <li><a href="{% static project.zip_url %}">Download the ZIP file</a>
-                  ({{ compressed_size }})
-                </li>
-              {% endif %}
               {% if project.gcp.sent_files %}
                 <li>Access the files using the Google Cloud Storage Browser <a
                   href="https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}/">here</a>.
@@ -338,9 +328,6 @@
                   <pre class="shell-command">gsutil -m -u YOUR_PROJECT_ID cp -r gs://{{ project.gcp.bucket_name }} DESTINATION</pre>
                 </li>
               {% endif %}
-            {% elif project.compressed_storage_size %}
-              <li><a href="{% static project.zip_url %}">Download the ZIP file</a> ({{ compressed_size }})
-              </li>
             {% endif %}
           {% endif %}
           {% include "project/published_project_data_access.html" %}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -316,18 +316,16 @@
               <li><a href="{% static project.zip_url %}">Download the ZIP file</a> ({{ compressed_size }})
               </li>
             {% endif %}
-            {% if project.gcp %}
-              {% if project.gcp.sent_files %}
-                <li>Access the files using the Google Cloud Storage Browser <a
-                  href="https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}/">here</a>.
-                  Login with a Google account is required.
-                <li>
-                  Access the data using the Google Cloud command line tools (please refer to the <a
-                    href="https://cloud.google.com/storage/docs/gsutil_install">gsutil</a>
-                  documentation for guidance):
-                  <pre class="shell-command">gsutil -m -u YOUR_PROJECT_ID cp -r gs://{{ project.gcp.bucket_name }} DESTINATION</pre>
-                </li>
-              {% endif %}
+            {% if project.gcp.sent_files %}
+              <li>Access the files using the Google Cloud Storage Browser <a
+                href="https://console.cloud.google.com/storage/browser/{{ project.gcp.bucket_name }}/">here</a>.
+                Login with a Google account is required.
+              <li>
+                Access the data using the Google Cloud command line tools (please refer to the <a
+                  href="https://cloud.google.com/storage/docs/gsutil_install">gsutil</a>
+                documentation for guidance):
+                <pre class="shell-command">gsutil -m -u YOUR_PROJECT_ID cp -r gs://{{ project.gcp.bucket_name }} DESTINATION</pre>
+              </li>
             {% endif %}
           {% endif %}
           {% include "project/published_project_data_access.html" %}


### PR DESCRIPTION
If a zip archive is available for a published project we display a link in the Files section.

Currently, if the project is *open*, we display a direct link like `https://physionet.org/static/published-projects/mitdb/mit-bih-arrhythmia-database-1.0.0.zip`.

Instead, we can use the "get-zip" link like `https://physionet.org/content/mitdb/get-zip/1.0.0/`, which works for all projects regardless of access policy.
