### PR TITLE
Fix card-authors flex overflow

### DIFF
--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -245,6 +245,8 @@ body .main {
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  flex-grow: 0;
+  flex-shrink: 0;
 }
 .modern-ui .card-authors {
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary

- Prevents `.card-authors` from inheriting `flex-grow: 1` from the `.card--flat > p:last-of-type` rule
- Adds `flex-grow: 0` and `flex-shrink: 0` to keep the author list at its natural size

## Problem

When `.card-authors` is the last `<p>` element in a card (e.g., when the abstract doesn't contain `<p>` tags), it inherits `flex-grow: 1` which causes it to stretch and overflow.

## Screenshot

Before
<img width="1372" height="402" alt="Screenshot 2025-12-30 at 2 50 11 PM" src="https://github.com/user-attachments/assets/51164abf-81ec-465f-9041-5a3608235710" />

After
<img width="1360" height="354" alt="Screenshot 2025-12-30 at 2 51 25 PM" src="https://github.com/user-attachments/assets/b06511ab-5633-4473-93ed-1eb2bf53c0f8" />

## Test plan

- [x] Verified locally that card authors no longer overflow
- [x] Confirmed card spacing remains consistent with other cards