### PR TITLE
Add management command for linking projects to already existing buckets and groups

### DIFF
--- a/physionet-django/project/management/commands/link_existing_gcp_bucket.py
+++ b/physionet-django/project/management/commands/link_existing_gcp_bucket.py
@@ -1,120 +1,86 @@
+
 import google.auth.transport.requests
 from django.core.management.base import BaseCommand, CommandError
 from project.cloud.gcp import ROLES, add_email_bucket_access
-from project.models import PublishedProject, DataAccess
 from project.modelcomponents.storage import GCP
+from project.models import PublishedProject, DataAccess
 from user.models import User
 
 
 class Command(BaseCommand):
-    help = "Link an existing GCP bucket and group to a project."
+    help = 'Link an existing GCP bucket and group to a project.'
 
     def add_arguments(self, parser):
-        parser.add_argument("--project-slug", required=True)
-        parser.add_argument("--project-version", required=True)
-        parser.add_argument("--group-email", required=True)
-        parser.add_argument("--bucket-name", required=True)
-        parser.add_argument(
-            "--user-email", required=True, help="Email of user to set as manager"
-        )
-        parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help="Show what would be changed, but do not modify anything",
-        )
+        parser.add_argument('--project-slug', required=True)
+        parser.add_argument('--project-version', required=True)
+        parser.add_argument('--group-email', required=True)
+        parser.add_argument('--bucket-name', required=True)
+        parser.add_argument('--user-email', required=True, help='Email of user to set as manager')
+        parser.add_argument('--dry-run', action='store_true', help='Show what would be changed')
 
     def handle(self, *args, **options):
-        slug = options["project_slug"]
-        version = options["project_version"]
-        group_email = options["group_email"]
-        bucket_name = options["bucket_name"]
-        user_email = options["user_email"]
-        dry_run = options["dry_run"]
+        slug = options['project_slug']
+        version = options['project_version']
+        group_email = options['group_email']
+        bucket_name = options['bucket_name']
+        user_email = options['user_email']
+        dry_run = options['dry_run']
 
         try:
             project = PublishedProject.objects.get(slug=slug, version=version)
         except PublishedProject.DoesNotExist:
-            raise CommandError(f"Project {slug} v{version} not found")
+            raise CommandError(f'Project {slug} v{version} not found')
 
         # Set manager (required)
         try:
             manager = User.objects.get(email=user_email)
         except User.DoesNotExist:
-            raise CommandError(f"User {user_email} not found")
+            raise CommandError(f'User {user_email} not found')
 
         if dry_run:
-            self.stdout.write(
-                self.style.WARNING(
-                    f"[DRY RUN] Would link project {slug} v{version} to bucket {bucket_name} with group {group_email}"
-                )
-            )
-            self.stdout.write(
-                self.style.WARNING(f"[DRY RUN] Would set manager to {user_email}")
-            )
-            self.stdout.write(
-                self.style.WARNING("[DRY RUN] Would create or update GCP record")
-            )
-            self.stdout.write(
-                self.style.WARNING(
-                    "[DRY RUN] Would create DataAccess record if not present"
-                )
-            )
+            self.stdout.write(self.style.WARNING(
+                f'[DRY RUN] Would link project {slug} v{version} to bucket {bucket_name} with group {group_email}'))
+            self.stdout.write(self.style.WARNING(f'[DRY RUN] Would set manager to {user_email}'))
+            self.stdout.write(self.style.WARNING('[DRY RUN] Would create or update GCP record'))
+            self.stdout.write(self.style.WARNING('[DRY RUN] Would create DataAccess record if not present'))
         else:
             # Create or update GCP record
             _, created = GCP.objects.update_or_create(
                 project=project,
                 defaults={
-                    "bucket_name": bucket_name,
-                    "access_group": group_email,
-                    "managed_by": manager,
-                    "is_private": True,
-                    "sent_files": True,  # Set to True since we assume that the bucket already has files. Can resend files from console if needed.
-                    "sent_zip": False,  # Keep False since we didn't send zip through normal process
-                },
+                    'bucket_name': bucket_name,
+                    'access_group': group_email,
+                    'managed_by': manager,
+                    'is_private': True,
+                    'sent_files': True,  # Assume bucket already has files. Can resend files from console if needed.
+                    'sent_zip': False,   # Keep False since we didn't send zip through normal process
+                }
             )
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f'GCP record {"created" if created else "updated"} for project {slug} v{version}'
-                )
-            )
+            self.stdout.write(self.style.SUCCESS(
+                f'GCP record {"created" if created else "updated"} for project {slug} v{version}'
+            ))
 
             # Create DataAccess record if not present
             _, da_created = DataAccess.objects.get_or_create(
                 project=project,
                 platform=3,  # 3 = GCP Bucket
-                defaults={"location": group_email},
+                defaults={'location': group_email}
             )
             if da_created:
-                self.stdout.write(self.style.SUCCESS("DataAccess record created."))
+                self.stdout.write(self.style.SUCCESS('DataAccess record created.'))
             else:
-                self.stdout.write("DataAccess record already exists.")
+                self.stdout.write('DataAccess record already exists.')
 
         # Add group to bucket IAM policy
         if dry_run:
-            self.stdout.write(
-                self.style.WARNING(
-                    f"[DRY RUN] Would add group {group_email} to bucket {bucket_name} IAM policy"
-                )
-            )
+            self.stdout.write(self.style.WARNING(
+                f'[DRY RUN] Would add group {group_email} to bucket {bucket_name} IAM policy'))
             for role in ROLES:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"[DRY RUN] Would add group:{group_email} to {role}"
-                    )
-                )
+                self.stdout.write(self.style.WARNING(f'[DRY RUN] Would add group:{group_email} to {role}'))
         else:
-            granted = add_email_bucket_access(
-                project, group_email, group=True, user_project="physionet-data"
-            )
+            granted = add_email_bucket_access(project, group_email, group=True, user_project='physionet-data')
             if granted:
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        f"Group {group_email} added to bucket {bucket_name} IAM policy with required roles."
-                    )
-                )
+                self.stdout.write(self.style.SUCCESS(
+                    f'Group {group_email} added to bucket {bucket_name} IAM policy with required roles.'))
             else:
-                self.stdout.write(
-                    self.style.ERROR(
-                        f"Failed to add group {group_email} to bucket IAM policy."
-                    )
-                )
+                self.stdout.write(self.style.ERROR(f'Failed to add group {group_email} to bucket IAM policy.'))

--- a/physionet-django/project/management/commands/link_existing_gcp_bucket.py
+++ b/physionet-django/project/management/commands/link_existing_gcp_bucket.py
@@ -1,0 +1,120 @@
+import google.auth.transport.requests
+from django.core.management.base import BaseCommand, CommandError
+from project.cloud.gcp import ROLES, add_email_bucket_access
+from project.models import PublishedProject, DataAccess
+from project.modelcomponents.storage import GCP
+from user.models import User
+
+
+class Command(BaseCommand):
+    help = "Link an existing GCP bucket and group to a project."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--project-slug", required=True)
+        parser.add_argument("--project-version", required=True)
+        parser.add_argument("--group-email", required=True)
+        parser.add_argument("--bucket-name", required=True)
+        parser.add_argument(
+            "--user-email", required=True, help="Email of user to set as manager"
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be changed, but do not modify anything",
+        )
+
+    def handle(self, *args, **options):
+        slug = options["project_slug"]
+        version = options["project_version"]
+        group_email = options["group_email"]
+        bucket_name = options["bucket_name"]
+        user_email = options["user_email"]
+        dry_run = options["dry_run"]
+
+        try:
+            project = PublishedProject.objects.get(slug=slug, version=version)
+        except PublishedProject.DoesNotExist:
+            raise CommandError(f"Project {slug} v{version} not found")
+
+        # Set manager (required)
+        try:
+            manager = User.objects.get(email=user_email)
+        except User.DoesNotExist:
+            raise CommandError(f"User {user_email} not found")
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"[DRY RUN] Would link project {slug} v{version} to bucket {bucket_name} with group {group_email}"
+                )
+            )
+            self.stdout.write(
+                self.style.WARNING(f"[DRY RUN] Would set manager to {user_email}")
+            )
+            self.stdout.write(
+                self.style.WARNING("[DRY RUN] Would create or update GCP record")
+            )
+            self.stdout.write(
+                self.style.WARNING(
+                    "[DRY RUN] Would create DataAccess record if not present"
+                )
+            )
+        else:
+            # Create or update GCP record
+            _, created = GCP.objects.update_or_create(
+                project=project,
+                defaults={
+                    "bucket_name": bucket_name,
+                    "access_group": group_email,
+                    "managed_by": manager,
+                    "is_private": True,
+                    "sent_files": True,  # Set to True since we assume that the bucket already has files. Can resend files from console if needed.
+                    "sent_zip": False,  # Keep False since we didn't send zip through normal process
+                },
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'GCP record {"created" if created else "updated"} for project {slug} v{version}'
+                )
+            )
+
+            # Create DataAccess record if not present
+            _, da_created = DataAccess.objects.get_or_create(
+                project=project,
+                platform=3,  # 3 = GCP Bucket
+                defaults={"location": group_email},
+            )
+            if da_created:
+                self.stdout.write(self.style.SUCCESS("DataAccess record created."))
+            else:
+                self.stdout.write("DataAccess record already exists.")
+
+        # Add group to bucket IAM policy
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"[DRY RUN] Would add group {group_email} to bucket {bucket_name} IAM policy"
+                )
+            )
+            for role in ROLES:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"[DRY RUN] Would add group:{group_email} to {role}"
+                    )
+                )
+        else:
+            granted = add_email_bucket_access(
+                project, group_email, group=True, user_project="physionet-data"
+            )
+            if granted:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Group {group_email} added to bucket {bucket_name} IAM policy with required roles."
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Failed to add group {group_email} to bucket IAM policy."
+                    )
+                )


### PR DESCRIPTION
Historically, projects and groups have been created manually (in addition to being created via the PN platform). This makes maintenance of these resources via the PN platform challenging since they don't have entries in the `GCP` and `DataAccess` objects. 

The management command being introduced here can be used to link a project with an existing bucket and group. 

I've tested this from the local demo database:
```
python3 manage.py link_existing_gcp_bucket \
  --project-slug demopsn \
  --project-version 1.0 \
  --group-email  sccmdatathon2023@physionet.org \
  --bucket-name reflacx-xray-localization-1.0.0.physionet.org \
  --user-email admin@mit.edu
```

checking the GCP and DataAccess objects shows:
```
print(gcp_obj.__dict__)
{'_state': <django.db.models.base.ModelState object at 0x107c32060>, 'id': 1, 'project_id': 5, 'bucket_name': 'reflacx-xray-localization-1.0.0.physionet.org', 'access_group': 'sccmdatathon2023@physionet.org', 'is_private': True, 'sent_zip': False, 'sent_files': True, 'managed_by_id': 1, 'creation_datetime': datetime.datetime(2025, 7, 31, 12, 1, 20, 499251, tzinfo=datetime.timezone.utc), 'finished_datetime': None}
```

```
data_access=DataAccess.objects.get(project=project)
for field, value in data_access.__dict__.items():
	if not field.startswith('_'):  
		print(f"{field}: {value}")
id: 1
project_id: 5
platform: 3
location: sccmdatathon2023@physionet.org
```
Please note that to test this from the local demo database, I had to allow passing of `user_project` in `project.gcp.add_email_bucket_access`. This should not be necessary from the production server since it knows what account to bill. 

For consistency with how the buckets and groups are currently created via the PN platform, I elected to:
- create a DataAccess object and set the location when doing this linkage. This is done as part of "Create bucket and send files". 
- set `sent_files` to `True` in the GCP object. Since the bucket was already created, we assume it was populated with files. If this isn't done, the admin console will show the message below. When this is done, the admin console will show "Resend files", as desired. 
  - The files are being sent to GCP. The bucket name is: reflacx-xray-localization-1.0.0.physionet.org. If this message is here for a long time, check the Django "process_tasks"