### PR TITLE
V0: Annotation API - Added annotation group fixture

### DIFF
--- a/physionet-django/user/fixtures/demo-user.json
+++ b/physionet-django/user/fixtures/demo-user.json
@@ -14669,6 +14669,49 @@
   }
 },
 {
+  "model": "auth.group",
+  "fields": {
+    "name": "Annotator",
+    "permissions": [
+      [
+        "add_annotation",
+        "annotation",
+        "annotation"
+      ],
+      [
+        "change_annotation",
+        "annotation",
+        "annotation"
+      ],
+      [
+        "view_annotation",
+        "annotation",
+        "annotation"
+      ],
+      [
+        "add_annotationcollection",
+        "annotation",
+        "annotationcollection"
+      ],
+      [
+        "change_annotationcollection",
+        "annotation",
+        "annotationcollection"
+      ],
+      [
+        "view_annotationcollection",
+        "annotation",
+        "annotationcollection"
+      ],
+      [
+        "view_annotationtype",
+        "annotation",
+        "annotationtype"
+      ]
+    ]
+  }
+},
+{
   "model": "user.training",
   "pk": 1,
   "fields": {


### PR DESCRIPTION
As per conversation [here](https://github.com/MIT-LCP/physionet-build/issues/1047#issuecomment-3285413494), we want to add fine-grained token authorization. This is the first step, wherein we've created the Annotator group fixture, which admin can manually add people to the group.

Members of the Annotator group have Write access to `AnnotationCollection, AnnotationType, and Annotation`s