### PR TITLE
Add OAuth endpoint for dataset access checks

### DIFF
--- a/physionet-django/oauth/tests.py
+++ b/physionet-django/oauth/tests.py
@@ -1,8 +1,6 @@
 import base64
-import random
 import hashlib
 from datetime import timedelta
-import re
 from django.test import TestCase
 from django.utils import timezone
 from user.models import User
@@ -12,6 +10,8 @@ from urllib.parse import parse_qs, urlparse
 from oauth2_provider.settings import oauth2_settings
 from django.utils.crypto import get_random_string
 from oauth.views import SCOPES_MAPPING
+from project.models import PublishedProject, AccessPolicy, CoreProject, ProjectType
+from unittest.mock import patch
 
 
 Application = get_application_model()
@@ -270,3 +270,131 @@ class TestUserInfoScopeValidation(BaseTest):
             self.assertIsInstance(result, dict, f"Scope '{scope}' did not return a dictionary")
             for field, value in result.items():
                 self.assertIsNotNone(field, f"Field name in scope '{scope}' is None")
+
+
+class TestDatasetAccessView(BaseTest):
+    """
+    Tests for GET /oauth/dataset-access/
+
+    The endpoint requires the ``credentialing:read`` scope and accepts
+    ``?slug=<slug>&version=<version>`` query parameters.  It delegates
+    access-checking to ``project.authorization.access.can_access_project``,
+    so the tests mock that function rather than reproducing the full
+    DUA / credentialing process.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.open_project = PublishedProject.objects.create(
+            slug="demoeicu",
+            version="1.0",
+            title="Demo Open Dataset",
+            access_policy=AccessPolicy.OPEN,
+            resource_type=ProjectType.objects.get(id=0),
+            submission_slug="demoeicu",
+            core_project=CoreProject.objects.create(),
+        )
+        self.credentialed_project = PublishedProject.objects.create(
+            slug="mimiciv",
+            version="3.1",
+            title="MIMIC-IV",
+            access_policy=AccessPolicy.CREDENTIALED,
+            resource_type=ProjectType.objects.get(id=0),
+            submission_slug="mimiciv",
+            core_project=CoreProject.objects.create(),
+        )
+
+        self.credentialing_token = AccessToken.objects.create(
+            user=self.test_user,
+            scope="credentialing:read",
+            expires=timezone.now() + timedelta(seconds=300),
+            token="credentialing-token-key",
+            application=self.application,
+        )
+
+    # Authentication
+    def test_no_token_returns_403(self):
+        response = self.client.get(
+            "/oauth/dataset-access/", {"slug": "demoeicu", "version": "1.0"}
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_wrong_scope_returns_403(self):
+        """A token with only profile:read must be rejected (needs credentialing:read)."""
+        auth = self._create_authorization_header(self.access_token.token)
+        response = self.client.get(
+            "/oauth/dataset-access/",
+            {"slug": "demoeicu", "version": "1.0"},
+            HTTP_AUTHORIZATION=auth,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    # Parameter validation
+    def test_missing_slug_returns_400(self):
+        auth = self._create_authorization_header(self.credentialing_token.token)
+        response = self.client.get(
+            "/oauth/dataset-access/", {"version": "1.0"}, HTTP_AUTHORIZATION=auth
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_missing_version_returns_400(self):
+        auth = self._create_authorization_header(self.credentialing_token.token)
+        response = self.client.get(
+            "/oauth/dataset-access/", {"slug": "demoeicu"}, HTTP_AUTHORIZATION=auth
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    # Project lookup
+    def test_nonexistent_project_returns_404(self):
+        auth = self._create_authorization_header(self.credentialing_token.token)
+        response = self.client.get(
+            "/oauth/dataset-access/",
+            {"slug": "does-not-exist", "version": "9.9"},
+            HTTP_AUTHORIZATION=auth,
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(response.json()["has_access"])
+
+    # Access checks — mock can_access_project
+    def test_open_project_user_has_access(self):
+        auth = self._create_authorization_header(self.credentialing_token.token)
+        with patch("oauth.views.can_access_project", return_value=True):
+            response = self.client.get(
+                "/oauth/dataset-access/",
+                {"slug": "demoeicu", "version": "1.0"},
+                HTTP_AUTHORIZATION=auth,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["has_access"])
+        self.assertEqual(data["slug"], "demoeicu")
+        self.assertEqual(data["version"], "1.0")
+
+    def test_credentialed_project_access_denied(self):
+        auth = self._create_authorization_header(self.credentialing_token.token)
+        with patch("oauth.views.can_access_project", return_value=False):
+            response = self.client.get(
+                "/oauth/dataset-access/",
+                {"slug": "mimiciv", "version": "3.1"},
+                HTTP_AUTHORIZATION=auth,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["has_access"])
+
+    def test_response_echoes_slug_and_version(self):
+        auth = self._create_authorization_header(self.credentialing_token.token)
+        with patch("oauth.views.can_access_project", return_value=True):
+            response = self.client.get(
+                "/oauth/dataset-access/",
+                {"slug": "mimiciv", "version": "3.1"},
+                HTTP_AUTHORIZATION=auth,
+            )
+
+        data = response.json()
+        self.assertEqual(data["slug"], "mimiciv")
+        self.assertEqual(data["version"], "3.1")

--- a/physionet-django/oauth/urls.py
+++ b/physionet-django/oauth/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 import oauth2_provider.views as oauth2_views
 from django.conf import settings
-from oauth.views import hello, UserInfoView
+from oauth.views import hello, UserInfoView, DatasetAccessView
 
 # OAuth2 provider endpoints
 oauth2_endpoint_views = [
@@ -60,4 +60,5 @@ urlpatterns = [
     ),
     path("hello", hello.as_view(), name="hello"),  # an example resource endpoint
     path("userinfo", UserInfoView.as_view(), name="userinfo"),
+    path("dataset-access/", DatasetAccessView.as_view(), name="oauth-dataset-access"),
 ]

--- a/physionet-django/oauth/views.py
+++ b/physionet-django/oauth/views.py
@@ -1,6 +1,8 @@
 from django.http import HttpResponse, JsonResponse
 from oauth2_provider.views.generic import ProtectedResourceView, ScopedProtectedResourceView
 from oauth2_provider.oauth2_backends import get_oauthlib_core
+from project.models import PublishedProject
+from project.authorization.access import can_access_project
 
 
 SCOPES_MAPPING = {
@@ -56,3 +58,59 @@ class UserInfoView(ScopedProtectedResourceView):
 class hello(ProtectedResourceView):
     def get(self, request, *args, **kwargs):
         return HttpResponse('Hello, OAuth2!')
+
+
+class DatasetAccessView(ScopedProtectedResourceView):
+    """
+    Returns dataset access information for a given project based on
+    the scopes associated with the provided OAuth2 token.
+
+    Requires the "credentialing:read" scope.
+
+    Accepts "slug" and "version" as query parameters and returns whether
+    the authenticated user has access to the specified version of the dataset.
+    """
+
+    required_scopes = ["credentialing:read"]
+
+    def get(self, request, *args, **kwargs):
+        valid, r = get_oauthlib_core().verify_request(
+            request, scopes=self.required_scopes
+        )
+        if not valid:
+            return JsonResponse(
+                {"error": "Invalid or missing token, or insufficient scope."},
+                status=403,
+            )
+
+        slug = request.GET.get("slug", "").strip()
+        version = request.GET.get("version", "").strip()
+
+        if not slug or not version:
+            return JsonResponse(
+                {"error": "Both 'slug' and 'version' query parameters are required."},
+                status=400,
+            )
+
+        try:
+            project = PublishedProject.objects.get(slug=slug, version=version)
+        except PublishedProject.DoesNotExist:
+            return JsonResponse(
+                {
+                    "has_access": False,
+                    "slug": slug,
+                    "version": version,
+                },
+                status=404,
+            )
+
+        user = r.access_token.user
+        has_access = can_access_project(project, user, request)
+
+        return JsonResponse(
+            {
+                "has_access": has_access,
+                "slug": slug,
+                "version": version,
+            }
+        )


### PR DESCRIPTION
This PR adds a new OAuth2-protected endpoint to allow external client applications to verify whether an authenticated PhysioNet user has access to a specific dataset version.

The main goal is to support future third-party integrations while keeping PhysioNet as the central authority for authentication, authorization, and dataset entitlement checks.

---

## Added endpoint

### `/oauth/dataset-access/`

Returns whether the authenticated user has access to a specific dataset version.

Required scope:

* `credentialing:read`

Accepted query parameters:

* `slug`
* `version`

Example request:

```http id="jlwmzb"
GET /oauth/dataset-access/?slug=demoeicu&version=1.0
Authorization: Bearer <access_token>
```

Example response:

```json id="qjkl18"
{
  "has_access": true,
  "slug": "demoeicu",
  "version": "1.0"
}
```

If the project/version does not exist, the endpoint returns:

```json id="6c7ixw"
{
  "has_access": false,
  "slug": "does-not-exist",
  "version": "9.9"
}
```

with HTTP 404.

The endpoint:
* requires a valid OAuth2 Bearer token
* validates the `credentialing:read` scope
* returns HTTP 404 with `has_access: false` when the project/version does not exist

---
## Tests


Added TestDatasetAccessView with tests covering authentication (no token, insufficient scope), parameter validation (missing slug, missing version), project lookup (nonexistent project), and access checks (granted, denied, response payload).

---

## Example client application

A minimal example client application used to test this integration end-to-end is available here:

`https://github.com/Chrystinne/test_oauth_physionet_flow.git`

The example application demonstrates:

* Authorization Code Flow with PKCE
* access token exchange
* calling `/oauth/dataset-access/`
* dataset entitlement verification
* automatic token refresh using `get_valid_token()` — renews the access token when expired, avoiding unnecessary re-logins

This repository is intended only as a lightweight testing/demo client for the OAuth integration. For detailed instructions on how to test the client app end-to-end, see the [README](https://github.com/Chrystinne/test_oauth_physionet_flow/blob/main/README.md).

> **Note for PhysioNet admins:** To test the example client application locally, register a new OAuth application at:
> `http://localhost:8000/oauth/applications/register/` and create an application with:
> - **Client type**: Confidential
> - **Authorization grant type**: Authorization code
> - **Redirect URI**: `http://localhost:8001/physionet/callback/`

Resolves #2618 