### PR TITLE
Test cases for S3 controlled buckets

### DIFF
--- a/physionet-django/project/test_s3.py
+++ b/physionet-django/project/test_s3.py
@@ -1,19 +1,36 @@
 import os
+import re
 from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase, override_settings
-from moto import mock_s3
+from django.urls import reverse
+from django.utils import timezone
+from moto import (
+    mock_s3,
+    mock_s3control,
+)
 
+from project.authorization.access import can_view_project_files
 from project.cloud.s3 import (
     check_s3_bucket_exists,
     create_s3_client,
+    create_s3_control_client,
     create_s3_server_access_log_bucket,
     get_bucket_name,
     has_s3_credentials,
     upload_project_to_S3,
 )
-from project.models import PublishedProject
+from project.models import (
+    AWS,
+    PublishedProject,
+)
+from user.models import (
+    User,
+    CloudInformation,
+    Training,
+    TrainingStatus,
+)
 from user.test_views import TestMixin
 
 
@@ -50,10 +67,15 @@ class TestS3(TestMixin):
         self.mock_env.start()
         self.mock_s3 = mock_s3()
         self.mock_s3.start()
+        self.mock_s3control = mock_s3control()
+        self.mock_s3control.start()
+
+        self.user_counter = 1
 
     def tearDown(self):
         super().tearDown()
         self.mock_s3.stop()
+        self.mock_s3control.stop()
         self.mock_env.stop()
 
     def test_s3_credentials(self):
@@ -142,6 +164,120 @@ class TestS3(TestMixin):
 
         self.assertEqual(bucket_files, expected_files)
 
+    def test_controlled_access_points(self):
+        """
+        Test creation of S3 access points.
+        """
+        create_s3_server_access_log_bucket()
+
+        project = PublishedProject.objects.get(slug='demoeicu',
+                                               version='2.0.0')
+
+        # Create some example users.
+
+        existing_aws_users = self.create_example_users(
+            project=project,
+            count=999,
+            aws_verified=True,
+            signed_dua=True,
+        )
+        existing_nonaws_users = self.create_example_users(
+            project=project,
+            count=50,
+            aws_verified=False,
+            signed_dua=True,
+        )
+        add_aws_users = self.create_example_users(
+            project=project,
+            count=5,
+            aws_verified=True,
+            signed_dua=False,
+        )
+        add_nonaws_users = self.create_example_users(
+            project=project,
+            count=5,
+            aws_verified=False,
+            signed_dua=False,
+        )
+
+        for user in [existing_nonaws_users[0], existing_aws_users[0]]:
+            self.assertTrue(can_view_project_files(project, user))
+        for user in [add_nonaws_users[0], add_aws_users[0]]:
+            self.assertFalse(can_view_project_files(project, user))
+
+        # Upload the project to S3 and create initial access points.
+
+        aws = AWS.objects.create(
+            project=project,
+            bucket_name=get_bucket_name(project),
+            is_private=True,
+        )
+        upload_project_to_S3(project)
+        aws.sent_files = True
+        aws.save()
+
+        # Existing users should have access immediately.
+
+        self.assert_project_users_authorized(project, existing_aws_users)
+        self.assertEqual(aws.access_points.count(), 2)
+
+        # As new users sign the DUA, they should be granted access.
+
+        for user in add_aws_users + add_nonaws_users:
+            self.client.force_login(user)
+            self.client.post(
+                reverse('sign_dua', args=(project.slug, project.version)),
+                data={'agree': ''},
+            )
+            self.assertTrue(can_view_project_files(project, user))
+
+            if user in add_aws_users:
+                existing_aws_users.append(user)
+            self.assert_project_users_authorized(project, existing_aws_users)
+
+        self.assertEqual(aws.access_points.count(), 3)
+
+    def assert_project_users_authorized(self, project, users):
+        """
+        Check that the given users can access the project via S3.
+        """
+        s3control = create_s3_control_client()
+
+        all_expected_users = set(user.username for user in users)
+        all_authorized_users = set()
+
+        principal_re = re.compile(r'"(AIDA[A-Z0-9]+)"')
+        for access_point in project.aws.access_points.all():
+            # Retrieve the policy for this access point.  Note that
+            # here, the behavior of moto differs drastically from AWS:
+            # moto returns the same JSON document we uploaded, whereas
+            # AWS returns a preprocessed version.  In particular, AWS
+            # converts valid userids into ARNs, which we're assuming
+            # is *not* done here!
+
+            response = s3control.get_access_point_policy(
+                AccountId=settings.AWS_ACCOUNT_ID,
+                Name=access_point.name,
+            )
+            policy = response['Policy']
+
+            # Find userids that are listed in the policy.
+            # These should match the list of users for this access point.
+
+            authorized_userids = set()
+            for m in principal_re.finditer(policy):
+                authorized_userids.add(m.group(1))
+
+            expected_userids = set()
+            for user in access_point.users.all():
+                if user.cloud_information.aws_verification_datetime:
+                    expected_userids.add(user.cloud_information.aws_userid)
+                    all_authorized_users.add(user.username)
+
+            self.assertSetEqual(authorized_userids, expected_userids)
+
+        self.assertSetEqual(all_authorized_users, all_expected_users)
+
     def assert_bucket_is_public(self, bucket_name):
         """
         Check that a bucket exists and allows some form of public access.
@@ -165,3 +301,48 @@ class TestS3(TestMixin):
         self.assertTrue(conf['IgnorePublicAcls'])
         self.assertTrue(conf['BlockPublicPolicy'])
         self.assertTrue(conf['RestrictPublicBuckets'])
+
+    def create_example_users(self, project, count, aws_verified, signed_dua):
+        """
+        Create example users for testing a project.
+
+        Each of the generated users will have completed the training
+        requirements for the given project.  If aws_verified is true,
+        the user will also have a verified AWS identity; if signed_dua
+        is true, the user will have signed the project DUA.
+        """
+        training_types = list(project.required_trainings.all())
+        users = []
+        now = timezone.now()
+        for _ in range(count):
+            n = self.user_counter
+            self.user_counter += 1
+
+            user = User.objects.create(
+                username=f"s3test{n}",
+                email=f"s3test{n}@example.org",
+                is_active=True,
+                is_credentialed=True,
+                credential_datetime=now,
+            )
+            users.append(user)
+            for i, training_type in enumerate(training_types):
+                Training.objects.create(
+                    user=user,
+                    slug=f"s3test{n}tr{i}",
+                    training_type=training_type,
+                    status=TrainingStatus.ACCEPTED,
+                    process_datetime=now,
+                )
+            if aws_verified:
+                CloudInformation.objects.create(
+                    user=user,
+                    aws_id=f"{n:012d}",
+                    aws_userid=f"AIDA{n:017X}",
+                    aws_user_arn=f"arn:aws:iam::{n:012d}:user/somebody",
+                    aws_verification_datetime=now,
+                )
+            if signed_dua:
+                user.dua_signatures.create(project=project)
+
+        return users

--- a/physionet-django/project/test_s3.py
+++ b/physionet-django/project/test_s3.py
@@ -91,13 +91,38 @@ class TestS3(TestMixin):
 
         self.assertTrue(check_s3_bucket_exists(project1))
         self.assertTrue(check_s3_bucket_exists(project2))
+        self.assert_bucket_is_public(get_bucket_name(project1))
+        self.assert_project_files_uploaded([project1, project2])
 
+    def test_upload_controlled_projects(self):
+        """
+        Test uploading controlled-access projects to S3.
+        """
+        create_s3_server_access_log_bucket()
+
+        project1 = PublishedProject.objects.get(slug='demoeicu',
+                                                version='2.0.0')
+
+        self.assertFalse(check_s3_bucket_exists(project1))
+
+        upload_project_to_S3(project1)
+
+        self.assertTrue(check_s3_bucket_exists(project1))
+
+        # FIXME: upload_project_to_S3 does not set an explicit
+        # PublicAccessBlockConfiguration for the controlled bucket.
+        # self.assert_bucket_is_not_public(get_bucket_name(project1))
+
+        self.assert_project_files_uploaded([project1])
+
+    def assert_project_files_uploaded(self, projects):
+        """
+        Check that the given projects' files were uploaded.
+        """
         s3 = create_s3_client()
         expected_files = {}
-        for project in (project1, project2):
-            bucket = get_bucket_name(project)
-            self.assert_bucket_is_public(bucket)
-
+        bucket = get_bucket_name(projects[0])
+        for project in projects:
             prefix = project.slug + '/' + project.version + '/'
             for subdir, _, files in os.walk(project.file_root()):
                 for name in files:


### PR DESCRIPTION
The site allows mirroring controlled projects to Amazon S3, using AWS S3 Access Points to grant permission only to authorized people.

Add some test cases for this functionality (not to test the access policy logic itself - moto doesn't emulate that - but to ensure the Django server behaves as we expect.)
