### PR TITLE
Fix purgeaccounts crash on accounts with no Profile

### DIFF
--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -3,17 +3,9 @@ import logging
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from user.models import User, AssociatedEmail, Profile
+from user.models import User, AssociatedEmail
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _display_name(user):
-    # Accounts created without a Profile must stay purgeable, not crash the run.
-    try:
-        return user.get_full_name()
-    except Profile.DoesNotExist:
-        return '(no profile)'
 
 
 class Command(BaseCommand):
@@ -30,7 +22,7 @@ class Command(BaseCommand):
         for user in user_list:
             deleted.append("\n - Username: {0}\n   Email: {1}\n   Full Name: "
                            "{2}".format(user.username, user.email,
-                                        _display_name(user)))
+                                        user.get_full_name(ignore_missing_profile=True)))
             user.delete()
 
         if deleted:
@@ -46,7 +38,7 @@ class Command(BaseCommand):
         for associated_email in associated_email_list:
             deleted.append("\n - Email: {0}\n   Belonged to: {1}\n   Username:"
                            " {2}".format(associated_email.email,
-                                         _display_name(associated_email.user),
+                                         associated_email.user.get_full_name(ignore_missing_profile=True),
                                          associated_email.user.username))
             associated_email.delete()
 

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -3,9 +3,17 @@ import logging
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from user.models import User, AssociatedEmail
+from user.models import User, AssociatedEmail, Profile
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _display_name(user):
+    # Accounts created without a Profile must stay purgeable, not crash the run.
+    try:
+        return user.get_full_name()
+    except Profile.DoesNotExist:
+        return '(no profile)'
 
 
 class Command(BaseCommand):
@@ -22,7 +30,7 @@ class Command(BaseCommand):
         for user in user_list:
             deleted.append("\n - Username: {0}\n   Email: {1}\n   Full Name: "
                            "{2}".format(user.username, user.email,
-                                        user.get_full_name()))
+                                        _display_name(user)))
             user.delete()
 
         if deleted:
@@ -38,7 +46,7 @@ class Command(BaseCommand):
         for associated_email in associated_email_list:
             deleted.append("\n - Email: {0}\n   Belonged to: {1}\n   Username:"
                            " {2}".format(associated_email.email,
-                                         associated_email.user.get_full_name(),
+                                         _display_name(associated_email.user),
                                          associated_email.user.username))
             associated_email.delete()
 

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -389,8 +389,13 @@ class User(AbstractBaseUser, PermissionsMixin):
         ]
 
     # Mandatory methods for default authentication backend
-    def get_full_name(self):
-        return self.profile.get_full_name()
+    def get_full_name(self, ignore_missing_profile=False):
+        try:
+            return self.profile.get_full_name()
+        except Profile.DoesNotExist:
+            if ignore_missing_profile:
+                return ''
+            raise
 
     def get_short_name(self):
         return self.profile.first_names

--- a/physionet-django/user/test_views.py
+++ b/physionet-django/user/test_views.py
@@ -537,6 +537,21 @@ class TestPublic(TestMixin):
         self.assertEqual(num_active_accounts,
                          User.objects.filter(is_active=True).count())
 
+    def test_purgeaccounts_missing_profile(self):
+        """Unactivated accounts with no Profile are still purged."""
+        orphan = User.objects.create(username='orphan', email='orphan@mit.edu')
+        normal = User.objects.create(username='normal', email='normal@mit.edu')
+        Profile.objects.create(user=normal, first_names='Normal', last_name='User')
+
+        for user in (orphan, normal):
+            user.join_date += datetime.timedelta(days=-30)
+            user.save()
+
+        call_command('purgeaccounts')
+
+        self.assertFalse(User.objects.filter(id=orphan.id).exists())
+        self.assertFalse(User.objects.filter(id=normal.id).exists())
+
 
 class TrainingTestCase(TestCase):
     @classmethod


### PR DESCRIPTION
purgeaccounts builds its log line via User.get_full_name(), which delegates to self.profile.get_full_name(). Accounts created by UserManager.create_user save the User and the Profile in two separate, non-atomic steps, so an interrupted registration can leave an inactive User with no Profile row. When the command reaches such an account, accessing user.profile raises Profile.DoesNotExist, which propagates out of handle() and aborts the entire run -- so no stale accounts get purged and the orphan is never deleted, causing the hourly CronJob to crash on the same account every run.

Guard the display-name lookup with a _display_name() helper that falls back to "(no profile)" when the Profile is missing, in both the user and associated-email loops. Orphaned accounts are now purged instead of blocking the run. Add a regression test covering a profile-less account.

This is a recurring failure since HDN's Production Database has users without profiles.

Follow-up (not in this change): make UserManager.create_user atomic so profile-less users are never created in the first place.