### PR TITLE
add logs page for number of signed DUAs

### DIFF
--- a/physionet-django/console/navbar.py
+++ b/physionet-django/console/navbar.py
@@ -194,6 +194,7 @@ CONSOLE_NAV_MENU = NavMenu([
         NavLink(_('User Logs'), 'user_access_logs'),
         NavLink(_('GCP Logs'), 'gcp_signed_urls_logs',
                 enabled=(settings.STORAGE_TYPE == StorageTypes.GCP)),
+        NavLink(_('DUA Logs'), 'dua_logs'),
     ]),
 
     NavSubmenu(_('Users'), 'users', 'user-check', [

--- a/physionet-django/console/templates/console/dua_logs.html
+++ b/physionet-django/console/templates/console/dua_logs.html
@@ -1,0 +1,59 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}DUA Logs{% endblock %}
+
+{% block local_css %}
+  <link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
+{% endblock %}
+
+{% block content %}
+ <script src="{% static 'console/js/generic-filter.js' %}"></script>
+ <div class="card mb-3">
+  <div class="card-header">
+    DUA Logs - Credentialed Projects <span class="badge badge-pill badge-info">{{ projects.paginator.count }}</span>
+  </div>
+  <div class="card-body">
+    <a href="{% url 'download_all_dua_signatures' %}" class="btn btn-md btn-success">Download All DUA Signatures CSV</a>
+    <hr>
+    <div class="row">
+      <div class="col-sm-12">
+        <label class="font-weight-bold" for="searchbox">Search for project:</label>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-12">
+        <input id="searchbox" type="search" oninput="search();" placeholder="Search...">
+      </div>
+    </div>
+    <div class="table-responsive" id="searchitems">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Project Name</th>
+            <th>Publish Datetime</th>
+            <th>Signed DUAs</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% include "console/dua_logs_list.html" %}
+        </tbody>
+      </table>
+      {% include "console/pagination.html" with pagination=projects %}
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block local_js_bottom %}
+  <script>
+    const search = () => {
+      const filters = {
+        q: $('#searchbox').val()
+      }
+      filter("{% url 'dua_logs' %}", filters)
+    }
+  </script>
+{% endblock %}

--- a/physionet-django/console/templates/console/dua_logs_detail.html
+++ b/physionet-django/console/templates/console/dua_logs_detail.html
@@ -1,0 +1,118 @@
+{% extends "console/base_console.html" %}
+
+{% load static %}
+
+{% block title %}DUA Logs - {{ project }}{% endblock %}
+
+{% block local_js_top %}
+  <script src="{% static 'daterangepicker/js/moment.min.js' %}"></script>
+  <script src="{% static 'daterangepicker/js/daterangepicker.min.js' %}"></script>
+  <script src="{% static 'console/js/generic-filter.js' %}"></script>
+  {{ user_filter_form.media.js }}
+{% endblock %}
+
+{% block local_css %}
+  <link rel="stylesheet" type="text/css" href="{% static 'custom/css/pagination.css' %}">
+  <link rel="stylesheet" type="text/css" href="{% static 'daterangepicker/css/daterangepicker.css' %}">
+  {{ user_filter_form.media.css }}
+{% endblock %}
+
+{% block content %}
+ <div class="card mb-3">
+  <div class="card-header">
+    {{ project }} - DUA Signatures <span class="badge badge-pill badge-info">{{ signatures.paginator.count }}</span>
+  </div>
+  <div class="card-body">
+    <a href="{% url 'download_dua_signatures' project.id %}" class="btn btn-md btn-success">Download CSV</a>
+    <hr>
+    <div class="row">
+      <div class="col-sm-6">
+        <label class="font-weight-bold" for="username">Filter by username:</label>
+      </div>
+      <div class="col-sm-6">
+        <label class="font-weight-bold" for="datefilter">Filter by time period:</label>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        {{ user_filter_form.username }}
+      </div>
+      <div class="col-sm-6">
+        <div id="datefilter" style="cursor: pointer;" class="border py-1 px-2 text-dark">
+          <i class="far fa-calendar"></i>
+          <span>Select period</span>
+          <i class="fa fa-angle-down"></i>
+        </div>
+      </div>
+    </div>
+    <div class="table-responsive" id="searchitems">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Email</th>
+            <th>Sign Datetime</th>
+          </tr>
+        </thead>
+        <tbody>
+            {% for sig in signatures %}
+              <tr>
+                <td><a href="{% url 'public_profile' sig.user.username %}">{{ sig.user.get_full_name }}</a></td>
+                <td>{{ sig.user.email }}</td>
+                <td>{{ sig.sign_datetime }}</td>
+              </tr>
+            {% endfor %}
+        </tbody>
+      </table>
+      {% include "console/pagination.html" with pagination=signatures %}
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block local_js_bottom %}
+<script>
+  let startDate = null;
+  let endDate = null;
+
+  const search = () => {
+    const start = startDate !== null ? startDate : '';
+    const end = endDate !== null ? endDate : '';
+    const user = $('#id_username').val() !== null ? $('#id_username').val() : '';
+
+    filter("{% url 'dua_logs_detail' project.id %}", {
+      startDate: start,
+      endDate: end,
+      user: user
+    });
+  }
+
+  $('#id_username').change(() => search());
+
+$(() => {
+  $('#datefilter').daterangepicker({
+    autoUpdateInput: false,
+    timePicker: true,
+    locale: {
+      cancelLabel: 'Clear'
+    }
+  });
+
+  $('#datefilter').on('apply.daterangepicker', function(ev, picker) {
+    startDate = picker.startDate.format('YYYY-MM-DD hh:mm');
+    endDate = picker.endDate.format('YYYY-MM-DD hh:mm');
+    $('#datefilter span').html(picker.startDate.format('M/DD hh:mm A') + ' - ' + picker.endDate.format('M/DD hh:mm A'));
+    search();
+  });
+
+  $('#datefilter').on('cancel.daterangepicker', function(ev, picker) {
+    $('#datefilter span').html('Select period');
+    picker.setStartDate(moment().startOf('day'))
+    picker.setEndDate(moment().endOf('day'))
+    startDate = null;
+    endDate = null;
+    search();
+  });
+});
+</script>
+{% endblock %}

--- a/physionet-django/console/templates/console/dua_logs_list.html
+++ b/physionet-django/console/templates/console/dua_logs_list.html
@@ -1,0 +1,8 @@
+{% for project in projects %}
+    <tr>
+        <td><a href="{% url 'published_project' project.slug project.version %}">{{ project }}</a></td>
+        <td>{{ project.publish_datetime }}</td>
+        <td>{{ project.dua_count }}</td>
+        <td><a href="{% url 'dua_logs_detail' project.id %}" class="btn btn-sm btn-primary" role="button">View</a></td>
+    </tr>
+{% endfor %}

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import json
 import logging
 import os
@@ -11,10 +13,12 @@ from django.test.utils import get_runner
 from django.urls import reverse
 from events.models import EventAgreement
 from project.models import (
+    AccessPolicy,
     ActiveProject,
     AnonymousAccess,
     Author,
     AuthorInvitation,
+    DUASignature,
     License,
     PublishedProject,
     StorageRequest,
@@ -1356,3 +1360,208 @@ class TestOnHold(TestMixin):
         response = self.client.get(reverse('editor_home'))
         self.assertNotIn(project, response.context['decision_projects'])
         self.assertIn(project, response.context['on_hold_projects'])
+
+
+class TestDUALogs(TestMixin):
+    """Test DUA Logs console views."""
+
+    ADMIN_USER = 'admin'
+    ADMIN_PASSWORD = 'Tester11!'
+    REGULAR_USER = 'rgmark'
+    REGULAR_PASSWORD = 'Tester11!'
+
+    def setUp(self):
+        super().setUp()
+        self.credentialed_project = PublishedProject.objects.get(
+            slug='demoeicu', access_policy=AccessPolicy.CREDENTIALED
+        )
+        self.admin = User.objects.get(username=self.ADMIN_USER)
+        self.regular_user = User.objects.get(username=self.REGULAR_USER)
+
+        # Track pre-existing signatures before adding test data
+        self.pre_existing_count = DUASignature.objects.filter(
+            project=self.credentialed_project
+        ).count()
+
+        # Create DUA signatures inline (Option B)
+        self.sig1 = DUASignature.objects.create(
+            project=self.credentialed_project,
+            user=self.admin,
+        )
+        self.sig2 = DUASignature.objects.create(
+            project=self.credentialed_project,
+            user=self.regular_user,
+        )
+
+    # View access tests
+
+    def test_dua_logs_list(self):
+        """GET the DUA logs list page returns 200 and shows credentialed projects."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(reverse('dua_logs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'console/dua_logs.html')
+        # The credentialed project should appear in the list
+        self.assertContains(response, self.credentialed_project.title)
+
+    def test_dua_logs_list_only_credentialed(self):
+        """Only credentialed projects appear on the DUA logs page."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(reverse('dua_logs'))
+        projects = response.context['projects']
+        for project in projects:
+            self.assertEqual(project.access_policy, AccessPolicy.CREDENTIALED)
+
+    def test_dua_logs_list_shows_counts(self):
+        """The list page annotates projects with their DUA signature count."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(reverse('dua_logs'))
+        projects = response.context['projects']
+        project = [p for p in projects if p.pk == self.credentialed_project.pk][0]
+        self.assertEqual(project.dua_count, self.pre_existing_count + 2)
+
+    def test_dua_logs_search(self):
+        """Search filter narrows results by title."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        # Search with matching term
+        response = self.client.get(reverse('dua_logs'), {'q': 'eicu'})
+        self.assertContains(response, self.credentialed_project.title)
+        # Search with non-matching term
+        response = self.client.get(reverse('dua_logs'), {'q': 'nonexistent'})
+        self.assertNotContains(response, self.credentialed_project.title)
+
+    def test_dua_logs_detail(self):
+        """GET the detail page for a credentialed project returns 200."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(
+            reverse('dua_logs_detail', args=[self.credentialed_project.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'console/dua_logs_detail.html')
+        self.assertContains(response, self.admin.email)
+        self.assertContains(response, self.regular_user.email)
+
+    @prevent_request_warnings
+    def test_dua_logs_detail_non_credentialed_404(self):
+        """Requesting detail for a non-credentialed project returns 404."""
+        open_project = PublishedProject.objects.filter(
+            access_policy=AccessPolicy.OPEN
+        ).first()
+        self.assertIsNotNone(open_project)
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(
+            reverse('dua_logs_detail', args=[open_project.pk])
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_dua_logs_detail_filter_by_user(self):
+        """Filtering by user shows only that user's signatures."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(
+            reverse('dua_logs_detail', args=[self.credentialed_project.pk]),
+            {'user': self.admin.pk}
+        )
+        self.assertEqual(response.status_code, 200)
+        signatures = response.context['signatures']
+        self.assertEqual(signatures.paginator.count, 1)
+
+    # CSV download tests
+
+    def test_download_dua_signatures_csv(self):
+        """Per-project CSV download contains correct headers and data."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(
+            reverse('download_dua_signatures', args=[self.credentialed_project.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertIn('project_', response['Content-Disposition'])
+
+        content = response.content.decode('utf-8')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+
+        self.assertEqual(rows[0], ['User', 'Email address', 'Sign datetime'])
+        self.assertEqual(len(rows), self.pre_existing_count + 2 + 1)  # +1 for header
+        emails_in_csv = {row[1] for row in rows[1:]}
+        self.assertIn(self.admin.email, emails_in_csv)
+        self.assertIn(self.regular_user.email, emails_in_csv)
+
+    def test_download_dua_signatures_csv_empty(self):
+        """CSV for a project with no signatures has only the header row."""
+        DUASignature.objects.filter(project=self.credentialed_project).delete()
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(
+            reverse('download_dua_signatures', args=[self.credentialed_project.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode('utf-8')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        self.assertEqual(len(rows), 1)  # header only
+
+    def test_download_all_dua_signatures_csv(self):
+        """Bulk CSV download contains correct headers and all signature data."""
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(reverse('download_all_dua_signatures'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertIn('all_dua_signatures', response['Content-Disposition'])
+
+        content = response.content.decode('utf-8')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+
+        self.assertEqual(
+            rows[0],
+            ['Project', 'Project slug', 'Version',
+             'User', 'Email address', 'Sign datetime']
+        )
+        # At least our 2 test signatures
+        self.assertGreaterEqual(len(rows), 3)
+
+    @prevent_request_warnings
+    def test_download_dua_signatures_non_credentialed_404(self):
+        """CSV download for a non-credentialed project returns 404."""
+        open_project = PublishedProject.objects.filter(
+            access_policy=AccessPolicy.OPEN
+        ).first()
+        self.assertIsNotNone(open_project)
+        self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)
+        response = self.client.get(
+            reverse('download_dua_signatures', args=[open_project.pk])
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # Permission tests
+
+    def test_dua_logs_anonymous_redirects(self):
+        """Anonymous users are redirected from DUA logs pages."""
+        self.client.logout()
+        for url_name in ['dua_logs', 'download_all_dua_signatures']:
+            response = self.client.get(reverse(url_name))
+            self.assertNotEqual(response.status_code, 200)
+
+    def test_dua_logs_unprivileged_denied(self):
+        """A user without can_view_access_logs permission gets 403."""
+        self.client.login(username=self.REGULAR_USER, password=self.REGULAR_PASSWORD)
+        response = self.client.get(reverse('dua_logs'))
+        self.assertEqual(response.status_code, 403)
+
+    def test_dua_logs_detail_unprivileged_denied(self):
+        """A user without can_view_access_logs permission gets 403 on detail."""
+        self.client.login(username=self.REGULAR_USER, password=self.REGULAR_PASSWORD)
+        response = self.client.get(
+            reverse('dua_logs_detail', args=[self.credentialed_project.pk])
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_download_unprivileged_denied(self):
+        """A user without can_view_access_logs permission gets 403 on CSV downloads."""
+        self.client.login(username=self.REGULAR_USER, password=self.REGULAR_PASSWORD)
+        for url_name, args in [
+            ('download_dua_signatures', [self.credentialed_project.pk]),
+            ('download_all_dua_signatures', []),
+        ]:
+            response = self.client.get(reverse(url_name, args=args))
+            self.assertEqual(response.status_code, 403)

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -316,10 +316,10 @@ TEST_CASES = {
     # DUA Logs: pk must be a credentialed project
     'dua_logs_detail': {
         # id of a PublishedProject with access_policy=CREDENTIALED
-        'pk': 2,
+        'pk': 1,
     },
     'download_dua_signatures': {
-        'pk': 2,
+        'pk': 1,
     },
 
     # Broken views: POST required for no reason

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -38,6 +38,12 @@ urlpatterns = [
     path('gcp-signed-urls-logs/<int:pk>/', views.gcp_signed_urls_logs_detail, name='gcp_signed_urls_logs_detail'),
     path('download-signed-urls-logs/<int:pk>/', views.download_signed_urls_logs, name='download_signed_urls_logs'),
 
+    # DUA Logs
+    path('dua-logs/', views.dua_logs, name='dua_logs'),
+    path('dua-logs/<int:pk>/', views.dua_logs_detail, name='dua_logs_detail'),
+    path('download-dua-signatures/<int:pk>/', views.download_dua_signatures, name='download_dua_signatures'),
+    path('download-all-dua-signatures/', views.download_all_dua_signatures, name='download_all_dua_signatures'),
+
     # On hold
     path('submitted-projects/<project_slug>/on-hold/', views.project_on_hold, name='project_on_hold'),
 
@@ -306,6 +312,15 @@ TEST_CASES = {
     'event_agreement_detail': {'_skip_': True},
     'event_agreement_delete': {'_skip_': True},
     'event_agreement_new_version': {'_skip_': True},
+
+    # DUA Logs: pk must be a credentialed project
+    'dua_logs_detail': {
+        # id of a PublishedProject with access_policy=CREDENTIALED
+        'pk': 2,
+    },
+    'download_dua_signatures': {
+        'pk': 2,
+    },
 
     # Broken views: POST required for no reason
     'users_list_search': {'group': 'all', '_skip_': True},

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -3046,6 +3046,139 @@ def download_signed_urls_logs(request, pk):
     return response
 
 
+# ---------------------- DUA Logs Views ---------------------- #
+
+
+@console_permission_required('project.can_view_access_logs')
+def dua_logs(request):
+    """
+    List credentialed published projects with their DUA signature counts.
+    """
+    projects = PublishedProject.objects.filter(
+        access_policy=AccessPolicy.CREDENTIALED
+    ).annotate(
+        dua_count=Count('duasignature')
+    ).order_by('-publish_datetime')
+
+    q = request.GET.get('q')
+    if q:
+        projects = projects.filter(title__icontains=q)
+
+    projects = paginate(request, projects, 50)
+
+    return render(request, 'console/dua_logs.html', {
+        'projects': projects,
+    })
+
+
+@console_permission_required('project.can_view_access_logs')
+def dua_logs_detail(request, pk):
+    """
+    Show DUA signatures for a specific credentialed project.
+    """
+    project = get_object_or_404(
+        PublishedProject, pk=pk, access_policy=AccessPolicy.CREDENTIALED
+    )
+    signatures = (
+        DUASignature.objects.filter(project=project)
+        .select_related('user__profile')
+        .order_by('-sign_datetime')
+    )
+
+    user = request.GET.get('user')
+    if user:
+        signatures = signatures.filter(user=user)
+
+    start_date = request.GET.get('startDate')
+    end_date = request.GET.get('endDate')
+    if start_date and end_date:
+        signatures = signatures.filter(
+            sign_datetime__gte=start_date, sign_datetime__lte=end_date
+        )
+
+    signatures = paginate(request, signatures, 50)
+    user_filter_form = UserFilterForm()
+
+    return render(request, 'console/dua_logs_detail.html', {
+        'project': project,
+        'signatures': signatures,
+        'user_filter_form': user_filter_form,
+    })
+
+
+@console_permission_required('project.can_view_access_logs')
+def download_dua_signatures(request, pk):
+    """
+    Download CSV of DUA signatures for a specific project.
+    """
+    project = get_object_or_404(
+        PublishedProject, pk=pk, access_policy=AccessPolicy.CREDENTIALED
+    )
+    headers = ['User', 'Email address', 'Sign datetime']
+
+    signatures = (
+        DUASignature.objects.filter(project=project)
+        .select_related('user__profile')
+        .order_by('-sign_datetime')
+    )
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = (
+        f'attachment; filename="project_{pk}_dua_signatures.csv"'
+    )
+
+    writer = csv.writer(response)
+    writer.writerow(headers)
+
+    for sig in signatures:
+        writer.writerow([
+            sig.user.get_full_name(),
+            sig.user.email,
+            sig.sign_datetime.strftime('%m/%d/%Y, %I:%M:%S %p'),
+        ])
+
+    return response
+
+
+@console_permission_required('project.can_view_access_logs')
+def download_all_dua_signatures(request):
+    """
+    Download CSV of all DUA signatures across all credentialed projects.
+    """
+    headers = [
+        'Project', 'Project slug', 'Version',
+        'User', 'Email address', 'Sign datetime',
+    ]
+
+    signatures = (
+        DUASignature.objects.filter(
+            project__access_policy=AccessPolicy.CREDENTIALED
+        )
+        .select_related('user__profile', 'project')
+        .order_by('project__title', '-sign_datetime')
+    )
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = (
+        'attachment; filename="all_dua_signatures.csv"'
+    )
+
+    writer = csv.writer(response)
+    writer.writerow(headers)
+
+    for sig in signatures:
+        writer.writerow([
+            sig.project.title,
+            sig.project.slug,
+            sig.project.version,
+            sig.user.get_full_name(),
+            sig.user.email,
+            sig.sign_datetime.strftime('%m/%d/%Y, %I:%M:%S %p'),
+        ])
+
+    return response
+
+
 class UserAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         """


### PR DESCRIPTION
This adds a page showing the number of DUA signatures for each project:

<img width="1198" height="392" alt="Screenshot 2026-04-17 at 2 45 48 PM" src="https://github.com/user-attachments/assets/6c6206a9-c03d-48f8-a9c6-329540ebadff" />

Basically the same as the project logs page, but for approved access to the datasets, rather than just viewing it.