### PR TITLE
Require name initials for DUA signing (#2106)

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -1116,9 +1116,9 @@ class DUASignatureForm(forms.Form):
     full_name = forms.CharField(
         widget=forms.TextInput(attrs={
             'class': 'form-control',
-            'placeholder': 'Type your full name to sign',
+            'placeholder': 'Type your full name',
         }),
-        label='Full Name',
+        label='Please sign your full name to indicate your consent',
     )
 
     def __init__(self, user, *args, **kwargs):

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -1111,27 +1111,28 @@ class AnonymousAccessLoginForm(forms.ModelForm):
 
 class DUASignatureForm(forms.Form):
     """
-    Form for signing Data Use Agreement by typing full name.
+    Form for signing Data Use Agreement by typing initials.
     """
-    full_name = forms.CharField(
+    initials = forms.CharField(
         widget=forms.TextInput(attrs={
             'class': 'form-control',
-            'placeholder': 'Type your full name',
+            'placeholder': 'Type your initials',
         }),
-        label='Please sign your full name to indicate your consent',
+        label='Please type your initials to indicate your consent',
     )
 
     def __init__(self, user, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.user = user
-        self.fields['full_name'].help_text = (
-            f'Please type your full name exactly as: {user.get_full_name()}'
+        expected_initials = DUASignature.get_user_initials(user)
+        self.fields['initials'].help_text = (
+            f'Please type your initials exactly as: {expected_initials}'
         )
 
-    def clean_full_name(self):
-        full_name = self.cleaned_data.get('full_name', '').strip()
-        DUASignature.validate_signature_name(self.user, full_name)
-        return full_name
+    def clean_initials(self):
+        initials = self.cleaned_data.get('initials', '').strip()
+        DUASignature.validate_signature_initials(self.user, initials)
+        return initials
 
 
 class DataAccessRequestForm(forms.ModelForm):

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -29,6 +29,7 @@ from project.models import (
     DataAccessRequest,
     DataAccessRequestReviewer,
     DUA,
+    DUASignature,
     License,
     Metadata,
     ProgrammingLanguage,
@@ -1106,6 +1107,31 @@ class AnonymousAccessLoginForm(forms.ModelForm):
             'passphrase':forms.PasswordInput(attrs={'class': 'form-control',
                 'placeholder': 'Passphrase', 'label': 'Passphrase'}),
         }
+
+
+class DUASignatureForm(forms.Form):
+    """
+    Form for signing Data Use Agreement by typing full name.
+    """
+    full_name = forms.CharField(
+        widget=forms.TextInput(attrs={
+            'class': 'form-control',
+            'placeholder': 'Type your full name to sign',
+        }),
+        label='Full Name',
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user = user
+        self.fields['full_name'].help_text = (
+            f'Please type your full name exactly as: {user.get_full_name()}'
+        )
+
+    def clean_full_name(self):
+        full_name = self.cleaned_data.get('full_name', '').strip()
+        DUASignature.validate_signature_name(self.user, full_name)
+        return full_name
 
 
 class DataAccessRequestForm(forms.ModelForm):

--- a/physionet-django/project/modelcomponents/access.py
+++ b/physionet-django/project/modelcomponents/access.py
@@ -1,3 +1,4 @@
+import unicodedata
 from datetime import timedelta
 from enum import IntEnum
 
@@ -44,13 +45,31 @@ class DUASignature(models.Model):
         default_permissions = ()
 
     @staticmethod
-    def validate_signature_name(user, full_name):
-        if not full_name or not full_name.strip():
-            raise ValidationError('You must enter your full name to sign the agreement.')
-        expected_name = user.get_full_name()
-        if full_name.strip().lower() != expected_name.lower():
+    def get_user_initials(user):
+        """Get initials from user's profile name."""
+        initials = ''
+        if user.profile.first_names:
+            for name in user.profile.first_names.split():
+                if name:
+                    initials += name[0].upper()
+        if user.profile.last_name:
+            initials += user.profile.last_name[0].upper()
+        return initials
+
+    @staticmethod
+    def normalize_for_comparison(text):
+        """Normalize text for Unicode-aware case-insensitive comparison."""
+        return unicodedata.normalize('NFKD', text.casefold())
+
+    @staticmethod
+    def validate_signature_initials(user, initials):
+        if not initials or not initials.strip():
+            raise ValidationError('You must enter your initials to sign the agreement.')
+        expected_initials = DUASignature.get_user_initials(user)
+        if DUASignature.normalize_for_comparison(initials.strip()) != \
+                DUASignature.normalize_for_comparison(expected_initials):
             raise ValidationError(
-                f'The name entered does not match your profile name: {expected_name}'
+                f'The initials entered do not match. Please enter: {expected_initials}'
             )
 
 

--- a/physionet-django/project/modelcomponents/access.py
+++ b/physionet-django/project/modelcomponents/access.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 from django.contrib.auth.hashers import check_password, make_password
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -41,6 +42,16 @@ class DUASignature(models.Model):
 
     class Meta:
         default_permissions = ()
+
+    @staticmethod
+    def validate_signature_name(user, full_name):
+        if not full_name or not full_name.strip():
+            raise ValidationError('You must enter your full name to sign the agreement.')
+        expected_name = user.get_full_name()
+        if full_name.strip().lower() != expected_name.lower():
+            raise ValidationError(
+                f'The name entered does not match your profile name: {expected_name}'
+            )
 
 
 class DataAccessRequest(models.Model):

--- a/physionet-django/project/templates/project/sign_dua.html
+++ b/physionet-django/project/templates/project/sign_dua.html
@@ -18,6 +18,16 @@ Sign Data Use Agreement for {{ project }}
   <hr>
   <form method="POST">
     {% csrf_token %}
+    <div class="form-group">
+      <label for="id_full_name">{{ form.full_name.label }}</label>
+      {{ form.full_name }}
+      {% if form.full_name.help_text %}
+        <small class="form-text text-muted">{{ form.full_name.help_text }}</small>
+      {% endif %}
+      {% if form.full_name.errors %}
+        <div class="text-danger">{{ form.full_name.errors }}</div>
+      {% endif %}
+    </div>
     <p class="text-center">
       <button class="btn btn-lg btn-success" name="agree" type="submit">I agree</button> <a class="btn btn-lg btn-danger" href="{% url 'published_project' project.slug project.version %}">I do not agree</a>
     </p>

--- a/physionet-django/project/templates/project/sign_dua.html
+++ b/physionet-django/project/templates/project/sign_dua.html
@@ -25,7 +25,7 @@ Sign Data Use Agreement for {{ project }}
         <small class="form-text text-muted">{{ form.full_name.help_text }}</small>
       {% endif %}
       {% if form.full_name.errors %}
-        <div class="text-danger">{{ form.full_name.errors }}</div>
+        <div class="text-danger">{{ form.full_name.errors.0 }}</div>
       {% endif %}
     </div>
     <p class="text-center">

--- a/physionet-django/project/templates/project/sign_dua.html
+++ b/physionet-django/project/templates/project/sign_dua.html
@@ -19,13 +19,13 @@ Sign Data Use Agreement for {{ project }}
   <form method="POST">
     {% csrf_token %}
     <div class="form-group">
-      <label for="id_full_name">{{ form.full_name.label }}</label>
-      {{ form.full_name }}
-      {% if form.full_name.help_text %}
-        <small class="form-text text-muted">{{ form.full_name.help_text }}</small>
+      <label for="id_initials">{{ form.initials.label }}</label>
+      {{ form.initials }}
+      {% if form.initials.help_text %}
+        <small class="form-text text-muted">{{ form.initials.help_text }}</small>
       {% endif %}
-      {% if form.full_name.errors %}
-        <div class="text-danger">{{ form.full_name.errors.0 }}</div>
+      {% if form.initials.errors %}
+        <div class="text-danger">{{ form.initials.errors.0 }}</div>
       {% endif %}
     </div>
     <p class="text-center">

--- a/physionet-django/project/test_s3.py
+++ b/physionet-django/project/test_s3.py
@@ -23,6 +23,7 @@ from project.cloud.s3 import (
 )
 from project.models import (
     AWS,
+    DUASignature,
     PublishedProject,
 )
 from user.models import (
@@ -280,9 +281,10 @@ class TestS3(TestMixin):
 
         for user in add_aws_users + add_nonaws_users:
             self.client.force_login(user)
+            initials = DUASignature.get_user_initials(user)
             self.client.post(
                 reverse('sign_dua', args=(project.slug, project.version)),
-                data={'agree': '', 'full_name': user.get_full_name()},
+                data={'agree': '', 'initials': initials},
             )
             self.assertTrue(can_view_project_files(project, user))
 

--- a/physionet-django/project/test_s3.py
+++ b/physionet-django/project/test_s3.py
@@ -28,6 +28,7 @@ from project.models import (
 from user.models import (
     User,
     CloudInformation,
+    Profile,
     Training,
     TrainingStatus,
 )
@@ -281,7 +282,7 @@ class TestS3(TestMixin):
             self.client.force_login(user)
             self.client.post(
                 reverse('sign_dua', args=(project.slug, project.version)),
-                data={'agree': ''},
+                data={'agree': '', 'full_name': user.get_full_name()},
             )
             self.assertTrue(can_view_project_files(project, user))
 
@@ -378,6 +379,11 @@ class TestS3(TestMixin):
                 is_active=True,
                 is_credentialed=True,
                 credential_datetime=now,
+            )
+            Profile.objects.create(
+                user=user,
+                first_names=f"Test{n}",
+                last_name=f"User{n}",
             )
             users.append(user)
             for i, training_type in enumerate(training_types):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -735,7 +735,7 @@ class TestAccessPublished(TestMixin):
         # Sign the dua and get file again
         response = self.client.post(reverse('sign_dua',
             args=(project.slug, project.version,)),
-            data={'agree': '', 'full_name': 'Roger Greenwood Mark'})
+            data={'agree': '', 'initials': 'RGM'})
         response = self.client.get(reverse(
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
@@ -952,7 +952,7 @@ class TestAccessPublished(TestMixin):
             self.client.login(username='rgmark@mit.edu', password='Tester11!')
             response = self.client.post(
                 reverse('sign_dua', args=(project.slug, project.version,)),
-                data={'agree': '', 'full_name': 'Roger Greenwood Mark'})
+                data={'agree': '', 'initials': 'RGM'})
 
             response = self.client.get(url + 'foo/')
             self.assertEqual(response.status_code, 200)
@@ -967,46 +967,46 @@ class TestAccessPublished(TestMixin):
 
 class TestDUASignatureValidation(TestMixin):
     """
-    Test DUA signing with full name validation.
+    Test DUA signing with initials validation.
     """
 
-    def test_sign_dua_with_correct_name(self):
-        """User can sign DUA when typing their correct full name."""
+    def test_sign_dua_with_correct_initials(self):
+        """User can sign DUA when typing their correct initials."""
         project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
         self.client.login(username='rgmark@mit.edu', password='Tester11!')
 
         response = self.client.post(
             reverse('sign_dua', args=(project.slug, project.version)),
-            data={'agree': '', 'full_name': 'Roger Greenwood Mark'}
+            data={'agree': '', 'initials': 'RGM'}
         )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(DUASignature.objects.filter(
             user__email='rgmark@mit.edu', project=project
         ).exists())
 
-    def test_sign_dua_with_wrong_name(self):
-        """User cannot sign DUA when typing wrong name."""
+    def test_sign_dua_with_wrong_initials(self):
+        """User cannot sign DUA when typing wrong initials."""
         project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
         self.client.login(username='rgmark@mit.edu', password='Tester11!')
 
         response = self.client.post(
             reverse('sign_dua', args=(project.slug, project.version)),
-            data={'agree': '', 'full_name': 'Wrong Name'}
+            data={'agree': '', 'initials': 'XYZ'}
         )
         self.assertEqual(response.status_code, 200)
         self.assertFalse(DUASignature.objects.filter(
             user__email='rgmark@mit.edu', project=project
         ).exists())
-        self.assertContains(response, 'does not match your profile name')
+        self.assertContains(response, 'do not match')
 
-    def test_sign_dua_with_empty_name(self):
-        """User cannot sign DUA without entering their name."""
+    def test_sign_dua_with_empty_initials(self):
+        """User cannot sign DUA without entering their initials."""
         project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
         self.client.login(username='rgmark@mit.edu', password='Tester11!')
 
         response = self.client.post(
             reverse('sign_dua', args=(project.slug, project.version)),
-            data={'agree': '', 'full_name': ''}
+            data={'agree': '', 'initials': ''}
         )
         self.assertEqual(response.status_code, 200)
         self.assertFalse(DUASignature.objects.filter(
@@ -1015,18 +1015,38 @@ class TestDUASignatureValidation(TestMixin):
         self.assertContains(response, 'This field is required')
 
     def test_sign_dua_case_insensitive(self):
-        """Name validation is case-insensitive."""
+        """Initials validation is case-insensitive."""
         project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
         self.client.login(username='rgmark@mit.edu', password='Tester11!')
 
         response = self.client.post(
             reverse('sign_dua', args=(project.slug, project.version)),
-            data={'agree': '', 'full_name': 'roger greenwood mark'}
+            data={'agree': '', 'initials': 'rgm'}
         )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(DUASignature.objects.filter(
             user__email='rgmark@mit.edu', project=project
         ).exists())
+
+
+class TestDUASignatureNormalization(TestCase):
+    """
+    Test Unicode normalization for initials comparison.
+    """
+
+    def test_normalize_for_comparison(self):
+        """Test that normalize_for_comparison handles Unicode properly."""
+        normalize = DUASignature.normalize_for_comparison
+
+        # Case insensitivity
+        self.assertEqual(normalize('ABC'), normalize('abc'))
+
+        # German sharp S (ß) casefolds to 'ss'
+        self.assertEqual(normalize('ß'), normalize('ss'))
+
+        # Different Unicode representations of same character
+        # é as single character vs e + combining acute accent
+        self.assertEqual(normalize('é'), normalize('é'))
 
 
 class TestState(TestMixin):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -19,6 +19,7 @@ from project.models import (
     CoreProject,
     DataAccessRequest,
     DataAccessRequestReviewer,
+    DUASignature,
     License,
     ProjectType,
     PublishedAuthor,
@@ -734,7 +735,7 @@ class TestAccessPublished(TestMixin):
         # Sign the dua and get file again
         response = self.client.post(reverse('sign_dua',
             args=(project.slug, project.version,)),
-            data={'agree':''})
+            data={'agree': '', 'full_name': 'Roger Greenwood Mark'})
         response = self.client.get(reverse(
             'serve_published_project_file',
             args=(project.slug, project.version, 'SHA256SUMS.txt')))
@@ -951,7 +952,7 @@ class TestAccessPublished(TestMixin):
             self.client.login(username='rgmark@mit.edu', password='Tester11!')
             response = self.client.post(
                 reverse('sign_dua', args=(project.slug, project.version,)),
-                data={'agree': ''})
+                data={'agree': '', 'full_name': 'Roger Greenwood Mark'})
 
             response = self.client.get(url + 'foo/')
             self.assertEqual(response.status_code, 200)
@@ -962,6 +963,70 @@ class TestAccessPublished(TestMixin):
             response = self.client.get(url + '%C3%80')
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response['X-Accel-Redirect'], path + '%C3%80')
+
+
+class TestDUASignatureValidation(TestMixin):
+    """
+    Test DUA signing with full name validation.
+    """
+
+    def test_sign_dua_with_correct_name(self):
+        """User can sign DUA when typing their correct full name."""
+        project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
+        self.client.login(username='rgmark@mit.edu', password='Tester11!')
+
+        response = self.client.post(
+            reverse('sign_dua', args=(project.slug, project.version)),
+            data={'agree': '', 'full_name': 'Roger Greenwood Mark'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(DUASignature.objects.filter(
+            user__email='rgmark@mit.edu', project=project
+        ).exists())
+
+    def test_sign_dua_with_wrong_name(self):
+        """User cannot sign DUA when typing wrong name."""
+        project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
+        self.client.login(username='rgmark@mit.edu', password='Tester11!')
+
+        response = self.client.post(
+            reverse('sign_dua', args=(project.slug, project.version)),
+            data={'agree': '', 'full_name': 'Wrong Name'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(DUASignature.objects.filter(
+            user__email='rgmark@mit.edu', project=project
+        ).exists())
+        self.assertContains(response, 'does not match your profile name')
+
+    def test_sign_dua_with_empty_name(self):
+        """User cannot sign DUA without entering their name."""
+        project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
+        self.client.login(username='rgmark@mit.edu', password='Tester11!')
+
+        response = self.client.post(
+            reverse('sign_dua', args=(project.slug, project.version)),
+            data={'agree': '', 'full_name': ''}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(DUASignature.objects.filter(
+            user__email='rgmark@mit.edu', project=project
+        ).exists())
+        self.assertContains(response, 'This field is required')
+
+    def test_sign_dua_case_insensitive(self):
+        """Name validation is case-insensitive."""
+        project = PublishedProject.objects.get(slug='demoeicu', version='2.0.0')
+        self.client.login(username='rgmark@mit.edu', password='Tester11!')
+
+        response = self.client.post(
+            reverse('sign_dua', args=(project.slug, project.version)),
+            data={'agree': '', 'full_name': 'roger greenwood mark'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(DUASignature.objects.filter(
+            user__email='rgmark@mit.edu', project=project
+        ).exists())
 
 
 class TestState(TestMixin):

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2138,8 +2138,9 @@ def sign_dua(request, project_slug, version):
             return render(request, 'project/sign_dua_complete.html', {
                 'project': project})
 
-    return render(request, 'project/sign_dua.html', {'project': project,
-        'license': license, 'license_content': license_content, 'form': form})
+    return render(request, 'project/sign_dua.html', {
+        'project': project, 'license': license,
+        'license_content': license_content, 'form': form})
 
 
 @login_required

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2121,21 +2121,25 @@ def sign_dua(request, project_slug, version):
 
     license = project.license
     license_content = project.license_content(fmt='html')
+    form = forms.DUASignatureForm(user)
+
     if request.method == 'POST' and 'agree' in request.POST:
-        DUASignature.objects.create(user=user, project=project)
-        if has_s3_credentials() and files_sent_to_S3(project):
-            if (
-                hasattr(user, 'cloud_information')
-                and user.cloud_information is not None
-                and user.cloud_information.aws_verification_datetime is not None
-            ):
-                add_user_to_access_point_policy(project, user)
+        form = forms.DUASignatureForm(user, data=request.POST)
+        if form.is_valid():
+            DUASignature.objects.create(user=user, project=project)
+            if has_s3_credentials() and files_sent_to_S3(project):
+                if (
+                    hasattr(user, 'cloud_information')
+                    and user.cloud_information is not None
+                    and user.cloud_information.aws_verification_datetime is not None
+                ):
+                    add_user_to_access_point_policy(project, user)
 
-        return render(request, 'project/sign_dua_complete.html', {
-            'project':project})
+            return render(request, 'project/sign_dua_complete.html', {
+                'project': project})
 
-    return render(request, 'project/sign_dua.html', {'project':project,
-        'license':license, 'license_content':license_content})
+    return render(request, 'project/sign_dua.html', {'project': project,
+        'license': license, 'license_content': license_content, 'form': form})
 
 
 @login_required


### PR DESCRIPTION
## Summary

   - [x] Users must now type their initials to sign a Data Use Agreement instead of just clicking "I agree".
   - [x] Initials are validated against the user's profile name (case-insensitive with unicode normalization).
   - [x] Provides stronger confirmation that users have read and agreed to the terms.

## Approach

   1. **Business logic in the model**: The initials validation rule lives in `DUASignature.validate_signature_initials()` as a static method. This keeps the business rule testable and reusable.

   2. **Unicode-aware comparison**: Uses `unicodedata.normalize('NFKD', text.casefold())` for proper unicode handling per review feedback.

   3. **Simple Form**: `DUASignatureForm` is a plain Django Form that only collects data. It delegates validation to the model's static method.

   4. **Explicit view logic**: The view explicitly creates the `DUASignature` object, making it clear what's being persisted.

## Screenshots
<img width="1338" height="831" alt="Screenshot 2026-01-16 at 1 42 36 PM" src="https://github.com/user-attachments/assets/989945ae-f228-4e4f-8eb0-e1e3746f88b1" />

Closes #2106