### PR TITLE
Rm unused FOOTER_ACCESSIBILITY_PAGE_URL variable.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,7 +139,6 @@ EMAIL_SIGNATURE="Regards, The Development Team"
 FOOTER_MANAGED_BY="DataShare Lab"
 FOOTER_SUPPORTED_BY="people"
 FOOTER_ACCESSIBILITY_PAGE=
-FOOTER_ACCESSIBILITY_PAGE_URL=
 SITE_HEADER_LOGO=images/physionet-logo.svg
 SITE_FOOTER_LOGO=images/physionet-logo-white.svg
 


### PR DESCRIPTION
Our example .env file includes a variable called `FOOTER_ACCESSIBILITY_PAGE_URL=`. This variable isn't used in the repository, so it can be removed.