### PR TITLE
Fix RelatedObjectDoesNotExist error when signing DUA

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2053,7 +2053,11 @@ def sign_dua(request, project_slug, version):
     if request.method == 'POST' and 'agree' in request.POST:
         DUASignature.objects.create(user=user, project=project)
         if has_s3_credentials() and files_sent_to_S3(project):
-            if user.cloud_information is not None and user.cloud_information.aws_verification_datetime is not None:
+            if (
+                hasattr(user, 'cloud_information')
+                and user.cloud_information is not None
+                and user.cloud_information.aws_verification_datetime is not None
+            ):
                 add_user_to_access_point_policy(project, user)
 
         return render(request, 'project/sign_dua_complete.html', {


### PR DESCRIPTION
Users without cloud_information records were encountering a RelatedObjectDoesNotExist error when signing DUAs for projects hosted on AWS. The error occurred because the code was attempting to access user.cloud_information directly without first checking if it exists. See error below:

RelatedObjectDoesNotExist at /sign-dua/b2ai-voice/2.0.0/
User has no cloud_information.

This PR adds an additional safety check using hasattr() to verify the user has a cloud_information record before attempting to access it.