### PR TITLE
Cleanup and simplification of GitHub workflows

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,10 +3,12 @@
 name: Codespell
 
 on:
-  push:
-    branches: [dev]
   pull_request:
-    branches: [dev]
+    branches:
+      - dev
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout physionet-build repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Note: run checkout after updating git
       - name: Checkout physionet-build repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Mark git repository as trusted
         run: |

--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -39,7 +39,6 @@ jobs:
         run: |
           apt-get install --yes \
                   build-essential \
-                  flake8 \
                   git \
                   libcap-dev \
                   libffi-dev \
@@ -56,8 +55,6 @@ jobs:
       # Note: run checkout after updating git
       - name: Checkout physionet-build repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Mark git repository as trusted
         run: |
@@ -117,45 +114,3 @@ jobs:
         run: |
           cd physionet-django
           python manage.py compilestatic
-
-      - name: Run code style check on changed files relative to PR base branch
-        if: github.event_name == 'pull_request'
-        run: |
-          git rev-parse --verify ${{ github.event.pull_request.base.sha }}
-          git diff -U0 ${{ github.event.pull_request.base.sha }} HEAD | \
-              flake8 --diff | \
-              perl -ne '
-                print; if (/^([^:]+):(\d+):(\d+):/) {
-                  $path = $1; $line = $2; $col = $3;
-                  open F, $path or die;
-                  print "\n";
-                  while (<F>) {
-                    next if $. < $line - 2;
-                    print " $_";
-                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
-                  }
-                  close F;
-                  $status = 1;
-                }
-                END { exit $status }'
-
-      - name: Run code style check relative to local dev branch
-        if: github.event_name != 'pull_request'
-        run: |
-          git fetch origin dev
-          git diff -U0 origin/dev HEAD | \
-              flake8 --diff | \
-              perl -ne '
-                print; if (/^([^:]+):(\d+):(\d+):/) {
-                  $path = $1; $line = $2; $col = $3;
-                  open F, $path or die;
-                  print "\n";
-                  while (<F>) {
-                    next if $. < $line - 2;
-                    print " $_";
-                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
-                  }
-                  close F;
-                  $status = 1;
-                }
-                END { exit $status }'

--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -3,9 +3,6 @@
 name: Debian / Build and Test
 
 on:
-  push:
-    branches:
-      - dev
   pull_request:
     branches:
       - dev

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -39,7 +39,7 @@ jobs:
                   zip
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -1,9 +1,6 @@
 name: Debian / Upgrade Test
 
 on:
-  push:
-    branches:
-      - dev
   pull_request:
     branches:
       - dev

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,7 +31,9 @@ jobs:
           fetch-depth: 2
 
       - name: Run code style check on files modified in pull request
+        shell: bash
         run: |
+          set -o pipefail
           git diff -U0 HEAD^ HEAD | \
               flake8 --diff | \
               perl -ne '

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,76 @@
+name: Style
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+  merge_group:
+    types:
+      - checks_requested
+
+jobs:
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install \
+              flake8==5.0.4 \
+              mccabe==0.7.0 \
+              pycodestyle==2.9.1 \
+              pyflakes==2.5.0
+
+      - name: Check out pull request
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run code style check on changed files relative to PR base branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git rev-parse --verify ${{ github.event.pull_request.base.sha }}
+          git diff -U0 ${{ github.event.pull_request.base.sha }} HEAD | \
+              flake8 --diff | \
+              perl -ne '
+                print; if (/^([^:]+):(\d+):(\d+):/) {
+                  $path = $1; $line = $2; $col = $3;
+                  open F, $path or die;
+                  print "\n";
+                  while (<F>) {
+                    next if $. < $line - 2;
+                    print " $_";
+                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
+                  }
+                  close F;
+                  $status = 1;
+                }
+                END { exit $status }'
+
+      - name: Run code style check relative to local dev branch
+        if: github.event_name != 'pull_request'
+        run: |
+          git fetch origin dev
+          git diff -U0 origin/dev HEAD | \
+              flake8 --diff | \
+              perl -ne '
+                print; if (/^([^:]+):(\d+):(\d+):/) {
+                  $path = $1; $line = $2; $col = $3;
+                  open F, $path or die;
+                  print "\n";
+                  while (<F>) {
+                    next if $. < $line - 2;
+                    print " $_";
+                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
+                  }
+                  close F;
+                  $status = 1;
+                }
+                END { exit $status }'

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,9 +1,6 @@
 name: Style
 
 on:
-  push:
-    branches:
-      - dev
   pull_request:
     branches:
       - dev
@@ -31,34 +28,11 @@ jobs:
       - name: Check out pull request
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
-      - name: Run code style check on changed files relative to PR base branch
-        if: github.event_name == 'pull_request'
+      - name: Run code style check on files modified in pull request
         run: |
-          git rev-parse --verify ${{ github.event.pull_request.base.sha }}
-          git diff -U0 ${{ github.event.pull_request.base.sha }} HEAD | \
-              flake8 --diff | \
-              perl -ne '
-                print; if (/^([^:]+):(\d+):(\d+):/) {
-                  $path = $1; $line = $2; $col = $3;
-                  open F, $path or die;
-                  print "\n";
-                  while (<F>) {
-                    next if $. < $line - 2;
-                    print " $_";
-                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
-                  }
-                  close F;
-                  $status = 1;
-                }
-                END { exit $status }'
-
-      - name: Run code style check relative to local dev branch
-        if: github.event_name != 'pull_request'
-        run: |
-          git fetch origin dev
-          git diff -U0 origin/dev HEAD | \
+          git diff -U0 HEAD^ HEAD | \
               flake8 --diff | \
               perl -ne '
                 print; if (/^([^:]+):(\d+):(\d+):/) {


### PR DESCRIPTION
Assorted minor improvements to GitHub workflows:

- Now that checks are always peformed *before* pushing (using `merge_group`), I don't see a point in running exactly the same checks on the same commits, *after* pushing (using `push`).  It just wastes time and energy.

- Separate the code style (flake8) checks into their own workflow.  They only need to run once (not once for every matrix configuration), and it's nice for developers not to have style errors conflated with test failures.

- Simplify the logic of the flake8 diff check and remove the duplicated code.
