### PR TITLE
Support PROXY protocol in nginx

### DIFF
--- a/deploy/common/etc/nginx/sites-available/physionet_nginx.conf
+++ b/deploy/common/etc/nginx/sites-available/physionet_nginx.conf
@@ -17,6 +17,9 @@ map $uri $pn_static_csp {
 ## configuration of the server
 server {
     listen 443 ssl default_server http2;
+    listen 943 ssl default_server http2 proxy_protocol;
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header proxy_protocol;
 
     # Site-specific configuration for HTTPS
     include /etc/nginx/snippets/physionet-site-https.conf;
@@ -30,6 +33,9 @@ server {
 
 server {
     listen      80 default_server;
+    listen     980 default_server proxy_protocol;
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header proxy_protocol;
 
     # Site-specific configuration for HTTP
     include /etc/nginx/snippets/physionet-site-http.conf;


### PR DESCRIPTION
We want to be able to put the nginx server behind a reverse proxy. When doing so, we still would like to know the IP address of each connecting client.

To do this, haproxy can be configured to use the (badly named) "PROXY protocol" - when it receives a connection on port 443, it connects to the upstream server port 943 and sends a tiny header saying "this connection was forwarded for 1.2.3.4", before sending/receiving regular TCP data from/to the client.

For this to work, nginx has to be listening on port 943 and must expect to receive the PROXY protocol.  (The whole point is that you can't mistake a proxy connection for a non-proxy connection or vice versa.)  We'll use the nonstandard ports 943 for proxied-HTTPS and 980 for proxied-HTTP since these are unassigned but privileged.  Access to those ports will be restricted by iptables to allow only trusted proxies.

The corresponding haproxy configuration will look something like this:
```
frontend example_http_front
    mode tcp
    option tcplog
    bind *:8000
    use_backend example_http_back

backend example_http_back
    mode tcp
    server example_http_server1 127.0.0.1:980 send-proxy-v2

frontend example_https_front
    mode tcp
    option tcplog
    bind *:4430
    use_backend example_https_back

backend example_https_back
    mode tcp
    server example_https_server1 127.0.0.1:943 send-proxy-v2
```
