### PR TITLE
Add Project Views metric to sidebar

### DIFF
--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -243,6 +243,23 @@
         </div>
 
         <div class="card my-4">
+          <h5 class="card-header">Project Views</h5>
+          <div class="card-body text-center">
+            <div class="d-flex justify-content-around mb-2">
+              <div>
+                <h3 class="mb-0">{{ project_views_count }}</h3>
+                <small class="text-muted">Current Version</small>
+              </div>
+              <div>
+                <h3 class="mb-0">{{ all_versions_views_count }}</h3>
+                <small class="text-muted">All Versions</small>
+              </div>
+            </div>
+            <small class="text-muted mb-0"><em>Project Views by Unique Registered Users</em></small>
+          </div>
+        </div>
+
+        <div class="card my-4">
           <h5 class="card-header">Corresponding Author</h5>
           <div class="card-body">
             {% if user.is_authenticated %}

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1705,3 +1705,32 @@ class TestBibTeXCitation(TestMixin):
 
         self.assertIn('BibTeX', citations)
         self.assertIn('@article{', citations['BibTeX'])
+
+
+class TestFileViewsMetric(TestMixin):
+    """Test the file views metric on published project pages."""
+
+    def test_project_views_count_displayed(self):
+        """Project views count is displayed on the published project page."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        response = self.client.get(reverse('published_project',
+                                           args=(project.slug, project.version)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Current Version')
+        self.assertContains(response, 'All Versions')
+        self.assertEqual(response.context['project_views_count'], 0)
+        self.assertEqual(response.context['all_versions_views_count'], 0)
+
+    def test_project_views_increments_on_authenticated_view(self):
+        """Project views count increments when authenticated user views files."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+
+        self.client.login(username='rgmark@mit.edu', password='Tester11!')
+        # First visit creates the AccessLog
+        self.client.get(reverse('published_project',
+                                args=(project.slug, project.version)))
+        # Second visit sees the incremented count
+        response = self.client.get(reverse('published_project',
+                                           args=(project.slug, project.version)))
+        self.assertEqual(response.context['project_views_count'], 1)
+        self.assertEqual(response.context['all_versions_views_count'], 1)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2013,6 +2013,18 @@ def published_project(request, project_slug, version, subdir=''):
     except AWS.DoesNotExist:
         user_in_access_point_policy = False
 
+    content_type = ContentType.objects.get_for_model(project)
+    project_views_count = AccessLog.objects.filter(
+        object_id=project.id,
+        content_type=content_type
+    ).values('user').distinct().count()
+
+    all_version_ids = PublishedProject.objects.filter(slug=project_slug).values_list('id', flat=True)
+    all_versions_views_count = AccessLog.objects.filter(
+        object_id__in=all_version_ids,
+        content_type=content_type
+    ).values('user').distinct().count()
+
     context = {
         'project': project,
         'authors': authors,
@@ -2046,6 +2058,8 @@ def published_project(request, project_slug, version, subdir=''):
         'show_platform_wide_citation': show_platform_wide_citation,
         'main_platform_citation': main_platform_citation,
         'user_country_blocked': user_country_blocked,
+        'project_views_count': project_views_count,
+        'all_versions_views_count': all_versions_views_count,
     }
     # The file and directory contents
     if can_view_files:


### PR DESCRIPTION
## Summary
- [x] Adds a "Project Views" card to the published project sidebar displaying unique file views count.
- [x] Counts unique authenticated users who have viewed the project's files section.
- [x] Includes tests for the new feature.

Part of #2336 (Phase 1a)

## Screenshot
<img width="436" height="193" alt="Screenshot 2026-01-14 at 5 29 48 PM" src="https://github.com/user-attachments/assets/0a3daa38-6e37-4b3a-95e7-d7e63bcf515a" />

## Future Optimizations
- Add composite index on `(content_type_id, object_id)` to the Log model for faster lookups.
- Consider denormalizing the count on the project model for high-traffic projects.