### PR TITLE
V0: Annotation API - Creating Views for Token Generation

### DIFF
--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pdb
 from datetime import datetime, date, timedelta
+from collections import defaultdict
 
 import django.contrib.auth.views as auth_views
 import pytz
@@ -71,6 +72,47 @@ from django.db.models import F
 
 logger = logging.getLogger(__name__)
 
+ANNOTATION_SCOPES = {
+    "annotations:collections:read": {
+        "endpoint": "annotations/collections/",
+        "name": "Annotation Collections",
+        "method": "read",
+    },
+    "annotations:collections:write": {
+        "endpoint": "annotations/collections/",
+        "name": "Annotation Collections",
+        "method": "write",
+    },
+    "annotations:types:read": {
+        "endpoint": "annotations/types/",
+        "name": "Annotation Types",
+        "method": "read",
+    },
+    "annotations:types:write": {
+        "endpoint": "annotations/types/",
+        "name": "Annotation Types",
+        "method": "write",
+    },
+    "annotations:annotations:read": {
+        "endpoint": "annotations/collections/<collection_slug>/",
+        "name": "Annotations",
+        "method": "read",
+    },
+    "annotations:annotations:write": {
+        "endpoint": "annotations/collections/<collection_slug>/",
+        "name": "Annotations",
+        "method": "write",
+    },
+}
+SCOPE_TO_ENDPOINT = {
+    scope: [data["endpoint"], data["name"]]
+    for scope, data in ANNOTATION_SCOPES.items()
+}
+
+ENDPOINT_TO_SCOPE = {
+    data["endpoint"] + data["method"]: scope
+    for scope, data in ANNOTATION_SCOPES.items()
+}
 
 @method_decorator(allow_post_during_maintenance, 'dispatch')
 class LoginView(auth_views.LoginView):
@@ -435,7 +477,7 @@ def edit_tokens(request):
     """
     View for users to manage their personal API access tokens.
 
-    - POST: Creates a new access token with default read scopes.
+    - POST: Creates a new access token with selected scopes.
     - GET with `?delete=<id>`: Deletes an access token.
     - GET: Lists current active tokens.
     """
@@ -452,18 +494,44 @@ def edit_tokens(request):
         raise Exception(f"OAuth application named '{app_name}' not found.")
 
     if request.method == "POST":
+        if (AccessToken.objects.filter(
+                user=request.user, application=application
+            ).count()
+            >= 3
+        ):
+            messages.error(
+                request, "You can only have up to 3 tokens. Please delete one first."
+            )
+            return redirect("edit_tokens")
+        selected_annotation_endpoints = request.POST.getlist("annotation_endpoints")
+        if not selected_annotation_endpoints:
+            messages.error(request, "Please select at least one scope for the token.")
+            return redirect("edit_tokens")
+        selected_scopes = []
+        for endpoint in selected_annotation_endpoints:
+            if endpoint in ENDPOINT_TO_SCOPE:
+                scope = ENDPOINT_TO_SCOPE[endpoint]
+                if scope not in selected_scopes:
+                    selected_scopes.append(scope)
+        # Validate scopes against available scopes
+        available_scopes = list(settings.OAUTH2_PROVIDER["SCOPES"].keys())
+        valid_scopes = [scope for scope in selected_scopes if scope in available_scopes]
 
-        if AccessToken.objects.filter(user=request.user, application=application).count() >= 3:
-            messages.error(request, "You can only have up to 3 tokens. Please delete one first.")
+        if not valid_scopes:
+            messages.error(request, "Please select valid scopes for the token.")
             return redirect("edit_tokens")
 
         expires_at = timezone.now() + timedelta(days=60)
-        AccessToken.objects.create(
+        created_token = AccessToken.objects.create(
             user=request.user,
             application=application,
             token=get_random_string(40),
             expires=expires_at,
-            scope="data:download",
+            scope=" ".join(valid_scopes),
+        )
+        messages.success(
+            request,
+            f"Token '{created_token.id}' created successfully with scopes: {', '.join(valid_scopes)}",
         )
         return redirect("edit_tokens")
 
@@ -471,9 +539,49 @@ def edit_tokens(request):
         AccessToken.objects.filter(user=request.user, id=request.GET["delete"]).delete()
         return redirect("edit_tokens")
 
-    tokens = AccessToken.objects.filter(user=request.user)
-    return render(request, "user/edit_tokens.html", {"tokens": tokens})
+    def group_scopes_by_model(scopes):
+        """Group scopes by their model type (collections, types, annotations)"""
+        grouped = defaultdict(list)
+        for scope in scopes:
+            parts = scope.split(":")
+            if len(parts) >= 3:
+                model_type = parts[1]  # collections, types, annotations
+                model_type = model_type.capitalize()
+                if model_type != "Annotations":
+                    model_type = "Annotation " + model_type
+                permission = parts[-1].capitalize()
+                grouped[model_type].append(permission)
+            else:
+                grouped["other"].append(scope)
 
+        return dict(grouped)
+
+    tokens = AccessToken.objects.filter(user=request.user)
+    for token in tokens:
+        scopes = token.scope.split(" ")
+        grouped_scopes = group_scopes_by_model(scopes)
+        token.grouped_scopes = grouped_scopes
+
+    available_scopes = settings.OAUTH2_PROVIDER["SCOPES"]
+    available_endpoints = {}
+    for scope in available_scopes:
+        if scope in SCOPE_TO_ENDPOINT:
+            endpoint, name = SCOPE_TO_ENDPOINT[scope]
+            if endpoint not in available_endpoints:
+                available_endpoints[endpoint] = {"name": name, "scopes": []}
+            # parsing the permission at the end of scope as R/W
+            scope_cleaned = scope.split(":")[-1]
+            available_endpoints[endpoint]["scopes"].append(scope_cleaned)
+        else:
+            pass
+    return render(
+        request,
+        "user/edit_tokens.html",
+        {
+            "tokens": tokens,
+            "available_endpoints": available_endpoints,
+        },
+    )
 
 @login_required
 def edit_orcid(request):


### PR DESCRIPTION
As per conversation https://github.com/MIT-LCP/physionet-build/issues/1047#issuecomment-3285413494, we want to add fine-grained token authorization. These are the views for token generation and management–for POST, DELETE requests.