### PR TITLE
Add SHA256SUMS.txt download endpoint

### DIFF
--- a/physionet-django/export/tests.py
+++ b/physionet-django/export/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/physionet-django/export/tests/test_files.py
+++ b/physionet-django/export/tests/test_files.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
+from project.models import PublishedProject, DUASignature, AccessPolicy
+from user.models import User
+
+
+class ProjectSHA256SumsTests(TestCase):
+    """Test suite for the SHA256SUMS endpoint"""
+
+    def setUp(self):
+        # Create users
+        self.user = User.objects.create(username='testuser',
+                                        email='test@example.com',
+                                        password='testpass123')
+        self.unauthorized_user = User.objects.create(username='unauthorized',
+                                                     email='unauthorized@example.com',
+                                                     password='testpass123')
+        self.rgmark = User.objects.create(username='rgmark',
+                                          email='rgmark@mit.edu',
+                                          password='Tester11!',
+                                          is_credentialed=True)
+        # Create project
+        self.project = PublishedProject.objects.create(
+            slug='demoeicu',
+            version='2.0.0',
+            title='Demo eICU Collaborative Research Database',
+            resource_type=0,
+            publish_datetime='2024-01-01T00:00:00Z',
+            access_policy=AccessPolicy.CREDENTIALED
+        )
+        # File setup
+        self.temp_dir = tempfile.mkdtemp()
+        self.project.file_root = lambda: self.temp_dir
+        self.sha256sums_path = os.path.join(self.temp_dir, 'SHA256SUMS.txt')
+        with open(self.sha256sums_path, 'w') as f:
+            f.write('test content')
+        self.client = APIClient()
+
+    def tearDown(self):
+        if os.path.exists(self.temp_dir):
+            for file in os.listdir(self.temp_dir):
+                os.remove(os.path.join(self.temp_dir, file))
+            os.rmdir(self.temp_dir)
+
+    def test_unauthorized_access(self):
+        url = reverse('published_project_sha256sums',
+                      kwargs={'project_slug': self.project.slug,
+                              'version': self.project.version})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.client.force_authenticate(user=self.unauthorized_user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_missing_file(self):
+        os.remove(self.sha256sums_path)
+        url = reverse('published_project_sha256sums',
+                      kwargs={'project_slug': self.project.slug,
+                              'version': self.project.version})
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.json()['error'], 'SHA256SUMS.txt not found for this project')
+
+    def test_successful_download(self):
+        url = reverse('published_project_sha256sums',
+                      kwargs={'project_slug': self.project.slug,
+                              'version': self.project.version})
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response['Content-Type'], 'text/plain')
+        self.assertEqual(response['Content-Disposition'], 'attachment; filename="SHA256SUMS.txt"')
+        self.assertEqual(response.content.decode(), 'test content')
+
+    def test_nonexistent_project(self):
+        url = reverse('published_project_sha256sums',
+                      kwargs={'project_slug': 'nonexistent',
+                              'version': '1.0.0'})
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_rgmark_dua_signing(self):
+        url = reverse('published_project_sha256sums',
+                      kwargs={'project_slug': self.project.slug,
+                              'version': self.project.version})
+        self.client.force_authenticate(user=self.rgmark)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        DUASignature.objects.create(user=self.rgmark, project=self.project)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response['Content-Type'], 'text/plain')
+        self.assertEqual(response['Content-Disposition'], 'attachment; filename="SHA256SUMS.txt"')
+        self.assertEqual(response.content.decode(), 'test content')

--- a/physionet-django/export/tests/test_views.py
+++ b/physionet-django/export/tests/test_views.py
@@ -72,7 +72,7 @@ class TestRateLimiting(TestCase):
     def test_project_detail_rate_limit(self):
         """Test rate limiting on project detail endpoint"""
         url = reverse('published_project_detail',
-                      kwargs={'project_slug': 'test-project', 'version': '1.0.0'})
+                      kwargs={'project_slug': 'demopsn', 'version': '1.0'})
 
         # Make requests up to the limit
         for _ in range(20):

--- a/physionet-django/export/urls.py
+++ b/physionet-django/export/urls.py
@@ -21,6 +21,10 @@ urlpatterns = [
          views.PublishedProjectDetail.as_view(),
          name='published_project_detail'),
 
+    path('v1/projects/published/<str:project_slug>/<str:version>/sha256sums/',
+         views.ProjectSHA256Sums.as_view(),
+         name='published_project_sha256sums'),
+
     # Legacy project endpoints (synonyms)
     path('v1/project/published/',
          views.PublishedProjectList.as_view(),
@@ -43,4 +47,12 @@ urlpatterns = [
 TEST_DEFAULTS = {
     'project_slug': 'demoeicu',
     'version': '2.0.0',
+}
+
+TEST_CASES = {
+    'published_project_sha256sums': {
+        '_user_': 'rgmark',
+        'project_slug': 'demopsn',
+        'version': '1.0',
+    },
 }

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -1,9 +1,14 @@
+import os
+
+from django.http import FileResponse
 from django.shortcuts import get_object_or_404
-from rest_framework import generics, mixins, status
+from rest_framework import generics, mixins, status, permissions
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle, AnonRateThrottle
+from rest_framework.views import APIView
 
+from project.authorization.access import can_access_project
 from project.models import PublishedProject, ProjectType
 from export.serializers import (
     PublishedProjectSerializer,
@@ -163,3 +168,29 @@ class PublishedProjectSearch(mixins.ListModelMixin, generics.GenericAPIView):
             )
 
         return self.list(request, *args, **kwargs)
+
+
+class ProjectSHA256Sums(APIView):
+    """
+    Download SHA256SUMS.txt file for a project.
+    """
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, project_slug, version):
+        project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
+
+        # Check if user has access to the project
+        if not can_access_project(project, request.user):
+            return Response({"error": "You do not have permission to access this project"}, status=403)
+
+        # Get the path to SHA256SUMS.txt
+        sha256sums_path = os.path.join(project.file_root(), 'SHA256SUMS.txt')
+
+        if not os.path.exists(sha256sums_path):
+            return Response({"error": "SHA256SUMS.txt not found for this project"}, status=404)
+
+        # Return the file as a download
+        response = FileResponse(open(sha256sums_path, 'rb'))
+        response['Content-Type'] = 'text/plain'
+        response['Content-Disposition'] = 'attachment; filename="SHA256SUMS.txt"'
+        return response


### PR DESCRIPTION
This pull request adds a new API endpoint that allows authorized users to download the SHA256SUMS.txt file for a specific project:

`/v1/projects/published/<project_slug>/<version>/sha256sums/`

The file contains SHA256 checksums for all files in the dataset, which is useful for verifying data integrity. If the file doesn't exist, a not found error is returned.

On the dev server, the following endpoint should return a file if logged in: 
http://localhost:8000/api/v1/projects/published/demopsn/1.0/sha256sums/

The following endpoint returns a not-found error:
http://localhost:8000/api/v1/projects/published/demowave/1.0.0/sha256sums/
