### PR TITLE
Allow georestricted flag to be set by editor prior to publication. Ref #2438

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -328,6 +328,11 @@ class PublishForm(forms.Form):
     """
     Form for publishing a project
     """
+    georestricted = forms.ChoiceField(
+        choices=[(True, 'True'), (False, 'False')],
+        label='Georestricted',
+        help_text='If True, georestriction rules will be applied to the dataset.'
+    )
     slug = forms.CharField(max_length=MAX_PROJECT_SLUG_LENGTH,
                            validators=[validate_slug])
     make_zip = forms.ChoiceField(choices=YES_NO, label='Make zip of all files')
@@ -335,6 +340,10 @@ class PublishForm(forms.Form):
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.project = project
+
+        # Set initial value for georestricted field
+        self.fields['georestricted'].initial = self.project.georestricted
+
         # No option to set slug if publishing new version
         if self.project.is_new_version:
             del(self.fields['slug'])

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -385,14 +385,14 @@ class TestState(TestMixin):
             taken_slug = PublishedProject.objects.all().first().slug
             response = self.client.post(reverse(
                 'publish_submission', args=(project.slug,)),
-                data={'slug':taken_slug, 'doi': False, 'make_zip':1})
+                data={'slug': taken_slug, 'doi': False, 'make_zip': 1, 'georestricted': False})
             self.assertTrue(bool(ActiveProject.objects.filter(
                 slug=project_slug)))
 
         # Publish with a valid custom slug
         response = self.client.post(reverse(
             'publish_submission', args=(project.slug,)),
-            data={'slug':custom_slug, 'doi': False, 'make_zip':1})
+            data={'slug': custom_slug, 'doi': False, 'make_zip': 1, 'georestricted': False})
 
         # Run background tasks
         self.assertTrue(bool(tasks.run_next_task()))

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -726,6 +726,10 @@ def publish_submission(request, project_slug, *args, **kwargs):
     if request.method == 'POST':
         publish_form = forms.PublishForm(project=project, data=request.POST)
         if project.is_publishable() and publish_form.is_valid():
+
+            project.georestricted = publish_form.cleaned_data['georestricted']
+            project.save()
+
             if project.is_new_version:
                 slug = project.get_previous_slug()
             else:


### PR DESCRIPTION
Currently there is no way of setting the `georestricted` flag for projects to True via the platform. 

This pull request responds to https://github.com/MIT-LCP/physionet-build/issues/2438 by adding a form item in the "Publish Submission" page of the editorial system that allows the editor to set the flag to True or False.

![Screenshot 2025-07-08 at 3 58 21 PM](https://github.com/user-attachments/assets/e799fb33-5d08-4f7e-8c4e-2e6ca83665ae)

This is not a long-term solution, but it does address the need for now. It is a flexible approach that is easily reversible.