### PR TITLE
Add yearly project counts to submission statistics

### DIFF
--- a/physionet-django/console/templates/console/submission_stats.html
+++ b/physionet-django/console/templates/console/submission_stats.html
@@ -39,7 +39,7 @@
     </div>
   </div>
   <div class="card-header">
-    New projects (past 6 years)
+    Projects (past 6 years)
   </div>
   <div class="card-body">
     <div class="table-responsive">

--- a/physionet-django/console/templates/console/submission_stats.html
+++ b/physionet-django/console/templates/console/submission_stats.html
@@ -38,5 +38,34 @@
 
     </div>
   </div>
+  <div class="card-header">
+    New projects (past 6 years)
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+
+      <table class="table table-bordered">
+        <tr>
+          <th>Year</th>
+          <th>Created</th>
+          <th>Submitted</th>
+          <th>Resubmitted</th>
+          <th>Published</th>
+          <th>Rejected</th>
+        </tr>
+        {% for year, val in yearly_stats.items %}
+          <tr>
+            <td>{{ year }}</td>
+            <td>{{ val.0 }}</td>
+            <td>{{ val.1 }}</td>
+            <td>{{ val.2 }}</td>
+            <td>{{ val.3 }}</td>
+            <td>{{ val.4 }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2445,8 +2445,42 @@ def submission_stats(request):
             except AttributeError:
                 pass
 
+    # Aggregate counts per year (last 6 years)
+    current_year = datetime.today().year
+    yearly_stats = OrderedDict()
+    for y in range(current_year - 5, current_year + 1):
+        yearly_stats[y] = [0, 0, 0, 0, 0]
+
+    for project_set in all_projects:
+        for project in project_set:
+            create_yr = project.creation_datetime.year
+            if create_yr in yearly_stats:
+                yearly_stats[create_yr][0] += 1
+
+            for log in project.edit_log_history():
+                sub_yr = log.submission_datetime.year
+                if sub_yr in yearly_stats:
+                    if log.is_resubmission:
+                        yearly_stats[sub_yr][2] += 1
+                    else:
+                        yearly_stats[sub_yr][1] += 1
+                try:
+                    if log.decision == 0 and log.decision_datetime is not None:
+                        rej_yr = log.decision_datetime.year
+                        if rej_yr in yearly_stats:
+                            yearly_stats[rej_yr][4] += 1
+                except AttributeError:
+                    pass
+
+            try:
+                pub_yr = project.publish_datetime.year
+                if pub_yr in yearly_stats:
+                    yearly_stats[pub_yr][3] += 1
+            except AttributeError:
+                pass
+
     return render(request, 'console/submission_stats.html',
-                  {'submenu': 'submission', 'stats': stats})
+                  {'submenu': 'submission', 'stats': stats, 'yearly_stats': yearly_stats})
 
 
 @console_permission_required('project.can_view_stats')


### PR DESCRIPTION

> **Note:** This PR should be merged after #2621 (Add rejection metrics to submission statistics page), as it depends on the Rejected field added there.

Part of #2620

Adds a "Projects (past 6 years)" table to the submission statistics page, showing yearly counts for Created, Submitted, Resubmitted, Published, and Rejected projects.

<img width="1376" height="768" alt="Screen Shot 2026-05-14 at 12 07 35 PM" src="https://github.com/user-attachments/assets/61b5fc6a-3319-41fa-8f6c-ff655ca4ca4a" />

