### PR TITLE
Handle errors in pipelines in git hooks

### DIFF
--- a/deploy/post-receive
+++ b/deploy/post-receive
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 install_dir=/physionet/physionet-build
 working_dir=/physionet/physionet-build.new

--- a/deploy/update
+++ b/deploy/update
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 install_dir=/physionet/physionet-build
 working_dir=/physionet/physionet-build.new


### PR DESCRIPTION
If something goes wrong in the installation process (for example, one of the "manage.py" commands fails), the git hooks should immediately stop what they're doing and not blindly keep going.

In particular, if there is an early migration that fails for any reason, then the old (working) server code should be left running, rather than installing the new (presumably dependent on the migration, and thus broken) server code.  That's certainly how it was intended to work, but it didn't work because the "migratetargets" command had its output redirected to a pipe.

Use bash's "pipefail" mode to ensure that we catch errors from all non-final commands in a pipeline.  Currently the "migrate" and "migratetargets" commands are the only ones where this should make a difference.
