### PR TITLE
Add missing slash to news post URL

### DIFF
--- a/physionet-django/notification/urls.py
+++ b/physionet-django/notification/urls.py
@@ -6,7 +6,7 @@ from notification import views
 urlpatterns = [
     path('news/', views.news, name='news'),
     path('news/<int:year>/', views.news_year, name='news_year'),
-    path('news/post/<news_slug>', views.news_by_slug, name='news_by_slug'),
+    path('news/post/<news_slug>/', views.news_by_slug, name='news_by_slug'),
     path('feed.xml', views.news_rss, name='news_rss'),
 ]
 


### PR DESCRIPTION
News URLs should have a trailing slash.  Clients will be redirected automatically.
