### PR TITLE
Do not overwrite unrelated fields when saving project file sizes

### DIFF
--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -117,7 +117,7 @@ class PublishedProject(Metadata, SubmissionInfo):
         fields
         """
         self.main_storage_size, self.compressed_storage_size = self.storage_used()
-        self.save()
+        self.save(update_fields=['main_storage_size', 'compressed_storage_size'])
 
     def slugged_label(self):
         """

--- a/physionet-django/project/projectfiles/local.py
+++ b/physionet-django/project/projectfiles/local.py
@@ -167,7 +167,7 @@ class LocalProjectFiles(BaseProjectFiles):
         )
 
         project.compressed_storage_size = os.path.getsize(fname)
-        project.save()
+        project.save(update_fields=['compressed_storage_size'])
 
     def make_checksum_file(self, project):
         fname = os.path.join(project.file_root(), 'SHA256SUMS.txt')


### PR DESCRIPTION
The main_storage_size and compressed_storage_size fields of a project are calculated by background task functions, because they take a long time.

When updating these fields, we should not be updating other unrelated project fields.  That caused crashes following the migration of pull #2603, but it's just not a good idea in general to be "saving" things you don't need to save.  It's entirely possible that this *has* broken other things that nobody noticed (e.g., if an administrator tried to fix a typo immediately after publishing, the move_files_as_readonly task would have silently reverted the change.)
