### PR TITLE
Add georestricted user information to admin console

### DIFF
--- a/physionet-django/console/templates/console/user_management.html
+++ b/physionet-django/console/templates/console/user_management.html
@@ -112,6 +112,24 @@
   {% endfor %}
 
   <br />
+  <h3>Georestriction</h3>
+  <hr>
+  <div class="row mb-1">
+    <div class="col-md-3">
+      Restricted:
+    </div>
+    <div class="col-md-9">
+      {% if is_restricted is None %}
+        Unknown (no registration IP)
+      {% elif is_restricted %}
+        True
+      {% else %}
+        False
+      {% endif %}
+    </div>
+  </div>
+
+  <br />
   <h3>Permission groups</h3>
   <hr>
     <div class="row mb-1">

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1468,6 +1468,8 @@ def user_management(request, username):
 
     groups = user.groups.all()
 
+    is_restricted = user.is_from_restricted_country()
+    
     return render(request, 'console/user_management.html', {'subject': user,
                                                             'profile': user.profile,
                                                             'groups': groups,
@@ -1476,7 +1478,8 @@ def user_management(request, username):
                                                             'training_list': training,
                                                             'credentialing_app': credentialing_app,
                                                             'aws_info': aws_info,
-                                                            'gcp_info': gcp_info})
+                                                            'gcp_info': gcp_info,
+                                                            'is_restricted': is_restricted})
 
 
 @console_permission_required('user.view_user')

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1469,7 +1469,7 @@ def user_management(request, username):
     groups = user.groups.all()
 
     is_restricted = user.is_from_restricted_country()
-    
+
     return render(request, 'console/user_management.html', {'subject': user,
                                                             'profile': user.profile,
                                                             'groups': groups,

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -23,6 +23,7 @@ from django.utils.text import slugify
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import gettext as _
 
+from physionet.utility import get_country_code
 from project.fields import SafeHTMLField
 from project.modelcomponents.access import AccessPolicy
 from project.validators import validate_version
@@ -464,6 +465,18 @@ class User(AbstractBaseUser, PermissionsMixin):
         except Orcid.DoesNotExist:
             return None
 
+    def is_from_restricted_country(self):
+        """
+        Check if user registered from a geographically restricted country.
+        Returns True if the registration IP is from a blocked region,
+        False otherwise, or None if unable to determine.
+        """
+        if not self.registration_ip:
+            return None
+        
+        country_code = get_country_code(self.registration_ip)
+        return country_code in settings.BLOCKED_REGIONS if country_code else None
+    
     @staticmethod
     def get_users_with_permission(app_label, permission_codename):
         """

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -473,10 +473,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         if not self.registration_ip:
             return None
-        
+
         country_code = get_country_code(self.registration_ip)
         return country_code in settings.BLOCKED_REGIONS if country_code else None
-    
+
     @staticmethod
     def get_users_with_permission(app_label, permission_codename):
         """


### PR DESCRIPTION
This PR add a method for checking if a user is registered with an IP from a georestricted region.

It also uses that method to display whether the user will be restricted (for applicable datasets) on the `/user/manage` page in the admin console. In the new `Georestriction` section there is a field called `Restricted` which will display `True`, `False`, or `Unknown (no registration IP)`. 