### PR TITLE
Filter 'NoneType' object has no attribute 'days' when getting editorial stats

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2307,7 +2307,7 @@ def editorial_stats(request):
 
     for y in stats:
         y_durations = sub_ed.filter(publish_datetime__year=y)
-        days = [d.days for d in y_durations if d.days >= 0]
+        days = [d.days for d in y_durations if d is not None and d.days >= 0]
         try:
             stats[y].append(median(days))
         except StatisticsError:
@@ -2319,7 +2319,7 @@ def editorial_stats(request):
 
     for y in stats:
         y_durations = sub_pub.filter(publish_datetime__year=y)
-        days = [d.days for d in y_durations if d.days >= 0]
+        days = [d.days for d in y_durations if d is not None and d.days >= 0]
         try:
             stats[y].append(median(days))
         except StatisticsError:


### PR DESCRIPTION
The editorial_stats view computes time-based metrics for published projects (specifically "submission to editor assigned" and "submission to publication"). The problem is that some published projects have NULL values for `editor_assignment_datetime` or `submission_datetime`, resulting in an error:

```
File "/physionet/python-env/physionet/lib/python3.11/site-packages/django/core/handlers/exception.py" in inner
 55.                 response = get_response(request)

File "/physionet/python-env/physionet/lib/python3.11/site-packages/django/core/handlers/base.py" in _get_response
 197.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/physionet/python-env/physionet/lib/python3.11/site-packages/django/contrib/auth/decorators.py" in _wrapper_view
 23.                 return view_func(request, *args, **kwargs)

File "/home/physionet/physionet-build/physionet-django/console/views.py" in editorial_stats
 2310.         days = [d.days for d in y_durations if d.days >= 0]

File "/home/physionet/physionet-build/physionet-django/console/views.py" in <listcomp>
 2310.         days = [d.days for d in y_durations if d.days >= 0]

Exception Type: AttributeError at /console/usage/editorial/stats/
Exception Value: 'NoneType' object has no attribute 'days'
```

This pull request fixes the error by excluding comparisons where either side of the comparison is None.