### PR TITLE
Bump test server to Debian 12

### DIFF
--- a/deploy/test-server/README
+++ b/deploy/test-server/README
@@ -8,8 +8,8 @@ Quick start:
    required.
 
 2. Download the latest installer (amd64 netinst) CD image from
-   https://www.debian.org/releases/bullseye/debian-installer/
-   (e.g., debian-11.2.0-amd64-netinst.iso) to this directory.
+   https://www.debian.org/releases/bookworm/debian-installer/
+   (e.g., debian-12.11.0-amd64-netinst.iso) to this directory.
 
 3. Run ./kvm-pntest-create to create the virtual disk image.
 

--- a/deploy/test-server/kvm-pntest-create
+++ b/deploy/test-server/kvm-pntest-create
@@ -8,7 +8,7 @@ IMAGE=physionet-test.img
 IMAGE_SIZE=20G
 IMAGE_FORMAT=qcow2
 
-INSTALLER_IMAGE=$(ls -v debian-11.*.*-amd64-netinst.iso | tail -1)
+INSTALLER_IMAGE=$(ls -v debian-12.*.*-amd64-netinst.iso | tail -1)
 INSTALLER_KERNEL=install.amd/vmlinuz
 INSTALLER_INITRD=install.amd/initrd.gz
 


### PR DESCRIPTION
This pull request updates the scripts for configuring a demo PhysioNet server in a virtual machine to use Debian 12, rather than Debian 11 (for consistency with the change introduced in https://github.com/MIT-LCP/physionet-build/pull/2421)