### PR TITLE
Provide access to users for open-geo-restricted datasets on new bucket using Access Points

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,7 +82,7 @@ S3_SERVER_ACCESS_LOG_BUCKET=
 # The default bucket name to store projects with a 'RESTRICTED/CREDENTIALED' access policy.
 S3_CONTROLLED_ACCESS_BUCKET=
 # The default bucket name to store geo-restricted projects with an 'OPEN' access policy.
-S3_GEO_RESTRICTED_ACCESS_BUCKET=
+S3_OPEN_ACCESS_BUCKET_WITH_LOGIN=
 
 # Datacite
 # Used to assign the DOIs

--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ S3_OPEN_ACCESS_BUCKET=
 S3_SERVER_ACCESS_LOG_BUCKET=
 # The default bucket name to store projects with a 'RESTRICTED/CREDENTIALED' access policy.
 S3_CONTROLLED_ACCESS_BUCKET=
+# The default bucket name to store geo-restricted projects with an 'OPEN' access policy.
+S3_GEO_RESTRICTED_ACCESS_BUCKET=
 
 # Datacite
 # Used to assign the DOIs

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1228,7 +1228,7 @@ def aws_bucket_management(request, project, user):
 
     is_private = True
 
-    if project.access_policy == AccessPolicy.OPEN:
+    if project.access_policy == AccessPolicy.OPEN and not project.georestricted:
         is_private = False
 
     bucket_name = get_bucket_name(project)

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -291,7 +291,7 @@ S3_SERVER_ACCESS_LOG_BUCKET = config('S3_SERVER_ACCESS_LOG_BUCKET', default=None
 # Bucket name for the S3 bucket containing the controlled access data
 S3_CONTROLLED_ACCESS_BUCKET = config('S3_CONTROLLED_ACCESS_BUCKET', default=None)
 
-# Bucket name for the S3 bucket containing the geo-restricted access data
+# Bucket name for the S3 bucket containing geo-restricted projects with an 'OPEN' access policy.
 S3_GEO_RESTRICTED_ACCESS_BUCKET = config('S3_GEO_RESTRICTED_ACCESS_BUCKET', default=None)
 
 # Header tags for the AWS lambda function that grants access to S3 storage

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -292,7 +292,7 @@ S3_SERVER_ACCESS_LOG_BUCKET = config('S3_SERVER_ACCESS_LOG_BUCKET', default=None
 S3_CONTROLLED_ACCESS_BUCKET = config('S3_CONTROLLED_ACCESS_BUCKET', default=None)
 
 # Bucket name for the S3 bucket containing geo-restricted projects with an 'OPEN' access policy.
-S3_GEO_RESTRICTED_ACCESS_BUCKET = config('S3_GEO_RESTRICTED_ACCESS_BUCKET', default=None)
+S3_OPEN_ACCESS_BUCKET_WITH_LOGIN = config('S3_OPEN_ACCESS_BUCKET_WITH_LOGIN', default=None)
 
 # Header tags for the AWS lambda function that grants access to S3 storage
 AWS_HEADER_KEY = config('AWS_KEY', default=False)

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -291,6 +291,9 @@ S3_SERVER_ACCESS_LOG_BUCKET = config('S3_SERVER_ACCESS_LOG_BUCKET', default=None
 # Bucket name for the S3 bucket containing the controlled access data
 S3_CONTROLLED_ACCESS_BUCKET = config('S3_CONTROLLED_ACCESS_BUCKET', default=None)
 
+# Bucket name for the S3 bucket containing the geo-restricted access data
+S3_GEO_RESTRICTED_ACCESS_BUCKET = config('S3_GEO_RESTRICTED_ACCESS_BUCKET', default=None)
+
 # Header tags for the AWS lambda function that grants access to S3 storage
 AWS_HEADER_KEY = config('AWS_KEY', default=False)
 AWS_HEADER_VALUE = config('AWS_VALUE', default=False)

--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -44,6 +44,19 @@ def has_S3_controlled_data_bucket_name():
     return bool(settings.S3_CONTROLLED_ACCESS_BUCKET)
 
 
+def has_S3_geo_restricted_data_bucket_name():
+    """
+    Check if the S3_GEO_RESTRICTED_ACCESS_BUCKET setting has a value set in the project's settings.
+
+    This method verifies whether a geo-restricted data bucket name has been specified for S3 storage.
+
+    Returns:
+        bool: Returns True if the S3_GEO_RESTRICTED_ACCESS_BUCKET setting is set
+        (i.e., truthy), False otherwise.
+    """
+    return bool(settings.S3_GEO_RESTRICTED_ACCESS_BUCKET)
+
+
 def has_s3_credentials():
     """
     Check if AWS credentials have been set in
@@ -59,6 +72,7 @@ def has_s3_credentials():
             settings.S3_OPEN_ACCESS_BUCKET,
             settings.S3_SERVER_ACCESS_LOG_BUCKET,
             settings.S3_CONTROLLED_ACCESS_BUCKET,
+            settings.S3_GEO_RESTRICTED_ACCESS_BUCKET,
         ]
     )
 
@@ -172,7 +186,11 @@ def get_bucket_name(project):
     """
     bucket_name = None
 
-    if project.access_policy == AccessPolicy.OPEN and has_S3_open_data_bucket_name():
+    if (project.georestricted
+            and project.access_policy == AccessPolicy.OPEN
+            and has_S3_geo_restricted_data_bucket_name()):
+        bucket_name = settings.S3_GEO_RESTRICTED_ACCESS_BUCKET
+    elif project.access_policy == AccessPolicy.OPEN and has_S3_open_data_bucket_name():
         bucket_name = settings.S3_OPEN_ACCESS_BUCKET
     elif (
         project.access_policy != AccessPolicy.OPEN
@@ -1235,7 +1253,7 @@ def upload_project_to_S3(project):
 
     # Set the bucket policy only if the bucket was newly created
     # and has controlled access
-    if bucket_created and project.access_policy != AccessPolicy.OPEN:
+    if bucket_created and project.access_policy != AccessPolicy.OPEN or project.georestricted:
         controlled_policy = create_controlled_bucket_policy(bucket_name)
         s3.put_bucket_policy(Bucket=bucket_name, Policy=controlled_policy)
 
@@ -1245,7 +1263,7 @@ def upload_project_to_S3(project):
     folder_path = project.file_root()
     s3_prefix = f"{project.slug}/{project.version}/"
     send_files_to_s3(folder_path, s3_prefix, bucket_name, project)
-    if project.access_policy == AccessPolicy.OPEN:
+    if project.access_policy == AccessPolicy.OPEN and not project.georestricted:
         update_open_bucket_policy(project, bucket_name)
     else:
         initialize_access_points(project)

--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -46,15 +46,15 @@ def has_S3_controlled_data_bucket_name():
 
 def has_S3_geo_restricted_data_bucket_name():
     """
-    Check if the S3_GEO_RESTRICTED_ACCESS_BUCKET setting has a value set in the project's settings.
+    Check if the S3_OPEN_ACCESS_BUCKET_WITH_LOGIN setting has a value set in the project's settings.
 
     This method verifies whether a geo-restricted data bucket name has been specified for S3 storage.
 
     Returns:
-        bool: Returns True if the S3_GEO_RESTRICTED_ACCESS_BUCKET setting is set
+        bool: Returns True if the S3_OPEN_ACCESS_BUCKET_WITH_LOGIN setting is set
         (i.e., truthy), False otherwise.
     """
-    return bool(settings.S3_GEO_RESTRICTED_ACCESS_BUCKET)
+    return bool(settings.S3_OPEN_ACCESS_BUCKET_WITH_LOGIN)
 
 
 def has_s3_credentials():
@@ -72,7 +72,7 @@ def has_s3_credentials():
             settings.S3_OPEN_ACCESS_BUCKET,
             settings.S3_SERVER_ACCESS_LOG_BUCKET,
             settings.S3_CONTROLLED_ACCESS_BUCKET,
-            settings.S3_GEO_RESTRICTED_ACCESS_BUCKET,
+            settings.S3_OPEN_ACCESS_BUCKET_WITH_LOGIN,
         ]
     )
 
@@ -189,7 +189,7 @@ def get_bucket_name(project):
     if (project.georestricted
             and project.access_policy == AccessPolicy.OPEN
             and has_S3_geo_restricted_data_bucket_name()):
-        bucket_name = settings.S3_GEO_RESTRICTED_ACCESS_BUCKET
+        bucket_name = settings.S3_OPEN_ACCESS_BUCKET_WITH_LOGIN
     elif project.access_policy == AccessPolicy.OPEN and has_S3_open_data_bucket_name():
         bucket_name = settings.S3_OPEN_ACCESS_BUCKET
     elif (

--- a/physionet-django/project/test_s3.py
+++ b/physionet-django/project/test_s3.py
@@ -40,7 +40,7 @@ from user.test_views import TestMixin
     S3_OPEN_ACCESS_BUCKET='datashare-public',
     S3_SERVER_ACCESS_LOG_BUCKET='datashare-logs',
     S3_CONTROLLED_ACCESS_BUCKET='datashare-protected',
-    S3_GEO_RESTRICTED_ACCESS_BUCKET='datashare-geo-restricted',
+    S3_OPEN_ACCESS_BUCKET_WITH_LOGIN='datashare-geo-restricted',
 )
 class TestS3(TestMixin):
     """

--- a/physionet-django/project/test_s3.py
+++ b/physionet-django/project/test_s3.py
@@ -40,6 +40,7 @@ from user.test_views import TestMixin
     S3_OPEN_ACCESS_BUCKET='datashare-public',
     S3_SERVER_ACCESS_LOG_BUCKET='datashare-logs',
     S3_CONTROLLED_ACCESS_BUCKET='datashare-protected',
+    S3_GEO_RESTRICTED_ACCESS_BUCKET='datashare-geo-restricted',
 )
 class TestS3(TestMixin):
     """

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1956,7 +1956,7 @@ def published_project(request, project_slug, version, subdir=''):
     s3_uri = None
     try:
         if project.aws.is_private:
-            if has_signed_dua and request.user.is_authenticated:
+            if request.user.is_authenticated:
                 # It prevents showing the cli command for users who are still associated with
                 # an access point for the project but have deleted their aws credentials
                 if hasattr(user, 'cloud_information') and user.cloud_information.aws_verification_datetime:


### PR DESCRIPTION
We need to provide access to users for open-geo-restricted datasets on AWS. This PR implements the new functionality.

Since open-geo-restricted datasets don't have a DUA associated with them, users can request access on AWS by clicking the "Enable AWS access" button on the project's page. 

The "Enable AWS access" button first checks whether the user can access files. If the user has access, we add them to the access point.

**Updates needed:**

**- [Done] AWS console:**
- Create the new bucket physionet-geo-restricted;
- Set up policy on the new bucket to delegate access management to Access Points.

**- [Done] Code:**
For providing access to users for open-geo-restricted projects via CLI:
- Removing the has_signed_dua verification from the S3 URI creation should be sufficient;
- Set is_private = True for open-geo-restricted datasets in the AWS object.

To upload open-geo-restricted projects to S3:
- Set the bucket policy if the bucket physionet-geo-restricted was newly created [this step won't be necessary as it was done via AWS console, but it's important to check whether the code is able to do that];
- Avoid updating open bucket policy if projects are geo-restricted.

**- [TO-DO] Database:**

is_private = True for all open and geo-restricted datasets;
bucket_name = 'physionet-geo-restricted' for all open and geo-restricted datasets.

**- [TO-DO] Server:**

Add configuration for the new bucket: S3_GEO_RESTRICTED_ACCESS_BUCKET=physionet-geo-restricted;