### PR TITLE
Prevent "'ActiveProject' object has no attribute 'integrity_errors' when "Submit project" is double clicked

### DIFF
--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1396,10 +1396,16 @@ def project_submission(request, project_slug, **kwargs):
                 project.submit(author_comments=comments)
                 notification.submit_notify(project)
                 messages.success(request, 'Your project has been submitted. You will be notified when an editor is assigned.')
-            elif project.integrity_errors:
-                messages.error(request, project.integrity_errors)
+                return redirect('project_submission', project_slug=project.slug)
             else:
-                messages.error(request, 'Fix the errors before submitting')
+                if project.under_submission():
+                    messages.error(request, 'Project has already been submitted.')
+                else:
+                    project.check_integrity()
+                    if project.integrity_errors:
+                        messages.error(request, project.integrity_errors)
+                    else:
+                        raise Exception(f"Submission error for project {project.slug}")
         elif 'resubmit_project' in request.POST and is_submitting:
             author_comments_form = forms.AuthorCommentsForm(data=request.POST)
             if project.is_resubmittable() and author_comments_form.is_valid():
@@ -1407,6 +1413,16 @@ def project_submission(request, project_slug, **kwargs):
                 project.resubmit(author_comments=comments)
                 notification.resubmit_notify(project, comments)
                 messages.success(request, 'Your project has been resubmitted. You will be notified when the editor makes their decision.')
+                return redirect('project_submission', project_slug=project.slug)
+            else:
+                if project.under_submission():
+                    messages.error(request, 'Project has already been submitted.')
+                else:
+                    project.check_integrity()
+                    if project.integrity_errors:
+                        messages.error(request, project.integrity_errors)
+                    else:
+                        raise Exception(f"Submission error for project {project.slug}")
         # Author approves publication
         elif 'approve_publication' in request.POST:
             author = authors.get(user=user)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1388,31 +1388,26 @@ def project_submission(request, project_slug, **kwargs):
     author_comments_form = forms.AuthorCommentsForm() if is_submitting and project.author_editable() else None
 
     if request.method == 'POST':
-        # ActiveProject is submitted for review
-        if 'submit_project' in request.POST and is_submitting:
+        # Handle project submission or resubmission
+        if ('submit_project' in request.POST or 'resubmit_project' in request.POST) and is_submitting:
+            is_resubmit = 'resubmit_project' in request.POST
             author_comments_form = forms.AuthorCommentsForm(data=request.POST)
-            if project.is_submittable() and author_comments_form.is_valid():
+            can_submit = project.is_resubmittable() if is_resubmit else project.is_submittable()
+
+            if can_submit and author_comments_form.is_valid():
                 comments = author_comments_form.cleaned_data['author_comments']
-                project.submit(author_comments=comments)
-                notification.submit_notify(project)
-                messages.success(request, 'Your project has been submitted. You will be notified when an editor is assigned.')
-                return redirect('project_submission', project_slug=project.slug)
-            else:
-                if project.under_submission():
-                    messages.error(request, 'Project has already been submitted.')
+                if is_resubmit:
+                    project.resubmit(author_comments=comments)
+                    notification.resubmit_notify(project, comments)
+                    messages.success(request,
+                                     'Your project has been resubmitted. '
+                                     'You will be notified when the editor makes their decision.')
                 else:
-                    project.check_integrity()
-                    if project.integrity_errors:
-                        messages.error(request, project.integrity_errors)
-                    else:
-                        raise Exception(f"Submission error for project {project.slug}")
-        elif 'resubmit_project' in request.POST and is_submitting:
-            author_comments_form = forms.AuthorCommentsForm(data=request.POST)
-            if project.is_resubmittable() and author_comments_form.is_valid():
-                comments = author_comments_form.cleaned_data['author_comments']
-                project.resubmit(author_comments=comments)
-                notification.resubmit_notify(project, comments)
-                messages.success(request, 'Your project has been resubmitted. You will be notified when the editor makes their decision.')
+                    project.submit(author_comments=comments)
+                    notification.submit_notify(project)
+                    messages.success(request,
+                                     'Your project has been submitted. '
+                                     'You will be notified when an editor is assigned.')
                 return redirect('project_submission', project_slug=project.slug)
             else:
                 if project.under_submission():


### PR DESCRIPTION
When someone tries to submit (or resubmit a project) they see the following form:

<img width="300" height="300" alt="Screenshot 2025-09-03 at 3 18 26 PM" src="https://github.com/user-attachments/assets/a00692ee-7258-45bc-adea-3da1b5ba2db6" />

Clicking "Submit project" twice (by accident) raises the following error on the second click:

```
Internal Server Error: /projects/JfGaNXHmTlVJJkR6gZoC/submission/


AttributeError at /projects/JfGaNXHmTlVJJkR6gZoC/submission/
'ActiveProject' object has no attribute 'integrity_errors'

Traceback:

File "/physionet/python-env/physionet/lib/python3.11/site-packages/django/core/handlers/exception.py" in inner
 55.                 response = get_response(request)

File "/physionet/python-env/physionet/lib/python3.11/site-packages/django/core/handlers/base.py" in _get_response
 197.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/home/physionet/physionet-build/physionet-django/project/views.py" in view_wrapper
 149.                 return base_view(request, *args, **kwargs)

File "/home/physionet/physionet-build/physionet-django/project/views.py" in project_submission
 1399.             elif project.integrity_errors:

Exception Type: AttributeError at /projects/xxx/submission/
Exception Value: 'ActiveProject' object has no attribute 'integrity_errors'
```

This pull request: (1) prevents the error from being raised by checking whether the project is under submission before highlighting integrity errors (2) refactors the submit and resubmit logic to avoid unnecessary duplication of code.