### PR TITLE
Remove Legacy "Database List" API Endpoint

### DIFF
--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -11,20 +11,6 @@ from search.views import get_content
 from project.models import ProjectType
 from rest_framework.renderers import JSONRenderer
 
-# Temporary imports for Database List Function.
-from django.http import JsonResponse
-
-
-def database_list(request):
-    """
-    List all published databases
-    """
-    projects = PublishedProject.objects.filter(resource_type=0).order_by(
-        'publish_datetime')
-    serializer = PublishedProjectSerializer(projects, many=True)
-    return JsonResponse(serializer.data, safe=False)
-
-
 class PublishedProjectList(mixins.ListModelMixin, generics.GenericAPIView):
     """
     List all Published Projects

--- a/physionet-django/physionet/urls.py
+++ b/physionet-django/physionet/urls.py
@@ -10,8 +10,6 @@ from django.urls import path
 from physionet import views
 from physionet.settings.base import StorageTypes
 
-from export.views import database_list
-
 handler403 = 'physionet.views.error_403'
 handler404 = 'physionet.views.error_404'
 handler500 = 'physionet.views.error_500'
@@ -80,10 +78,6 @@ urlpatterns = [
 
     # path for the Browsable API Authentication
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-
-    # path for Database List - to be deprecated soon
-    path('rest/database-list/', database_list,
-         name='database_list')
 ]
 
 if settings.ENABLE_LIGHTWAVE:


### PR DESCRIPTION
This pull request removes the legacy `/rest/database-list/` endpoint and its associated view function.
 
The functionality is replaced by the `/api/projects/` endpoint.