### PR TITLE
Add rejection metrics to submission statistics page

### DIFF
--- a/physionet-django/console/templates/console/submission_stats.html
+++ b/physionet-django/console/templates/console/submission_stats.html
@@ -17,6 +17,7 @@
           <th>Submitted</th>
           <th>Resubmitted</th>
           <th>Published</th>
+          <th>Rejected</th>
         </tr>
         {% for year, month_list in stats.items%}
           {% for month, val in month_list.items%}
@@ -31,6 +32,7 @@
             <td>{{ val.1 }}</td>
             <td>{{ val.2 }}</td>
             <td>{{ val.3 }}</td>
+            <td>{{ val.4 }}</td>
           </tr>
           {% endfor %}
         {% endfor %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2307,7 +2307,7 @@ def editorial_stats(request):
 
     for y in stats:
         y_durations = sub_ed.filter(publish_datetime__year=y)
-        days = [d.days for d in y_durations if d.days >= 0]
+        days = [d.days for d in y_durations if d is not None and d.days >= 0]
         try:
             stats[y].append(median(days))
         except StatisticsError:
@@ -2319,7 +2319,7 @@ def editorial_stats(request):
 
     for y in stats:
         y_durations = sub_pub.filter(publish_datetime__year=y)
-        days = [d.days for d in y_durations if d.days >= 0]
+        days = [d.days for d in y_durations if d is not None and d.days >= 0]
         try:
             stats[y].append(median(days))
         except StatisticsError:
@@ -2409,7 +2409,7 @@ def submission_stats(request):
         if cur_year not in stats:
             stats[cur_year] = OrderedDict()
         month = datetime(cur_year, cur_month, 1).strftime("%B")
-        stats[cur_year][month] = [0, 0, 0, 0]
+        stats[cur_year][month] = [0, 0, 0, 0, 0]
         cur_month -= 1
         if cur_month == 0:
             cur_month = 12
@@ -2435,6 +2435,13 @@ def submission_stats(request):
                         stats[sub_date_yr][sub_date_mo][2] += 1
                     else:
                         stats[sub_date_yr][sub_date_mo][1] += 1
+
+                # Get times when projects were rejected, if applicable
+                if log.decision == 0 and log.decision_datetime:
+                    reject_yr = log.decision_datetime.year
+                    reject_mo = log.decision_datetime.strftime("%B")
+                    if reject_yr in stats and reject_mo in stats[reject_yr]:
+                        stats[reject_yr][reject_mo][4] += 1
 
             # Get times when projects were published, if applicable
             try:


### PR DESCRIPTION
Part of #2620 

This PR adds metrics for rejected projects to the submission statistics page. 

It tracks project rejection dates based on `EditLog.decision_datetime` when `decision == 0` and aggregates the counts alongside the existing project creation, submission, resubmission, and publication metrics.

<img width="1306" height="866" alt="Screen Shot 2026-05-13 at 11 25 41 AM" src="https://github.com/user-attachments/assets/e7ba974a-751a-41aa-844f-fb7e1c4dd340" />
