### PR TITLE
Display more information about cloud mirrors

### DIFF
--- a/physionet-django/console/static/console/css/cloud-mirrors.css
+++ b/physionet-django/console/static/console/css/cloud-mirrors.css
@@ -42,14 +42,14 @@
     content: "\f375";           /* aws */
 }
 
-.project-site-status-open,
-.project-site-status-restricted,
-.project-site-status-embargo,
-.project-site-status-forbidden,
-.project-cloud-status-public,
-.project-cloud-status-private,
-.project-cloud-status-pending,
-.project-cloud-status-none {
+.table-cloud-status .project-site-status-open,
+.table-cloud-status .project-site-status-restricted,
+.table-cloud-status .project-site-status-embargo,
+.table-cloud-status .project-site-status-forbidden,
+.table-cloud-status .project-cloud-status-public,
+.table-cloud-status .project-cloud-status-private,
+.table-cloud-status .project-cloud-status-pending,
+.table-cloud-status .project-cloud-status-none {
     font-size: 0;
 }
 .project-site-status-open::before,

--- a/physionet-django/console/templates/console/cloud_mirror_info_card.html
+++ b/physionet-django/console/templates/console/cloud_mirror_info_card.html
@@ -1,0 +1,63 @@
+<div class="card">
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">
+      <dl class="row mb-0">
+        <dt class="col-md-3">Location</dt>
+        <dd class="col-md-9">{{ mirror.cloud_uri }}</dd>
+        <dt class="col-md-3">Project files</dt>
+        <dd class="col-md-9">
+          {% if mirror.sent_files %}
+            <span class="project-cloud-status-public">Uploaded</span>
+          {% else %}
+            <span class="project-cloud-status-pending">Not yet uploaded</span>
+          {% endif %}
+        </dd>
+        <dt class="col-md-3">ZIP archive</dt>
+        <dd class="col-md-9">
+          {% if mirror.sent_zip %}
+            <span class="project-cloud-status-public">Uploaded</span>
+          {% elif mirror.project.compressed_storage_size %}
+            <span class="project-cloud-status-pending">Not yet uploaded</span>
+          {% else %}
+            <span class="project-cloud-status-none">None</span>
+          {% endif %}
+        </dd>
+        <dt class="col-md-3">Created</dt>
+        <dd class="col-md-9">{{ mirror.creation_datetime }}</dd>
+        <dt class="col-md-3">Upload finished</dt>
+        <dd class="col-md-9">
+          {% if mirror.finished_datetime %}
+            {{ mirror.finished_datetime }}
+          {% else %}
+            Not yet uploaded
+          {% endif %}
+        </dd>
+      </dl>
+    </li>
+    <li class="list-group-item">
+      <dl class="row mb-0">
+        <dt class="col-md-3">Policy</dt>
+        <dd class="col-md-9">
+          {% if mirror.is_private %}
+            <span class="project-cloud-status-private">Private</span>
+          {% else %}
+            <span class="project-cloud-status-public">Public</span>
+          {% endif %}
+        </dd>
+        {% if mirror.access_group %}
+          <dt class="col-md-3">Access group</dt>
+          <dd class="col-md-9">{{ mirror.access_group }}</dd>
+        {% endif %}
+        {% if mirror.access_points.exists %}
+          <dt class="col-md-3">Access points</dt>
+          <dd class="col-md-9">
+            {% for access_point in mirror.access_points.all %}
+              {{ access_point.name }} ({{ access_point.users.count }})
+              {% if not forloop.last %}<br>{% endif %}
+            {% endfor %}
+          </dd>
+        {% endif %}
+      </dl>
+    </li>
+  </ul>
+</div>

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -8,6 +8,7 @@
 
 {% block local_css %}
 <link rel="stylesheet" type="text/css" href="{% static 'project/css/submission-timeline.css' %}">
+<link rel="stylesheet" type="text/css" href="{% static 'console/css/cloud-mirrors.css' %}">
 {% endblock %}
 
 {% block local_js_top %}
@@ -386,6 +387,10 @@
       </li>
       <li class="list-group-item">
         <h5 class="card-title mt-3 mb-1">Google Cloud</h5>
+        {% if project.gcp %}
+          {% include "console/cloud_mirror_info_card.html" with mirror=project.gcp %}
+        {% endif %}
+
         {% if not has_credentials %}
           <p>You are missing the Google Cloud credentials.</p>
         {% elif not project.gcp.bucket_name %}
@@ -412,6 +417,10 @@
       </li>
       <li class="list-group-item">
         <h5 class="card-title mt-3 mb-1">AWS</h5>
+        {% if project.aws %}
+          {% include "console/cloud_mirror_info_card.html" with mirror=project.aws %}
+        {% endif %}
+
         {% if not has_s3_credentials %}
           <p>
             Support for Amazon S3 is not enabled.  (Check that

--- a/physionet-django/project/modelcomponents/storage.py
+++ b/physionet-django/project/modelcomponents/storage.py
@@ -44,6 +44,9 @@ class GCP(models.Model):
     def __str__(self):
         return self.bucket_name
 
+    def cloud_uri(self):
+        return f'gs://{self.bucket_name}/'
+
 
 class AWS(models.Model):
     """
@@ -61,6 +64,9 @@ class AWS(models.Model):
 
     class Meta:
         default_permissions = ()
+
+    def cloud_uri(self):
+        return self.public_s3_uri()
 
     def public_s3_uri(self):
         """


### PR DESCRIPTION
In the Manage Project page (/console/published-projects/X/Y/) for a published project, there are buttons to create cloud mirrors (Google Cloud Storage and Amazon S3).

Currently, there's very little information shown here (or anywhere else on the site) about the status of the cloud mirror.  Add some basic information about the mirror if it exists:

**Location of the data:** the URI for the data in the cloud system

**Whether project files have been uploaded,** which is also the flag that controls whether the cloud mirror is advertised to users

**Whether the project zip archive has been uploaded**

**Creation time:** the time that somebody first clicked the "send files" button

**Last upload completion time:** the time that the most recent successful upload process finished

**Access policy type** (public or private)

**Associated access groups:** identifiers for user groups (GCP) or access points (AWS) that can be used to access the mirror
