### PR TITLE
Add configuration link when user lacks verified AWS credentials

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -337,10 +337,10 @@
               Download the files using AWS command line tools:
               <pre class="shell-command">aws s3 sync {{ s3_uri }} DESTINATION</pre>
             </li>
-          {% elif project.access_policy != AccessPolicy.OPEN and not user.cloud_information.aws_verification_datetime %}
+          {% elif show_aws_configuration_link %}
             <li>
               To download the files using AWS command line tools, first
-              <a href="https://physionet.org/settings/cloud/">configure your AWS credentials</a>.
+              <a href="{% url 'edit_cloud' %}">configure your AWS credentials</a>.
             </li>
           {% endif %}
           {% endif %}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -330,11 +330,19 @@
               <pre class="shell-command">wget -r -N -c -np{% if project.access_policy %} --user {{ user }} --ask-password{% endif %} {{ bulk_url_prefix }}{% url 'serve_published_project_file' project.slug project.version '' %}</pre>
             </li>
           {% endif %}
-          {% if has_s3_credentials and project.aws.sent_files and s3_uri %}
+
+          {% if has_s3_credentials and project.aws.sent_files %}
+          {% if s3_uri %}
             <li>
               Download the files using AWS command line tools:
               <pre class="shell-command">aws s3 sync {{ s3_uri }} DESTINATION</pre>
             </li>
+          {% elif project.access_policy != AccessPolicy.OPEN and not user.cloud_information.aws_verification_datetime %}
+            <li>
+              To download the files using AWS command line tools, first
+              <a href="https://physionet.org/settings/cloud/">configure your AWS credentials</a>.
+            </li>
+          {% endif %}
           {% endif %}
 
         </ul>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -63,6 +63,7 @@ from project.cloud.s3 import (
 )
 from django.db.models import F, DateTimeField, ExpressionWrapper
 from physionet.utility import get_client_ip, get_country_code
+from user.awsverification import aws_verification_available
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1964,6 +1965,21 @@ def published_project(request, project_slug, version, subdir=''):
     except AWS.DoesNotExist:
         s3_uri = None
 
+    # Determine when to show AWS configuration link
+    try:
+        show_aws_configuration_link = (
+            not s3_uri
+            and project.aws.sent_files
+            and project.aws.is_private
+            and aws_verification_available()
+            and (
+                not hasattr(user, 'cloud_information')
+                or not user.cloud_information.aws_verification_datetime
+            )
+        )
+    except AWS.DoesNotExist:
+        show_aws_configuration_link = False
+
     context = {
         'project': project,
         'authors': authors,
@@ -1992,6 +2008,7 @@ def published_project(request, project_slug, version, subdir=''):
         'is_wget_supported': project.files.is_wget_supported(),
         'has_s3_credentials': has_s3_credentials(),
         's3_uri': s3_uri,
+        'show_aws_configuration_link': show_aws_configuration_link,
         'show_platform_wide_citation': show_platform_wide_citation,
         'main_platform_citation': main_platform_citation,
         'user_country_blocked': user_country_blocked,


### PR DESCRIPTION
We are currently managing AWS CLI commands for downloading datasets from S3 buckets based on access policies:

* **Open-access datasets**: AWS CLI download commands are always displayed, and users don't need to configure credentials
* **Controlled-access datasets**: Users must configure their AWS credentials in the platform before they can download datasets

This PR informs users when AWS credential configuration is required to download a given dataset from S3, and provides a direct link to the configuration page (https://physionet.org/settings/cloud/).