### PR TITLE
Tweak wording of credentialing application email. Ref #2520

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_credential_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_credential_request.html
@@ -1,11 +1,9 @@
 {% load i18n %}{% autoescape off %}{% filter wordwrap:70 %}
 Dear {{ applicant_name }},
 
-Thank you for submitting your request for credentialed access to {{ SITE_NAME }}. If your request is approved, you will be authorized to use protected databases upon signing Data Use Agreements and completing any required training. 
+Thank you for submitting your request for credentialed access to {{ SITE_NAME }}. If your request is approved, you will be authorized to use protected databases upon signing Data Use Agreements.
 
-To submit your training documents for review, please visit: {{ url_prefix }}{% url 'edit_training' %}.
-
-Please note that each dataset may have its own data usage terms and/or training requirements. The specific training requirements and data usage terms for each dataset are listed in the project description.
+Please note that each dataset may have its own data usage terms and training requirements. Some datasets require completion of training courses before access is granted. The specific training requirements and data usage terms for each dataset are listed in the project description. If training is required for a dataset you wish to access, you can submit your training documents for review at: {{ url_prefix }}{% url 'edit_training' %}.
 
 Please allow {{ estimated_time_for_credentialing }} for your application to be reviewed and processed. Thank you for your understanding and patience. You can follow the status of your application at: {{ url_prefix }}{% url 'credential_application' %}.
 


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/physionet-build/issues/2520, some datasets require an identity check but do not require training. We have had reports to say that the email sent to applicants can be confusing where this is the case. 

This is a minor change to the email content to (I hope) make it clear that the training requirement depends on the dataset.

