### PR TITLE
Truncate author lists using model method

### DIFF
--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -115,6 +115,15 @@ class Metadata(models.Model):
         """
         return self.authors.all().order_by('display_order')
 
+    def display_authors(self, max_authors=3):
+        """
+        Get a truncated display string of author names.
+        Shows up to max_authors names, with 'et al.' if there are more.
+        """
+        authors = list(self.authors.all().order_by('display_order'))
+        names = ', '.join(a.get_full_name() for a in authors[:max_authors])
+        return f'{names}, et al.' if len(authors) > max_authors else names
+
     def get_author_info(self, separate_submitting=False, include_emails=False):
         """
         Get the project's authors, setting information needed to display

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1576,3 +1576,38 @@ class TestGeoRestrictedAccess(TestCase):
         self.credentialed_project.save()
         self.open_project.georestricted = False
         self.open_project.save()
+
+
+class TestDisplayAuthors(TestMixin):
+    """Test the display_authors method on projects."""
+
+    def test_display_authors_few(self):
+        """Projects with 3 or fewer authors show all names."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        result = project.display_authors()
+        self.assertNotIn('et al.', result)
+        # Should contain all author names
+        for author in project.authors.all():
+            self.assertIn(author.get_full_name(), result)
+
+    def test_display_authors_many(self):
+        """Projects with more than 3 authors show truncated list."""
+        project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
+        # This project should have many authors from the fixture
+        if project.authors.count() > 3:
+            result = project.display_authors()
+            self.assertIn('et al.', result)
+            # Should only contain first 3 author names
+            authors = list(project.authors.all().order_by('display_order'))
+            for author in authors[:3]:
+                self.assertIn(author.get_full_name(), result)
+
+    def test_display_authors_custom_max(self):
+        """Test custom max_authors parameter."""
+        project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
+        if project.authors.count() > 1:
+            result = project.display_authors(max_authors=1)
+            authors = list(project.authors.all().order_by('display_order'))
+            self.assertIn(authors[0].get_full_name(), result)
+            if project.authors.count() > 1:
+                self.assertIn('et al.', result)

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -7,11 +7,7 @@
     </p>
     <{% firstof content_list_header 'h2' %}><a href="{% url 'published_project' published_project.slug published_project.version %}">{{ published_project.title }}</a></{% firstof content_list_header 'h2' %}>
     {% if not published_project.is_legacy %}
-      <p class="text-muted card-authors">
-          {% for author in published_project.author_list %}
-          {{ author.get_full_name }}{% if not forloop.last %}, {% endif %}
-          {% endfor %}
-      </p>
+      <p class="text-muted card-authors">{{ published_project.display_authors }}</p>
     {% endif %}
     <div style="margin-bottom: 1rem;">
       {% if not published_project.short_description %}

--- a/physionet-django/search/templates/search/homepage_content_list.html
+++ b/physionet-django/search/templates/search/homepage_content_list.html
@@ -12,11 +12,7 @@
       </a>
     </h3>
     {% if not published_project.is_legacy %}
-      <p class="card-authors">
-          {% for author in published_project.author_list %}
-          {{ author.get_full_name }}{% if not forloop.last %}, {% endif %}
-          {% endfor %}
-      </p>
+      <p class="card-authors">{{ published_project.display_authors }}</p>
     {% endif %}
 
     {% if not published_project.short_description %}

--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -241,12 +241,9 @@ body .main {
   color: var(--gray-color);
 }
 .card-authors {
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
   overflow: hidden;
-  flex-grow: 0;
-  flex-shrink: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .modern-ui .card-authors {
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary

Replaces CSS-based author truncation with a model method approach for more reliable and consistent behavior.

- Adds `display_authors(max_authors=3)` method to project metadata mixin
- Shows first 3 authors followed by "et al." when there are more
- Simplifies templates to use `{{ published_project.display_authors }}`
- Includes unit tests for the new method

## Why

The previous CSS approach (`line-clamp`, `flex-grow`) had layout issues where `flex-grow: 1` from parent rules caused overflow. A model-based approach gives predictable output regardless of CSS context.

## Test plan

- [x] Unit tests pass (`python manage.py test project.test_views.TestDisplayAuthors`)
- [x] Verified locally on homepage and search results