### PR TITLE
Add support for deleting project files and access points from S3

### DIFF
--- a/physionet-django/console/templates/console/manage_published_project.html
+++ b/physionet-django/console/templates/console/manage_published_project.html
@@ -447,6 +447,17 @@
                   Upload files
                 {% endif %}
               </button>
+              {% if project.aws.sent_files %}
+                <button class="btn btn-primary"
+                        name="aws-delete-project-files" value="{{ project.slug }}"
+                        {% if aws_upload_pending or rw_tasks %}
+                          disabled="disabled"
+                        {% endif %}
+                        type="submit">
+                    <span class="fa fa-trash"></span>
+                    Delete project files
+                </button>
+              {% endif %}
             </p>
           </form>
         {% endif %}

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1197,7 +1197,7 @@ def manage_published_project(request, project_slug, version):
                 messages.error(request, 'Project has tasks pending.')
             else:
                 delete_project_files_from_s3(project)
-                messages.success(request, 'The project files have been deleted from S3.')
+                messages.success(request, 'The project files are being deleted from S3')
                 # Redirect is required after deletion to avoid rendering the page with
                 # a stale AWS instance that no longer has a primary key in the database.
                 return redirect('manage_published_project', project_slug=project_slug, version=version)

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -87,6 +87,7 @@ from project.cloud.s3 import (
     get_bucket_name,
     check_s3_bucket_exists,
     has_s3_credentials,
+    delete_project_files_from_s3,
 )
 
 from django.core.management import call_command
@@ -1165,6 +1166,15 @@ def manage_published_project(request, project_slug, version):
                 messages.error(request, 'Project has tasks pending.')
             else:
                 aws_bucket_management(request, project, user)
+        elif 'aws-delete-project-files' in request.POST and has_s3_credentials():
+            if any(get_associated_tasks(project, read_only=False)):
+                messages.error(request, 'Project has tasks pending.')
+            else:
+                delete_project_files_from_s3(project)
+                messages.success(request, 'The project files have been deleted from S3.')
+                # Redirect is required after deletion to avoid rendering the page with
+                # a stale AWS instance that no longer has a primary key in the database.
+                return redirect('manage_published_project', project_slug=project_slug, version=version)
         elif 'platform' in request.POST:
             data_access_form = forms.DataAccessForm(project=project, data=request.POST)
             if data_access_form.is_valid():

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -88,6 +88,7 @@ from project.cloud.s3 import (
     check_s3_bucket_exists,
     has_s3_credentials,
     delete_project_files_from_s3,
+    create_s3_resource,
 )
 
 from django.core.management import call_command
@@ -1027,6 +1028,31 @@ def send_files_to_aws(pid):
     if project.compressed_storage_size:
         project.aws.sent_zip = True
     project.aws.save()
+
+
+@associated_task(PublishedProject, 'pid')
+@background()
+def delete_project_files_task(pid):
+    """
+    Background task to delete project files from S3.
+    Called after access has already been revoked synchronously.
+    """
+    project = PublishedProject.objects.get(id=pid)
+
+    s3 = create_s3_resource()
+    bucket_name = get_bucket_name(project)
+    prefix = f"{project.slug}/{project.version}/"
+    bucket = s3.Bucket(bucket_name)
+    bucket.objects.filter(Prefix=prefix).delete()
+
+    # Delete zip file if it was uploaded
+    if project.aws.sent_zip:
+        zip_key = os.path.join(f"{project.slug}/", project.zip_name(legacy=False))
+        bucket.Object(zip_key).delete()
+
+    # Delete the AWS record from the database
+    project.aws.sent_zip = False
+    project.aws.delete()
 
 
 @console_permission_required('project.change_publishedproject')

--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -10,7 +10,6 @@ import botocore
 from botocore.exceptions import ClientError
 from django.conf import settings
 from django.db.models import Q
-
 from project.authorization.access import can_view_project_files
 from project.models import PublishedProject, AWS, AccessPolicy, AWSAccessPoint, AWSAccessPointUser
 from user.models import (
@@ -1573,48 +1572,32 @@ def create_s3_server_access_log_bucket():
 
 
 def delete_project_files_from_s3(project):
+    # Import here to avoid circular import
+    from console.views import delete_project_files_task
     """
-    Delete all files under the project's prefix from its S3 bucket.
-
-    Args:
-        project (PublishedProject): The project whose files will be deleted.
+    Immediately revoke access by deleting access points,
+    set project.aws.sent_files = False, then schedule
+    file deletion as a background task.
     """
     if not check_s3_bucket_exists(project):
         return
-    s3 = create_s3_resource()
-    bucket_name = get_bucket_name(project)
-    prefix = f"{project.slug}/{project.version}/"
-    bucket = s3.Bucket(bucket_name)
-    bucket.objects.filter(Prefix=prefix).delete()
 
-    # Delete zip file if it was uploaded
-    if project.aws.sent_zip:
-        zip_key = os.path.join(f"{project.slug}/", project.zip_name(legacy=False))
-        bucket.Object(zip_key).delete()
-
+    # Delete access points first to immediately revoke access
     if project.aws.is_private:
-        delete_project_access_points(project)
-    else:
-        project.aws.delete()
+        s3control = create_s3_control_client()
+        for ap in project.aws.access_points.all():
+            s3control.delete_access_point(
+                AccountId=settings.AWS_ACCOUNT_ID,
+                Name=ap.name
+            )
+        project.aws.access_points.all().delete()
 
+    # Mark sent_files flag to False before deletion starts
+    project.aws.sent_files = False
+    project.aws.save()
 
-def delete_project_access_points(project):
-    """
-    Delete all S3 access points associated with a project and remove
-    the corresponding AWS records from the database.
-
-    Args:
-        project (PublishedProject): The project whose access points
-        will be deleted.
-    """
-    s3control = create_s3_control_client()
-
-    for ap in project.aws.access_points.all():
-        s3control.delete_access_point(
-            AccountId=settings.AWS_ACCOUNT_ID,
-            Name=ap.name
-        )
-
-    # Deletes AWS, AWSAccessPoint, and AWSAccessPointUser
-    # from our database as well via CASCADE
-    project.aws.delete()
+    # Schedule file deletion as a background task
+    delete_project_files_task(
+        project.id,
+        verbose_name='Delete S3 files - {}'.format(project)
+    )

--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -1572,13 +1572,13 @@ def create_s3_server_access_log_bucket():
 
 
 def delete_project_files_from_s3(project):
-    # Import here to avoid circular import
-    from console.views import delete_project_files_task
     """
     Immediately revoke access by deleting access points,
     set project.aws.sent_files = False, then schedule
     file deletion as a background task.
     """
+    # Import here to avoid circular import
+    from console.views import delete_project_files_task
     if not check_s3_bucket_exists(project):
         return
 

--- a/physionet-django/project/cloud/s3.py
+++ b/physionet-django/project/cloud/s3.py
@@ -1570,3 +1570,51 @@ def create_s3_server_access_log_bucket():
             }
         ),
     )
+
+
+def delete_project_files_from_s3(project):
+    """
+    Delete all files under the project's prefix from its S3 bucket.
+
+    Args:
+        project (PublishedProject): The project whose files will be deleted.
+    """
+    if not check_s3_bucket_exists(project):
+        return
+    s3 = create_s3_resource()
+    bucket_name = get_bucket_name(project)
+    prefix = f"{project.slug}/{project.version}/"
+    bucket = s3.Bucket(bucket_name)
+    bucket.objects.filter(Prefix=prefix).delete()
+
+    # Delete zip file if it was uploaded
+    if project.aws.sent_zip:
+        zip_key = os.path.join(f"{project.slug}/", project.zip_name(legacy=False))
+        bucket.Object(zip_key).delete()
+
+    if project.aws.is_private:
+        delete_project_access_points(project)
+    else:
+        project.aws.delete()
+
+
+def delete_project_access_points(project):
+    """
+    Delete all S3 access points associated with a project and remove
+    the corresponding AWS records from the database.
+
+    Args:
+        project (PublishedProject): The project whose access points
+        will be deleted.
+    """
+    s3control = create_s3_control_client()
+
+    for ap in project.aws.access_points.all():
+        s3control.delete_access_point(
+            AccountId=settings.AWS_ACCOUNT_ID,
+            Name=ap.name
+        )
+
+    # Deletes AWS, AWSAccessPoint, and AWSAccessPointUser
+    # from our database as well via CASCADE
+    project.aws.delete()


### PR DESCRIPTION
Part of #2348

This PR adds support for deleting project files from AWS S3 through the console. It includes deletion of the zip file and, for private projects, the associated access points.

A "Delete files" button has been added to the AWS cloud management section of the manage published project page, visible only when `sent_files` is `True`.

For public projects, the function removes all files and the zip file from S3 and deletes the AWS record from the database. For private projects, it also deletes all associated access points from S3 and removes the AWS, AWSAccessPoint, and AWSAccessPointUser records via cascade.

>Note: Despite the branch name, this PR covers both public and private projects.

>Note: the "Delete project files" button has been renamed to "Delete files" in #2628 for consistency with the other buttons.