### PR TITLE
Rotate system nginx logs

### DIFF
--- a/deploy/common/etc/logrotate.d/nginx
+++ b/deploy/common/etc/logrotate.d/nginx
@@ -1,4 +1,6 @@
-/data/log/nginx/*.log {
+/var/log/nginx/*.log
+/data/log/nginx/*.log
+{
 	daily
 	missingok
 	rotate 90


### PR DESCRIPTION
Because our custom /etc/logrotate.d/nginx file replaces the standard configuration, the *standard* nginx log files (in /var/log/nginx/) were not being rotated, and could eventually fill up the root filesystem.
