### PR TITLE
Enable users to be added to access point policies after they have signed DUA

### DIFF
--- a/physionet-django/project/modelcomponents/storage.py
+++ b/physionet-django/project/modelcomponents/storage.py
@@ -68,6 +68,21 @@ class AWS(models.Model):
         """
         return f's3://{self.bucket_name}/{self.project.slug}/{self.project.version}/'
 
+    def user_included_in_ap_policy(self, user):
+        """
+        Check if a user has access to this AWS project through any access point.
+
+        Args:
+            user (User): The user to check
+
+        Returns:
+            bool: True if user has access, False otherwise
+        """
+        return AWSAccessPointUser.objects.filter(
+            user=user,
+            aws=self
+        ).exists()
+
     def __str__(self):
         return f"AWS instance for project: {self.project.slug}"
 

--- a/physionet-django/project/modelcomponents/storage.py
+++ b/physionet-django/project/modelcomponents/storage.py
@@ -68,7 +68,7 @@ class AWS(models.Model):
         """
         return f's3://{self.bucket_name}/{self.project.slug}/{self.project.version}/'
 
-    def user_included_in_ap_policy(self, user):
+    def user_in_access_point_policy(self, user):
         """
         Check if a user has access to this AWS project through any access point.
 

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -342,6 +342,13 @@
               To download the files using AWS command line tools, first
               <a href="{% url 'edit_cloud' %}">configure your AWS credentials</a>.
             </li>
+          {% elif not user_included_in_ap_policy %}
+            <li>
+              Click to access the files using AWS command line tools:
+              <a href="{% url 'enable_aws_access' project.slug project.version %}">
+                Enable AWS access
+              </a>
+            </li>
           {% endif %}
           {% endif %}
 

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -342,7 +342,7 @@
               To download the files using AWS command line tools, first
               <a href="{% url 'edit_cloud' %}">configure your AWS credentials</a>.
             </li>
-          {% elif not user_included_in_ap_policy %}
+          {% elif not user_in_access_point_policy %}
             <li>
               Click to access the files using AWS command line tools:
               <a href="{% url 'enable_aws_access' project.slug project.version %}">

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -345,9 +345,12 @@
           {% elif not user_in_access_point_policy %}
             <li>
               Click to access the files using AWS command line tools:
-              <a href="{% url 'enable_aws_access' project.slug project.version %}">
-                Enable AWS access
-              </a>
+              <form method="post" action="{% url 'enable_aws_access' project.slug project.version %}">
+                {% csrf_token %}
+                <button class="btn btn-primary btn-fixed" type="submit">
+                  Enable AWS access
+                </button>
+              </form>
             </li>
           {% endif %}
           {% endif %}

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2272,6 +2272,11 @@ def enable_aws_access(request, project_slug, version):
         messages.error(request, 'Project not found.')
         return redirect('project_home')
 
+    # Verify if the user has access to the project
+    if not can_access_project(project, user, request):
+        messages.error(request, 'You do not have permission to access this project.')
+        return redirect('published_project', project_slug=project_slug, version=version)
+
     try:
         result = add_user_to_access_point_policy(project, user)
         if result:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2273,27 +2273,38 @@ def enable_aws_access(request, project_slug, version):
         return redirect('project_home')
 
     # Verify if the user has access to the project
-    if not can_access_project(project, user, request):
+    if not can_view_project_files(project, user, request):
         messages.error(request, 'You do not have permission to access this project.')
         return redirect('published_project', project_slug=project_slug, version=version)
 
-    try:
-        result = add_user_to_access_point_policy(project, user)
-        if result:
-            messages.success(
-                request,
-                'AWS access has been enabled! You can now download files using AWS CLI.'
-            )
+    if request.method == 'POST':
+        if has_s3_credentials() and files_sent_to_S3(project):
+            if (
+                hasattr(user, 'cloud_information')
+                and user.cloud_information is not None
+                and user.cloud_information.aws_verification_datetime is not None
+            ):
+                try:
+                    result = add_user_to_access_point_policy(project, user)
+                    if result:
+                        messages.success(
+                            request,
+                            'AWS access has been enabled! You can now download files using AWS CLI.'
+                        )
+                    else:
+                        messages.error(
+                            request,
+                            'Failed to enable AWS access.'
+                        )
+                except Exception as e:
+                    messages.error(
+                        request,
+                        f'An error occurred while enabling AWS access: {str(e)}'
+                    )
+            else:
+                messages.error(request, 'Please configure and verify your AWS credentials first.')
         else:
-            messages.error(
-                request,
-                'Failed to enable AWS access.'
-            )
-    except Exception as e:
-        messages.error(
-            request,
-            f'An error occurred while enabling AWS access: {str(e)}'
-        )
+            messages.error(request, 'AWS access is not available for this project.')
 
     return redirect('published_project', project_slug=project_slug, version=version)
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1980,6 +1980,13 @@ def published_project(request, project_slug, version, subdir=''):
     except AWS.DoesNotExist:
         show_aws_configuration_link = False
 
+    try:
+        aws_instance = project.aws
+        if aws_instance.is_private:
+            user_included_in_ap_policy = aws_instance.user_included_in_ap_policy(user)
+    except AWS.DoesNotExist:
+        user_included_in_ap_policy = False
+
     context = {
         'project': project,
         'authors': authors,
@@ -2008,6 +2015,7 @@ def published_project(request, project_slug, version, subdir=''):
         'is_wget_supported': project.files.is_wget_supported(),
         'has_s3_credentials': has_s3_credentials(),
         's3_uri': s3_uri,
+        'user_included_in_ap_policy': user_included_in_ap_policy,
         'show_aws_configuration_link': show_aws_configuration_link,
         'show_platform_wide_citation': show_platform_wide_citation,
         'main_platform_citation': main_platform_citation,
@@ -2250,6 +2258,39 @@ def data_access_requests_overview(request, project_slug, version):
                    'requests': all_requests,
                    'accepted_requests': accepted_requests,
                    'is_additional_reviewer': proj.is_data_access_reviewer(reviewer)})
+
+
+@login_required
+def enable_aws_access(request, project_slug, version):
+    """
+    Enable AWS access for a user by adding them to the access point policy.
+    """
+    user = request.user
+    try:
+        project = PublishedProject.objects.get(slug=project_slug, version=version)
+    except PublishedProject.DoesNotExist:
+        messages.error(request, 'Project not found.')
+        return redirect('project_home')
+
+    try:
+        result = add_user_to_access_point_policy(project, user)
+        if result:
+            messages.success(
+                request,
+                'AWS access has been enabled! You can now download files using AWS CLI.'
+            )
+        else:
+            messages.error(
+                request,
+                'Failed to enable AWS access.'
+            )
+    except Exception as e:
+        messages.error(
+            request,
+            f'An error occurred while enabling AWS access: {str(e)}'
+        )
+
+    return redirect('published_project', project_slug=project_slug, version=version)
 
 
 @login_required

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1983,7 +1983,7 @@ def published_project(request, project_slug, version, subdir=''):
     try:
         aws_instance = project.aws
         if aws_instance.is_private:
-            user_included_in_ap_policy = aws_instance.user_included_in_ap_policy(user)
+            user_included_in_ap_policy = aws_instance.user_in_access_point_policy(user)
     except AWS.DoesNotExist:
         user_included_in_ap_policy = False
 

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     path('model/', views.model_index, name='model_index'),
     path('content/', views.content_index, name='content_index'),
     path(
-        'content/<project_slug>/<version>/enable-aws-access/',
+        'enable-aws-access/<project_slug>/<version>/',
         project_views.enable_aws_access,
         name='enable_aws_access'
     ),

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
     path('challenge/', views.challenge_index, name='challenge_index'),
     path('model/', views.model_index, name='model_index'),
     path('content/', views.content_index, name='content_index'),
+    path(
+        'content/<project_slug>/<version>/enable-aws-access/',
+        project_views.enable_aws_access,
+        name='enable_aws_access'
+    ),
 
     # published project content
     re_path('^(?P<anonymous_url>[\w\d]{64})/$', project_views.anonymous_login,
@@ -118,6 +123,7 @@ TEST_CASES = {
     'display_published_project_file': {'full_file_name': 'Makefile'},
 
     'sign_dua': _demo_credentialed_access,
+    'enable_aws_access': _demo_credentialed_access,
 
     'request_data_access': _demo_access_requester,
     'data_access_request_status': _demo_access_requester,


### PR DESCRIPTION
PhysioNet users are not able to access projects from S3 buckets if they sign the DUA before configuring their AWS credentials on PhysioNet (by verifying their identity).

This PR adds the button "Enable AWS access" that users will click to access the files using AWS command line tools. In that case, they will be added to the access point policy linked to the project.

### Changes Made:

Added method to AWS model to check if a user is already included in any access point policy for a project;

Added "Enable AWS access" link in project templates that appears when users can't see the S3 URI for private projects but are eligible for AWS access.

### Prerequisites:

- User must have signed the DUA for the project;
- User must have verified AWS credentials in their cloud settings;
- Project must be private and have files sent to S3.