### PR TITLE
Add project view counts to Export data page

### DIFF
--- a/physionet-django/console/templates/console/downloads.html
+++ b/physionet-django/console/templates/console/downloads.html
@@ -30,6 +30,14 @@
       </div>
 
       <div class="mb-4">
+        <h6>Project view counts</h6>
+        <p>Download list of unique registered project views per published project.</p>
+        <a href="{% url 'download_projects_view_counts' %}" class="btn btn-primary">
+          Download projects view counts
+        </a>
+      </div>
+
+      <div class="mb-4">
         <h6>Published authors</h6>
         <p>Download a complete list of published authors, including their names, email addresses, and affiliations.</p>
         <a href="{% url 'download_published_authors' %}" class="btn btn-primary">

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -123,6 +123,7 @@ urlpatterns = [
     path('downloads/', views.downloads, name='downloads'),
     path('download/users/', views.download_users, name='download_users'),
     path('download/projects/', views.download_projects, name='download_projects'),
+    path('download/projects_view_counts/', views.download_projects_view_counts, name='download_projects_view_counts'),
     path('download/published_authors/', views.download_published_authors, name='download_published_authors'),
 
     # redirects

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2663,6 +2663,40 @@ def download_projects(request):
 
 
 @console_permission_required('user.change_credentialapplication')
+def download_projects_view_counts(request):
+    """
+    Delivers a CSV file containing unique registered project views per published project.
+    """
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename="projects_views_counts.csv"'
+
+    writer = csv.writer(response, quoting=csv.QUOTE_ALL)
+    writer.writerow(["title",
+                     "project_slug",
+                     "resource_type",
+                     "DOI (latest version)",
+                     "current_version",
+                     "count_current_version",
+                     "count_all_versions",
+                     ])
+
+    projects = PublishedProject.objects.filter(is_latest_version=True)
+
+    for project in projects:
+        project_data = [project.title,
+                        project.slug,
+                        project.resource_type.name,
+                        f"https://doi.org/{project.core_project.doi}" if project.core_project.doi else None,
+                        project.version,
+                        project.view_count(),
+                        project.view_count(all_versions=True),
+                        ]
+
+        writer.writerow(project_data)
+    return response
+
+
+@console_permission_required('user.change_credentialapplication')
 def download_published_authors(request):
     """
     Delivers a CSV file containing data on published authors.


### PR DESCRIPTION
Part of #2620

Adds a new button on the Export data page under "Project view counts" to download unique registered project view counts per published project (current version and all versions), including the following fields:

- title;
- project slug;
- resource type;
- DOI URL;
- current version;
- unique view count for current version;
- unique view count across all versions.

---
CSV exported

Example output using local demo data:

<img width="1112" height="237" alt="image" src="https://github.com/user-attachments/assets/86e89d37-3e03-4fab-a7a9-c156b6bf3e91" />



