### PR TITLE
Prevent cloud uploads when an upload task is already pending

### DIFF
--- a/physionet-django/console/tasks.py
+++ b/physionet-django/console/tasks.py
@@ -100,7 +100,7 @@ def associated_task(model, param, *, read_only=False, field='pk'):
     return decorate
 
 
-def get_associated_tasks(instance, *, read_only=None):
+def get_associated_tasks(instance, *, read_only=None, name=None):
     """
     Find pending tasks associated with a model instance.
 
@@ -118,9 +118,15 @@ def get_associated_tasks(instance, *, read_only=None):
 
     model = type(instance)._meta.label
 
-    # Consider all possible task_names that might be associated with
-    # this object.
-    for (task_name, param_info) in sorted(_model_tasks[model].items()):
+    if name is None:
+        # Consider all possible task_names that might be associated with
+        # this object.
+        task_names = sorted(_model_tasks[model].keys())
+    else:
+        task_names = [name]
+
+    for task_name in task_names:
+        param_info = _model_tasks[model][task_name]
 
         # If we are only interested in read-only tasks, skip checking
         # read-write parameters, and vice versa.

--- a/physionet-django/console/templates/console/cloud_mirror_info_card.html
+++ b/physionet-django/console/templates/console/cloud_mirror_info_card.html
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card mb-2">
   <ul class="list-group list-group-flush">
     <li class="list-group-item">
       <dl class="row mb-0">

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -396,9 +396,22 @@
         {% else %}
           <form action="" method="post">
             {% csrf_token %}
-            <button class="btn btn-primary" name="bucket" value='{{project.slug}}'
-                    {% if gcp_upload_pending or rw_tasks %} disabled="disabled" {% endif %}
-                    type="submit">Upload files</button><br><br>
+            <p>
+              <button class="btn btn-primary"
+                      name="bucket" value="{{ project.slug }}"
+                      {% if gcp_upload_pending or rw_tasks %}
+                        disabled="disabled"
+                      {% endif %}
+                      type="submit">
+                {% if project.gcp.sent_files %}
+                  <span class="fa fa-sync-alt"></span>
+                  Reupload files
+                {% else %}
+                  <span class="fa fa-cloud-upload-alt"></span>
+                  Upload files
+                {% endif %}
+              </button>
+            </p>
           </form>
         {% endif %}
       </li>
@@ -417,9 +430,22 @@
         {% else %}
           <form action="" method="post">
             {% csrf_token %}
-            <button class="btn btn-primary" name="aws-bucket" value='{{project.slug}}'
-                    {% if aws_upload_pending or rw_tasks %} disabled="disabled" {% endif %}
-                    type="submit">Upload files</button><br><br>
+            <p>
+              <button class="btn btn-primary"
+                      name="aws-bucket" value="{{ project.slug }}"
+                      {% if aws_upload_pending or rw_tasks %}
+                        disabled="disabled"
+                      {% endif %}
+                      type="submit">
+                {% if project.aws.sent_files %}
+                  <span class="fa fa-sync-alt"></span>
+                  Reupload files
+                {% else %}
+                  <span class="fa fa-cloud-upload-alt"></span>
+                  Upload files
+                {% endif %}
+              </button>
+            </p>
           </form>
         {% endif %}
       </li>

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -393,26 +393,13 @@
 
         {% if not has_credentials %}
           <p>You are missing the Google Cloud credentials.</p>
-        {% elif not project.gcp.bucket_name %}
-          <p>Create a bucket on the Google Cloud Platform (GCP) to store the files associated with this project. Please create the special files before sending the files to GCP.</p>
-          <form action="" method="post">
-          {% csrf_token %}
-          <button class="btn btn-primary" name="bucket" value='{{project.slug}}'
-                  {% if rw_tasks %} disabled="disabled" {% endif %}
-                  type="submit">Create bucket and send files </button><br><br>
-          </form>
-        {% elif project.gcp.sent_files and project.gcp.bucket_name %}
-          <p>The files have been sent to GCP. The bucket name is: {{project.gcp.bucket_name}}.</p>
-          <form action="" method="post">
-          {% csrf_token %}
-          <button class="btn btn-primary" name="bucket" value='{{project.slug}}'
-                  {% if rw_tasks %} disabled="disabled" {% endif %}
-                  type="submit">Resend files </button><br><br>
-        </form>
-
         {% else %}
-          <p>The files are being sent to GCP. The bucket name is: {{project.gcp.bucket_name}}.</p>
-          <p>If this message is here for a long time, check the Django "process_tasks"</p>
+          <form action="" method="post">
+            {% csrf_token %}
+            <button class="btn btn-primary" name="bucket" value='{{project.slug}}'
+                    {% if gcp_upload_pending or rw_tasks %} disabled="disabled" {% endif %}
+                    type="submit">Upload files</button><br><br>
+          </form>
         {% endif %}
       </li>
       <li class="list-group-item">
@@ -427,23 +414,14 @@
             <code>AWS_PROFILE</code> and <code>S3_OPEN_ACCESS_BUCKET</code>
             are set.)
           </p>
-        {% elif not project.aws.bucket_name %}
-          <p>Create a bucket on AWS to store the files associated with this project.</p>
+        {% else %}
           <form action="" method="post">
             {% csrf_token %}
             <button class="btn btn-primary" name="aws-bucket" value='{{project.slug}}'
-                    {% if rw_tasks %} disabled="disabled" {% endif %}
-                    type="submit">Create AWS bucket and send files</button><br><br>
-            </form>
-        {% elif project.aws.sent_files and project.aws.bucket_name %}
-          <p>The files have been sent to AWS. The bucket name is: {{project.aws.bucket_name}}.</p>
-          <form action="" method="post">
-          {% csrf_token %}
-          <button class="btn btn-primary" name="aws-bucket" value='{{project.slug}}'
-                  {% if rw_tasks %} disabled="disabled" {% endif %}
-                  type="submit">Resend files to AWS</button><br><br>
-        </form>
-        {% endif %} 
+                    {% if aws_upload_pending or rw_tasks %} disabled="disabled" {% endif %}
+                    type="submit">Upload files</button><br><br>
+          </form>
+        {% endif %}
       </li>
     </ul>
 

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1138,6 +1138,10 @@ def gcp_bucket_management(request, project, user):
     Create the database object and cloud bucket if they do not exist, and send
     the files to the bucket.
     """
+    if any(get_associated_tasks(project, name=send_files_to_gcp.name)):
+        messages.info(request, 'Project is already scheduled to be uploaded.')
+        return
+
     is_private = True
 
     if project.access_policy == AccessPolicy.OPEN:
@@ -1194,6 +1198,10 @@ def aws_bucket_management(request, project, user):
     - Ensure that AWS credentials and configurations are correctly set
     up for the S3 client.
     """
+    if any(get_associated_tasks(project, name=send_files_to_aws.name)):
+        messages.info(request, 'Project is already scheduled to be uploaded.')
+        return
+
     is_private = True
 
     if project.access_policy == AccessPolicy.OPEN:

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1094,6 +1094,10 @@ def manage_published_project(request, project_slug, version):
     ro_tasks = [task for (task, read_only) in tasks if read_only]
     rw_tasks = [task for (task, read_only) in tasks if not read_only]
 
+    task_names = [task.task_name for (task, read_only) in tasks]
+    gcp_upload_pending = (send_files_to_gcp.name in task_names)
+    aws_upload_pending = (send_files_to_aws.name in task_names)
+
     url_prefix = notification.get_url_prefix(request)
     bulk_url_prefix = notification.get_url_prefix(request)
 
@@ -1119,6 +1123,8 @@ def manage_published_project(request, project_slug, version):
             'data_access': data_access,
             'rw_tasks': rw_tasks,
             'ro_tasks': ro_tasks,
+            'gcp_upload_pending': gcp_upload_pending,
+            'aws_upload_pending': aws_upload_pending,
             'anonymous_url': anonymous_url,
             'passphrase': passphrase,
             'url_prefix': url_prefix,


### PR DESCRIPTION
In the published project management page there are buttons to upload a project to Google Cloud and/or AWS.  If the project has already been uploaded then it can be re-uploaded.

We don't want to upload the same project twice accidentally; that would be pointless and wasteful.

Previously, therefore, the button would be hidden if the `sent_files` flag was false (on the grounds that, if `sent_files` was false, that presumably meant that somebody had clicked the button but the task had not yet completed.)  Even then, the button being hidden wouldn't prevent you from submitting the same form twice.

`sent_files` can be false even though there is no pending upload task - the upload task may have failed, or the sent_files flag may have been manually cleared to indicate the bucket was removed.  (In the future, we should add console functions to remove cloud buckets.)

And there can be a pending upload task even though `sent_files` is true - the project is currently being re-uploaded.

So instead of using `sent_files`, use `get_associated_tasks` to check whether there is actually a task pending.  If there is a task pending, then don't create a new one if the form is submitted again; and also, if there is a task pending, then make the HTML button disabled (but still visible.)
