### PR TITLE
Fix clipping of news items on front page

### DIFF
--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -228,7 +228,7 @@ body .main {
   flex-grow: 1;
   font-size: 0.875rem;
 }
-.modern-ui .card--news p {
+.modern-ui .card--news .card-content {
   font-size: 0.875rem;
   margin: 0;
   display: -webkit-box;

--- a/physionet-django/templates/home.html
+++ b/physionet-django/templates/home.html
@@ -41,9 +41,9 @@
               <h2 class="card-title">
                 <a href="{% url 'news_by_slug' news.slug %}">{{ news.title }}</a>
               </h2>
-              <p class="card-content light-text">
+              <div class="card-content light-text">
                 {{ news.content|safe }}
-              </p>
+              </div>
             </div>
           </div>
         {% endfor %}
@@ -89,9 +89,9 @@
                 <h2 class="card-title">
                   <a href="{% url 'news_by_slug' news.slug %}">{{ news.title }}</a>
                 </h2>
-                <p class="card-content light-text">
+                <div class="card-content light-text">
                   {{ news.content|safe }}
-                </p>
+                </div>
               </div>
             </div>
           {% endfor %}


### PR DESCRIPTION
Large news items on the front page should be clipped (using CSS) so they don't take up a huge amount of space.

We want to clip the entire content, not to clip each individual paragraph.
