### PR TITLE
Remove csrfmiddlewaretoken where it is inappropriate

### DIFF
--- a/physionet-django/console/templates/console/code_of_conduct_detail.html
+++ b/physionet-django/console/templates/console/code_of_conduct_detail.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'code_of_conduct_detail' code_of_conduct.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=code_of_conduct_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/console/templates/console/code_of_conduct_list.html
+++ b/physionet-django/console/templates/console/code_of_conduct_list.html
@@ -84,6 +84,7 @@
   </div>
   <div class="card-body">
       <form method="post" action="{% url 'code_of_conduct_list' %}">
+          {% csrf_token %}
           {% include "inline_form_snippet.html" with form=code_of_conduct_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Create</button>
       </form>

--- a/physionet-django/console/templates/console/code_of_conduct_new_version.html
+++ b/physionet-django/console/templates/console/code_of_conduct_new_version.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'code_of_conduct_new_version' code_of_conduct.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=code_of_conduct_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Create</button>
         </form>

--- a/physionet-django/console/templates/console/copyedit_submission.html
+++ b/physionet-django/console/templates/console/copyedit_submission.html
@@ -49,6 +49,7 @@
       </div>
       <div class="tab-pane fade" id="content" role="tabpanel" aria-labelledby="content-tab">
         <form action="" method="post">
+          {% csrf_token %}
           <h3>Description</h3>
           {{ description_form.media }}
           {% include "project/content_inline_form_snippet.html" with form=description_form %}

--- a/physionet-django/console/templates/console/dua_detail.html
+++ b/physionet-django/console/templates/console/dua_detail.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'dua_detail' dua.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=dua_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/console/templates/console/dua_list.html
+++ b/physionet-django/console/templates/console/dua_list.html
@@ -99,6 +99,7 @@
   </div>
   <div class="card-body">
       <form method="post" action="{% url 'dua_list' %}">
+          {% csrf_token %}
           {% include "inline_form_snippet.html" with form=dua_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Create</button>
       </form>

--- a/physionet-django/console/templates/console/dua_new_version.html
+++ b/physionet-django/console/templates/console/dua_new_version.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'dua_new_version' dua.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=dua_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Create</button>
         </form>

--- a/physionet-django/console/templates/console/event_agreement_detail.html
+++ b/physionet-django/console/templates/console/event_agreement_detail.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
       <form method="post" action="{% url 'event_agreement_detail' event_agreement.pk %}">
+        {% csrf_token %}
         {% include "project/content_inline_form_snippet.html" with form=event_agreement_form %}
         <button class="btn btn-primary btn-fixed" type="submit">Save</button>
       </form>

--- a/physionet-django/console/templates/console/event_agreement_list.html
+++ b/physionet-django/console/templates/console/event_agreement_list.html
@@ -81,6 +81,7 @@
   </div>
   <div class="card-body">
       <form method="post" action="{% url 'event_agreement_list' %}">
+          {% csrf_token %}
           {% include "project/content_inline_form_snippet.html" with form=event_agreement_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Create</button>
       </form>

--- a/physionet-django/console/templates/console/event_agreement_new_version.html
+++ b/physionet-django/console/templates/console/event_agreement_new_version.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
       <form method="post" action="{% url 'event_agreement_new_version' event_agreement.pk %}">
+        {% csrf_token %}
         {% include "project/content_inline_form_snippet.html" with form=event_agreement_form %}
         <button class="btn btn-primary btn-fixed" type="submit">Create</button>
       </form>

--- a/physionet-django/console/templates/console/frontpage_button/add.html
+++ b/physionet-django/console/templates/console/frontpage_button/add.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'frontpage_button_add' %}">
+            {% csrf_token %}
             {% include "descriptive_inline_form_snippet.html" with form=frontpage_button_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Add Button</button>
         </form>

--- a/physionet-django/console/templates/console/frontpage_button/edit.html
+++ b/physionet-django/console/templates/console/frontpage_button/edit.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'frontpage_button_edit' button.pk %}">
+            {% csrf_token %}
             {% include "descriptive_inline_form_snippet.html" with form=frontpage_button_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Save Button</button>
         </form>

--- a/physionet-django/console/templates/console/license_detail.html
+++ b/physionet-django/console/templates/console/license_detail.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'license_detail' license.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=license_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/console/templates/console/license_list.html
+++ b/physionet-django/console/templates/console/license_list.html
@@ -95,6 +95,7 @@
   </div>
   <div class="card-body">
       <form method="post" action="{% url 'license_list' %}">
+          {% csrf_token %}
           {% include "inline_form_snippet.html" with form=license_form %}
           <button class="btn btn-primary btn-fixed" type="submit">Create</button>
       </form>

--- a/physionet-django/console/templates/console/license_new_version.html
+++ b/physionet-django/console/templates/console/license_new_version.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'license_new_version' license.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=license_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -61,6 +61,7 @@
       <h3>Add an author</h3>
 
       <form method="POST" id="legacy_author_form">
+        {% csrf_token %}
         {% include "inline_form_snippet.html" with form=legacy_author_form %}
         <button class="btn btn-primary btn-fixed" name="set_legacy_author" type="submit">Set author</button>
       </form>
@@ -82,6 +83,7 @@
       {% endfor %}
     {% else %}
       <form method="POST" id="publication_form">
+        {% csrf_token %}
         {% include "inline_form_snippet.html" with form=publication_form %}
         <button class="btn btn-primary btn-fixed" name="set_publication" type="submit">Add publication</button>
       </form>

--- a/physionet-django/console/templates/console/static_page/add.html
+++ b/physionet-django/console/templates/console/static_page/add.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'static_page_add' %}">
+            {% csrf_token %}
             {% include "descriptive_inline_form_snippet.html" with form=static_page_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Add</button>
         </form>

--- a/physionet-django/console/templates/console/static_page/edit.html
+++ b/physionet-django/console/templates/console/static_page/edit.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'static_page_edit' page.pk %}">
+            {% csrf_token %}
             {% include "descriptive_inline_form_snippet.html" with form=static_page_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/console/templates/console/static_page_sections.html
+++ b/physionet-django/console/templates/console/static_page_sections.html
@@ -57,6 +57,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'static_page_sections' page.pk %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=section_form %}
             <button class="btn btn-primary btn-fixed" name="set_legacy_author" type="submit">Create</button>
         </form>

--- a/physionet-django/console/templates/console/static_page_sections_edit.html
+++ b/physionet-django/console/templates/console/static_page_sections_edit.html
@@ -11,6 +11,7 @@
     </div>
     <div class="card-body">
         <form method="post" action="{% url 'static_page_sections_edit' page.pk section.id %}">
+            {% csrf_token %}
             {% include "inline_form_snippet.html" with form=section_form %}
             <button class="btn btn-primary btn-fixed" type="submit">Save</button>
         </form>

--- a/physionet-django/project/templates/project/content_inline_form_snippet.html
+++ b/physionet-django/project/templates/project/content_inline_form_snippet.html
@@ -1,4 +1,3 @@
-{% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
     <label class="col-md-{{ first_col_size|default:2 }}" for="{{ field.id_for_label }}">

--- a/physionet-django/project/templates/project/create_project.html
+++ b/physionet-django/project/templates/project/create_project.html
@@ -12,6 +12,7 @@
 {% block content %}
 <div class="container">
   <form action="{% url 'create_project' %}" method="post" class="no-pd">
+    {% csrf_token %}
     <h2 class="form-signin-heading">Create New Project</h2>
     {% if warning_message %}
       <hr>

--- a/physionet-django/project/templates/project/project_access.html
+++ b/physionet-django/project/templates/project/project_access.html
@@ -21,6 +21,7 @@
 {% endif %}
 
 <form action="{% url 'project_access' project.slug %}" method="post" class="no-pd" id="access">
+  {% csrf_token %}
   {% include "project/content_inline_form_snippet.html" with form=access_form %}
   {% if is_submitting and project.author_editable %}
   <hr>

--- a/physionet-django/project/templates/project/project_content.html
+++ b/physionet-django/project/templates/project/project_content.html
@@ -18,6 +18,7 @@
 <hr>
 
 <form action="{% url 'project_content' project.slug %}" onsubmit="return validateItems('reference-list', 'description', 'References')" method="post">
+  {% csrf_token %}
   {% if not project.author_editable %}
     <div class="alert alert-form alert-warning alert-dismissible">
       <strong>The project cannot be edited right now.</strong>

--- a/physionet-django/project/templates/project/project_discovery.html
+++ b/physionet-django/project/templates/project/project_discovery.html
@@ -23,6 +23,7 @@
   </div>
 {% endif %}
 <form action="{% url 'project_discovery' project.slug %}" method="post" onsubmit="return validateItems('topic-list', 'description', 'Topics', 'short_description')" class="no-pd">
+  {% csrf_token %}
   {% include "project/content_inline_form_snippet.html" with form=discovery_form %}
   {% include 'project/item_list.html' with item="publication" item_label=publication_formset.item_label formset=publication_formset form_name=publication_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
   {% include 'project/item_list.html' with item="topic" item_label=topic_formset.item_label formset=topic_formset form_name=topic_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}

--- a/physionet-django/project/templates/project/project_ethics.html
+++ b/physionet-django/project/templates/project/project_ethics.html
@@ -20,6 +20,7 @@
 {% endif %}
 
 <form enctype="multipart/form-data" action="{% url 'project_ethics' project.slug %}" method="post" class="no-pd">
+  {% csrf_token %}
   {% include "project/content_inline_form_snippet.html" with form=ethics_form %}
   <p>You may upload supporting documents here. These documents will be reviewed by our editorial staff, but they will not be shared publicly. For further guidance, please refer to our <a href="{% url 'static_view' static_url='publish' %}#author_guidelines" target="_blank">author guidelines</a>.</p>
   {% include 'project/item_list.html' with item="document" item_label=documents_formset.item_label formset=documents_formset form_name=documents_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}  {% if is_submitting and project.author_editable %}

--- a/physionet-django/templates/descriptive_inline_form_snippet.html
+++ b/physionet-django/templates/descriptive_inline_form_snippet.html
@@ -1,4 +1,3 @@
-{% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
     <label class="col-md-3" for="{{ field.id_for_label }}">

--- a/physionet-django/templates/inline_form_snippet.html
+++ b/physionet-django/templates/inline_form_snippet.html
@@ -1,4 +1,3 @@
-{% csrf_token %}
 {% for field in form.visible_fields %}
   <div class="form-group row">
     <label class="col-md-2" for="{{ field.id_for_label }}" title="{{ field.help_text }}">{{ field.label }}

--- a/physionet-django/user/templates/user/edit_training.html
+++ b/physionet-django/user/templates/user/edit_training.html
@@ -24,6 +24,7 @@
   {% endif %}</p>
 
   <form action="{% url "edit_training" %}" method="post" enctype="multipart/form-data" id="training">
+      {% csrf_token %}
       {% include "descriptive_inline_form_snippet.html" with form=training_form %}
       <button type="button" class="btn btn-primary btn-rsp" data-toggle="modal" data-target="#submit-training">Submit Training</button>
       <div class="modal fade" id="submit-training" tabindex="-1" role="dialog" aria-labelledby="submit-training-modal" aria-hidden="true">
@@ -52,6 +53,7 @@
   {% if take_course_form %}
       <h4>Complete training course on Platform</h4>
   <form action="{% url 'edit_training' %}" method="post" id="on_platform_training">
+    {% csrf_token %}
     {% include "descriptive_inline_form_snippet.html" with form=take_course_form %}
     <button type="button" class="btn btn-primary btn-rsp" data-toggle="modal" data-target="#start-training">Open Training</button>
 


### PR DESCRIPTION
The /content/ page and a few other pages currently contain an `<input type="hidden" name="csrfmiddlewaretoken">` in a GET form.

This is dangerous for various reasons (CSRF tokens should *not* be transmitted in URLs), as well as being useless (GET forms do not use CSRF tokens) and making the URLs ugly.

I think at some point somebody thought it would be convenient to embed the Django csrf_token tag in the "form snippet" templates so that you wouldn't have to include it in the parent template.  But in addition to being dangerous for GET forms, this wasn't consistently used, and leads to confusion and redundancy.

Better to keep the `{% csrf_token %}` together with the `<form>` tag, so it is clear that there is one token for each POST form and vice versa.
