### PR TITLE
Do not assume background tasks are dead after one hour

### DIFF
--- a/deploy/production/etc/systemd/system/django-background-tasks.service
+++ b/deploy/production/etc/systemd/system/django-background-tasks.service
@@ -4,6 +4,7 @@ After=emperor.uwsgi.service
 
 [Service]
 Environment=DJANGO_SETTINGS_MODULE=physionet.settings.production
+ExecStartPre=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py unlock_background_tasks
 ExecStart=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py process_tasks --log-std
 StandardError=syslog
 SyslogIdentifier=django-background-tasks

--- a/deploy/staging/etc/systemd/system/django-background-tasks.service
+++ b/deploy/staging/etc/systemd/system/django-background-tasks.service
@@ -4,6 +4,7 @@ After=emperor.uwsgi.service
 
 [Service]
 Environment=DJANGO_SETTINGS_MODULE=physionet.settings.staging
+ExecStartPre=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py unlock_background_tasks
 ExecStart=/physionet/python-env/physionet/bin/python /physionet/physionet-build/physionet-django/manage.py process_tasks --log-std
 StandardError=syslog
 SyslogIdentifier=django-background-tasks

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -242,6 +242,7 @@ Q_CLUSTER = {
 
 BACKGROUND_TASK_RUN_ASYNC = True
 MAX_ATTEMPTS = 5
+MAX_RUN_TIME = 9999999999      # 316 years
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/

--- a/physionet-django/user/management/commands/unlock_background_tasks.py
+++ b/physionet-django/user/management/commands/unlock_background_tasks.py
@@ -1,0 +1,39 @@
+from background_task.models import Task
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django.db import transaction
+
+
+class Command(BaseCommand):
+    """
+    Unlock all pending background tasks.
+
+    When the django-background-tasks daemon starts running a task, the
+    task is "locked" so that another daemon won't try to run it at the
+    same time.  If the daemon is interrupted without completing the
+    task, the task may never be "unlocked".
+
+    Manually unlocking tasks is generally not desirable since it can
+    result in multiple instances of the same task running (although as
+    a rule, tasks should be designed to be idempotent and not to break
+    if this happens.)
+
+    This command is primarily intended to be invoked by systemd when
+    starting or restarting the django-background-tasks daemon.
+    """
+
+    def handle(self, *args, **options):
+        verbosity = options['verbosity']
+
+        with transaction.atomic():
+            tasks = Task.objects.filter(locked_by__isnull=False)
+            for task in tasks:
+                duration = timezone.now() - task.locked_at
+                task.locked_at = None
+                task.locked_by = None
+                task.save(update_fields=['locked_at', 'locked_by'])
+                if verbosity > 0:
+                    self.stdout.write(
+                        f'Unlocked task {task.pk} ({task.task_name}) '
+                        f'which was started {duration} ago'
+                    )


### PR DESCRIPTION
The django-background-tasks daemon allows a task to be started if it is not currently "locked", or if it was "locked" more than MAX_RUN_TIME seconds ago (presumably as a safety valve to handle the daemon being killed.)

Since MAX_RUN_TIME is 3600 by default, this means that a new copy of every task is getting spawned once per hour (assuming there are threads available - this was not a problem prior to #699 because there was only one thread running.)

We need to make MAX_RUN_TIME much larger to avoid spawning multiple instances of the same task.

But we also don't want to wait for a long time to restart tasks when the daemon is restarted.

So, instead, let's make the assumption that there is only one django-background-tasks service, and therefore if we are restarting the service then we can assume any existing locks are stale.
