### PR TITLE
feat: display view tracking start date on metrics page

### DIFF
--- a/physionet-django/project/templates/project/published_project_metrics.html
+++ b/physionet-django/project/templates/project/published_project_metrics.html
@@ -27,7 +27,7 @@ Metrics for {{ project }}
               <small class="text-muted">All Versions</small>
             </div>
           </div>
-          <small class="text-muted"><em>Total number of unique registered users who have viewed this project</em></small>
+          <small class="text-muted"><em>Total number of unique registered users who have viewed this project.{% if tracking_start_date %} Views tracked since {{ tracking_start_date|date:"F Y" }}.{% endif %}</em></small>
         </div>
       </div>
     </div>

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1847,6 +1847,7 @@ class TestProjectViewsMetric(TestMixin):
         self.assertIn('project_views_count', response.context)
         self.assertIn('views_over_time', response.context)
         self.assertIn('views_by_version', response.context)
+        self.assertIn('tracking_start_date', response.context)
 
     def test_metrics_link_on_project_page(self):
         """Project page includes link to metrics detail page."""
@@ -1881,6 +1882,30 @@ class TestProjectViewsMetric(TestMixin):
         self.assertEqual(response.context['project_views_count'], 2)
         self.assertEqual(len(response.context['views_by_version']), 1)
         self.assertEqual(response.context['views_by_version'][0]['count'], 2)
+
+    def test_tracking_start_date_with_views(self):
+        """Tracking start date is set when views exist."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user = User.objects.get(email='rgmark@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        AccessLog.objects.create(
+            user=user,
+            object_id=project.id,
+            content_type=content_type,
+            data=''
+        )
+
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        self.assertIsNotNone(response.context['tracking_start_date'])
+
+    def test_tracking_start_date_without_views(self):
+        """Tracking start date is None when no views exist."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        self.assertIsNone(response.context['tracking_start_date'])
 
     def test_unique_viewers_count(self):
         """AccessLog.unique_viewers_count() returns correct count."""

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2104,13 +2104,16 @@ def published_project_metrics(request, project_slug, version):
     Public metrics page for a published project.
     """
     project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
+    views_over_time = project.views_over_time()
+    tracking_start_date = views_over_time[0]['month'] if views_over_time else None
 
     return render(request, 'project/published_project_metrics.html', {
         'project': project,
         'project_views_count': project.view_count(),
         'all_versions_views_count': project.view_count(all_versions=True),
-        'views_over_time': project.views_over_time(),
+        'views_over_time': views_over_time,
         'views_by_version': project.views_by_version(),
+        'tracking_start_date': tracking_start_date,
     })
 
 


### PR DESCRIPTION
## Summary

Displays when view tracking began for a project on the metrics page, addressing the issue that view counts do not cover the entire history of all datasets.

Closes #2563

## Changes

- [x] Extract tracking start date from existing `views_over_time()` data (no additional DB query).
- [x] Display "Views tracked since [Month Year]" on metrics page.
- [x] Add tests for tracking_start_date context.

## Approach

Rather than adding a new method with a separate database query, we derive the tracking start date from the existing `views_over_time()` data that's already being fetched. The first month in that data is when tracking began. This follows the DRY principle and avoids unnecessary database queries.

## Screenshots
<img width="1459" height="720" alt="Screenshot 2026-01-27 at 9 59 22 AM" src="https://github.com/user-attachments/assets/4ba3d17e-110a-4a70-8a1b-22e40bd753a4" />

The metrics page now shows:
> *Total number of unique registered users who have viewed this project. Views tracked since November 2025.*