### PR TITLE
Add pagination and reverse ordering to metrics views over time

### DIFF
--- a/physionet-django/console/templates/console/pagination.html
+++ b/physionet-django/console/templates/console/pagination.html
@@ -1,29 +1,29 @@
 {% if pagination.has_other_pages %}
-  <div style="text-align: center;">
+  <div class="d-flex justify-content-center">
     <ul class="pagination">
-      <li><a href="?{{ querystring }}&page=1">&laquo;</a></li>
+      <li class="page-item"><a class="page-link" href="?{{ querystring }}&page=1">&laquo;</a></li>
       {% if pagination.has_previous %}
-        <li><a href="?{{ querystring }}&page={{ pagination.previous_page_number }}">&lsaquo;</a></li>
+        <li class="page-item"><a class="page-link" href="?{{ querystring }}&page={{ pagination.previous_page_number }}">&lsaquo;</a></li>
       {% else %}
-        <li class="disabled"><span>&lsaquo;</span></li>
+        <li class="page-item disabled"><span class="page-link">&lsaquo;</span></li>
       {% endif %}
       {% for i in i|ljust:10 %}
         {% with num=forloop.counter|add:pagination.number|add:"-4" %}
         {% if num > 0 and num <= pagination.paginator.num_pages %}
           {% if pagination.number == num %}
-            <li class="active"><span>{{ num }} <span class="sr-only">(current)</span></span></li>
+            <li class="page-item active"><span class="page-link">{{ num }} <span class="sr-only">(current)</span></span></li>
           {% else %}
-            <li><a href="?{{ querystring }}&page={{ num }}">{{ num }}</a></li>
+            <li class="page-item"><a class="page-link" href="?{{ querystring }}&page={{ num }}">{{ num }}</a></li>
           {% endif %}
         {% endif %}
         {% endwith %}
       {% endfor %}
       {% if pagination.has_next %}
-        <li><a href="?{{ querystring }}&page={{ pagination.next_page_number }}">&rsaquo;</a></li>
+        <li class="page-item"><a class="page-link" href="?{{ querystring }}&page={{ pagination.next_page_number }}">&rsaquo;</a></li>
       {% else %}
-        <li class="disabled"><span>&rsaquo;</span></li>
+        <li class="page-item disabled"><span class="page-link">&rsaquo;</span></li>
       {% endif %}
-      <li><a href="?{{ querystring }}&page={{ pagination.paginator.num_pages }}">&raquo;</a></li>
+      <li class="page-item"><a class="page-link" href="?{{ querystring }}&page={{ pagination.paginator.num_pages }}">&raquo;</a></li>
     </ul>
   </div>
 {% endif %}

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -2586,5 +2586,215 @@
     "creation_datetime": "2026-01-05T09:00:00Z",
     "last_access_datetime": "2026-01-05T09:00:00Z"
   }
+},
+{
+  "model": "project.log",
+  "pk": 8,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 1,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2024-12-10T09:00:00Z",
+    "last_access_datetime": "2024-12-15T11:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 9,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 2,
+    "data": "",
+    "count": 3,
+    "creation_datetime": "2025-01-08T10:00:00Z",
+    "last_access_datetime": "2025-01-20T14:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 10,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 3,
+    "data": "",
+    "count": 1,
+    "creation_datetime": "2025-02-05T11:00:00Z",
+    "last_access_datetime": "2025-02-05T11:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 11,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 1,
+    "data": "",
+    "count": 4,
+    "creation_datetime": "2025-03-12T08:00:00Z",
+    "last_access_datetime": "2025-03-25T16:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 12,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 2,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2025-04-03T09:30:00Z",
+    "last_access_datetime": "2025-04-18T13:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 13,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 3,
+    "data": "",
+    "count": 1,
+    "creation_datetime": "2025-05-15T14:00:00Z",
+    "last_access_datetime": "2025-05-15T14:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 14,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 1,
+    "data": "",
+    "count": 3,
+    "creation_datetime": "2025-06-02T10:00:00Z",
+    "last_access_datetime": "2025-06-20T15:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 15,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 2,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2025-07-10T11:00:00Z",
+    "last_access_datetime": "2025-07-22T17:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 16,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 3,
+    "data": "",
+    "count": 1,
+    "creation_datetime": "2025-08-05T09:00:00Z",
+    "last_access_datetime": "2025-08-05T09:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 17,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 1,
+    "data": "",
+    "count": 5,
+    "creation_datetime": "2025-09-01T08:00:00Z",
+    "last_access_datetime": "2025-09-28T16:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 18,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 2,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2025-10-10T10:00:00Z",
+    "last_access_datetime": "2025-10-25T14:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 19,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 3,
+    "data": "",
+    "count": 3,
+    "creation_datetime": "2025-11-03T11:00:00Z",
+    "last_access_datetime": "2025-11-18T15:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 20,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 1,
+    "data": "",
+    "count": 4,
+    "creation_datetime": "2025-12-08T09:00:00Z",
+    "last_access_datetime": "2025-12-22T13:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 21,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 2,
+    "data": "",
+    "count": 2,
+    "creation_datetime": "2026-01-15T10:00:00Z",
+    "last_access_datetime": "2026-01-28T16:00:00Z"
+  }
+},
+{
+  "model": "project.log",
+  "pk": 22,
+  "fields": {
+    "category": "LogCategory.ACCESS",
+    "content_type": ["project", "publishedproject"],
+    "object_id": 2,
+    "user": 3,
+    "data": "",
+    "count": 1,
+    "creation_datetime": "2026-02-03T08:00:00Z",
+    "last_access_datetime": "2026-02-03T08:00:00Z"
+  }
 }
 ]

--- a/physionet-django/project/templates/project/published_project_metrics.html
+++ b/physionet-django/project/templates/project/published_project_metrics.html
@@ -75,6 +75,7 @@ Metrics for {{ project }}
       </tbody>
     </table>
   </div>
+  {% include "console/pagination.html" with pagination=views_over_time %}
   {% endif %}
 
   <hr>

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -1955,3 +1955,67 @@ class TestProjectViewsMetric(TestMixin):
         # Sum of monthly counts is 3 (user1 counted in both months + user2 in current month)
         total_from_months = sum(m['count'] for m in views_by_month)
         self.assertEqual(total_from_months, 3)
+
+    def test_views_over_time_reverse_ordering(self):
+        """Views over time are displayed newest month first."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user = User.objects.get(email='rgmark@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        now = timezone.now()
+        old_month = now - timedelta(days=60)
+
+        # Create access logs in two different months
+        log1 = AccessLog.objects.create(
+            user=user, object_id=project.id, content_type=content_type, data='')
+        AccessLog.objects.filter(pk=log1.pk).update(creation_datetime=old_month)
+        AccessLog.objects.create(
+            user=user, object_id=project.id, content_type=content_type, data='')
+
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        page = response.context['views_over_time']
+        months = [item['month'] for item in page]
+        self.assertGreater(months[0], months[1])
+
+    def test_views_over_time_pagination(self):
+        """Views over time are paginated with 12 items per page."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user = User.objects.get(email='rgmark@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        now = timezone.now()
+        # Create access logs spanning 14 months
+        for i in range(14):
+            log = AccessLog.objects.create(
+                user=user, object_id=project.id, content_type=content_type, data='')
+            AccessLog.objects.filter(pk=log.pk).update(
+                creation_datetime=now - timedelta(days=30 * i))
+
+        response = self.client.get(reverse('published_project_metrics',
+                                           args=(project.slug, project.version)))
+        page = response.context['views_over_time']
+        self.assertEqual(len(page), 12)
+        self.assertTrue(page.has_next())
+
+    def test_views_over_time_page_parameter(self):
+        """Page 2 returns the remaining older months."""
+        project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        user = User.objects.get(email='rgmark@mit.edu')
+        content_type = ContentType.objects.get_for_model(project)
+
+        now = timezone.now()
+        # Create access logs spanning 14 months
+        for i in range(14):
+            log = AccessLog.objects.create(
+                user=user, object_id=project.id, content_type=content_type, data='')
+            AccessLog.objects.filter(pk=log.pk).update(
+                creation_datetime=now - timedelta(days=30 * i))
+
+        response = self.client.get(
+            reverse('published_project_metrics',
+                    args=(project.slug, project.version)) + '?page=2')
+        page = response.context['views_over_time']
+        self.assertGreater(len(page), 0)
+        self.assertLessEqual(len(page), 12)
+        self.assertFalse(page.has_next())

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -24,7 +24,7 @@ from django.utils.html import format_html, format_html_join
 from physionet.forms import set_saved_fields_cookie
 from physionet.middleware.maintenance import ServiceUnavailable
 from physionet.storage import generate_signed_url_helper
-from physionet.utility import serve_file
+from physionet.utility import paginate, serve_file
 from project import forms, utility
 from project.fileviews import display_project_file
 from project.models import (
@@ -2106,6 +2106,10 @@ def published_project_metrics(request, project_slug, version):
     project = get_object_or_404(PublishedProject, slug=project_slug, version=version)
     views_over_time = project.views_over_time()
     tracking_start_date = views_over_time[0]['month'] if views_over_time else None
+
+    # Display newest months first, paginated
+    views_over_time.reverse()
+    views_over_time = paginate(request, views_over_time, 12)
 
     return render(request, 'project/published_project_metrics.html', {
         'project': project,


### PR DESCRIPTION
## Summary
- [x] Display newest months first and paginate at 12 items per page on the project metrics page.
- [x] Update shared pagination template (`console/pagination.html`) to use Bootstrap 4 `page-item`/`page-link` classes for proper styling across all 29 paginated views.
- [x] Add 15 months of demo AccessLog fixture data so pagination is visible out of the box.

## Approach
- **Ordering in the view, not the model.** The queryset method `unique_viewers_by_month()` returns data in chronological order which is correct for the data layer. Newest-first is a presentation concern, so we reverse in the view to keep the model reusable for other contexts (charts, exports, API).
- **Reuse existing pagination infrastructure.** The codebase already has `paginate()` in `physionet/utility.py` and `console/pagination.html`, so no new utilities were needed.
- **12 months per page.** One year of data per page is a natural unit and matches the suggestion in #2561.
- **Bootstrap 4 pagination classes.** The shared template was using Bootstrap 3-style markup (bare `<li>` and `<a>` tags). Adding `page-item` and `page-link` classes gives proper spacing, borders, and active/disabled states site-wide.

## Screenshot
<img width="1380" height="805" alt="Screenshot 2026-02-10 at 2 17 31 PM" src="https://github.com/user-attachments/assets/7ca06128-a348-4c11-90a6-0b9a6bd39f09" />

Closes #2561