### PR TITLE
Add optional platform RRID to suggested citations (Ref #2404)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,11 @@ FOOTER_MANAGED_BY="DataShare Lab"
 FOOTER_SUPPORTED_BY="people"
 FOOTER_ACCESSIBILITY_PAGE=
 
+# Platform Research Resource Identifer: https://rrid.site/
+# Added to citations to support tracking of reuse.
+# e.g. PhysioNet is "SCR_007345"
+PLATFORM_RRID=
+
 # PRIVACY_POLICY_HTML can be also used with html tags inside it which will be resolved to actual html
 # Possible message with html tag inside: "I consent to the collection and use of my personal information consistent with <a href=PRIVACY_POLICY_URL>Privacy Policy</a>. Without your consent, we can not create an account"
 # The PRIVACY_POLICY_URL should be swapped with actual url to the Privacy Policy page.

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -721,6 +721,11 @@ LOG_TIMEDELTA = config('LOG_TIMEDELTA', cast=int, default='10')
 # Ticket system for user support
 TICKET_SYSTEM_URL = config('TICKET_SYSTEM_URL', default=None)
 
+# Platform Research Resource Identifer: https://rrid.site/
+# Added to citations to support tracking of reuse.
+# e.g. PhysioNet is "SCR_007345"
+PLATFORM_RRID = config('PLATFORM_RRID', default=None)
+
 #  Platform wide citation config
 PLATFORM_WIDE_CITATION = {
     'APA': config('PLATFORM_WIDE_CITATION_APA', default=None),

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -414,17 +414,19 @@ class Metadata(models.Model):
             year = timezone.now().year
             doi = '10.13026/*****'
 
+        rrid_text = f"RRID:{settings.PLATFORM_RRID}." if settings.PLATFORM_RRID else ""
         shared_content = {'year': year,
                           'title': self.title,
                           'version': self.version,
-                          'platform_name': settings.SITE_NAME}
+                          'platform_name': settings.SITE_NAME,
+                          'rrid': rrid_text}
 
         if style == 'MLA':
 
             style_format = ('{author}. "{title}" (version {version}). '
-                            '<i>{platform_name}</i> ({year})')
+                            '<i>{platform_name}</i> ({year}). {rrid}')
 
-            doi_format = (', <a href="https://doi.org/{doi}">'
+            doi_format = (' <a href="https://doi.org/{doi}">'
                           'https://doi.org/{doi}</a>.')
 
             if (len(authors) == 1):
@@ -440,9 +442,9 @@ class Metadata(models.Model):
         elif style == 'APA':
 
             style_format = ('{author} ({year}). {title} (version '
-                            '{version}). <i>{platform_name}</i>')
+                            '{version}). <i>{platform_name}</i>. {rrid}')
 
-            doi_format = ('. <a href="https://doi.org/{doi}">'
+            doi_format = (' <a href="https://doi.org/{doi}">'
                           'https://doi.org/{doi}</a>.')
 
             if (len(authors) == 1):
@@ -465,9 +467,9 @@ class Metadata(models.Model):
         elif style == 'Chicago':
 
             style_format = ('{author}. "{title}" (version {version}). '
-                            '<i>{platform_name}</i> ({year})')
+                            '<i>{platform_name}</i> ({year}). {rrid}')
 
-            doi_format = ('. <a href="https://doi.org/{doi}">'
+            doi_format = (' <a href="https://doi.org/{doi}">'
                           'https://doi.org/{doi}</a>.')
 
             if (len(authors) == 1):
@@ -482,9 +484,9 @@ class Metadata(models.Model):
         elif style == 'Harvard':
 
             style_format = ("{author} ({year}) '{title}' (version "
-                            "{version}), <i>{platform_name}</i>")
+                            "{version}), <i>{platform_name}</i>. {rrid}")
 
-            doi_format = (". Available at: "
+            doi_format = (" Available at: "
                           "<a href='https://doi.org/{doi}'>"
                           "https://doi.org/{doi}</a>.")
 
@@ -499,9 +501,9 @@ class Metadata(models.Model):
         elif style == 'Vancouver':
 
             style_format = ('{author}. {title} (version {version}). '
-                            '{platform_name}. {year}')
+                            '{platform_name}. {year}. {rrid}')
 
-            doi_format = ('. Available from: '
+            doi_format = (' Available from: '
                           '<a href="https://doi.org/{doi}">'
                           'https://doi.org/{doi}</a>.')
 

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -427,7 +427,7 @@ class Metadata(models.Model):
                             '<i>{platform_name}</i> ({year}). {rrid}')
 
             doi_format = (' <a href="https://doi.org/{doi}">'
-                          'https://doi.org/{doi}</a>.')
+                          'https://doi.org/{doi}</a>')
 
             if (len(authors) == 1):
                 all_authors = authors[0].get_full_name(reverse=True)
@@ -445,7 +445,7 @@ class Metadata(models.Model):
                             '{version}). <i>{platform_name}</i>. {rrid}')
 
             doi_format = (' <a href="https://doi.org/{doi}">'
-                          'https://doi.org/{doi}</a>.')
+                          'https://doi.org/{doi}</a>')
 
             if (len(authors) == 1):
                 all_authors = authors[0].initialed_name()
@@ -470,7 +470,7 @@ class Metadata(models.Model):
                             '<i>{platform_name}</i> ({year}). {rrid}')
 
             doi_format = (' <a href="https://doi.org/{doi}">'
-                          'https://doi.org/{doi}</a>.')
+                          'https://doi.org/{doi}</a>')
 
             if (len(authors) == 1):
                 all_authors = authors[0].get_full_name(reverse=True)
@@ -488,7 +488,7 @@ class Metadata(models.Model):
 
             doi_format = (" Available at: "
                           "<a href='https://doi.org/{doi}'>"
-                          "https://doi.org/{doi}</a>.")
+                          "https://doi.org/{doi}</a>")
 
             if (len(authors) == 1):
                 all_authors = authors[0].initialed_name()
@@ -505,7 +505,7 @@ class Metadata(models.Model):
 
             doi_format = (' Available from: '
                           '<a href="https://doi.org/{doi}">'
-                          'https://doi.org/{doi}</a>.')
+                          'https://doi.org/{doi}</a>')
 
             all_authors = ', '.join(a.initialed_name(commas=False,
                                     periods=False) for a in authors)


### PR DESCRIPTION
This pull request allows platforms to include a Research Resource Identifier (RRID) to the suggested citations at the request of MIT Libraries. The RRID can be used to help track where the PhysioNet resource is being used, referenced, etc.

See: https://www.rrids.org/ for more information on RRIDs. There isn't great guidance on how to incorporate the RRID into each citation style, so I did what I thought was cleanest (inserting just before the DOI).

Not directly related to the core task, but I also removed the full stop at the end of the DOI url. On multiple occasions I have seen people think the `.` belongs in the URL, so I think it is safer for it not to be there.

### Screenshots:

## No RRID in .env:

<img width="590" alt="Screenshot 2025-05-28 at 5 06 07 PM" src="https://github.com/user-attachments/assets/cde1d72b-6015-4fb1-9442-d37195689403" />

## RRID in .env:

<img width="582" alt="Screenshot 2025-05-28 at 5 05 04 PM" src="https://github.com/user-attachments/assets/53169664-5ff2-4d01-afd7-e142defcb2a7" />




