### PR TITLE
Fix the link to Required training on project landing page.

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -186,7 +186,7 @@
                 {% if project.required_trainings.all|length > 0 %}
                   {% for training in project.required_trainings.all %}
                     <br>
-                    <a href="{% url 'project_required_trainings_preview' project.slug %}#{{ training.id }}">{{ training }}</a>
+                    <a href="{% url 'published_project_required_training' project.slug project.version %}#{{ training.id }}"{{ training }}>{{ training }}</a>
                   {% endfor %}
                 {% else %}
                   <br>No training required


### PR DESCRIPTION
This PR fixes the broken hyperlinks to required training pages on project landing pages as reported in #2401. 

It resolves the Forbidden Access (403) error when accessing training requirement details (e.g., "CITI Data or Specimens Only Research") from project pages.