### PR TITLE
Fix: Fix wrongly displayed main page button

### DIFF
--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -67,6 +67,8 @@
   user-select: none;
 }
 
+.modern-ui .banner__buttons .primary-button:not(.primary-button--outline):hover { color: white; }
+
 .modern-ui .circle-button,
 .modern-ui .nav__user {
   background-color: var(--light-color);


### PR DESCRIPTION
<img width="629" height="356" alt="image" src="https://github.com/user-attachments/assets/c699e921-985a-4b73-9636-052d58e952bc" />


the main page button should be displayed as in the image instead of disappearing 