### PR TITLE
Workflow test for .env settings with missing defaults

### DIFF
--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Create .env file
         run: |
-          ln -sT .env.example .env
+          git cat-file blob origin/production:.env.example > .env
 
       - name: Test PhysioNet server setup and upgrade
         run: |


### PR DESCRIPTION
If new variables are added to the .env file, they should have sensible, working defaults, so that the administrator isn't required to manually edit the .env file before installing the new code.

For example, pull #2430 would instantly break the server (it's an easy mistake to make!) and none of our existing GitHub workflows would detect that situtation.

Try to catch this, by requiring the *new* test suite to pass using the *old* .env.example file.
