### PR TITLE
Allow reopening copyedit after author approval

### DIFF
--- a/physionet-django/console/templates/console/awaiting_authors.html
+++ b/physionet-django/console/templates/console/awaiting_authors.html
@@ -62,7 +62,7 @@
         do this unless you need to make additional changes to the project.
       </div>
       <div class="modal-footer">
-        <form action="" method="post">
+        <form action="{% url 'reopen_copyedit' project.slug %}" method="post">
           {% csrf_token %}
           <button class="btn btn-danger btn-fixed" name="reopen_copyedit" type="submit">Reopen Copyedit</button>
         </form>

--- a/physionet-django/console/templates/console/awaiting_authors.html
+++ b/physionet-django/console/templates/console/awaiting_authors.html
@@ -60,11 +60,11 @@
       <div class="modal-body">
         Are you sure you want to reopen the project for copyediting? Do not
         do this unless you need to make additional changes to the project.
-        <form action="" method="post" class="form-signin">
-          {% csrf_token %}
       </div>
       <div class="modal-footer">
-        <button class="btn btn-danger btn-fixed" name="reopen_copyedit" type="submit">Reopen Copyedit</button>
+        <form action="" method="post">
+          {% csrf_token %}
+          <button class="btn btn-danger btn-fixed" name="reopen_copyedit" type="submit">Reopen Copyedit</button>
         </form>
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
       </div>

--- a/physionet-django/console/templates/console/awaiting_authors.html
+++ b/physionet-django/console/templates/console/awaiting_authors.html
@@ -37,40 +37,8 @@
     <hr>
   </div>
 </div>
-<div class="card mb-3">
-  <div class="card-header">
-    Reopen Copyedit
-  </div>
-  <div class="card-body">
-    <p>If the authors have requested additional changes, you may reopen the project for copyediting.</p>
-    <p><button id="reopen-copyedit-modal-button" type="button" class="btn btn-danger btn-lg" data-toggle="modal" data-target="#reopenModal">
-        Reopen Copyedit</button></p>
-  </div>
-</div>
 
-<div class="modal" tabindex="-1" role="dialog" id="reopenModal">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Reopen Copyedit</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        Are you sure you want to reopen the project for copyediting? Do not
-        do this unless you need to make additional changes to the project.
-      </div>
-      <div class="modal-footer">
-        <form action="{% url 'reopen_copyedit' project.slug %}" method="post">
-          {% csrf_token %}
-          <button class="btn btn-danger btn-fixed" name="reopen_copyedit" type="submit">Reopen Copyedit</button>
-        </form>
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
+{% include "console/reopen_copyedit_form.html" %}
 {% endblock %}
 
 {% block local_js_bottom %}

--- a/physionet-django/console/templates/console/publish_submission.html
+++ b/physionet-django/console/templates/console/publish_submission.html
@@ -58,6 +58,8 @@
     </form>
   </div>
 </div>
+
+{% include "console/reopen_copyedit_form.html" %}
 {% endblock %}
 
 {% block local_js_bottom %}

--- a/physionet-django/console/templates/console/reopen_copyedit_form.html
+++ b/physionet-django/console/templates/console/reopen_copyedit_form.html
@@ -1,0 +1,34 @@
+<div class="card mb-3">
+  <div class="card-header">
+    Reopen Copyedit
+  </div>
+  <div class="card-body">
+    <p>If the authors have requested additional changes, you may reopen the project for copyediting.</p>
+    <p><button id="reopen-copyedit-modal-button" type="button" class="btn btn-danger btn-lg" data-toggle="modal" data-target="#reopenModal">
+        Reopen Copyedit</button></p>
+  </div>
+</div>
+
+<div class="modal" tabindex="-1" role="dialog" id="reopenModal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Reopen Copyedit</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to reopen the project for copyediting? Do not
+        do this unless you need to make additional changes to the project.
+      </div>
+      <div class="modal-footer">
+        <form action="{% url 'reopen_copyedit' project.slug %}" method="post">
+          {% csrf_token %}
+          <button class="btn btn-danger btn-fixed" name="reopen_copyedit" type="submit">Reopen Copyedit</button>
+        </form>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -267,7 +267,7 @@ class TestState(TestMixin):
         self.assertFalse(project.copyeditable())
         # Reopen copyedit
         response = self.client.post(reverse(
-            'awaiting_authors', args=(project.slug,)),
+            'reopen_copyedit', args=(project.slug,)),
             data={'reopen_copyedit':''})
         project = ActiveProject.objects.get(id=project.id)
         self.assertTrue(project.copyeditable())

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -357,6 +357,40 @@ class TestState(TestMixin):
 
         self.assertTrue(ActiveProject.objects.get(id=project.id).is_publishable())
 
+        # Reopen copyedit
+        self.client.login(username='admin', password='Tester11!')
+        self.client.post(reverse(
+            'reopen_copyedit', args=(project.slug,)
+        ), data={
+            'reopen_copyedit': '',
+        })
+        project.refresh_from_db()
+        self.assertTrue(project.copyeditable())
+        self.assertFalse(project.is_publishable())
+
+        # Complete copyedit again
+        self.client.post(reverse(
+            'copyedit_submission', args=(project.slug,)
+        ), data={
+            'complete_copyedit': '',
+            'made_changes': 1,
+            'changelog_summary': 'blah blah',
+        })
+        project.refresh_from_db()
+        self.assertFalse(project.copyeditable())
+        self.assertFalse(project.is_publishable())
+
+        # Approve again
+        self.client.login(username='rgmark', password='Tester11!')
+        self.client.post(reverse(
+            'project_submission', args=(project.slug,)
+        ), data={
+            'approve_publication': '',
+        })
+        project.refresh_from_db()
+        self.assertTrue(project.is_publishable())
+
+
     def test_publish(self):
         """
         Test publishing project

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path('submitted-projects/<project_slug>/info/', views.submission_info, name='submission_info'),
     path('submitted-projects/<project_slug>/edit/', views.edit_submission, name='edit_submission'),
     path('submitted-projects/<project_slug>/copyedit/', views.copyedit_submission, name='copyedit_submission'),
+    path('submitted-projects/<project_slug>/reopen/', views.reopen_copyedit, name='reopen_copyedit'),
     path('submitted-projects/<project_slug>/awaiting-authors/', views.awaiting_authors, name='awaiting_authors'),
     path('submitted-projects/<project_slug>/publish/', views.publish_submission, name='publish_submission'),
     path('publish-slug-available/<project_slug>/', views.publish_slug_available, name='publish_slug_available'),
@@ -220,6 +221,10 @@ TEST_CASES = {
         '_skip_': True,
     },
     'awaiting_authors': {
+        'project_slug': 'xxxxxxxxxxxxxxxxxxxx',
+        '_skip_': True,
+    },
+    'reopen_copyedit': {
         'project_slug': 'xxxxxxxxxxxxxxxxxxxx',
         '_skip_': True,
     },

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -689,7 +689,10 @@ def reopen_copyedit(request, project_slug, *args, **kwargs):
     """
     project = kwargs['project']
 
-    if project.submission_status != SubmissionStatus.NEEDS_APPROVAL:
+    if project.submission_status not in (
+        SubmissionStatus.NEEDS_APPROVAL,
+        SubmissionStatus.NEEDS_PUBLICATION,
+    ):
         return redirect('submission_info', project_slug=project_slug)
 
     if request.method == 'POST':

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -655,12 +655,7 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
     internal_note_form = forms.InternalNoteForm()
 
     if request.method == 'POST':
-        if 'reopen_copyedit' in request.POST:
-            project.reopen_copyedit()
-            notification.reopen_copyedit_notify(request, project)
-            return render(request, 'console/reopen_copyedit_complete.html',
-                          {'project': project})
-        elif 'send_reminder' in request.POST:
+        if 'send_reminder' in request.POST:
             notification.copyedit_complete_notify(request, project,
                                                   project.copyedit_logs.last(), reminder=True)
             messages.success(request, 'The reminder email has been sent.')
@@ -685,6 +680,26 @@ def awaiting_authors(request, project_slug, *args, **kwargs):
                    'yesterday': yesterday,
                    'editor_home': True,
                    'reassign_editor_form': reassign_editor_form})
+
+
+@handling_editor
+def reopen_copyedit(request, project_slug, *args, **kwargs):
+    """
+    Re-open a project for another round of copyediting.
+    """
+    project = kwargs['project']
+
+    if project.submission_status != SubmissionStatus.NEEDS_APPROVAL:
+        return redirect('submission_info', project_slug=project_slug)
+
+    if request.method == 'POST':
+        if 'reopen_copyedit' in request.POST:
+            project.reopen_copyedit()
+            notification.reopen_copyedit_notify(request, project)
+            return render(request, 'console/reopen_copyedit_complete.html',
+                          {'project': project})
+
+    return redirect('submission_info', project_slug=project_slug)
 
 
 @handling_editor

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -444,11 +444,12 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         Reopen the project for copyediting
         """
         if self.submission_status == SubmissionStatus.NEEDS_APPROVAL:
-            self.submission_status = SubmissionStatus.NEEDS_COPYEDIT
-            self.copyedit_completion_datetime = None
-            self.save()
-            CopyeditLog.objects.create(project=self, is_reedit=True)
-            self.authors.all().update(approval_datetime=None)
+            with transaction.atomic():
+                self.submission_status = SubmissionStatus.NEEDS_COPYEDIT
+                self.copyedit_completion_datetime = None
+                self.save()
+                CopyeditLog.objects.create(project=self, is_reedit=True)
+                self.authors.all().update(approval_datetime=None)
 
     def approve_author(self, author):
         """"

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -443,10 +443,14 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
         """
         Reopen the project for copyediting
         """
-        if self.submission_status == SubmissionStatus.NEEDS_APPROVAL:
+        if self.submission_status in (
+            SubmissionStatus.NEEDS_APPROVAL,
+            SubmissionStatus.NEEDS_PUBLICATION,
+        ):
             with transaction.atomic():
                 self.submission_status = SubmissionStatus.NEEDS_COPYEDIT
                 self.copyedit_completion_datetime = None
+                self.author_approval_datetime = None
                 self.save()
                 CopyeditLog.objects.create(project=self, is_reedit=True)
                 self.authors.all().update(approval_datetime=None)


### PR DESCRIPTION
Sometimes authors/editors might spot errors in a project after it has already been approved. The handling editor should have a way to "reopen copyediting" at this point, just as when the project is "awaiting author approval".

This pull request adds a "Reopen Copyedit" form to the "Publish Submission" page.  After reopening copyedit, the editor should be able to make changes to the project and then "re-complete" copyedit.

Once the copyediting is "re-completed", all authors are required to approve the final version (just as if this was done from the "Awaiting Authors" stage.)  As in all cases, the submitting author can "approve on behalf of another author".

Fixes #1943
