### PR TITLE
Require flake8 suppressions to be valid and explicit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 119
 ignore = F401, F403, W503
+noqa-require-code = true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           pip install \
               flake8==5.0.4 \
+              flake8-noqa==1.5.0 \
               mccabe==0.7.0 \
               pycodestyle==2.9.1 \
               pyflakes==2.5.0


### PR DESCRIPTION
flake8 allows warnings to be suppressed by adding a comment with the word `noqa`.

(In general, obviously, you should avoid doing this and instead rewrite the code to avoid the warning.  But sometimes ignoring the warning is best.)

The flake8-noqa package provides better validation of these "noqa" comments, ensuring that:

- it will complain about useless noqa comments (if you try to suppress a warning and there is nothing to warn about on that line)

- it will complain about non-specific noqa comments (if you write `# noqa` without listing specific warning code(s))

These rules will only apply to *newly modified* code in a pull request, but we may extend these rules to all code in the future.
