### PR TITLE
Update Reference response time to display metrics in hours instead of days

### DIFF
--- a/physionet-django/console/templates/console/credentialing_stats.html
+++ b/physionet-django/console/templates/console/credentialing_stats.html
@@ -21,7 +21,7 @@
           <th>Approved (%)</th>
           <th>Decision time (days, median)</th>
           <th>Time to contact reference (days, median)</th>
-          <th>Reference response time (days, median)</th>
+          <th>Reference response time (hours, median)</th>
         </tr>
         {% for year, value in stats.items %}
           <tr>

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2367,15 +2367,15 @@ def credentialing_stats(request):
         except (AttributeError, StatisticsError):
             stats[y]['time_to_ref'] = None
 
-    # Time taken for the reference to respond
+    # Time taken for the reference to respond (in hours)
     time_to_reply = apps.annotate(tm=Cast(F('reference_response_datetime')
                                   - F('reference_contact_datetime'),
                                   DurationField())).values_list('tm', flat=True)
     for y in stats:
         durations = time_to_reply.filter(application_datetime__year=y)
         try:
-            days = [d.days for d in durations if d and d.days >= 0]
-            stats[y]['time_to_reply'] = median(days)
+            hours = [round(d.total_seconds() / 3600, 2) for d in durations if d and d.total_seconds() >= 0]
+            stats[y]['time_to_reply'] = median(hours)
         except (AttributeError, StatisticsError):
             stats[y]['time_to_reply'] = None
 


### PR DESCRIPTION
Part of #2620
Closes #2623

On Credentialing metrics, the Reference response time (days, median) column shows zero for all years (2019-2026). 

This PR replaces days with hours in the reference response time metric so we can see more meaningful information.