### PR TITLE
Add Scholar Data metrics to published project metrics page ref #2577

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -291,3 +291,7 @@ CREATE_PROJECT_WARNING=
 # Path to the directory containing GeoIP2 database files (GeoLite2-Country.mmdb, etc.)
 # Example: GEOIP_PATH=/usr/share/GeoIP (optional)
 GEOIP_PATH=
+
+# ScholarData API for external dataset metrics (citations, FUJI score, d-index)
+ENABLE_SCHOLAR_DATA_API=False
+SCHOLAR_DATA_API_URL=https://scholardata.io/api/v1

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -833,6 +833,10 @@ OAUTH2_PROVIDER = {
     }
 }
 
+# ScholarData API for external dataset metrics
+ENABLE_SCHOLAR_DATA_API = config('ENABLE_SCHOLAR_DATA_API', default=False, cast=bool)
+SCHOLAR_DATA_API_URL = config('SCHOLAR_DATA_API_URL', default='https://scholardata.io/api/v1')
+
 # Path to GeoIP2 database directory
 GEOIP_PATH = config('GEOIP_PATH', default=None)
 

--- a/physionet-django/project/templates/project/published_project_metrics.html
+++ b/physionet-django/project/templates/project/published_project_metrics.html
@@ -33,6 +33,55 @@ Metrics for {{ project }}
     </div>
   </div>
 
+  {% if scholar_data %}
+  <h3>Scholar Data Metrics</h3>
+  <div class="alert alert-info">
+    <small>
+      These metrics are provided by <a href="https://scholardata.io" target="_blank" rel="noopener">Scholar Data</a>
+      as part of the <a href="https://www.challenge.gov/challenge/s-index/" target="_blank" rel="noopener">NIH S-Index Challenge</a>.
+      They are experimental and currently being evaluated for potential integration.
+    </small>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <div class="card text-center mb-4">
+        <h5 class="card-header">Citations</h5>
+        <div class="card-body">
+          <h3 class="mb-0">{{ scholar_data.totalCitations }}</h3>
+          <small class="text-muted">Total scholarly citations</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card text-center mb-4">
+        <h5 class="card-header">Mentions</h5>
+        <div class="card-body">
+          <h3 class="mb-0">{{ scholar_data.totalMentions }}</h3>
+          <small class="text-muted">Non-academic references</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card text-center mb-4">
+        <h5 class="card-header">FUJI Score</h5>
+        <div class="card-body">
+          <h3 class="mb-0">{{ scholar_data.fujiScore.score|floatformat:1 }}</h3>
+          <small class="text-muted">FAIR assessment (v{{ scholar_data.fujiScore.metricVersion }})</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card text-center mb-4">
+        <h5 class="card-header">D-Index</h5>
+        <div class="card-body">
+          <h3 class="mb-0">{{ scholar_data.latestDIndex.score|floatformat:1 }}</h3>
+          <small class="text-muted">Dataset impact index ({{ scholar_data.latestDIndex.year }})</small>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   {% if views_by_version|length > 1 %}
   <h3>Views by Version</h3>
   <div class="table-responsive mb-4">

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -6,9 +6,11 @@ from http import HTTPStatus
 import json
 from unittest import mock
 
+import requests
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
+from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -2019,3 +2021,131 @@ class TestProjectViewsMetric(TestMixin):
         self.assertGreater(len(page), 0)
         self.assertLessEqual(len(page), 12)
         self.assertFalse(page.has_next())
+
+
+class TestScholarDataIntegration(TestMixin):
+    """Test the ScholarData API integration on the metrics page."""
+
+    SCHOLAR_DATA_RESPONSE = {
+        'datasetId': 12463514,
+        'totalCitations': 42,
+        'totalMentions': 0,
+        'fujiScore': {
+            'score': 85,
+            'evaluationDate': '2026-01-02T00:25:27.000Z',
+            'metricVersion': '0.8',
+            'softwareVersion': '3.5.1',
+        },
+        'latestDIndex': {
+            'score': 7,
+            'year': 2025,
+        },
+    }
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.project = PublishedProject.objects.get(title='Demo ECG Signal Toolbox')
+        self.metrics_url = reverse(
+            'published_project_metrics',
+            args=(self.project.slug, self.project.version),
+        )
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=False)
+    def test_api_not_called_when_disabled(self):
+        """ScholarData API is not called when ENABLE_SCHOLAR_DATA_API is False."""
+        with mock.patch('project.views.requests.get') as mock_get:
+            response = self.client.get(self.metrics_url)
+        mock_get.assert_not_called()
+        self.assertIsNone(response.context['scholar_data'])
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=True)
+    def test_api_called_when_enabled_with_doi(self):
+        """ScholarData API is called when enabled and project has a DOI."""
+        self.project.doi = '10.1234/test'
+        self.project.save()
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = self.SCHOLAR_DATA_RESPONSE
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch('project.views.requests.get', return_value=mock_response) as mock_get:
+            response = self.client.get(self.metrics_url)
+
+        mock_get.assert_called_once()
+        self.assertEqual(response.context['scholar_data'], self.SCHOLAR_DATA_RESPONSE)
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=True)
+    def test_api_not_called_without_doi(self):
+        """ScholarData API is not called when project has no DOI."""
+        self.project.doi = ''
+        self.project.save()
+
+        with mock.patch('project.views.requests.get') as mock_get:
+            response = self.client.get(self.metrics_url)
+
+        mock_get.assert_not_called()
+        self.assertIsNone(response.context['scholar_data'])
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=True)
+    def test_graceful_degradation_on_api_error(self):
+        """Metrics page renders normally when ScholarData API returns an error."""
+        self.project.doi = '10.1234/test'
+        self.project.save()
+
+        with mock.patch('project.views.requests.get', side_effect=requests.ConnectionError):
+            response = self.client.get(self.metrics_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['scholar_data'])
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=True)
+    def test_graceful_degradation_on_timeout(self):
+        """Metrics page renders normally when ScholarData API times out."""
+        self.project.doi = '10.1234/test'
+        self.project.save()
+
+        with mock.patch('project.views.requests.get', side_effect=requests.Timeout):
+            response = self.client.get(self.metrics_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['scholar_data'])
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=True)
+    def test_scholar_data_in_template(self):
+        """Scholar data values appear in the rendered template."""
+        self.project.doi = '10.1234/test'
+        self.project.save()
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = self.SCHOLAR_DATA_RESPONSE
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch('project.views.requests.get', return_value=mock_response):
+            response = self.client.get(self.metrics_url)
+
+        self.assertContains(response, 'Total scholarly citations')
+        self.assertContains(response, '42')
+        self.assertContains(response, 'FUJI Score')
+        self.assertContains(response, '85')
+        self.assertContains(response, 'D-Index')
+        self.assertContains(response, '7')
+
+    @override_settings(ENABLE_SCHOLAR_DATA_API=True)
+    def test_caching(self):
+        """Second request uses cached data instead of calling the API again."""
+        self.project.doi = '10.1234/test'
+        self.project.save()
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = self.SCHOLAR_DATA_RESPONSE
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch('project.views.requests.get', return_value=mock_response) as mock_get:
+            self.client.get(self.metrics_url)
+            self.client.get(self.metrics_url)
+
+        mock_get.assert_called_once()

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2,6 +2,7 @@ import datetime as dt
 import logging
 import os
 
+import requests
 import notification.utility as notification
 from dal import autocomplete
 from django.conf import settings
@@ -11,6 +12,7 @@ from django.contrib.auth.views import redirect_to_login
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import Q
@@ -2100,6 +2102,30 @@ def published_project(request, project_slug, version, subdir=''):
                   status=status)
 
 
+def fetch_scholar_data(doi):
+    """
+    Fetch external dataset statistics from the ScholarData API.
+
+    Returns the parsed JSON dict on success, or None on any failure.
+    Results are cached for 24 hours, keyed by DOI.
+    """
+    cache_key = f'scholar_data:{doi}'
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        url = f'{settings.SCHOLAR_DATA_API_URL}/datasets/by-doi'
+        response = requests.get(url, params={'doi': doi}, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except Exception:
+        return None
+
+    cache.set(cache_key, data, 86400)
+    return data
+
+
 def published_project_metrics(request, project_slug, version):
     """
     Public metrics page for a published project.
@@ -2112,6 +2138,10 @@ def published_project_metrics(request, project_slug, version):
     views_over_time.reverse()
     views_over_time = paginate(request, views_over_time, 12)
 
+    scholar_data = None
+    if settings.ENABLE_SCHOLAR_DATA_API and project.doi:
+        scholar_data = fetch_scholar_data(project.doi)
+
     return render(request, 'project/published_project_metrics.html', {
         'project': project,
         'project_views_count': project.view_count(),
@@ -2119,6 +2149,7 @@ def published_project_metrics(request, project_slug, version):
         'views_over_time': views_over_time,
         'views_by_version': project.views_by_version(),
         'tracking_start_date': tracking_start_date,
+        'scholar_data': scholar_data,
     })
 
 


### PR DESCRIPTION
Summary

- Integrate the https://scholardata.io API to display external dataset metrics (citations, mentions, FUJI score, D-Index) on the published project metrics page
- The feature requires the `ENABLE_SCHOLAR_DATA_API` setting to be enabled in .env
- API responses are cached for 24 hours
- The metrics section is simply hidden in the case of a failed API call

Changes

- `.env.example` / `settings/base.py` — Add `ENABLE_SCHOLAR_DATA_API` and `SCHOLAR_DATA_API_URL` configuration
- `project/views.py` — Add `fetch_scholar_data()` helper and pass scholar_data context to the metrics template
- `published_project_metrics.html` — Render a new "Scholar Data Metrics" card row when data is available
- `project/test_views.py` — Add tests covering enabled/disabled toggle, DOI presence, error handling, template rendering, and caching

Not pretty, but this is how it looks:

<img width="1344" height="302" alt="Screenshot 2026-05-20 at 10 54 45 PM" src="https://github.com/user-attachments/assets/f62e8da4-e54d-4926-853d-371670f884da" />

Test plan

- Verify metrics page renders without errors when ENABLE_SCHOLAR_DATA_API=False (default)
- Verify metrics page renders Scholar Data cards when enabled and project has a DOI
- Verify graceful degradation when the Scholar Data API is unreachable or returns errors
- Run `python manage.py test project.test_views.TestScholarDataIntegration`

