### PR TITLE
Send reviewer comments, when entered, for Identity and Training check approvals

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -2115,6 +2115,11 @@ def training_process(request, pk):
             if questions_formset.is_valid():
                 questions_formset.save()
 
+                training_review_form = forms.TrainingReviewForm(data=request.POST)
+                if training_review_form.is_valid():
+                    training.reviewer_comments = training_review_form.cleaned_data['reviewer_comments']
+                    training.save(update_fields=['reviewer_comments'])
+
                 training.accept(reviewer=request.user)
 
                 messages.success(request, 'The training was approved.')
@@ -2136,6 +2141,11 @@ def training_process(request, pk):
 
             if questions_formset.is_valid():
                 questions_formset.save()
+
+                training_review_form = forms.TrainingReviewForm(data=request.POST)
+                if training_review_form.is_valid():
+                    training.reviewer_comments = training_review_form.cleaned_data['reviewer_comments']
+                    training.save(update_fields=['reviewer_comments'])
 
                 training.accept(reviewer=request.user)
 

--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -22,8 +22,13 @@ Dear {{ applicant_name }},
 If you are able to address the issue(s), please open a new credentialing application at {{ url_prefix }}{% url 'credential_application' %}.
 
 {% elif application.status == CredentialApplication.Status.ACCEPTED %}Thank you for your interest in the {{ SITE_NAME }} Clinical Databases. We are pleased to say that your application for credentialed access has been approved.
+{% if include_comments and application.responder_comments %}
 
+We also wanted to share these comments from the reviewer:
+{{ application.responder_comments }}
+{% endif %}
 {% if example_project %}
+
 You are now able to access protected databases upon agreeing to the terms of usage and completing any required training. For example, you can access {{ example_project.title }} by following the steps below:
 
 - Go to the project page at {{ url_prefix }}{% url 'published_project_latest' example_project.slug %}

--- a/physionet-django/notification/templates/notification/email/process_training_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_training_complete.html
@@ -15,6 +15,11 @@ Dear {{ applicant_name }},
 If you are able to address the issue(s), please resubmit your training at: {{ url_prefix }}{% url 'edit_training' %}.
 
 {% elif training.status.name == "ACCEPTED" %}We are pleased to say that your "{{ training.training_type.name }}" training was approved.
+{% if include_comments and training.reviewer_comments %}
+
+We also wanted to share these comments from the reviewer:
+{{ training.reviewer_comments }}
+{% endif %}
 {% if training.user.is_credentialed and example_project %}
 You are now able to access protected databases upon agreeing to the terms of usage. For example, you can access {{ example_project.title }} by following the steps below:
 


### PR DESCRIPTION
As discussed here: https://github.com/MIT-LCP/physionet-build/issues/2267 , when a reviewer enters comments into the Reviewer comments box in the Identity check or Training check forms, the comments do not get sent when an "approval" button is clicked. 

At times, it is desirable to be able to send comments along with an approval. For example, to remind users of our LLM policy if they indicate that they will be using an LLM. 

This PR fixes this issue by including the reviewer comments in a new second paragraph in the sent email:

> We also wanted to share these comments from the reviewer: <reviewer comments>

If the reviewer comments box is empty the new second paragraph is not included. I have tested that this is working for all "approval" cases and that it does not add the new paragraph when the Reviewer comments box is empty.