### PR TITLE
Fix search returning multiple results

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - dev
       - test
     ports:
-      - 5432:5432
+      - 5433:5432
 
   gcs:
     image: fsouza/fake-gcs-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - dev
       - test
     ports:
-      - 5433:5432
+      - 5432:5432
 
   gcs:
     image: fsouza/fake-gcs-server

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -1495,6 +1495,7 @@
     "deprecated_files": false,
     "doi": "10.13026/G2F309",
     "slug": "demoeicu",
+    "public_project_uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "is_legacy": false,
     "full_description": "",
     "is_latest_version": true,

--- a/physionet-django/search/fixtures/demo-search.json
+++ b/physionet-django/search/fixtures/demo-search.json
@@ -12,5 +12,25 @@
             "created": "2024-01-01T00:00:00Z",
             "modified": "2024-01-01T00:00:00Z"
         }
+    },
+    {
+        "model": "search.federatedproject",
+        "pk": 1,
+        "fields": {
+            "source_site": 1,
+            "public_project_uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "slug": "demoeicu",
+            "version": "2.0.0",
+            "title": "Demo eICU Collaborative Research Database",
+            "abstract": "The eICU Collaborative Research Database is a large multi-center critical care database.",
+            "doi": "10.13026/G2F309",
+            "source_url": "https://demo.example.com/content/demoeicu/2.0.0/",
+            "resource_type": "Database",
+            "access_policy": "Credentialed",
+            "publish_datetime": "2018-12-17T21:11:17.040Z",
+            "main_storage_size": 3195,
+            "topics": ["critical care", "eicu"],
+            "last_fetched": "2024-01-01T00:00:00Z"
+        }
     }
 ]

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -1,5 +1,4 @@
 import operator
-import pdb
 import re
 from functools import reduce
 
@@ -120,15 +119,16 @@ def get_content_postgres_full_text_search(resource_type, orderby, direction, sea
         search_query = SearchQuery('')
         query = Q(resource_type__in=resource_type)
 
-    vector = (SearchVector('title', weight='A') + SearchVector('abstract', weight='B')
-              + SearchVector('topics__description', weight='C'))
+    match_vector = (SearchVector('title', weight='A') + SearchVector('abstract', weight='B')
+                    + SearchVector('topics__description', weight='C'))
+    
+    # Create a vector without the topics to avoid row multiplication from the M2M join when ranking
+    rank_vector = SearchVector('title', weight='A') + SearchVector('abstract', weight='B')
+    published_projects = PublishedProject.objects.annotate(search=match_vector).filter(query, is_latest_version=True)
 
-    # Filter projects by latest version and annotate relevance field
-    published_projects = PublishedProject.objects.annotate(search=vector).filter(query, is_latest_version=True)
-
-    # get distinct projects with subquery and also include relevance from published_projects
+    # Get distinct projects including relevance annotation
     published_projects = PublishedProject.objects.filter(id__in=published_projects.values('id')).annotate(
-        relevance=SearchRank(vector, search_query)).distinct()
+        relevance=SearchRank(rank_vector, search_query))
 
     # Sorting
     direction = '-' if direction == 'desc' else ''

--- a/physionet-django/search/views.py
+++ b/physionet-django/search/views.py
@@ -121,7 +121,7 @@ def get_content_postgres_full_text_search(resource_type, orderby, direction, sea
 
     match_vector = (SearchVector('title', weight='A') + SearchVector('abstract', weight='B')
                     + SearchVector('topics__description', weight='C'))
-    
+
     # Create a vector without the topics to avoid row multiplication from the M2M join when ranking
     rank_vector = SearchVector('title', weight='A') + SearchVector('abstract', weight='B')
     published_projects = PublishedProject.objects.annotate(search=match_vector).filter(query, is_latest_version=True)


### PR DESCRIPTION
This PR fixes the current search returning more than one result for the same object - raised in #663 

Two fixes:

1. Deduplicate federated projects if they also occur locally; I thought this was the issue originally but it wasn't. Still I think it's correct to not include federated projects if they are local to the current platform (not that we have any).
2. The issue was the search vector doing an M2M join with the topic. Fixed it by using a separate vector for ranking. Details in [081faaa4](https://github.com/MIT-LCP/physionet-build/commit/081faaa474f37d93f256c620b529ac5807ca5c24).

I also added a fixture for the federated project to demonstrate that fix.