### PR TITLE
Rewrite /physiobank/database/ to new URLs

### DIFF
--- a/deploy/common/etc/nginx/snippets/physionet-common.conf
+++ b/deploy/common/etc/nginx/snippets/physionet-common.conf
@@ -38,16 +38,10 @@
         location ~ /physiobank/database/([-\w]+)/$ {
             try_files $uri/index.html @dynamic;
         }
-        # other files/directories are served normally; 404 is handled
-        # by nginx
+        # other files/directories are served if they exist;
+        # otherwise rewrite to /files/, which is handled by django
         location ~ /physiobank/database/(.*)$ {
-            set $fpath $1;
-            alias /;
-            try_files "data/pn-static/published-projects/$fpath"
-                      "data/pn-static/published-projects/$fpath/"
-                      "data/pn-static/physiobank/database/$fpath"
-                      "data/pn-static/physiobank/database/$fpath/"
-                      =404;
+            try_files $uri $uri/ /files/$1;
         }
     }
 


### PR DESCRIPTION
Update the old WFDB API to go through Django rather than accessing files in pn-static/published-projects (which is going away.)

Simplifying the nginx logic is a good thing in any case.
