### PR TITLE
Fix Events Update page query to filter by active datasets

### DIFF
--- a/physionet-django/events/views.py
+++ b/physionet-django/events/views.py
@@ -28,7 +28,9 @@ def update_event(request, event_slug, **kwargs):
     event = Event.objects.get(slug=event_slug)
 
     # if the event has dataset added to it, it cannot be edited
-    if event.datasets.exists():
+    if event.datasets.filter(is_active=True).exists():
+        if not can_change_event:
+            messages.error(request, "You don't have permission to edit this event")
         messages.error(request, "Event with datasets cannot be edited")
         return redirect(reverse('event_detail', args=[event_slug]))
 


### PR DESCRIPTION
The update event functionality now correctly filters datasets by their active status before checking for existence. This change prevents errors when editing events that are no longer connected to active datasets.

Fixes T-CAIREM/physionet-build#21