### PR TITLE
Add warning to create project page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -272,6 +272,10 @@ OAUTH_CLIENT_APP_NAME=local_web_client
 # Example: BLOCKED_REGIONS=RU,CN,IR,NK
 BLOCKED_REGIONS=localhost
 
+# CREATE_PROJECT_GEORESTRICTION: Custom warning message to display on create project page
+# Example: CREATE_PROJECT_GEORESTRICTION=strong>TITLE:</strong> MESSAGE, LINK:<a href="LINK URL">LINK TEXT</a>..
+CREATE_PROJECT_GEORESTRICTION=
+
 # GeoIP2 database directory path
 # Path to the directory containing GeoIP2 database files (GeoLite2-Country.mmdb, etc.)
 # Example: GEOIP_PATH=/usr/share/GeoIP (optional)

--- a/.env.example
+++ b/.env.example
@@ -272,9 +272,9 @@ OAUTH_CLIENT_APP_NAME=local_web_client
 # Example: BLOCKED_REGIONS=RU,CN,IR,NK
 BLOCKED_REGIONS=localhost
 
-# CREATE_PROJECT_GEORESTRICTION: Custom warning message to display on create project page
-# Example: CREATE_PROJECT_GEORESTRICTION=strong>TITLE:</strong> MESSAGE, LINK:<a href="LINK URL">LINK TEXT</a>..
-CREATE_PROJECT_GEORESTRICTION=
+# CREATE_PROJECT_WARNING: Custom warning message to display on create project page
+# Example: CREATE_PROJECT_WARNING=strong>TITLE:</strong> MESSAGE, LINK:<a href="LINK URL">LINK TEXT</a>..
+CREATE_PROJECT_WARNING=
 
 # GeoIP2 database directory path
 # Path to the directory containing GeoIP2 database files (GeoLite2-Country.mmdb, etc.)

--- a/.env.example
+++ b/.env.example
@@ -273,7 +273,7 @@ OAUTH_CLIENT_APP_NAME=local_web_client
 BLOCKED_REGIONS=localhost
 
 # CREATE_PROJECT_WARNING: Custom warning message to display on create project page
-# Example: CREATE_PROJECT_WARNING=strong>TITLE:</strong> MESSAGE, LINK:<a href="LINK URL">LINK TEXT</a>..
+# Example: CREATE_PROJECT_WARNING=<strong>TITLE:</strong> MESSAGE, LINK:<a href="LINK URL">LINK TEXT</a>..
 CREATE_PROJECT_WARNING=
 
 # GeoIP2 database directory path

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -60,7 +60,7 @@ BLOCKED_REGIONS = set(
 
 # Create project warning message
 # CREATE_PROJECT_WARNING: Custom message to display on create project page
-# Example: CREATE_PROJECT_WARNING=strong>TITLE:</strong> MESSAGE LINK<a href="LINK URL">LINK TEXT</a>.
+# Example: CREATE_PROJECT_WARNING=<strong>TITLE:</strong> MESSAGE LINK<a href="LINK URL">LINK TEXT</a>.
 CREATE_PROJECT_WARNING = config('CREATE_PROJECT_WARNING', default='')
 
 # Installed apps

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -58,10 +58,10 @@ BLOCKED_REGIONS = set(
     if region.strip()
 )
 
-# Create project georestriction warning message
-# CREATE_PROJECT_GEORESTRICTION: Custom message to display on create project page
-# Example: CREATE_PROJECT_GEORESTRICTION=strong>TITLE:</strong> MESSAGE LINK<a href="LINK URL">LINK TEXT</a>.
-CREATE_PROJECT_GEORESTRICTION = config('CREATE_PROJECT_GEORESTRICTION', default='')
+# Create project warning message
+# CREATE_PROJECT_WARNING: Custom message to display on create project page
+# Example: CREATE_PROJECT_WARNING=strong>TITLE:</strong> MESSAGE LINK<a href="LINK URL">LINK TEXT</a>.
+CREATE_PROJECT_WARNING = config('CREATE_PROJECT_WARNING', default='')
 
 # Installed apps
 INSTALLED_APPS = [

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -58,6 +58,11 @@ BLOCKED_REGIONS = set(
     if region.strip()
 )
 
+# Create project georestriction warning message
+# CREATE_PROJECT_GEORESTRICTION: Custom message to display on create project page
+# Example: CREATE_PROJECT_GEORESTRICTION=strong>TITLE:</strong> MESSAGE LINK<a href="LINK URL">LINK TEXT</a>.
+CREATE_PROJECT_GEORESTRICTION = config('CREATE_PROJECT_GEORESTRICTION', default='')
+
 # Installed apps
 INSTALLED_APPS = [
     'dal',

--- a/physionet-django/project/templates/project/create_project.html
+++ b/physionet-django/project/templates/project/create_project.html
@@ -13,6 +13,12 @@
 <div class="container">
   <form action="{% url 'create_project' %}" method="post" class="no-pd">
     <h2 class="form-signin-heading">Create New Project</h2>
+    {% if georestriction_message %}
+      <hr>
+      <div class="alert alert-warning" role="alert">
+        {{ georestriction_message|safe }}
+      </div>
+    {% endif %}
     <hr>
     <p>Complete the fields below to create a new project. Once created, it must be submitted for publication within 180 days.</p>
     <p>Before creating your project, please read the <a href="{% url 'static_view' static_url='publish' %}#author_guidelines" target="_blank">author guidelines</a>. Note that the resource type <strong>cannot</strong> be changed after the project is created.</p>

--- a/physionet-django/project/templates/project/create_project.html
+++ b/physionet-django/project/templates/project/create_project.html
@@ -13,10 +13,10 @@
 <div class="container">
   <form action="{% url 'create_project' %}" method="post" class="no-pd">
     <h2 class="form-signin-heading">Create New Project</h2>
-    {% if georestriction_message %}
+    {% if warning_message %}
       <hr>
       <div class="alert alert-warning" role="alert">
-        {{ georestriction_message|safe }}
+        {{ warning_message|safe }}
       </div>
     {% endif %}
     <hr>

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -341,8 +341,8 @@ def create_project(request):
 
     return render(request, 'project/create_project.html', {
         'form': form,
-        'georestriction_message': getattr(settings, 'CREATE_PROJECT_GEORESTRICTION', ''),
-    })
+        'warning_message': settings.CREATE_PROJECT_WARNING}
+    )
 
 @login_required
 def new_project_version(request, project_slug):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -339,7 +339,10 @@ def create_project(request):
     else:
         form = forms.CreateProjectForm(user=user)
 
-    return render(request, 'project/create_project.html', {'form':form})
+    return render(request, 'project/create_project.html', {
+        'form': form,
+        'georestriction_message': getattr(settings, 'CREATE_PROJECT_GEORESTRICTION', ''),
+    })
 
 @login_required
 def new_project_version(request, project_slug):


### PR DESCRIPTION
This PR adds an environment variable which can be used to set an alert/warning on the create project page. The warning is intended to convey information about how access restrictions impact whether we can accept a submitted project. The example I provide shows how to reference a link since we will likely want to point to more detailed information (in a News article, etc). If the environment variable is left empty, no warning will be displayed. 