### PR TITLE
Add authentication check before access point policy verification

### DIFF
--- a/physionet-django/project/modelcomponents/storage.py
+++ b/physionet-django/project/modelcomponents/storage.py
@@ -78,6 +78,8 @@ class AWS(models.Model):
         Returns:
             bool: True if user has access, False otherwise
         """
+        if not user.is_authenticated:
+            return False
         return AWSAccessPointUser.objects.filter(
             user=user,
             aws=self


### PR DESCRIPTION
This PR checks if user is authenticated before checking if they are in access point policy in the user_in_access_point_policy method.