### PR TITLE
Hide quality assurance checklist from authors

### DIFF
--- a/physionet-django/console/static/console/css/console.css
+++ b/physionet-django/console/static/console/css/console.css
@@ -565,3 +565,9 @@ footer.sticky-footer {
 .table-process {
   width: 11%;
 }
+.qa-checklist .qa-item {
+  margin-bottom: 1rem;
+}
+.qa-checklist .qa-label {
+  display: inline;
+}

--- a/physionet-django/console/templates/console/edit_submission.html
+++ b/physionet-django/console/templates/console/edit_submission.html
@@ -23,7 +23,7 @@
   <div class="card-body">
     <form action="" method="post" class="form-signin">
       {% csrf_token %}
-      {% include "form_snippet.html" with form=edit_submission_form %}
+      {% include "console/editor_response_form_snippet.html" with form=edit_submission_form %}
       <button class="btn btn-primary btn-fixed" name="submit_response" type="submit">Submit Response</button>
     </form>
   </div>

--- a/physionet-django/console/templates/console/editor_response_form_snippet.html
+++ b/physionet-django/console/templates/console/editor_response_form_snippet.html
@@ -1,0 +1,40 @@
+<div class="qa-checklist">
+  <p><strong>Quality assurance checks (not shared with authors)</strong></p>
+  <ol>
+    {% for field in form.visible_fields %}
+      {% if field.name in form.quality_assurance_fields %}
+        <li class="qa-item">
+          <label class="qa-label" for="{{ field.id_for_label }}" title="{{ field.help_text }}">{{ field.label|safe }}</label>
+          <div class="qa-field">{{ field }}</div>
+          {% for error in field.errors %}
+            <div class="alert alert-danger">
+              <strong>{{ error|escape }}</strong>
+            </div>
+          {% endfor %}
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ol>
+</div>
+
+{% for field in form.visible_fields %}
+  {% if field.name not in form.quality_assurance_fields %}
+    <div class="form-group">
+      <label for="{{ field.id_for_label }}" title="{{ field.help_text }}">{{ field.label|safe }}
+      </label> {{ field }}
+      {% for error in field.errors %}
+        <div class="alert alert-danger">
+          <strong>{{ error|escape }}</strong>
+        </div>
+      {% endfor %}
+      </div>
+  {% endif %}
+{% endfor %}
+{% for error in form.non_field_errors %}
+  <div class="alert alert-danger">
+    <strong>{{ error|escape }}</strong>
+  </div>
+{% endfor %}
+{% for field in form.hidden_fields %}
+  {{ field }}
+{% endfor %}

--- a/physionet-django/notification/templates/notification/email/accept_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/accept_submission_notify.html
@@ -5,9 +5,6 @@ Dear {{ name }},
 
 Based on the recommendations of our editors, we are delighted to accept your project entitled "{{ project.title }}" for publication on {{ SITE_NAME }}.
 
-A summary of our standard set of editorial checks is listed below:
-{% for result in edit_log.quality_assurance_results %}- {{ result }}
-{% endfor %}
 Additional comments from the editorial team are listed below:
 {{ edit_log.editor_comments }}
 

--- a/physionet-django/notification/templates/notification/email/reject_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/reject_submission_notify.html
@@ -5,10 +5,6 @@ Dear {{ name }},
 
 We are writing to inform you that the review process for your project entitled "{{ project.title }}" is complete. Based on the review, our decision is that the project is not suitable for publication in its current form.
 
-A summary of the review is listed below:
-{% for result in edit_log.quality_assurance_results %}- {{ result }}
-{% endfor %}
-
 Additional comments by the editorial team follow below:
 {{ edit_log.editor_comments }}
 

--- a/physionet-django/notification/templates/notification/email/revise_submission_notify.html
+++ b/physionet-django/notification/templates/notification/email/revise_submission_notify.html
@@ -5,9 +5,6 @@ Dear {{ name }},
 
 Thank you for submitting your project entitled "{{ project.title }}" to {{ SITE_NAME }}.
 
-A summary of our standard set of editorial checks is listed below:
-{% for result in edit_log.quality_assurance_results %}- {{ result }}
-{% endfor %}
 We ask that you address the following comments before we proceed:
 {{ edit_log.editor_comments }}
 

--- a/physionet-django/project/templates/project/active_submission_timeline.html
+++ b/physionet-django/project/templates/project/active_submission_timeline.html
@@ -156,12 +156,6 @@
           {% elif e.decision == 2 %}
             <p>The editor accepted the submission.</p>
           {% endif %}
-          <p>The standard quality assurance results are as follows:</p>
-          <ul>
-            {% for result in e.quality_assurance_results %}
-              <li>{{ result }}</li>
-            {% endfor %}
-          </ul>
         <br>
         <p>The editor comments regarding the submission are as follows:</p>
         <a class="editor-comments">{{ e.editor_comments|linebreaks }}</a>

--- a/physionet-django/project/templates/project/static_submission_timeline.html
+++ b/physionet-django/project/templates/project/static_submission_timeline.html
@@ -77,12 +77,6 @@
           {% elif e.decision == 2 %}
             <p>The editor accepted the submission.</p>
           {% endif %}
-          <p>The standard quality assurance results are as follows:</p>
-          <ul>
-            {% for result in e.quality_assurance_results %}
-              <li>{{ result }}</li>
-            {% endfor %}
-          </ul>
         <br>
         <p>The editor comments regarding the submission are as follows:</p>
         <a class="editor-comments">{{ e.editor_comments|linebreaks }}</a>


### PR DESCRIPTION
The editorial "quality assurance checklist" consists of a bunch of questions that the editor must answer when responding to a project submission.

These questions are helpful for internal use, but we don't need to send this information to the authors and it may be misleading.  Remove this information from the email messages sent to authors, and from the submission timeline shown in the project pages.
