### PR TITLE
Restrict archiving to the handling editor.

### DIFF
--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -33,7 +33,7 @@
           {{ notes|task_count_badge|safe }}
         </a>
       </li>
-      {% if project.submission_status == SubmissionStatus.NEEDS_RESUBMISSION %}
+      {% if project.submission_status == SubmissionStatus.NEEDS_RESUBMISSION and project.editor == user %}
       <li class="nav-item">
         <a class="nav-link" id="archive-tab" data-toggle="tab" href="#archive" role="tab" aria-controls="archive" aria-selected="false">Archive Project</a>
       </li>
@@ -164,16 +164,17 @@
       </div>
 
       {# Archive Project #}
-      {% if project.submission_status == SubmissionStatus.NEEDS_RESUBMISSION %}
+      {% if project.submission_status == SubmissionStatus.NEEDS_RESUBMISSION and project.editor == user %}
       <div class="tab-pane fade" id="archive" role="tabpanel" aria-labelledby="archive-tab">
         <div class="alert alert-warning" role="alert">
-          <p>You may archive the project <strong>"{{ project.title }}"</strong>.</p>
+          <p>As the project editor, you may archive the project <strong>"{{ project.title }}"</strong>.</p>
           <p>This action will:</p>
           <ul>
             <li>Move the project to "Archived" status</li>
             <li>Prevent authors from editing the project</li>
             <li>Remove the project from active submission workflow</li>
           </ul>
+          <p><strong>Note:</strong> Only the project editor can archive a project.</p>
         </div>
 
         <form action="{% url 'submission_info' project.slug %}" method="POST" id="archive_project_form">
@@ -190,7 +191,7 @@
 
           <div class="form-group">
             <div class="form-check">
-              <input class="form-check-input" type="checkbox" id="send_email" name="send_email" value="1">
+              <input class="form-check-input" type="checkbox" id="send_email" name="send_email" value="1" checked>
               <label class="form-check-label" for="send_email">
                 Send email notification to authors
               </label>

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -173,7 +173,11 @@
                         <button class="btn btn-primary btn-sm" name="send_revision_reminder" value="{{ project.id }}" disabled type="submit">Send Reminder</button>
                         {% endif %}
                       </form>
-                      <a href="{% url 'submission_info' project.slug %}?tab=archive" class="btn btn-warning btn-sm ml-2" role="button">Archive</a>
+                      {% if project.editor == user %}
+                        <a href="{% url 'submission_info' project.slug %}?tab=archive" class="btn btn-warning btn-sm ml-2" role="button">Archive</a>
+                      {% else %}
+                        <button class="btn btn-warning btn-sm ml-2" disabled title="Only the handling editor ({{ project.editor }}) can archive this project" data-toggle="tooltip">Archive</button>
+                      {% endif %}
                     </div>
                   </td>
                 </tr>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -379,6 +379,9 @@ def submission_info(request, project_slug):
             messages.error(request, "You are not authorized to delete this note.")
         return redirect(f'{request.path}?tab=notes')
     if 'archive_project' in request.POST:
+        if user != project.editor:
+            messages.error(request, 'Only the project editor can archive a project.')
+            return redirect(f'{request.path}?tab=archive')
 
         if project.submission_status != SubmissionStatus.NEEDS_RESUBMISSION:
             messages.error(request, 'Only projects awaiting author revisions can be archived.')


### PR DESCRIPTION
In https://github.com/MIT-LCP/physionet-build/pull/2489 we allowed projects to be archived in the editors console. This pull request restricts the ability to archive to the project's handling editor.