### PR TITLE
Bump pdfminer.six dependency to version 20251107

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1704,24 +1704,25 @@ files = [
 ]
 
 [[package]]
-name = "pdfminer.six"
-version = "20211012"
+name = "pdfminer-six"
+version = "20251107"
 description = "PDF parser and analyzer"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pdfminer.six-20211012-py3-none-any.whl", hash = "sha256:d3efb75c0249b51c1bf795e3a8bddf1726b276c77bf75fb136adea471ee2825b"},
-    {file = "pdfminer.six-20211012.tar.gz", hash = "sha256:0351f17d362ee2d48b158be52bcde6576d96460efd038a3e89a043fba6d634d7"},
+    {file = "pdfminer_six-20251107-py3-none-any.whl", hash = "sha256:c09df33e4cbe6b26b2a79248a4ffcccafaa5c5d39c9fff0e6e81567f165b5401"},
+    {file = "pdfminer_six-20251107.tar.gz", hash = "sha256:5fb0c553799c591777f22c0c72b77fc2522d7d10c70654e25f4c5f1fd996e008"},
 ]
 
 [package.dependencies]
-chardet = {version = "*", markers = "python_version > \"3.0\""}
-cryptography = "*"
+charset-normalizer = ">=2.0.0"
+cryptography = ">=36.0.0"
 
 [package.extras]
-dev = ["mypy (==0.910)", "nose", "tox"]
+dev = ["atheris ; python_version < \"3.12\"", "black", "mypy (==0.931)", "nox", "pytest"]
 docs = ["sphinx", "sphinx-argparse"]
+image = ["Pillow"]
 
 [[package]]
 name = "pillow"
@@ -2921,4 +2922,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "048ae4917ea236a80e5bc96b49a952807aaf2dd6e9276a14153f8199742be81a"
+content-hash = "49749cd96f260c13cdcb6a97b8bb7c96ca4c4b8902c5ea578aff7dc227c4896a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requests-oauthlib = "^1.3.0"
 sentry-sdk = "^2.8.0"
 python-json-logger = "^2.0.2"
 django-storages = { version = "^1.11.1", extras = ["google"] }
-"pdfminer.six" = "^20211012"
+"pdfminer.six" = "^20251107"
 requests = "2.32.4"
 cffi = "^2.0.0"
 pytz = "^2022.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -850,9 +850,9 @@ oauthlib==3.2.2 ; python_version >= "3.11" and python_version < "4.0" \
 packaging==25.0 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
     --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
-pdfminer-six==20211012 ; python_version >= "3.11" and python_version < "4.0" \
-    --hash=sha256:0351f17d362ee2d48b158be52bcde6576d96460efd038a3e89a043fba6d634d7 \
-    --hash=sha256:d3efb75c0249b51c1bf795e3a8bddf1726b276c77bf75fb136adea471ee2825b
+pdfminer-six==20251107 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:5fb0c553799c591777f22c0c72b77fc2522d7d10c70654e25f4c5f1fd996e008 \
+    --hash=sha256:c09df33e4cbe6b26b2a79248a4ffcccafaa5c5d39c9fff0e6e81567f165b5401
 pillow==11.3.0 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2 \
     --hash=sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214 \


### PR DESCRIPTION
Update pdfminer.six dependency to address CVE-2025-64512.
