### PR TITLE
Add KHDP account unlink functionality

### DIFF
--- a/physionet-django/user/templates/user/edit_khdp.html
+++ b/physionet-django/user/templates/user/edit_khdp.html
@@ -21,12 +21,12 @@
     </p>
 
     <ul>
-        <li>userId</li>
-        <li>userName</li>
-        <li>affiliation</li>
-        <li>mail</li>
-        <li>orcid</li>
-        <li>physionetId</li>
+        <li>User ID</li>
+        <li>Username</li>
+        <li>Affiliation</li>
+        <li>Email</li>
+        <li>ORCID</li>
+        <li>PhysioNet ID</li>
     </ul>
 
     <p>

--- a/physionet-django/user/templates/user/edit_khdp.html
+++ b/physionet-django/user/templates/user/edit_khdp.html
@@ -42,7 +42,7 @@
             <li>Affiliation: {{ request.user.khdp.affiliation }}</li>
             <li>Email: {{ request.user.khdp.email }}</li>
         </ul>
-        <button class="btn btn-primary btn-rsp" type="submit" name="remove_khdp" value="make_request">
+        <button class="btn btn-primary btn-rsp" type="submit" name="remove_khdp" value="make_request" onclick="return confirm('Are you sure you want to unlink your KHDP account?');">
             Unlink KHDP Account
         </button>
     {% else %}

--- a/physionet-django/user/templates/user/edit_khdp.html
+++ b/physionet-django/user/templates/user/edit_khdp.html
@@ -42,12 +42,14 @@
             <li>Affiliation: {{ request.user.khdp.affiliation }}</li>
             <li>Email: {{ request.user.khdp.email }}</li>
         </ul>
+        <button class="btn btn-primary btn-rsp" type="submit" name="remove_khdp" value="make_request">
+            Unlink KHDP Account
+        </button>
     {% else %}
         <p><strong>No KHDP account linked.</strong></p>
+        <button class="btn btn-primary btn-rsp" type="submit" name="request_khdp" value="make_request">
+            Link KHDP Account
+        </button>
     {% endif %}
-
-    <button class="btn btn-primary btn-rsp" type="submit" name="request_khdp" value="make_request">
-        Link KHDP Account
-    </button>
 </form>
 {% endblock %}

--- a/physionet-django/user/templates/user/edit_khdp.html
+++ b/physionet-django/user/templates/user/edit_khdp.html
@@ -46,7 +46,6 @@
             Unlink KHDP Account
         </button>
     {% else %}
-        <p><strong>No KHDP account linked.</strong></p>
         <button class="btn btn-primary btn-rsp" type="submit" name="request_khdp" value="make_request">
             Link KHDP Account
         </button>

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -1422,40 +1422,51 @@ def edit_khdp(request):
     """
     KHDP account linking settings page.
     """
-    if request.method == 'POST' and request.POST.get('request_khdp'):
-        client_id = getattr(settings, 'KHDP_CLIENT_ID', None)
-        khdp_auth_url = getattr(settings, 'KHDP_AUTH_URL', None)
+    if request.method == 'POST':
+        if request.POST.get('request_khdp'):
+            client_id = getattr(settings, 'KHDP_CLIENT_ID', None)
+            khdp_auth_url = getattr(settings, 'KHDP_AUTH_URL', None)
 
-        if not client_id or not khdp_auth_url:
-            logger.error(
-                'KHDP config missing: client_id=%s, khdp_auth_url=%s',
-                bool(client_id), bool(khdp_auth_url),
-            )
-            messages.error(
-                request,
-                'KHDP configuration is incomplete. Please contact support.',
-            )
-            return redirect('edit_khdp')
+            if not client_id or not khdp_auth_url:
+                logger.error(
+                    'KHDP config missing: client_id=%s, khdp_auth_url=%s',
+                    bool(client_id), bool(khdp_auth_url),
+                )
+                messages.error(
+                    request,
+                    'KHDP configuration is incomplete. Please contact support.',
+                )
+                return redirect('edit_khdp')
 
-        # Generate callback URL dynamically using reverse + build_absolute_uri
-        redirect_uri = request.build_absolute_uri(reverse('auth_khdp'))
+            # Generate callback URL dynamically using reverse + build_absolute_uri
+            redirect_uri = request.build_absolute_uri(reverse('auth_khdp'))
 
-        # Generate random nonce for security (stored in session for CSRF/session validation)
-        # Note: KHDP does not implement OAuth2 state parameter in callback, so we only use nonce
-        nonce = get_random_string(32)
+            # Generate random nonce for security (stored in session for CSRF/session validation)
+            # Note: KHDP does not implement OAuth2 state parameter in callback, so we only use nonce
+            nonce = get_random_string(32)
 
-        # Store nonce in session for CSRF validation
-        request.session['khdp_nonce'] = nonce
-        request.session.modified = True  # Ensure session is saved
+            # Store nonce in session for CSRF validation
+            request.session['khdp_nonce'] = nonce
+            request.session.modified = True  # Ensure session is saved
 
-        # KHDP expects appId and redirectUrl instead of standard OAuth2 params
-        params = {
-            'appId': client_id,
-            'redirectUrl': redirect_uri,
-            'nonce': nonce,
-        }
-        final_url = f"{khdp_auth_url}?{urlencode(params)}"
-        return redirect(final_url)
+            # KHDP expects appId and redirectUrl instead of standard OAuth2 params
+            params = {
+                'appId': client_id,
+                'redirectUrl': redirect_uri,
+                'nonce': nonce,
+            }
+            final_url = f"{khdp_auth_url}?{urlencode(params)}"
+            return redirect(final_url)
+
+        if request.POST.get('remove_khdp'):
+            try:
+                KhdpAccount.objects.get(user=request.user).delete()
+                messages.success(request, 'Your KHDP account has been unlinked.')
+            except KhdpAccount.DoesNotExist:
+                messages.error(
+                    request,
+                    'Object Does Not Exist Error: tried to unlink an object which does not exist.',
+                )
 
     return render(request, 'user/edit_khdp.html')
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -1458,7 +1458,7 @@ def edit_khdp(request):
             final_url = f"{khdp_auth_url}?{urlencode(params)}"
             return redirect(final_url)
 
-        if request.POST.get('remove_khdp'):
+        elif request.POST.get('remove_khdp'):
             try:
                 KhdpAccount.objects.get(user=request.user).delete()
                 messages.success(request, 'Your KHDP account has been unlinked.')

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -1467,6 +1467,7 @@ def edit_khdp(request):
                     request,
                     'No KHDP account currently linked.',
                 )
+            return redirect('edit_khdp')
 
     return render(request, 'user/edit_khdp.html')
 

--- a/physionet-django/user/views.py
+++ b/physionet-django/user/views.py
@@ -1465,7 +1465,7 @@ def edit_khdp(request):
             except KhdpAccount.DoesNotExist:
                 messages.error(
                     request,
-                    'Object Does Not Exist Error: tried to unlink an object which does not exist.',
+                    'No KHDP account currently linked.',
                 )
 
     return render(request, 'user/edit_khdp.html')


### PR DESCRIPTION
This PR implements the possibility to unlink a KHDP account from the user's PhysioNet profile by adding an "Unlink KHDP Account" button on the settings page. 

The button is displayed conditionally when an account is already linked, mirroring the pattern used for ORCID account management.