### PR TITLE
Fix incorrect URL in data access request notification email. Ref #2516

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_owner_data_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_owner_data_access_request.html
@@ -4,6 +4,6 @@ There is a new data access request for the project
 {{ data_access_request.project }}.
 
 You can view and reply to the request following this link:
-{{ request_protocol }}://{{ request_host}}{% url 'data_access_request_view' data_access_request.project.slug data_access_request.project.version data_access_request.requester.id %}
+{{ request_protocol }}://{{ request_host}}{% url 'data_access_request_view' data_access_request.project.slug data_access_request.project.version data_access_request.id %}
 
 {{ signature }}

--- a/physionet-django/notification/tests.py
+++ b/physionet-django/notification/tests.py
@@ -1,6 +1,12 @@
 import doctest
 
+from django.template import loader
+from django.test import TestCase
+from django.conf import settings
+
 from notification import utility
+from project.models import DataAccessRequest, PublishedProject
+from user.models import User
 
 # Automatically run documentation tests in these modules.
 DOCTEST_MODULES = [
@@ -14,3 +20,48 @@ def load_tests(loader, tests, ignore):
     for module in DOCTEST_MODULES:
         tests.addTests(doctest.DocTestSuite(module, optionflags=DOCTEST_FLAGS))
     return tests
+
+
+class TestDataAccessRequestNotification(TestCase):
+    """
+    Test that data access request notification emails contain correct URLs.
+    """
+    fixtures = ['demo-project.json']
+
+    def test_notify_owner_data_access_request_url(self):
+        """
+        Test that the notification email contains the correct URL with
+        data_access_request.id (not requester.id).
+        """
+        owner = User.objects.get(username='george')
+        requester = User.objects.get(username='rgmark')
+        project = PublishedProject.objects.get(title="Self Managed Access Database Demo")
+
+        dar = DataAccessRequest.objects.create(
+            requester=requester,
+            project=project,
+            data_use_title='Test Request',
+            data_use_purpose='Testing purposes',
+            status=DataAccessRequest.PENDING_VALUE
+        )
+
+        # Ensure the IDs are different
+        self.assertNotEqual(dar.id, requester.id,
+                            "Test setup error: DataAccessRequest ID should differ from requester ID")
+
+        body = loader.render_to_string(
+            'notification/email/notify_owner_data_access_request.html', {
+                'user': owner,
+                'data_access_request': dar,
+                'signature': settings.EMAIL_SIGNATURE,
+                'request_host': 'example.com',
+                'request_protocol': 'https'
+            })
+
+        expected_url_path = f'/access-requests/{project.slug}/{project.version}/{dar.id}/'
+        wrong_url_path = f'/access-requests/{project.slug}/{project.version}/{requester.id}/'
+
+        self.assertIn(expected_url_path, body,
+                      f"Email should contain correct URL with DataAccessRequest ID {dar.id}")
+        self.assertNotIn(wrong_url_path, body,
+                         f"Email should not contain wrong URL with requester ID {requester.id}")

--- a/physionet-django/notification/tests.py
+++ b/physionet-django/notification/tests.py
@@ -37,6 +37,15 @@ class TestDataAccessRequestNotification(TestCase):
         requester = User.objects.get(username='rgmark')
         project = PublishedProject.objects.get(title="Self Managed Access Database Demo")
 
+        # Dummy DataAccessRequest to avoid ID collision with rgmark
+        DataAccessRequest.objects.create(
+            requester=requester,
+            project=project,
+            data_use_title='Dummy Request',
+            data_use_purpose='Dummy purposes',
+            status=DataAccessRequest.PENDING_VALUE
+        )
+
         dar = DataAccessRequest.objects.create(
             requester=requester,
             project=project,


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/2516, the email notification sent to project owners when they receive a new data access request contains an incorrect URL.  

The [notify_owner_data_access_request.html](https://github.com/MIT-LCP/physionet-build/blob/dev/physionet-django/notification/templates/notification/email/notify_owner_data_access_request.html) template currently uses the `data_access_request.requester.id` (the user's ID) instead of `data_access_request.id` (the request's ID) as the final parameter. This causes the URL to point to the wrong data access request, or potentially a non-existent one. 

This pull request fixes the issue by changing the URL in the template from:

```
{% url 'data_access_request_view' data_access_request.project.slug data_access_request.project.version data_access_request.requester.id %}
```

to:

```
{% url 'data_access_request_view' data_access_request.project.slug data_access_request.project.version data_access_request.id %}
```

I also added a new test that:

  - Uses the existing "Self Managed Access Database Demo" project from fixtures
  - Creates a DataAccessRequest with a different ID than the requester's ID
  - Renders the email template and verifies it contains the correct URL