### PR TITLE
Display front_page_banner items at top of page. Fixes #2457.

### DIFF
--- a/physionet-django/physionet/views.py
+++ b/physionet-django/physionet/views.py
@@ -24,7 +24,7 @@ def home(request):
     """
     featured = PublishedProject.objects.filter(featured__isnull=False).order_by('featured')[:6]
     latest = PublishedProject.objects.filter(is_latest_version=True).order_by('-publish_datetime')[:6]
-    news_pieces = News.objects.all().order_by('-publish_datetime')[:5]
+    news_pieces = News.objects.filter(front_page_banner=False).order_by('-publish_datetime')[:5]
     front_page_buttons = FrontPageButton.objects.all()
     front_page_banner = News.objects.filter(front_page_banner=True)
 

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -34,7 +34,7 @@
   <div class="container pb-5 mt-0 px-0">
     <div class="swiper">
       <div class="swiper-wrapper">
-        {% for news in news_pieces|slice:":10" %}
+        {% for news in front_page_banner|slice:":10" %}
           <div class="swiper-slide">
             <div class="card card--news">
               <span class="caption-text">{{ news.publish_datetime|date }}</span>


### PR DESCRIPTION
The new front page displays two news carousels. As discussed in https://github.com/MIT-LCP/physionet-build/issues/2457, both carousels currently display the same news items.

This pull request fixes this issue:

- The top carousel now only displays news items marked as "front page banner".
- The lower carousel displays all news items (we could exclude front page banner items, but I prefer to display them in both places).

