### PR TITLE
Use the word "controlled" instead of "restricted"

### DIFF
--- a/physionet-django/console/templates/console/cloud_mirrors.html
+++ b/physionet-django/console/templates/console/cloud_mirrors.html
@@ -17,8 +17,8 @@
              href="?group=open">Open</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {% if group == 'restricted' %}active{% endif %}"
-             href="?group=restricted">Restricted</a>
+          <a class="nav-link {% if group == 'controlled' %}active{% endif %}"
+             href="?group=controlled">Controlled</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
In the Cloud Mirrors page, projects are divided into "Open" and "Restricted" categories, which may be confusing because the word "restricted" can also refer to a specific `access_policy`.

"Controlled" is the more general term that we've been using, at least internally, to mean "not-open", so use this term in the console UI.
