### PR TITLE
Truncate long author lists on front page cards

### DIFF
--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -496,6 +496,201 @@
   }
 },
 {
+  "model": "project.publishedauthor",
+  "pk": 9,
+  "fields": {
+    "user": ["george"],
+    "display_order": 2,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "George",
+    "last_name": "Moody",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 10,
+  "fields": {
+    "user": ["aewj"],
+    "display_order": 3,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Alistair",
+    "last_name": "Johnson",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 11,
+  "fields": {
+    "user": ["admin"],
+    "display_order": 4,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Admin",
+    "last_name": "Bot",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 12,
+  "fields": {
+    "user": ["jameslawson"],
+    "display_order": 5,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "James",
+    "last_name": "Lawson",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 13,
+  "fields": {
+    "user": ["eulaeasley"],
+    "display_order": 6,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Eula",
+    "last_name": "Easley",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 14,
+  "fields": {
+    "user": ["miriamturner"],
+    "display_order": 7,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Miriam",
+    "last_name": "Turner",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 15,
+  "fields": {
+    "user": ["deborahbui"],
+    "display_order": 8,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Deborah",
+    "last_name": "Bui",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 16,
+  "fields": {
+    "user": ["theresachesney"],
+    "display_order": 9,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Theresa",
+    "last_name": "Chesney",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 17,
+  "fields": {
+    "user": ["franwilliams"],
+    "display_order": 10,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Fran",
+    "last_name": "Williams",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 18,
+  "fields": {
+    "user": ["johnmassey"],
+    "display_order": 11,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "John",
+    "last_name": "Massey",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 19,
+  "fields": {
+    "user": ["olympiaquillen"],
+    "display_order": 12,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Olympia",
+    "last_name": "Quillen",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 20,
+  "fields": {
+    "user": ["odissinger"],
+    "display_order": 13,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Odis",
+    "last_name": "Singer",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
+  "model": "project.publishedauthor",
+  "pk": 21,
+  "fields": {
+    "user": ["josehardy"],
+    "display_order": 14,
+    "is_submitting": false,
+    "is_corresponding": false,
+    "approval_datetime": "2018-11-14T21:11:11.781Z",
+    "first_names": "Jose",
+    "last_name": "Hardy",
+    "corresponding_email": null,
+    "project": 1
+  }
+},
+{
   "model": "project.topic",
   "pk": 1,
   "fields": {

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -7,7 +7,7 @@
     </p>
     <{% firstof content_list_header 'h2' %}><a href="{% url 'published_project' published_project.slug published_project.version %}">{{ published_project.title }}</a></{% firstof content_list_header 'h2' %}>
     {% if not published_project.is_legacy %}
-      <p class="text-muted">
+      <p class="text-muted card-authors">
           {% for author in published_project.author_list %}
           {{ author.get_full_name }}{% if not forloop.last %}, {% endif %}
           {% endfor %}

--- a/physionet-django/search/templates/search/homepage_content_list.html
+++ b/physionet-django/search/templates/search/homepage_content_list.html
@@ -12,7 +12,7 @@
       </a>
     </h3>
     {% if not published_project.is_legacy %}
-      <p>
+      <p class="card-authors">
           {% for author in published_project.author_list %}
           {{ author.get_full_name }}{% if not forloop.last %}, {% endif %}
           {% endfor %}

--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -240,6 +240,16 @@ body .main {
   overflow: hidden;
   color: var(--gray-color);
 }
+.card-authors {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.modern-ui .card-authors {
+  font-size: 0.875rem;
+  color: var(--gray-color);
+}
 .modern-ui .badge-dark {
   background-color: var(--gray-200);
   color: var(--secondary-color);


### PR DESCRIPTION
## Summary
- [x] Add CSS `line-clamp` truncation for author lists on front page and search results.
- [x] Apply `.card-authors` class to both `homepage_content_list.html` and `content_list.html`.
- [x] Update demo fixtures to include a project with 14 authors to demonstrate truncation.

## Approach
Uses CSS-only truncation with `line-clamp` to limit author lists to a single line with ellipsis. This is simpler than a Django filter approach and provides consistent rendering across all cards.

## Screenshots
<img width="647" height="237" alt="author-trunc" src="https://github.com/user-attachments/assets/2d944986-b62c-4960-87b7-acc81361a521" />
<img width="904" height="273" alt="content-list-trunc" src="https://github.com/user-attachments/assets/6e6f0298-1034-40b2-b9f0-1c29f4d93a7a" />


Fixes #2462