### PR TITLE
Add BibTeX citation export for published projects

### DIFF
--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -572,6 +572,24 @@ class Metadata(models.Model):
             lambda m: cls._BIBTEX_REPLACEMENTS[m.group(1)], text
         )
 
+    @classmethod
+    def _format_bibtex_author(cls, author):
+        """
+        Format author name for BibTeX, handling multi-word last names.
+
+        Converts "Van der Berg, John" to "{Van der Berg}, John" so BibTeX
+        parsers correctly identify the last name.
+        """
+        name = author.get_full_name(reverse=True)
+        if ', ' in name:
+            last_name, first_names = name.split(', ', 1)
+            last_name = cls._escape_bibtex(last_name)
+            first_names = cls._escape_bibtex(first_names)
+            if ' ' in last_name:
+                last_name = '{' + last_name + '}'
+            return last_name + ', ' + first_names
+        return cls._escape_bibtex(name)
+
     def citation_text_bibtex(self):
         """
         Generate a BibTeX citation for the project.
@@ -600,7 +618,7 @@ class Metadata(models.Model):
             citation_key = 'unpublished'
 
         author_list = ' and '.join(
-            self._escape_bibtex(a.get_full_name(reverse=True)) for a in authors
+            self._format_bibtex_author(a) for a in authors
         )
 
         title = self._escape_bibtex(self.title)

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -605,8 +605,8 @@ class Metadata(models.Model):
                 return ''
 
             slug = getattr(self, 'slug', 'project')
-            version_str = self.version.replace('.', '_') if self.version else ''
-            citation_key = f"{slug}-{version_str}"
+            version_str = self.version if self.version else ''
+            citation_key = f"{settings.SITE_NAME}-{slug}-{version_str}"
         else:
             year = timezone.now().year
             month = timezone.now().strftime('%b').lower()
@@ -629,11 +629,11 @@ class Metadata(models.Model):
             f"  title = {{{title}}},",
             f"  journal = {{{settings.SITE_NAME}}},",
             f"  year = {{{year}}},",
-            f"  month = {{{month}}},",
+            f"  month = {month},",
         ]
 
         if self.version:
-            bibtex_lines.append(f"  note = {{version {self.version}}},")
+            bibtex_lines.append(f"  note = {{Version {self.version}}},")
 
         if doi:
             bibtex_lines.append(f"  doi = {{{doi}}},")

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -557,6 +557,21 @@ class Metadata(models.Model):
 
         return citation_dict
 
+    # Compile regex once at class level for BibTeX escaping
+    _BIBTEX_SPECIAL_CHARS = re.compile(r'([\\%#&_${}])')
+    _BIBTEX_REPLACEMENTS = {
+        '\\': r'\textbackslash{}',
+        '%': r'\%', '#': r'\#', '&': r'\&',
+        '_': r'\_', '$': r'\$', '{': r'\{', '}': r'\}'
+    }
+
+    @classmethod
+    def _escape_bibtex(cls, text):
+        """Escape special characters for BibTeX compatibility."""
+        return cls._BIBTEX_SPECIAL_CHARS.sub(
+            lambda m: cls._BIBTEX_REPLACEMENTS[m.group(1)], text
+        )
+
     def citation_text_bibtex(self):
         """
         Generate a BibTeX citation for the project.
@@ -585,10 +600,10 @@ class Metadata(models.Model):
             citation_key = 'unpublished'
 
         author_list = ' and '.join(
-            a.get_full_name(reverse=True) for a in authors
+            self._escape_bibtex(a.get_full_name(reverse=True)) for a in authors
         )
 
-        title = self.title.replace('&', r'\&').replace('%', r'\%').replace('_', r'\_')
+        title = self._escape_bibtex(self.title)
 
         bibtex_lines = [
             f"@article{{{citation_key},",

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -553,7 +553,63 @@ class Metadata(models.Model):
         for style in styles:
             citation_dict[style] = self.citation_text(style)
 
+        citation_dict['BibTeX'] = self.citation_text_bibtex()
+
         return citation_dict
+
+    def citation_text_bibtex(self):
+        """
+        Generate a BibTeX citation for the project.
+        """
+        authors = self.authors.all().order_by('display_order')
+
+        if self.is_published():
+            year = self.publish_datetime.year
+            month = self.publish_datetime.strftime('%b').lower()
+            doi = self.doi
+
+            if self.is_legacy:
+                return ''
+
+            slug = getattr(self, 'slug', 'project')
+            version_str = self.version.replace('.', '_') if self.version else ''
+            citation_key = f"{slug}-{version_str}"
+        else:
+            year = timezone.now().year
+            month = timezone.now().strftime('%b').lower()
+            prefix = self.future_doi_prefix()
+            if prefix:
+                doi = prefix + '/*****'
+            else:
+                doi = None
+            citation_key = 'unpublished'
+
+        author_list = ' and '.join(
+            a.get_full_name(reverse=True) for a in authors
+        )
+
+        title = self.title.replace('&', r'\&').replace('%', r'\%').replace('_', r'\_')
+
+        bibtex_lines = [
+            f"@article{{{citation_key},",
+            f"  author = {{{author_list}}},",
+            f"  title = {{{title}}},",
+            f"  journal = {{{settings.SITE_NAME}}},",
+            f"  year = {{{year}}},",
+            f"  month = {{{month}}},",
+        ]
+
+        if self.version:
+            bibtex_lines.append(f"  note = {{version {self.version}}},")
+
+        if doi:
+            bibtex_lines.append(f"  doi = {{{doi}}},")
+            bibtex_lines.append(f"  url = {{https://doi.org/{doi}}},")
+
+        bibtex_lines[-1] = bibtex_lines[-1].rstrip(',')
+        bibtex_lines.append("}")
+
+        return '\n'.join(bibtex_lines)
 
     def content_sections(self):
         """

--- a/physionet-django/project/modelcomponents/metadata.py
+++ b/physionet-django/project/modelcomponents/metadata.py
@@ -626,8 +626,8 @@ class Metadata(models.Model):
         bibtex_lines = [
             f"@article{{{citation_key},",
             f"  author = {{{author_list}}},",
-            f"  title = {{{title}}},",
-            f"  journal = {{{settings.SITE_NAME}}},",
+            f"  title = {{{{{title}}}}},",
+            f"  journal = {{{{{settings.SITE_NAME}}}}},",
             f"  year = {{{year}}},",
             f"  month = {month},",
         ]

--- a/physionet-django/project/templates/project/citation_box.html
+++ b/physionet-django/project/templates/project/citation_box.html
@@ -13,38 +13,60 @@
     {% if not project.is_legacy %}
       <p>
         <strong>{% if publication %}Additionally, when {% else %}When {% endif %}using this resource, please cite: </strong>
-        <a href="#citationModal" data-toggle="modal">(show more options)</a>
+        <button type="button" class="btn btn-sm btn-outline-secondary" data-toggle="modal" data-target="#citationModal" title="View citation formats"><i class="bi bi-quote"></i> Cite</button>
+        {% if citations.BibTeX %}<button type="button" class="btn btn-sm btn-outline-secondary ml-1" title="Copy BibTeX" onclick="copyToClipboard(document.getElementById('bibtex-data').value); this.innerHTML='<i class=\'bi bi-check\'></i> Copied'; var btn=this; setTimeout(function(){ btn.innerHTML='<i class=\'bi bi-clipboard\'></i> Copy BibTeX'; }, 2000);"><i class="bi bi-clipboard"></i> Copy BibTeX</button>{% endif %}
         <br><span>{{ citations.APA }}</span>
       </p>
+      {% if citations.BibTeX %}<textarea id="bibtex-data" style="display:none;">{{ citations.BibTeX }}</textarea>{% endif %}
 
       {% include 'modal_start.html' with id_name='citationModal' title='Cite' %}
       <table><tbody>
         {% for style, citation in citations.items %}
+          {% if style != 'BibTeX' %}
           <tr>
             <th>{{ style }}</th>
             <td>{{ citation }}</td>
           </tr>
+          {% endif %}
         {% endfor %}
       </tbody></table>
+      {% if citations.BibTeX %}
+      <div class="mt-3">
+        <strong>BibTeX</strong>
+        <button class="btn btn-sm btn-outline-secondary ml-2" onclick="copyToClipboard(document.getElementById('bibtex-data').value); var btn=this; btn.textContent='Copied!'; setTimeout(function(){ btn.textContent='Copy'; }, 2000)">Copy</button>
+        <pre id="bibtex-citation" class="mt-2 p-2 border rounded" style="white-space: pre-wrap; background-color: #f8f9fa;">{{ citations.BibTeX }}</pre>
+      </div>
+      {% endif %}
       {% include 'modal_end.html' %}
     {% endif %}
   {% else %}
     {% if not project.is_legacy %}
       <p>
         <strong>When using this resource, please cite: </strong>
-        <a href="#citationModal" data-toggle="modal">(show more options)</a>
+        <button type="button" class="btn btn-sm btn-outline-secondary" data-toggle="modal" data-target="#citationModal" title="View citation formats"><i class="bi bi-quote"></i> Cite</button>
+        {% if citations.BibTeX %}<button type="button" class="btn btn-sm btn-outline-secondary ml-1" title="Copy BibTeX" onclick="copyToClipboard(document.getElementById('bibtex-data-2').value); this.innerHTML='<i class=\'bi bi-check\'></i> Copied'; var btn=this; setTimeout(function(){ btn.innerHTML='<i class=\'bi bi-clipboard\'></i> Copy BibTeX'; }, 2000);"><i class="bi bi-clipboard"></i> Copy BibTeX</button>{% endif %}
         <br><span>{{ citations.APA }}</span>
       </p>
+      {% if citations.BibTeX %}<textarea id="bibtex-data-2" style="display:none;">{{ citations.BibTeX }}</textarea>{% endif %}
 
       {% include 'modal_start.html' with id_name='citationModal' title='Cite' %}
       <table><tbody>
         {% for style, citation in citations.items %}
+          {% if style != 'BibTeX' %}
           <tr>
             <th>{{ style }}</th>
             <td>{{ citation }}</td>
           </tr>
+          {% endif %}
         {% endfor %}
       </tbody></table>
+      {% if citations.BibTeX %}
+      <div class="mt-3">
+        <strong>BibTeX</strong>
+        <button class="btn btn-sm btn-outline-secondary ml-2" onclick="copyToClipboard(document.getElementById('bibtex-data-2').value); var btn=this; btn.textContent='Copied!'; setTimeout(function(){ btn.textContent='Copy'; }, 2000)">Copy</button>
+        <pre id="bibtex-citation-2" class="mt-2 p-2 border rounded" style="white-space: pre-wrap; background-color: #f8f9fa;">{{ citations.BibTeX }}</pre>
+      </div>
+      {% endif %}
       {% include 'modal_end.html' %}
     {% endif %}
 

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -24,6 +24,7 @@
 {% block local_js_top %}
   <script src="{% static 'mathjax/MathJax.js' %}?config=MML_HTMLorMML"></script>
   <script src="{% static 'highlight/js/highlight.min.js' %}"></script>
+  <script src="{% static 'custom/js/copy-to-clipboard.js' %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1675,8 +1675,11 @@ class TestBibTeXCitation(TestMixin):
 
         project.title = 'Test & Title with % special _ chars'
         bibtex = project.citation_text_bibtex()
-
         self.assertIn(r'Test \& Title with \% special \_ chars', bibtex)
+
+        project.title = 'Price $100 and {braces} with #hashtag'
+        bibtex = project.citation_text_bibtex()
+        self.assertIn(r'Price \$100 and \{braces\} with \#hashtag', bibtex)
 
         project.title = original_title
 

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1626,7 +1626,7 @@ class TestBibTeXCitation(TestMixin):
         self.assertIn('title = {', bibtex)
         self.assertIn('journal = {', bibtex)
         self.assertIn('year = {', bibtex)
-        self.assertIn('month = {', bibtex)
+        self.assertIn('month = ', bibtex)
         self.assertIn('}', bibtex)
 
     def test_bibtex_authors_format(self):
@@ -1657,15 +1657,15 @@ class TestBibTeXCitation(TestMixin):
         bibtex = project.citation_text_bibtex()
 
         if project.version:
-            self.assertIn(f'note = {{version {project.version}}}', bibtex)
+            self.assertIn(f'note = {{Version {project.version}}}', bibtex)
 
     def test_bibtex_citation_key(self):
-        """Citation key uses slug and version."""
+        """Citation key uses site name, slug, and version."""
         project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
         bibtex = project.citation_text_bibtex()
 
-        version_str = project.version.replace('.', '_') if project.version else ''
-        expected_key = f'{project.slug}-{version_str}'
+        version_str = project.version if project.version else ''
+        expected_key = f'{settings.SITE_NAME}-{project.slug}-{version_str}'
         self.assertIn(f'@article{{{expected_key},', bibtex)
 
     def test_bibtex_special_characters_escaped(self):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1611,3 +1611,79 @@ class TestDisplayAuthors(TestMixin):
             self.assertIn(authors[0].get_full_name(), result)
             if project.authors.count() > 1:
                 self.assertIn('et al.', result)
+
+
+class TestBibTeXCitation(TestMixin):
+    """Test the BibTeX citation generation."""
+
+    def test_bibtex_structure(self):
+        """BibTeX output has correct structure."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        bibtex = project.citation_text_bibtex()
+
+        self.assertIn('@article{', bibtex)
+        self.assertIn('author = {', bibtex)
+        self.assertIn('title = {', bibtex)
+        self.assertIn('journal = {', bibtex)
+        self.assertIn('year = {', bibtex)
+        self.assertIn('month = {', bibtex)
+        self.assertIn('}', bibtex)
+
+    def test_bibtex_authors_format(self):
+        """Authors are formatted as 'Last, First and Last2, First2'."""
+        project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
+        bibtex = project.citation_text_bibtex()
+
+        authors = project.authors.all().order_by('display_order')
+        if authors.count() > 1:
+            self.assertIn(' and ', bibtex)
+
+        for author in authors:
+            expected_name = author.get_full_name(reverse=True)
+            self.assertIn(expected_name, bibtex)
+
+    def test_bibtex_doi_and_url(self):
+        """BibTeX includes DOI and URL when available."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        bibtex = project.citation_text_bibtex()
+
+        if project.doi:
+            self.assertIn(f'doi = {{{project.doi}}}', bibtex)
+            self.assertIn(f'url = {{https://doi.org/{project.doi}}}', bibtex)
+
+    def test_bibtex_version_in_note(self):
+        """BibTeX includes version in note field."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        bibtex = project.citation_text_bibtex()
+
+        if project.version:
+            self.assertIn(f'note = {{version {project.version}}}', bibtex)
+
+    def test_bibtex_citation_key(self):
+        """Citation key uses slug and version."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        bibtex = project.citation_text_bibtex()
+
+        version_str = project.version.replace('.', '_') if project.version else ''
+        expected_key = f'{project.slug}-{version_str}'
+        self.assertIn(f'@article{{{expected_key},', bibtex)
+
+    def test_bibtex_special_characters_escaped(self):
+        """Special characters in title are escaped."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        original_title = project.title
+
+        project.title = 'Test & Title with % special _ chars'
+        bibtex = project.citation_text_bibtex()
+
+        self.assertIn(r'Test \& Title with \% special \_ chars', bibtex)
+
+        project.title = original_title
+
+    def test_bibtex_in_citation_text_all(self):
+        """BibTeX is included in citation_text_all() output."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        citations = project.citation_text_all()
+
+        self.assertIn('BibTeX', citations)
+        self.assertIn('@article{', citations['BibTeX'])

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1683,6 +1683,21 @@ class TestBibTeXCitation(TestMixin):
 
         project.title = original_title
 
+    def test_bibtex_multiword_last_name(self):
+        """Multi-word last names are wrapped in braces."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        author = project.authors.first()
+        original_last_name = author.last_name
+
+        author.last_name = 'Van der Berg'
+        author.save()
+
+        bibtex = project.citation_text_bibtex()
+        self.assertIn('{Van der Berg}', bibtex)
+
+        author.last_name = original_last_name
+        author.save()
+
     def test_bibtex_in_citation_text_all(self):
         """BibTeX is included in citation_text_all() output."""
         project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1623,8 +1623,8 @@ class TestBibTeXCitation(TestMixin):
 
         self.assertIn('@article{', bibtex)
         self.assertIn('author = {', bibtex)
-        self.assertIn('title = {', bibtex)
-        self.assertIn('journal = {', bibtex)
+        self.assertIn('title = {{', bibtex)
+        self.assertIn('journal = {{', bibtex)
         self.assertIn('year = {', bibtex)
         self.assertIn('month = ', bibtex)
         self.assertIn('}', bibtex)


### PR DESCRIPTION
## Summary

This implements the feature request from #2536 to add BibTeX citation support for PhysioNet projects.

### Changes

- [x] Add `citation_text_bibtex()` method to Metadata class that generates BibTeX formatted citations using `@article` entry type.
- [x] Update `citation_text_all()` to include BibTeX in the citations dict.
- [x] Add "Cite" button on project page that opens citation modal.
- [x] Add "Copy BibTeX" button for one-click clipboard copy.
- [x] Include `copy-to-clipboard.js` on published project pages.
- [x] Add BibTeX section with copy button in citation modal.
- [x] Add 8 unit tests covering structure, author formatting, DOI/URL, version, citation key, special character escaping, and integration.

### BibTeX Output Example

```bibtex
@article{demoecg-10_5_24,
  author = {Moody, George B.},
  title = {Demo ECG Signal Toolbox},
  journal = {PhysioNet},
  year = {2019},
  month = {sep},
  note = {version 10.5.24},
  doi = {10.13026/xxxx},
  url = {https://doi.org/10.13026/xxxx}
}
```

### Screenshots

<img width="893" height="168" alt="Screenshot 2026-01-06 at 5 52 09 PM" src="https://github.com/user-attachments/assets/eeef7560-3135-4551-bc59-75dfd9024a5e" />
<img width="1377" height="823" alt="Screenshot 2026-01-06 at 5 52 20 PM" src="https://github.com/user-attachments/assets/c0579cb6-c05c-499b-b5ba-f02a09d6418c" />


The UI adds two buttons next to the citation text:
- **Cite** - Opens modal with all citation formats (MLA, APA, Chicago, Harvard, Vancouver, BibTeX)
- **Copy BibTeX** - One-click copy to clipboard

Closes #2536