### PR TITLE
Always show version list for published projects

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -255,10 +255,8 @@
             {% endif %}
           </div>
         </div>
-        {% if not project.is_latest_version or project.version_order or project.has_other_versions %}
-          {% include "project/version_list_card.html" %}
-        {% endif %}
 
+        {% include "project/version_list_card.html" %}
       </div>
       <!-- /.sidebar -->
     </div>

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -256,17 +256,7 @@
           </div>
         </div>
         {% if not project.is_latest_version or project.version_order or project.has_other_versions %}
-          <div class="card my-4">
-            <h5 class="card-header">Versions</h5>
-            <ul class="list-group">
-              {% for project in all_project_versions %}
-                <li class="list-group-item"><a
-                  href="{% url 'published_project' project.slug project.version %}">{{ project.version }}</a>
-                  - {{ project.publish_datetime|date }}
-                </li>
-              {% endfor %}
-            </ul>
-          </div>
+          {% include "project/version_list_card.html" %}
         {% endif %}
 
       </div>

--- a/physionet-django/project/templates/project/version_list_card.html
+++ b/physionet-django/project/templates/project/version_list_card.html
@@ -1,10 +1,14 @@
 <div class="card my-4">
   <h5 class="card-header">Versions</h5>
-  <ul class="list-group">
+  <ul class="list-group list-group-flush project-version-list">
     {% for project in all_project_versions %}
-      <li class="list-group-item"><a
-        href="{% url 'published_project' project.slug project.version %}">{{ project.version }}</a>
-        - {{ project.publish_datetime|date }}
+      <li class="list-group-item">
+        <a href="{% url 'published_project' project.slug project.version %}">
+          <span class="project-version">{{ project.version }}</span>
+          <time datetime="{{ project.publish_datetime|date:'Y-m-d' }}">
+            {{ project.publish_datetime|date }}
+          </time>
+        </a>
       </li>
     {% endfor %}
   </ul>

--- a/physionet-django/project/templates/project/version_list_card.html
+++ b/physionet-django/project/templates/project/version_list_card.html
@@ -1,0 +1,11 @@
+<div class="card my-4">
+  <h5 class="card-header">Versions</h5>
+  <ul class="list-group">
+    {% for project in all_project_versions %}
+      <li class="list-group-item"><a
+        href="{% url 'published_project' project.slug project.version %}">{{ project.version }}</a>
+        - {{ project.publish_datetime|date }}
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/physionet-django/static/custom/css/physionet.css
+++ b/physionet-django/static/custom/css/physionet.css
@@ -615,3 +615,13 @@ body .tox .tox-dialog-wrap__backdrop {
     background-color: #000; /* bootstrap: $modal-backdrop-bg */
     opacity: 0.5;           /* bootstrap: $modal-backdrop-opacity */
 }
+
+.project-version-list .list-group-item > a {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+.project-version-list .list-group-item time {
+    padding-left: 0.5em;
+    text-align: right;
+}


### PR DESCRIPTION
The list of versions (shown in the sidebar of each published project page) is currently only shown when the project has multiple versions.

For the sake of clarity, show the list for every published project, even if there's only one version.  The list still is not shown for *unpublished* (active) projects.

Also, improve the styling and accessibility a little.

Fixes #2532
