### PR TITLE
Redirect /static/published-projects/ to new URLs

### DIFF
--- a/deploy/common/etc/nginx/snippets/physionet-common.conf
+++ b/deploy/common/etc/nginx/snippets/physionet-common.conf
@@ -11,12 +11,13 @@
     location /static {
         alias /data/pn-static;
         add_header Content-Security-Policy $pn_static_csp;
-    }
 
-    location /static/published-projects {
-        autoindex on;
-        alias /data/pn-static/published-projects;
-        add_header Content-Security-Policy $pn_static_csp;
+        location ~ ^/static/published-projects/([-\w]+)/[^/]+-([0-9.]+)\.zip$ {
+            return 301 https://$host/content/$1/get-zip/$2/;
+        }
+        location ~ ^/static/published-projects/(.*)$ {
+            return 301 https://$host/files/$1;
+        }
     }
 
     location /favicon.ico {


### PR DESCRIPTION
Add rules to redirect old /static/published-projects/ URLs to the current, supported URLs.  This includes published project zip files as well as published project files.

(Once this is done, the actual files under /pn-static/published-projects/ should no longer be accessible, and we should be able to remove that directory.)
