### PR TITLE
Add resource_type, access_policy, and topics to API responses

### DIFF
--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 
 from rest_framework import serializers
 
@@ -20,12 +21,66 @@ class DUASerializer(serializers.ModelSerializer):
         )
 
 
-class PublishedProjectSerializer(serializers.ModelSerializer):
+class ProjectFieldsMixin:
+    """
+    Mixin providing serialization for resource_type, access_policy, and topics.
+
+    This mixin provides methods to serialize these fields as human-readable
+    strings instead of internal integer codes, making the API more extensible
+    and future-proof.
+    """
+
+    def get_resource_type(self, obj):
+        """
+        Return resource type as string name (e.g., 'Database', 'Software').
+
+        Args:
+            obj: PublishedProject instance
+
+        Returns:
+            str or None: Resource type name or None if not set
+        """
+        return obj.resource_type.name if obj.resource_type else None
+
+    def get_access_policy(self, obj):
+        """
+        Return access policy as string name (e.g., 'Open', 'Credentialed').
+
+        Args:
+            obj: PublishedProject instance
+
+        Returns:
+            str or None: Access policy name or None if not set
+        """
+        from project.models import AccessPolicy
+        for value, name in AccessPolicy.choices():
+            if value == obj.access_policy:
+                return name
+        return None
+
+    def get_topics(self, obj):
+        """
+        Return list of topic descriptions.
+
+        Args:
+            obj: PublishedProject instance
+
+        Returns:
+            list: List of topic description strings
+        """
+        return [topic.description for topic in obj.topics.all()]
+
+
+class PublishedProjectSerializer(ProjectFieldsMixin, serializers.ModelSerializer):
     license = LicenseSerializer()
     dua = DUASerializer()
     publish_date = serializers.SerializerMethodField()
     core_doi = serializers.SerializerMethodField()
     version_doi = serializers.SerializerMethodField()
+    resource_type = serializers.SerializerMethodField()
+    access_policy = serializers.SerializerMethodField()
+    topics = serializers.SerializerMethodField()
+    source_url = serializers.SerializerMethodField()
 
     class Meta:
         model = PublishedProject
@@ -43,6 +98,10 @@ class PublishedProjectSerializer(serializers.ModelSerializer):
             'dua',
             'main_storage_size',
             'compressed_storage_size',
+            'resource_type',
+            'access_policy',
+            'topics',
+            'source_url',
         )
 
     def get_publish_date(self, obj):
@@ -53,6 +112,15 @@ class PublishedProjectSerializer(serializers.ModelSerializer):
 
     def get_version_doi(self, obj):
         return obj.doi
+
+    def get_source_url(self, obj):
+        """Generate the full URL to this project's page."""
+        request = self.context.get('request')
+        if request:
+            return request.build_absolute_uri(
+                reverse('published_project', args=[obj.slug, obj.version])
+            )
+        return None
 
 
 class ProjectVersionsSerializer(serializers.ModelSerializer):
@@ -72,8 +140,12 @@ class ProjectVersionsSerializer(serializers.ModelSerializer):
         return obj.citation_text(style="Vancouver")
 
 
-class PublishedProjectDetailSerializer(serializers.ModelSerializer):
+class PublishedProjectDetailSerializer(ProjectFieldsMixin, serializers.ModelSerializer):
     license = LicenseSerializer()
+    resource_type = serializers.SerializerMethodField()
+    access_policy = serializers.SerializerMethodField()
+    topics = serializers.SerializerMethodField()
+    source_url = serializers.SerializerMethodField()
 
     class Meta:
         model = PublishedProject
@@ -89,4 +161,17 @@ class PublishedProjectDetailSerializer(serializers.ModelSerializer):
             'doi',
             'main_storage_size',
             'compressed_storage_size',
+            'resource_type',
+            'access_policy',
+            'topics',
+            'source_url',
         )
+
+    def get_source_url(self, obj):
+        """Generate the full URL to this project's page."""
+        request = self.context.get('request')
+        if request:
+            return request.build_absolute_uri(
+                reverse('published_project', args=[obj.slug, obj.version])
+            )
+        return None

--- a/physionet-django/export/serializers.py
+++ b/physionet-django/export/serializers.py
@@ -53,10 +53,13 @@ class ProjectFieldsMixin:
             str or None: Access policy name or None if not set
         """
         from project.models import AccessPolicy
-        for value, name in AccessPolicy.choices():
-            if value == obj.access_policy:
-                return name
-        return None
+        if obj.access_policy is None:
+            return None
+        try:
+            return AccessPolicy(obj.access_policy).name.replace("_", " ").title()
+        except ValueError:
+            # Handle unexpected/invalid access policy values gracefully
+            return None
 
     def get_topics(self, obj):
         """
@@ -69,6 +72,15 @@ class ProjectFieldsMixin:
             list: List of topic description strings
         """
         return [topic.description for topic in obj.topics.all()]
+
+    def get_source_url(self, obj):
+        """Generate the full URL to this project's page."""
+        request = self.context.get('request')
+        if request:
+            return request.build_absolute_uri(
+                reverse('published_project', args=[obj.slug, obj.version])
+            )
+        return None
 
 
 class PublishedProjectSerializer(ProjectFieldsMixin, serializers.ModelSerializer):
@@ -112,15 +124,6 @@ class PublishedProjectSerializer(ProjectFieldsMixin, serializers.ModelSerializer
 
     def get_version_doi(self, obj):
         return obj.doi
-
-    def get_source_url(self, obj):
-        """Generate the full URL to this project's page."""
-        request = self.context.get('request')
-        if request:
-            return request.build_absolute_uri(
-                reverse('published_project', args=[obj.slug, obj.version])
-            )
-        return None
 
 
 class ProjectVersionsSerializer(serializers.ModelSerializer):
@@ -166,12 +169,3 @@ class PublishedProjectDetailSerializer(ProjectFieldsMixin, serializers.ModelSeri
             'topics',
             'source_url',
         )
-
-    def get_source_url(self, obj):
-        """Generate the full URL to this project's page."""
-        request = self.context.get('request')
-        if request:
-            return request.build_absolute_uri(
-                reverse('published_project', args=[obj.slug, obj.version])
-            )
-        return None

--- a/physionet-django/export/tests/test_views.py
+++ b/physionet-django/export/tests/test_views.py
@@ -96,14 +96,15 @@ class TestAPIFieldSerialization(TestCase):
         self.client = APIClient()
 
         # Create core project
-        self.core_project = CoreProject.objects.create(
-            title="Test Core Project"
-        )
+        self.core_project = CoreProject.objects.create()
 
         # Create license
-        self.license = License.objects.create(
-            name='Open Data Commons Open Database License v1.0',
-            slug='odbl-1.0'
+        self.license, _ = License.objects.get_or_create(
+            slug='test-license-slug',
+            defaults={
+                'name': 'Test License For API',
+                'version': '1.0'
+            }
         )
 
         # Create project types for testing
@@ -194,6 +195,7 @@ class TestAPIFieldSerialization(TestCase):
         """Test all access policy values serialize correctly"""
         from datetime import datetime
         from django.utils import timezone as tz
+        from project.models import CoreProject
 
         test_cases = [
             (AccessPolicy.OPEN, 'Open'),
@@ -204,6 +206,10 @@ class TestAPIFieldSerialization(TestCase):
 
         for policy_value, expected_name in test_cases:
             with self.subTest(policy=policy_value):
+                # Create a new core project for each iteration to avoid uniqueness constraints
+                # on (core_project, version) if version is kept constant
+                core_project = CoreProject.objects.create(doi=None)
+                
                 project = PublishedProject.objects.create(
                     slug=f'test-policy-{policy_value}',
                     version='1.0.0',
@@ -211,7 +217,7 @@ class TestAPIFieldSerialization(TestCase):
                     abstract='Test',
                     resource_type=self.db_type,
                     access_policy=policy_value,
-                    core_project=self.core_project,
+                    core_project=core_project,
                     license=self.license,
                     publish_datetime=tz.make_aware(datetime(2024, 1, 1))
                 )
@@ -228,6 +234,7 @@ class TestAPIFieldSerialization(TestCase):
         """Test all resource type values serialize correctly"""
         from datetime import datetime
         from django.utils import timezone as tz
+        from project.models import CoreProject
 
         type_data = [
             (self.db_type, 'Database'),
@@ -238,6 +245,9 @@ class TestAPIFieldSerialization(TestCase):
 
         for project_type, type_name in type_data:
             with self.subTest(resource_type=type_name):
+                # Create a new core project for each iteration
+                core_project = CoreProject.objects.create(doi=None)
+
                 project = PublishedProject.objects.create(
                     slug=f'test-type-{project_type.id}',
                     version='1.0.0',
@@ -245,7 +255,7 @@ class TestAPIFieldSerialization(TestCase):
                     abstract='Test',
                     resource_type=project_type,
                     access_policy=AccessPolicy.OPEN,
-                    core_project=self.core_project,
+                    core_project=core_project,
                     license=self.license,
                     publish_datetime=tz.make_aware(datetime(2024, 1, 1))
                 )
@@ -262,6 +272,9 @@ class TestAPIFieldSerialization(TestCase):
         """Test that projects without topics return empty list"""
         from datetime import datetime
         from django.utils import timezone as tz
+        from project.models import CoreProject
+
+        core_project = CoreProject.objects.create(doi=None)
 
         project = PublishedProject.objects.create(
             slug='test-no-topics',
@@ -270,7 +283,7 @@ class TestAPIFieldSerialization(TestCase):
             abstract='Test',
             resource_type=self.db_type,
             access_policy=AccessPolicy.OPEN,
-            core_project=self.core_project,
+            core_project=core_project,
             license=self.license,
             publish_datetime=tz.make_aware(datetime(2024, 1, 1))
         )

--- a/physionet-django/export/tests/test_views.py
+++ b/physionet-django/export/tests/test_views.py
@@ -209,7 +209,7 @@ class TestAPIFieldSerialization(TestCase):
                 # Create a new core project for each iteration to avoid uniqueness constraints
                 # on (core_project, version) if version is kept constant
                 core_project = CoreProject.objects.create(doi=None)
-                
+
                 project = PublishedProject.objects.create(
                     slug=f'test-policy-{policy_value}',
                     version='1.0.0',

--- a/physionet-django/export/tests/test_views.py
+++ b/physionet-django/export/tests/test_views.py
@@ -82,3 +82,223 @@ class TestRateLimiting(TestCase):
         # Next request should be rate limited
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+
+class TestAPIFieldSerialization(TestCase):
+    """Test that new API fields are correctly serialized"""
+
+    def setUp(self):
+        """Set up test data"""
+        from project.models import CoreProject, PublishedTopic, License
+        from datetime import datetime
+        from django.utils import timezone as tz
+
+        self.client = APIClient()
+
+        # Create core project
+        self.core_project = CoreProject.objects.create(
+            title="Test Core Project"
+        )
+
+        # Create license
+        self.license = License.objects.create(
+            name='Open Data Commons Open Database License v1.0',
+            slug='odbl-1.0'
+        )
+
+        # Create project types for testing
+        self.db_type = ProjectType.objects.get_or_create(
+            id=0,
+            defaults={'name': 'Database', 'description': 'Test database type'}
+        )[0]
+        self.sw_type = ProjectType.objects.get_or_create(
+            id=1,
+            defaults={'name': 'Software', 'description': 'Test software type'}
+        )[0]
+        self.ch_type = ProjectType.objects.get_or_create(
+            id=2,
+            defaults={'name': 'Challenge', 'description': 'Test challenge type'}
+        )[0]
+        self.md_type = ProjectType.objects.get_or_create(
+            id=3,
+            defaults={'name': 'Model', 'description': 'Test model type'}
+        )[0]
+
+        # Create published project
+        self.project = PublishedProject.objects.create(
+            slug='test-api-project',
+            version='1.0.0',
+            title='Test API Project',
+            abstract='Test abstract for API',
+            short_description='Short desc',
+            resource_type=self.db_type,
+            access_policy=AccessPolicy.CREDENTIALED,
+            core_project=self.core_project,
+            license=self.license,
+            publish_datetime=tz.make_aware(datetime(2024, 1, 1))
+        )
+
+        # Create and add topics
+        self.topic1 = PublishedTopic.objects.create(
+            description='critical care'
+        )
+        self.topic2 = PublishedTopic.objects.create(
+            description='ehr'
+        )
+        self.project.topics.add(self.topic1, self.topic2)
+
+    def test_published_project_list_includes_new_fields(self):
+        """Test that list endpoint includes resource_type, access_policy, topics"""
+        url = reverse('published_project_list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Find our test project in the results
+        data = response.json()
+        results = data.get('results', data) if isinstance(data, dict) else data
+        test_project = next(
+            (p for p in results if p['slug'] == 'test-api-project'),
+            None
+        )
+
+        self.assertIsNotNone(test_project, "Test project not found in API response")
+
+        # Verify new fields exist and have correct values
+        self.assertEqual(test_project['resource_type'], 'Database')
+        self.assertEqual(test_project['access_policy'], 'Credentialed')
+        self.assertIn('critical care', test_project['topics'])
+        self.assertIn('ehr', test_project['topics'])
+        self.assertEqual(len(test_project['topics']), 2)
+        self.assertIsNotNone(test_project.get('source_url'))
+
+    def test_published_project_detail_includes_new_fields(self):
+        """Test that detail endpoint includes resource_type, access_policy, topics"""
+        url = reverse('published_project_detail',
+                      kwargs={'project_slug': 'test-api-project',
+                              'version': '1.0.0'})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # Verify new fields exist and have correct values
+        self.assertEqual(data['resource_type'], 'Database')
+        self.assertEqual(data['access_policy'], 'Credentialed')
+        self.assertIn('critical care', data['topics'])
+        self.assertIn('ehr', data['topics'])
+        self.assertEqual(len(data['topics']), 2)
+        self.assertIsNotNone(data.get('source_url'))
+
+    def test_access_policy_values(self):
+        """Test all access policy values serialize correctly"""
+        from datetime import datetime
+        from django.utils import timezone as tz
+
+        test_cases = [
+            (AccessPolicy.OPEN, 'Open'),
+            (AccessPolicy.RESTRICTED, 'Restricted'),
+            (AccessPolicy.CREDENTIALED, 'Credentialed'),
+            (AccessPolicy.CONTRIBUTOR_REVIEW, 'Contributor Review'),
+        ]
+
+        for policy_value, expected_name in test_cases:
+            with self.subTest(policy=policy_value):
+                project = PublishedProject.objects.create(
+                    slug=f'test-policy-{policy_value}',
+                    version='1.0.0',
+                    title=f'Test Policy {policy_value}',
+                    abstract='Test',
+                    resource_type=self.db_type,
+                    access_policy=policy_value,
+                    core_project=self.core_project,
+                    license=self.license,
+                    publish_datetime=tz.make_aware(datetime(2024, 1, 1))
+                )
+
+                url = reverse('published_project_detail',
+                              kwargs={'project_slug': project.slug,
+                                      'version': project.version})
+                response = self.client.get(url)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.json()['access_policy'], expected_name)
+
+    def test_resource_type_values(self):
+        """Test all resource type values serialize correctly"""
+        from datetime import datetime
+        from django.utils import timezone as tz
+
+        type_data = [
+            (self.db_type, 'Database'),
+            (self.sw_type, 'Software'),
+            (self.ch_type, 'Challenge'),
+            (self.md_type, 'Model'),
+        ]
+
+        for project_type, type_name in type_data:
+            with self.subTest(resource_type=type_name):
+                project = PublishedProject.objects.create(
+                    slug=f'test-type-{project_type.id}',
+                    version='1.0.0',
+                    title=f'Test Type {type_name}',
+                    abstract='Test',
+                    resource_type=project_type,
+                    access_policy=AccessPolicy.OPEN,
+                    core_project=self.core_project,
+                    license=self.license,
+                    publish_datetime=tz.make_aware(datetime(2024, 1, 1))
+                )
+
+                url = reverse('published_project_detail',
+                              kwargs={'project_slug': project.slug,
+                                      'version': project.version})
+                response = self.client.get(url)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.json()['resource_type'], type_name)
+
+    def test_project_without_topics(self):
+        """Test that projects without topics return empty list"""
+        from datetime import datetime
+        from django.utils import timezone as tz
+
+        project = PublishedProject.objects.create(
+            slug='test-no-topics',
+            version='1.0.0',
+            title='Test No Topics',
+            abstract='Test',
+            resource_type=self.db_type,
+            access_policy=AccessPolicy.OPEN,
+            core_project=self.core_project,
+            license=self.license,
+            publish_datetime=tz.make_aware(datetime(2024, 1, 1))
+        )
+
+        url = reverse('published_project_detail',
+                      kwargs={'project_slug': project.slug,
+                              'version': project.version})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['topics'], [])
+
+    def test_backward_compatibility(self):
+        """Test that all existing fields are still present"""
+        url = reverse('published_project_detail',
+                      kwargs={'project_slug': 'test-api-project',
+                              'version': '1.0.0'})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # Verify all existing fields are still present
+        expected_existing_fields = [
+            'slug', 'title', 'version', 'abstract', 'license',
+            'short_description', 'project_home_page', 'publish_datetime',
+            'doi', 'main_storage_size', 'compressed_storage_size'
+        ]
+
+        for field in expected_existing_fields:
+            self.assertIn(field, data, f"Field '{field}' missing from response")

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -39,7 +39,7 @@ class PublishedProjectList(mixins.ListModelMixin, generics.GenericAPIView):
         - Basic metadata (title, version, slug, DOIs, etc.)
         - License and DUA information
         - Storage sizes
-        - Resource type (Database, Software, Challenge, Model) - as string
+        - Resource type as descriptive string (e.g., Database, Software, Challenge, Model)
         - Access policy (Open, Restricted, Credentialed, Contributor Review) - as string
         - Topics (list of descriptive keywords)
         - Source URL (full URL to project page)
@@ -49,7 +49,7 @@ class PublishedProjectList(mixins.ListModelMixin, generics.GenericAPIView):
         - Rate limited: 100 requests/hour for authenticated users
         - Rate limited: 20 requests/hour for anonymous users
     """
-    queryset = PublishedProject.objects.all().order_by('id')
+    queryset = PublishedProject.objects.all().order_by('id').prefetch_related('topics')
     authentication_classes = [SessionAuthentication, BasicAuthentication]
     serializer_class = PublishedProjectSerializer
     throttle_classes = [StandardRateThrottle, StandardAnonRateThrottle]
@@ -100,7 +100,7 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
         - Project home page
         - DOI
         - Storage sizes
-        - Resource type (Database, Software, Challenge, Model) - as string
+        - Resource type as descriptive string (e.g., Database, Software, Challenge, Model)
         - Access policy (Open, Restricted, Credentialed, Contributor Review) - as string
         - Topics (list of descriptive keywords)
         - Source URL (full URL to project page)
@@ -115,7 +115,7 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
 
     def get(self, request, project_slug, version, *args, **kwargs):
         project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
-        serializer = PublishedProjectDetailSerializer(project)
+        serializer = PublishedProjectDetailSerializer(project, context={'request': request})
         return Response(serializer.data)
 
 

--- a/physionet-django/export/views.py
+++ b/physionet-django/export/views.py
@@ -35,6 +35,15 @@ class PublishedProjectList(mixins.ListModelMixin, generics.GenericAPIView):
     Returns a paginated list of all published projects, ordered by ID.
     Supports filtering by resource type and search terms.
 
+    Response includes:
+        - Basic metadata (title, version, slug, DOIs, etc.)
+        - License and DUA information
+        - Storage sizes
+        - Resource type (Database, Software, Challenge, Model) - as string
+        - Access policy (Open, Restricted, Credentialed, Contributor Review) - as string
+        - Topics (list of descriptive keywords)
+        - Source URL (full URL to project page)
+
     Authentication:
         - Session or Basic authentication required
         - Rate limited: 100 requests/hour for authenticated users
@@ -84,6 +93,17 @@ class PublishedProjectDetail(mixins.RetrieveModelMixin, generics.GenericAPIView)
     Parameters:
         project_slug (str): The unique identifier for the project
         version (str): The version number of the project
+
+    Response includes:
+        - Complete project metadata (title, version, slug, abstract, etc.)
+        - License information
+        - Project home page
+        - DOI
+        - Storage sizes
+        - Resource type (Database, Software, Challenge, Model) - as string
+        - Access policy (Open, Restricted, Credentialed, Contributor Review) - as string
+        - Topics (list of descriptive keywords)
+        - Source URL (full URL to project page)
 
     Authentication:
         - Session or Basic authentication required


### PR DESCRIPTION
Enhance API responses by including resource type, access policy, and topics for published projects. This change improves the metadata provided to users, making the API more informative and user-friendly.