### PR TITLE
Display correct DOI prefix in project previews

### DIFF
--- a/physionet-django/project/modelcomponents/coreproject.py
+++ b/physionet-django/project/modelcomponents/coreproject.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
@@ -57,6 +58,21 @@ class CoreProject(models.Model):
         # The sum will be None if there are no publishedprojects.  It will
         # also be None if any projects have incremental_storage_size=None.
         return result['total'] or 0
+
+    def future_doi_prefix(self):
+        """
+        The organizational prefix for the project's future DOI.
+
+        This is a string like "10.12345", which will be the prefix of
+        the DOI when and if the project is published.  This is meant
+        to be used as a hint for placeholder citations.
+        """
+        if self.doi:
+            return self.doi.split('/')[0]
+        elif settings.DATACITE_PREFIX:
+            return settings.DATACITE_PREFIX
+        else:
+            return None
 
 
 class ProgrammingLanguage(models.Model):

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -413,7 +413,11 @@ class Metadata(models.Model):
             DOI suffix.
             """
             year = timezone.now().year
-            doi = '10.13026/*****'
+            prefix = self.future_doi_prefix()
+            if prefix:
+                doi = prefix + '/*****'
+            else:
+                doi = None
 
         rrid_text = f"RRID:{settings.PLATFORM_RRID}." if settings.PLATFORM_RRID else ""
         shared_content = {'year': year,

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -523,7 +523,7 @@ class Metadata(models.Model):
                                           **shared_content)
 
         else:
-            final_style = style_format + '.'
+            final_style = style_format
             citation_format = format_html(final_style,
                                           author=all_authors,
                                           **shared_content)

--- a/physionet-django/project/modelcomponents/unpublishedproject.py
+++ b/physionet-django/project/modelcomponents/unpublishedproject.py
@@ -89,6 +89,20 @@ class UnpublishedProject(models.Model):
         else:
             raise Exception('Not a new version')
 
+    def future_doi_prefix(self):
+        """
+        The organizational prefix for the project's future DOI.
+
+        This is a string like "10.12345", which will be the prefix of
+        the DOI when and if the project is published.  This is meant
+        to be used as a hint for placeholder citations.
+        """
+        if self.doi:
+            return self.doi.split('/')[0]
+        elif settings.DATACITE_PREFIX:
+            return settings.DATACITE_PREFIX
+        else:
+            return None
 
     def remove(self):
         """

--- a/physionet-django/project/templates/project/project_preview.html
+++ b/physionet-django/project/templates/project/project_preview.html
@@ -166,13 +166,17 @@
       <div class="card my-4">
         <h5 class="card-header">Discovery</h5>
         <div class="card-body">
-          <p><strong>DOI (version {{ project.version }}):</strong><br>
-            https://doi.org/10.13026/*****
-          </p>
+          {% if project.future_doi_prefix %}
+            <p><strong>DOI (version {{ project.version }}):</strong><br>
+              https://doi.org/{{ project.future_doi_prefix }}/*****
+            </p>
+          {% endif %}
 
-          <p><strong>DOI (latest version):</strong><br>
-            https://doi.org/10.13026/*****
-          </p>
+          {% if project.core_project.future_doi_prefix %}
+            <p><strong>DOI (latest version):</strong><br>
+              https://doi.org/{{ project.core_project.future_doi_prefix }}/*****
+            </p>
+          {% endif %}
 
           {% if languages %}
             <p><strong>Programming Languages:</strong>


### PR DESCRIPTION
The project preview page shows a placeholder citation for the project, as well as placeholder DOIs in the sidebar.

Instead of hardcoding PhysioNet's DOI prefix (10.13026), this should use the configured DATACITE_PREFIX (or the actual DOI prefix, if a DOI has already been assigned.)

If the project has no DOI and there is no configured DATACITE_PREFIX, then the preview shouldn't show DOIs at all.

Also fix the formatting of DOI-less citations which was broken by pull #2409.
