### PR TITLE
Add detailed public metrics view for published projects

### DIFF
--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -2488,5 +2488,103 @@
     "object_id": 1,
     "document": "ethics/Ethics_Approval_567b029d-9ea6-41b8-b738-bf45675b24ce.txt"
   }
+},
+{
+  "model": "project.log",
+  "pk": 1,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 1,
+    "data": "",
+    "count": 3,
+    "creation_datetime": "2025-11-15T10:00:00Z",
+    "last_access_datetime": "2025-11-20T14:30:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 2,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 2,
+    "data": "",
+    "count": 5,
+    "creation_datetime": "2025-11-10T09:00:00Z",
+    "last_access_datetime": "2025-11-25T16:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 3,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 3,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2025-12-05T11:00:00Z",
+    "last_access_datetime": "2025-12-10T15:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 4,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 4,
+    "data": "",
+    "count": 1,
+    "creation_datetime": "2025-12-20T08:00:00Z",
+    "last_access_datetime": "2025-12-20T08:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 5,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 5,
+    "data": "",
+    "count": 4,
+    "creation_datetime": "2026-01-02T13:00:00Z",
+    "last_access_datetime": "2026-01-10T17:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 6,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 1,
+    "user": 2,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2025-12-01T10:00:00Z",
+    "last_access_datetime": "2025-12-15T12:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 7,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 1,
+    "user": 3,
+    "data": "",
+    "count": 1,
+    "creation_datetime": "2026-01-05T09:00:00Z",
+    "last_access_datetime": "2026-01-05T09:00:00Z"
+  }
 }
 ]

--- a/physionet-django/project/managers/log.py
+++ b/physionet-django/project/managers/log.py
@@ -1,9 +1,9 @@
 import datetime as dt
-from collections import defaultdict
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import QuerySet, Manager, Min
+from django.db.models import QuerySet, Manager, Count
+from django.db.models.functions import TruncMonth
 from django.utils import timezone
 
 from physionet.enums import LogCategory
@@ -28,19 +28,17 @@ class AccessLogQuerySet(QuerySet):
         """Count unique users who have viewed."""
         return self.values('user').distinct().count()
 
-    def first_views_by_month(self):
+    def unique_viewers_by_month(self):
         """
-        Count first-time viewers per month.
-        Each user is only counted in the month of their first view.
+        Count unique viewers per month.
+        A user viewing in multiple months is counted once per month.
         """
-        first_views = self.values('user').annotate(first_view=Min('creation_datetime'))
-
-        monthly_counts = defaultdict(int)
-        for fv in first_views:
-            month = fv['first_view'].replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-            monthly_counts[month] += 1
-
-        return [{'month': m, 'count': c} for m, c in sorted(monthly_counts.items())]
+        return list(
+            self.annotate(month=TruncMonth('creation_datetime'))
+            .values('month')
+            .annotate(count=Count('user', distinct=True))
+            .order_by('month')
+        )
 
     def update_or_create(self, defaults=None, **kwargs):
         user = kwargs.get('user')

--- a/physionet-django/project/managers/log.py
+++ b/physionet-django/project/managers/log.py
@@ -1,8 +1,9 @@
 import datetime as dt
+from collections import defaultdict
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import QuerySet, Manager
+from django.db.models import QuerySet, Manager, Min
 from django.utils import timezone
 
 from physionet.enums import LogCategory
@@ -22,6 +23,24 @@ class AccessLogQuerySet(QuerySet):
     def create(self, **kwargs):
         kwargs['category'] = LogCategory.ACCESS
         return super().create(**kwargs)
+
+    def unique_viewers_count(self):
+        """Count unique users who have viewed."""
+        return self.values('user').distinct().count()
+
+    def first_views_by_month(self):
+        """
+        Count first-time viewers per month.
+        Each user is only counted in the month of their first view.
+        """
+        first_views = self.values('user').annotate(first_view=Min('creation_datetime'))
+
+        monthly_counts = defaultdict(int)
+        for fv in first_views:
+            month = fv['first_view'].replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            monthly_counts[month] += 1
+
+        return [{'month': m, 'count': c} for m, c in sorted(monthly_counts.items())]
 
     def update_or_create(self, defaults=None, **kwargs):
         user = kwargs.get('user')

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -430,11 +430,11 @@ class PublishedProject(Metadata, SubmissionInfo):
 
     def views_over_time(self):
         """
-        Return monthly view counts for this project version.
-        Each user is only counted in the month of their first view.
+        Return monthly unique viewer counts for this project version.
+        A user viewing in multiple months is counted once per month.
         """
         content_type = ContentType.objects.get_for_model(self)
         return AccessLog.objects.filter(
             object_id=self.id,
             content_type=content_type
-        ).first_views_by_month()
+        ).unique_viewers_by_month()

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -16,7 +16,8 @@ from project.modelcomponents.access import DataAccessRequest, DataAccessRequestR
 from project.modelcomponents.fields import SafeHTMLField
 from project.modelcomponents.metadata import Metadata, PublishedTopic
 from project.modelcomponents.submission import SubmissionInfo
-from project.models import AccessPolicy
+from project.modelcomponents.access import AccessPolicy
+from project.modelcomponents.log import AccessLog
 from project.utility import StorageInfo, clear_directory, get_tree_size
 from project.validators import MAX_PROJECT_SLUG_LENGTH, validate_slug, validate_subdir
 from user.models import Training
@@ -395,8 +396,6 @@ class PublishedProject(Metadata, SubmissionInfo):
             all_versions: If True, count views across all versions of this project.
                          If False (default), count only views of this specific version.
         """
-        from project.models import AccessLog
-
         if all_versions:
             versions = PublishedProject.objects.filter(slug=self.slug)
             total = 0
@@ -418,8 +417,6 @@ class PublishedProject(Metadata, SubmissionInfo):
         """
         Return a list of view counts for each version of this project.
         """
-        from project.models import AccessLog
-
         versions = PublishedProject.objects.filter(slug=self.slug).order_by('version_order')
         result = []
         for v in versions:
@@ -436,8 +433,6 @@ class PublishedProject(Metadata, SubmissionInfo):
         Return monthly view counts for this project version.
         Each user is only counted in the month of their first view.
         """
-        from project.models import AccessLog
-
         content_type = ContentType.objects.get_for_model(self)
         return AccessLog.objects.filter(
             object_id=self.id,

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -4,6 +4,7 @@ import datetime
 from distutils.version import StrictVersion
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
@@ -385,3 +386,60 @@ class PublishedProject(Metadata, SubmissionInfo):
             link_all_versions=True).exclude(project=self)
 
         return direct_news | linked_news
+
+    def view_count(self, all_versions=False):
+        """
+        Return the count of unique registered users who have viewed this project.
+
+        Args:
+            all_versions: If True, count views across all versions of this project.
+                         If False (default), count only views of this specific version.
+        """
+        from project.models import AccessLog
+
+        if all_versions:
+            versions = PublishedProject.objects.filter(slug=self.slug)
+            total = 0
+            for v in versions:
+                content_type = ContentType.objects.get_for_model(v)
+                total += AccessLog.objects.filter(
+                    object_id=v.id,
+                    content_type=content_type
+                ).unique_viewers_count()
+            return total
+        else:
+            content_type = ContentType.objects.get_for_model(self)
+            return AccessLog.objects.filter(
+                object_id=self.id,
+                content_type=content_type
+            ).unique_viewers_count()
+
+    def views_by_version(self):
+        """
+        Return a list of view counts for each version of this project.
+        """
+        from project.models import AccessLog
+
+        versions = PublishedProject.objects.filter(slug=self.slug).order_by('version_order')
+        result = []
+        for v in versions:
+            content_type = ContentType.objects.get_for_model(v)
+            count = AccessLog.objects.filter(
+                object_id=v.id,
+                content_type=content_type
+            ).unique_viewers_count()
+            result.append({'version': v.version, 'count': count})
+        return result
+
+    def views_over_time(self):
+        """
+        Return monthly view counts for this project version.
+        Each user is only counted in the month of their first view.
+        """
+        from project.models import AccessLog
+
+        content_type = ContentType.objects.get_for_model(self)
+        return AccessLog.objects.filter(
+            object_id=self.id,
+            content_type=content_type
+        ).first_views_by_month()

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -256,6 +256,9 @@
               </div>
             </div>
             <small class="text-muted mb-0"><em>Project Views by Unique Registered Users</em></small>
+            <div class="mt-2">
+              <a href="{% url 'published_project_metrics' project.slug project.version %}" class="btn btn-sm btn-outline-secondary">View Details</a>
+            </div>
           </div>
         </div>
 

--- a/physionet-django/project/templates/project/published_project_metrics.html
+++ b/physionet-django/project/templates/project/published_project_metrics.html
@@ -15,7 +15,7 @@ Metrics for {{ project }}
   <div class="row">
     <div class="col-md-6">
       <div class="card text-center mb-4">
-        <h5 class="card-header">Project Views</h5>
+        <h5 class="card-header">Unique Registered Project Views</h5>
         <div class="card-body">
           <div class="d-flex justify-content-around mb-2">
             <div>
@@ -27,7 +27,7 @@ Metrics for {{ project }}
               <small class="text-muted">All Versions</small>
             </div>
           </div>
-          <small class="text-muted"><em>Project Views by Unique Registered Users</em></small>
+          <small class="text-muted"><em>Total number of unique registered users who have viewed this project</em></small>
         </div>
       </div>
     </div>

--- a/physionet-django/project/templates/project/published_project_metrics.html
+++ b/physionet-django/project/templates/project/published_project_metrics.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block title %}
+Metrics for {{ project }}
+{% endblock %}
+
+{% block content %}
+<div class="container">
+  <h1>Metrics</h1>
+  <p class="text-muted">{{ project.title }} (v{{ project.version }})</p>
+  <hr>
+
+  <div class="row">
+    <div class="col-md-6">
+      <div class="card text-center mb-4">
+        <h5 class="card-header">Project Views</h5>
+        <div class="card-body">
+          <div class="d-flex justify-content-around mb-2">
+            <div>
+              <h3 class="mb-0">{{ project_views_count }}</h3>
+              <small class="text-muted">Current Version</small>
+            </div>
+            <div>
+              <h3 class="mb-0">{{ all_versions_views_count }}</h3>
+              <small class="text-muted">All Versions</small>
+            </div>
+          </div>
+          <small class="text-muted"><em>Project Views by Unique Registered Users</em></small>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if views_by_version|length > 1 %}
+  <h3>Views by Version</h3>
+  <div class="table-responsive mb-4">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Version</th>
+          <th>Project Views</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in views_by_version %}
+        <tr>
+          <td>{{ item.version }}</td>
+          <td>{{ item.count }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
+  {% if views_over_time %}
+  <h3>Views Over Time</h3>
+  <div class="table-responsive mb-4">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Month</th>
+          <th>Unique Viewers</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in views_over_time %}
+        <tr>
+          <td>{{ item.month|date:"F Y" }}</td>
+          <td>{{ item.count }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
+  <hr>
+  <p><a href="{% url 'published_project' project.slug project.version %}">Back to {{ project }}</a></p>
+</div>
+{% endblock %}

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import timedelta
 import html.parser
 import os
 from http import HTTPStatus
@@ -6,12 +7,15 @@ import json
 from unittest import mock
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from project.forms import ContentForm
 from project.models import (
+    AccessLog,
     AccessPolicy,
     ActiveProject,
     Author,
@@ -20,6 +24,7 @@ from project.models import (
     DataAccessRequest,
     DataAccessRequestReviewer,
     License,
+    Log,
     ProjectType,
     PublishedAuthor,
     PublishedProject,
@@ -1707,8 +1712,13 @@ class TestBibTeXCitation(TestMixin):
         self.assertIn('@article{', citations['BibTeX'])
 
 
-class TestFileViewsMetric(TestMixin):
-    """Test the file views metric on published project pages."""
+class TestProjectViewsMetric(TestMixin):
+    """Test the project views metric on published project pages."""
+
+    def setUp(self):
+        """Clear AccessLog data before each test for isolation."""
+        super().setUp()
+        Log.objects.all().delete()
 
     def test_project_views_count_displayed(self):
         """Project views count is displayed on the published project page."""
@@ -1734,3 +1744,101 @@ class TestFileViewsMetric(TestMixin):
                                            args=(project.slug, project.version)))
         self.assertEqual(response.context['project_views_count'], 1)
         self.assertEqual(response.context['all_versions_views_count'], 1)
+
+    def test_metrics_detail_page_accessible(self):
+        """Metrics detail page is publicly accessible."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Metrics')
+        self.assertContains(response, 'Project Views')
+
+    def test_metrics_detail_page_context(self):
+        """Metrics detail page includes required context data."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        self.assertIn('project_views_count', response.context)
+        self.assertIn('views_over_time', response.context)
+        self.assertIn('views_by_version', response.context)
+
+    def test_metrics_link_on_project_page(self):
+        """Project page includes link to metrics detail page."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        response = self.client.get(reverse('published_project',
+                                           args=(project.slug, project.version)))
+        self.assertContains(response, 'View Details')
+
+    def test_metrics_detail_with_access_data(self):
+        """Metrics detail page shows correct counts with access data."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user1 = User.objects.get(email='rgmark@mit.edu')
+        user2 = User.objects.get(email='admin@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        # Create access logs for two users
+        AccessLog.objects.create(
+            user=user1,
+            object_id=project.id,
+            content_type=content_type,
+            data=''
+        )
+        AccessLog.objects.create(
+            user=user2,
+            object_id=project.id,
+            content_type=content_type,
+            data=''
+        )
+
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        self.assertEqual(response.context['project_views_count'], 2)
+        self.assertEqual(len(response.context['views_by_version']), 1)
+        self.assertEqual(response.context['views_by_version'][0]['count'], 2)
+
+    def test_unique_viewers_count(self):
+        """AccessLog.unique_viewers_count() returns correct count."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user1 = User.objects.get(email='rgmark@mit.edu')
+        user2 = User.objects.get(email='admin@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        # Create multiple logs for same user
+        AccessLog.objects.create(
+            user=user1, object_id=project.id, content_type=content_type, data='')
+        AccessLog.objects.create(
+            user=user1, object_id=project.id, content_type=content_type, data='')
+        AccessLog.objects.create(
+            user=user2, object_id=project.id, content_type=content_type, data='')
+
+        logs = AccessLog.objects.filter(object_id=project.id, content_type=content_type)
+        self.assertEqual(logs.unique_viewers_count(), 2)
+
+    def test_first_views_by_month_no_duplicates(self):
+        """AccessLog.first_views_by_month() counts each user only once."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user1 = User.objects.get(email='rgmark@mit.edu')
+        user2 = User.objects.get(email='admin@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        now = timezone.now()
+        last_month = now - timedelta(days=35)
+
+        # User1 views in both months
+        AccessLog.objects.create(
+            user=user1, object_id=project.id, content_type=content_type, data='')
+        AccessLog.objects.filter(user=user1).update(creation_datetime=last_month)
+        AccessLog.objects.create(
+            user=user1, object_id=project.id, content_type=content_type, data='')
+
+        # User2 views only this month
+        AccessLog.objects.create(
+            user=user2, object_id=project.id, content_type=content_type, data='')
+
+        logs = AccessLog.objects.filter(object_id=project.id, content_type=content_type)
+        views_by_month = logs.first_views_by_month()
+
+        # Sum of monthly counts should equal total unique viewers
+        total_from_months = sum(m['count'] for m in views_by_month)
+        self.assertEqual(total_from_months, logs.unique_viewers_count())

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1815,8 +1815,8 @@ class TestProjectViewsMetric(TestMixin):
         logs = AccessLog.objects.filter(object_id=project.id, content_type=content_type)
         self.assertEqual(logs.unique_viewers_count(), 2)
 
-    def test_first_views_by_month_no_duplicates(self):
-        """AccessLog.first_views_by_month() counts each user only once."""
+    def test_unique_viewers_by_month(self):
+        """AccessLog.unique_viewers_by_month() counts unique users per month."""
         project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
         user1 = User.objects.get(email='rgmark@mit.edu')
         user2 = User.objects.get(email='admin@mit.edu')
@@ -1825,7 +1825,7 @@ class TestProjectViewsMetric(TestMixin):
         now = timezone.now()
         last_month = now - timedelta(days=35)
 
-        # User1 views in both months
+        # User1 views in both months (should be counted in both)
         AccessLog.objects.create(
             user=user1, object_id=project.id, content_type=content_type, data='')
         AccessLog.objects.filter(user=user1).update(creation_datetime=last_month)
@@ -1837,8 +1837,11 @@ class TestProjectViewsMetric(TestMixin):
             user=user2, object_id=project.id, content_type=content_type, data='')
 
         logs = AccessLog.objects.filter(object_id=project.id, content_type=content_type)
-        views_by_month = logs.first_views_by_month()
+        views_by_month = logs.unique_viewers_by_month()
 
-        # Sum of monthly counts should equal total unique viewers
+        # Total unique viewers across all time is 2
+        self.assertEqual(logs.unique_viewers_count(), 2)
+
+        # Sum of monthly counts is 3 (user1 counted in both months + user2 in current month)
         total_from_months = sum(m['count'] for m in views_by_month)
-        self.assertEqual(total_from_months, logs.unique_viewers_count())
+        self.assertEqual(total_from_months, 3)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2013,17 +2013,8 @@ def published_project(request, project_slug, version, subdir=''):
     except AWS.DoesNotExist:
         user_in_access_point_policy = False
 
-    content_type = ContentType.objects.get_for_model(project)
-    project_views_count = AccessLog.objects.filter(
-        object_id=project.id,
-        content_type=content_type
-    ).values('user').distinct().count()
-
-    all_version_ids = PublishedProject.objects.filter(slug=project_slug).values_list('id', flat=True)
-    all_versions_views_count = AccessLog.objects.filter(
-        object_id__in=all_version_ids,
-        content_type=content_type
-    ).values('user').distinct().count()
+    project_views_count = project.view_count()
+    all_versions_views_count = project.view_count(all_versions=True)
 
     context = {
         'project': project,
@@ -2112,38 +2103,14 @@ def published_project_metrics(request, project_slug, version):
     """
     Public metrics page for a published project.
     """
-    from django.db.models import Count
-    from django.db.models.functions import TruncMonth
-
-    try:
-        project = PublishedProject.objects.get(slug=project_slug, version=version)
-    except ObjectDoesNotExist:
-        raise Http404()
-
-    content_type = ContentType.objects.get_for_model(project)
-
-    project_logs = AccessLog.objects.filter(object_id=project.id, content_type=content_type)
-    project_views_count = project_logs.unique_viewers_count()
-    views_over_time = project_logs.first_views_by_month()
-
-    all_versions = PublishedProject.objects.filter(slug=project_slug).order_by('version_order')
-    views_by_version = []
-    all_versions_views_count = 0
-    for v in all_versions:
-        v_content_type = ContentType.objects.get_for_model(v)
-        v_count = AccessLog.objects.filter(
-            object_id=v.id,
-            content_type=v_content_type
-        ).unique_viewers_count()
-        views_by_version.append({'version': v.version, 'count': v_count})
-        all_versions_views_count += v_count
+    project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
 
     return render(request, 'project/published_project_metrics.html', {
         'project': project,
-        'project_views_count': project_views_count,
-        'all_versions_views_count': all_versions_views_count,
-        'views_over_time': views_over_time,
-        'views_by_version': views_by_version,
+        'project_views_count': project.view_count(),
+        'all_versions_views_count': project.view_count(all_versions=True),
+        'views_over_time': project.views_over_time(),
+        'views_by_version': project.views_by_version(),
     })
 
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2108,6 +2108,45 @@ def published_project(request, project_slug, version, subdir=''):
                   status=status)
 
 
+def published_project_metrics(request, project_slug, version):
+    """
+    Public metrics page for a published project.
+    """
+    from django.db.models import Count
+    from django.db.models.functions import TruncMonth
+
+    try:
+        project = PublishedProject.objects.get(slug=project_slug, version=version)
+    except ObjectDoesNotExist:
+        raise Http404()
+
+    content_type = ContentType.objects.get_for_model(project)
+
+    project_logs = AccessLog.objects.filter(object_id=project.id, content_type=content_type)
+    project_views_count = project_logs.unique_viewers_count()
+    views_over_time = project_logs.first_views_by_month()
+
+    all_versions = PublishedProject.objects.filter(slug=project_slug).order_by('version_order')
+    views_by_version = []
+    all_versions_views_count = 0
+    for v in all_versions:
+        v_content_type = ContentType.objects.get_for_model(v)
+        v_count = AccessLog.objects.filter(
+            object_id=v.id,
+            content_type=v_content_type
+        ).unique_viewers_count()
+        views_by_version.append({'version': v.version, 'count': v_count})
+        all_versions_views_count += v_count
+
+    return render(request, 'project/published_project_metrics.html', {
+        'project': project,
+        'project_views_count': project_views_count,
+        'all_versions_views_count': all_versions_views_count,
+        'views_over_time': views_over_time,
+        'views_by_version': views_by_version,
+    })
+
+
 @login_required
 def sign_dua(request, project_slug, version):
     """

--- a/physionet-django/search/urls.py
+++ b/physionet-django/search/urls.py
@@ -59,6 +59,11 @@ urlpatterns = [
         project_views.published_project_dua,
         name='published_project_dua',
     ),
+    path(
+        'content/<project_slug>/metrics/<version>/',
+        project_views.published_project_metrics,
+        name='published_project_metrics',
+    ),
 
     path('sign-dua/<project_slug>/<version>/', project_views.sign_dua,
          name='sign_dua'),


### PR DESCRIPTION
## Summary
- [x] Add `view_count()`, `views_by_version()`, and `views_over_time()` methods to PublishedProject model.
- [x] Add `unique_viewers_count()` and `unique_viewers_by_month()` methods to AccessLogQuerySet.
- [x] Add new `published_project_metrics` view using model methods.
- [x] Create metrics template showing Unique Registered Project Views (current + all versions), views by version table, and views over time.
- [x] Add URL route at `/content/<slug>/metrics/<version>/`.
- [x] Add "View Details" button to Project Views sidebar card.
- [x] Add fixture data with AccessLog entries for local testing.
- [x] Add tests for metrics view and manager methods.

## Approach
Created a dedicated metrics page accessible from the Project Views card in the sidebar. View counting logic is encapsulated in PublishedProject model methods (`view_count()`, `views_by_version()`, `views_over_time()`), which delegate to AccessLogQuerySet methods for the actual queries.

## Reasoning
- Model methods make the logic reusable and testable.
- Using `unique_viewers_by_month()` counts unique viewers per month (same user viewing in multiple months is counted once per month).
- Fixture data uses "LogCategory.ACCESS" format to match Django's enum string representation.

## Screenshots

<img width="457" height="237" alt="Screenshot 2026-01-19 at 10 25 03 AM" src="https://github.com/user-attachments/assets/fc706842-87e2-492a-8298-13e8521b2aa1" />
<img width="1398" height="643" alt="Screenshot 2026-01-19 at 10 25 23 AM" src="https://github.com/user-attachments/assets/4d9b9038-6435-40f6-95f1-e4bff448659e" />


Part of #2336