### PR TITLE
Implement retry mechanism for malformed S3 access point policies

### DIFF
--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -478,7 +478,7 @@ def get_aws_accounts_for_access_point(access_point_name):
             if user.cloud_information.aws_userid
             else None
         )
-        if re.search(aws_id_pattern, aws_id):
+        if aws_id and re.search(aws_id_pattern, aws_id):
             aws_accounts.append({'aws_id': aws_id, 'aws_userid': aws_userid})
 
     return aws_accounts
@@ -522,7 +522,7 @@ def get_aws_accounts_for_dataset(dataset_name):
                         aws_userid = user.cloud_information.aws_userid
                     else:
                         aws_userid = None
-                    if re.search(aws_id_pattern, aws_id):
+                    if aws_id and re.search(aws_id_pattern, aws_id):
                         aws_accounts.append({'aws_id': aws_id, 'aws_userid': aws_userid})
             break  # Stop iterating once the dataset is found
 
@@ -884,7 +884,7 @@ def extract_invalid_userid(client_error):
     try:
         detail = client_error.response['Error']['Detail']
         import re
-        match = re.search(r'"AWS"\s*:\s*"(AIDA[A-Z0-9]+)"', detail)
+        match = re.search(r'"AWS"\s*:\s*"([^"]+)"', detail)
         if match:
             return match.group(1)
     except (KeyError, AttributeError):
@@ -911,68 +911,28 @@ def mark_user_unverified(invalid_userid):
         return False
 
 
-def set_data_access_point_policy(data_access_point_name, data_access_point_policy, new_user_to_add=None):
+def set_data_access_point_policy(data_access_point_name, data_access_point_policy):
     """
     Apply a custom policy to an AWS S3 data access point.
-    Retries until all invalid users are processed or no more users exist.
 
     Args:
         data_access_point_name (str): The name of the data access point.
         data_access_point_policy (str): The policy to be applied, in JSON string format.
-        new_user_to_add (dict, optional): New user being added (format: {'aws_userid': 'AIDA...'})
 
     Returns:
         bool: True if the policy was successfully applied, False otherwise.
     """
     s3_control = create_s3_control_client()
-    # Limit number of attempts to prevent infinite loop
 
-    for attempt in range(MAX_RETRIES):
-        try:
-            s3_control.put_access_point_policy(
-                AccountId=settings.AWS_ACCOUNT_ID,
-                Name=data_access_point_name,
-                Policy=data_access_point_policy,
-            )
-            return True
-
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'MalformedPolicy':
-                invalid_userid = extract_invalid_userid(e)
-                if invalid_userid:
-                    mark_user_unverified(invalid_userid)
-                    # Recreate policy without the invalid user
-                    try:
-                        # Get current users after marking invalid user
-                        current_aws_accounts = get_aws_accounts_for_access_point(data_access_point_name)
-                        # Add the new user if provided
-                        if new_user_to_add:
-                            current_aws_accounts.append(new_user_to_add)
-
-                        if not current_aws_accounts:
-                            return True
-
-                        access_point = AWSAccessPoint.objects.get(name=data_access_point_name)
-                        project = access_point.aws.project
-
-                        # Recreate policy with remaining valid users + new user
-                        data_access_point_policy = create_data_access_point_policy(
-                            data_access_point_name,
-                            project.slug,
-                            project.version,
-                            current_aws_accounts
-                        )
-
-                        continue
-
-                    except AWSAccessPoint.DoesNotExist:
-                        return False
-                else:
-                    return False
-            else:
-                raise
-
-    return False
+    try:
+        s3_control.put_access_point_policy(
+            AccountId=settings.AWS_ACCOUNT_ID,
+            Name=data_access_point_name,
+            Policy=data_access_point_policy,
+        )
+        return True
+    except ClientError:
+        raise
 
 
 def add_user_to_access_point_policy(project, user):
@@ -1084,30 +1044,48 @@ def get_access_point_with_capacity(project):
 def insert_access_point_policy(access_point, data_access_point_name, project, subset_aws_ids):
     """
     Set policies and associate users for an access point.
+    Handles invalid users by retrying with them removed from the list.
     """
-    # Identify if we're adding a new user (last user in the list)
-    new_user = None
-    existing_users = get_aws_accounts_for_access_point(data_access_point_name)
+    # Work with a copy to avoid modifying the original list
+    working_aws_ids = subset_aws_ids.copy()
+    for attempt in range(MAX_RETRIES):
+        if not working_aws_ids:
+            # No valid users left
+            return True
 
-    if len(subset_aws_ids) > len(existing_users):
-        # Find the new user (the one not in existing_users)
-        existing_userids = {user['aws_userid'] for user in existing_users}
-        for user in subset_aws_ids:
-            if user['aws_userid'] not in existing_userids:
-                new_user = user
-                break
+        access_point_policy = create_data_access_point_policy(
+            data_access_point_name, project.slug, project.version, working_aws_ids
+        )
+        try:
+            valid_ap_policy = set_data_access_point_policy(
+                data_access_point_name, access_point_policy
+            )
+            if valid_ap_policy:
+                associate_aws_users_with_data_access_point(access_point, working_aws_ids)
+                return True
+            else:
+                return False
 
-    access_point_policy = create_data_access_point_policy(
-        data_access_point_name, project.slug, project.version, subset_aws_ids
-    )
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'MalformedPolicy':
+                invalid_userid = extract_invalid_userid(e)
+                if invalid_userid:
+                    # Mark user as unverified
+                    mark_user_unverified(invalid_userid)
 
-    valid_ap_policy = set_data_access_point_policy(
-        data_access_point_name, access_point_policy, new_user
-    )
+                    # Remove the invalid user
+                    working_aws_ids = [
+                        user for user in working_aws_ids
+                        if user['aws_userid'] != invalid_userid
+                    ]
+                    # Continue to next attempt with reduced user list
+                    continue
+                else:
+                    return False
+            else:
+                raise
 
-    if valid_ap_policy:
-        associate_aws_users_with_data_access_point(access_point, subset_aws_ids)
-        return True
+    # Exceeded max retries
     return False
 
 

--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -15,6 +15,7 @@ from math import ceil
 from django.db.models import Q
 
 MAX_PRINCIPALS_PER_AP_POLICY = 500
+MAX_RETRIES = 500
 
 # Manage AWS buckets and objects
 def has_S3_open_data_bucket_name():
@@ -870,32 +871,108 @@ def create_data_access_point_policy(
     return policy_str
 
 
-def set_data_access_point_policy(data_access_point_name, data_access_point_policy):
+def extract_invalid_userid(client_error):
+    """
+    Extract the invalid AWS user ID from the ClientError detail.
+
+    Args:
+        client_error (ClientError): The boto3 ClientError exception
+
+    Returns:
+        str or None: The invalid user ID if found, None otherwise
+    """
+    try:
+        detail = client_error.response['Error']['Detail']
+        import re
+        match = re.search(r'"AWS"\s*:\s*"(AIDA[A-Z0-9]+)"', detail)
+        if match:
+            return match.group(1)
+    except (KeyError, AttributeError):
+        pass
+    return None
+
+
+def mark_user_unverified(invalid_userid):
+    """
+    Mark a user as unverified based on their AWS user ID.
+
+    Args:
+        invalid_userid (str): The AWS user ID that's invalid
+
+    Returns:
+        bool: True if user was found and marked as unverified, False otherwise
+    """
+    try:
+        cloud_info = CloudInformation.objects.get(aws_userid=invalid_userid)
+        cloud_info.aws_verification_datetime = None
+        cloud_info.save()
+        return True
+    except CloudInformation.DoesNotExist:
+        return False
+
+
+def set_data_access_point_policy(data_access_point_name, data_access_point_policy, new_user_to_add=None):
     """
     Apply a custom policy to an AWS S3 data access point.
-
-    This function sets a custom access policy for the specified
-    S3 data access point.
+    Retries until all invalid users are processed or no more users exist.
 
     Args:
         data_access_point_name (str): The name of the data access point.
         data_access_point_policy (str): The policy to be applied, in JSON string format.
+        new_user_to_add (dict, optional): New user being added (format: {'aws_userid': 'AIDA...'})
 
     Returns:
         bool: True if the policy was successfully applied, False otherwise.
-
-    Note:
-    - Ensure that AWS credentials (Access Key and Secret Key)
-    are properly configured for the S3 client used in this function.
     """
     s3_control = create_s3_control_client()
+    # Limit number of attempts to prevent infinite loop
 
-    s3_control.put_access_point_policy(
-        AccountId=settings.AWS_ACCOUNT_ID,
-        Name=data_access_point_name,
-        Policy=data_access_point_policy,
-    )
-    return True
+    for attempt in range(MAX_RETRIES):
+        try:
+            s3_control.put_access_point_policy(
+                AccountId=settings.AWS_ACCOUNT_ID,
+                Name=data_access_point_name,
+                Policy=data_access_point_policy,
+            )
+            return True
+
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'MalformedPolicy':
+                invalid_userid = extract_invalid_userid(e)
+                if invalid_userid:
+                    mark_user_unverified(invalid_userid)
+                    # Recreate policy without the invalid user
+                    try:
+                        # Get current users after marking invalid user
+                        current_aws_accounts = get_aws_accounts_for_access_point(data_access_point_name)
+                        # Add the new user if provided
+                        if new_user_to_add:
+                            current_aws_accounts.append(new_user_to_add)
+
+                        if not current_aws_accounts:
+                            return True
+
+                        access_point = AWSAccessPoint.objects.get(name=data_access_point_name)
+                        project = access_point.aws.project
+
+                        # Recreate policy with remaining valid users + new user
+                        data_access_point_policy = create_data_access_point_policy(
+                            data_access_point_name,
+                            project.slug,
+                            project.version,
+                            current_aws_accounts
+                        )
+
+                        continue
+
+                    except AWSAccessPoint.DoesNotExist:
+                        return False
+                else:
+                    return False
+            else:
+                raise
+
+    return False
 
 
 def add_user_to_access_point_policy(project, user):
@@ -1005,15 +1082,33 @@ def get_access_point_with_capacity(project):
 
 
 def insert_access_point_policy(access_point, data_access_point_name, project, subset_aws_ids):
-    # Set policies and associate users for the newly created access point
+    """
+    Set policies and associate users for an access point.
+    """
+    # Identify if we're adding a new user (last user in the list)
+    new_user = None
+    existing_users = get_aws_accounts_for_access_point(data_access_point_name)
+
+    if len(subset_aws_ids) > len(existing_users):
+        # Find the new user (the one not in existing_users)
+        existing_userids = {user['aws_userid'] for user in existing_users}
+        for user in subset_aws_ids:
+            if user['aws_userid'] not in existing_userids:
+                new_user = user
+                break
+
     access_point_policy = create_data_access_point_policy(
         data_access_point_name, project.slug, project.version, subset_aws_ids
     )
+
     valid_ap_policy = set_data_access_point_policy(
-        data_access_point_name, access_point_policy
+        data_access_point_name, access_point_policy, new_user
     )
+
     if valid_ap_policy:
         associate_aws_users_with_data_access_point(access_point, subset_aws_ids)
+        return True
+    return False
 
 
 def initialize_access_points(project):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1957,9 +1957,12 @@ def published_project(request, project_slug, version, subdir=''):
     try:
         if project.aws.is_private:
             if has_signed_dua and request.user.is_authenticated:
-                access_point = project.aws.access_points.filter(linked_users__user=request.user).first()
-                if access_point:
-                    s3_uri = access_point.private_s3_uri()
+                # It prevents showing the cli command for users who are still associated with
+                # an access point for the project but have deleted their aws credentials
+                if hasattr(user, 'cloud_information') and user.cloud_information.aws_verification_datetime:
+                    access_point = project.aws.access_points.filter(linked_users__user=request.user).first()
+                    if access_point:
+                        s3_uri = access_point.private_s3_uri()
         else:
             s3_uri = '--no-sign-request ' + project.aws.public_s3_uri()
     except AWS.DoesNotExist:


### PR DESCRIPTION
This PR aims to solve the issue reported in #2330 

We implement a retry mechanism to insert S3 access point policies to prevent errors when updating them after users delete their AWS credentials on PhysioNet after having been added to policies.

Our strategy is to parse out the invalid users, mark them as unverified, and retry inserting the access point policy.

### Changes Made:
- Detect and remove invalid AWS user IDs from policies until all of them are processed;
- Preserve new users being added during retry attempts;
- Add safety limit to prevent infinite loops.