### PR TITLE
Move check for GEOIP installation to settings.py. Fixes 2436

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -790,3 +790,11 @@ OAUTH2_PROVIDER = {
 
 # Path to GeoIP2 database directory
 GEOIP_PATH = config('GEOIP_PATH', default=None)
+
+# Validate GeoIP configuration
+if BLOCKED_REGIONS and any(region != 'localhost' for region in BLOCKED_REGIONS):
+    if not GEOIP_PATH:
+        raise RuntimeError(
+            "BLOCKED_REGIONS is set to block real countries, but GEOIP_PATH is not configured. "
+            "Please set GEOIP_PATH to the directory containing your GeoIP2 database files."
+        )

--- a/physionet-django/physionet/utility.py
+++ b/physionet-django/physionet/utility.py
@@ -23,26 +23,16 @@ LOGGER = logging.getLogger(__name__)
 GEOIP = None
 
 
-def is_blocking_countries():
-    """Returns True if any region other than 'localhost' is blocked."""
-    return any(region != 'localhost' for region in getattr(settings, 'BLOCKED_REGIONS', []))
-
-
 def _get_geoip():
     """
     Get the GeoIP2 object, initializing it if necessary.
     """
     global GEOIP
     if GEOIP is None:
-        if not settings.GEOIP_PATH:
-            if is_blocking_countries():
-                raise RuntimeError(
-                    "BLOCKED_REGIONS is set to block real countries, but GEOIP_PATH is not configured. "
-                    "Please set GEOIP_PATH to the directory containing your GeoIP2 database files."
-                )
-            GEOIP = None
-        else:
+        if settings.GEOIP_PATH:
             GEOIP = GeoIP2(path=settings.GEOIP_PATH)
+        else:
+            GEOIP = None
     return GEOIP
 
 


### PR DESCRIPTION
This pull request addresses https://github.com/MIT-LCP/physionet-build/issues/2436

> From the discussion of pull https://github.com/MIT-LCP/physionet-build/pull/2434

>> Instead of reloading the GEOIP data, I moved initialization to a _get_geoip() function that skips initialization if the object already exists.

> This is a bit of a problem because now the server will not fail immediately if it's misconfigured (e.g., BLOCKED_REGIONS is set and GEOIP_PATH is not).

> Better, I would think, to move the check-for-broken-config into settings/base.py.

## Changes:

- Updates `settings/base.py` to check that `GEOIP_PATH` is assigned if there are `BLOCKED_REGIONS`.
- Updates `_get_geoip()` to handle initialization without configuration checks
- Removed the now unused `is_blocking_countries()`