### PR TITLE
Add country to project author affiliations

### DIFF
--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -62,7 +62,7 @@ class TestState(TestMixin):
             user=editor,
             display_order=project.authors.count() + 1,
         )
-        temp_author.affiliations.create(name='MIT')
+        temp_author.affiliations.create(name='MIT', country='US')
 
         # Submit project
         self.assertTrue(project.is_submittable())
@@ -107,7 +107,7 @@ class TestState(TestMixin):
             user=editor2,
             display_order=project.authors.count() + 1,
         )
-        temp_author.affiliations.create(name='MIT')
+        temp_author.affiliations.create(name='MIT', country='US')
 
         # Submit project
         self.assertTrue(project.is_submittable())
@@ -322,6 +322,8 @@ class TestState(TestMixin):
         Author approves publication
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        for author in project.authors.all():
+            author.affiliations.filter(country='').update(country='US')
 
         def get_project():
             return ActiveProject.objects.get(id=project.id)
@@ -461,6 +463,10 @@ class TestState(TestMixin):
         project = PublishedProject.objects.get(slug=custom_slug,
                                                version=project.version)
         self.assertEqual(project.submission_slug, project_slug)
+        published_affiliation = project.authors.get(
+            user__username='rgmark'
+        ).affiliations.first()
+        self.assertEqual(published_affiliation.country, 'US')
         # Access the published project's page and its (open) files
         response = self.client.get(reverse('published_project',
             args=(project.slug, project.version)))

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -10,7 +10,6 @@ import pdb
 import requests_mock
 from django.contrib.sites.models import Site
 from django.core import mail
-from django.db.models import Q
 from django.test import TestCase
 from django.test.utils import get_runner
 from django.urls import reverse
@@ -36,13 +35,6 @@ from user.test_views import TestMixin, prevent_request_warnings
 LOGGER = logging.getLogger(__name__)
 
 
-def _fill_missing_affiliation_countries(project, country='US'):
-    for author in project.authors.all():
-        author.affiliations.filter(
-            Q(country='') | Q(country__isnull=True)
-        ).update(country=country)
-
-
 class TestState(TestMixin):
     """
     Test that all objects are in their intended states, during and
@@ -63,7 +55,6 @@ class TestState(TestMixin):
         Assign an editor
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        _fill_missing_affiliation_countries(project)
         editor = User.objects.get(username='amitupreti')
 
         # Add editor as a project author
@@ -107,7 +98,6 @@ class TestState(TestMixin):
         Assign an editor, then reassign it
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        _fill_missing_affiliation_countries(project)
         editor1 = User.objects.get(username='cindyehlert')
         editor2 = User.objects.get(username='amitupreti')
 
@@ -166,7 +156,6 @@ class TestState(TestMixin):
         Edit a project, rejecting it.
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
@@ -190,7 +179,6 @@ class TestState(TestMixin):
         Edit a project. Request resubmission, then accept.
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
@@ -244,7 +232,6 @@ class TestState(TestMixin):
         Copyedit a project
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
@@ -335,7 +322,6 @@ class TestState(TestMixin):
         Author approves publication
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        _fill_missing_affiliation_countries(project)
 
         def get_project():
             return ActiveProject.objects.get(id=project.id)
@@ -1287,7 +1273,6 @@ class TestOnHold(TestMixin):
     def _submit_and_assign(self, editor_username=None):
         """Submit the project and optionally assign an editor."""
         project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
-        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         if editor_username:
             editor = User.objects.get(username=editor_username)
@@ -1614,7 +1599,6 @@ class TestExternalReview(TestMixin):
     def _submit_and_assign(self):
         """Submit the project and assign an editor."""
         project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
-        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username=self.EDITOR_USER)
         self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -35,6 +35,11 @@ from user.test_views import TestMixin, prevent_request_warnings
 LOGGER = logging.getLogger(__name__)
 
 
+def _fill_missing_affiliation_countries(project, country='US'):
+    for author in project.authors.all():
+        author.affiliations.filter(country='').update(country=country)
+
+
 class TestState(TestMixin):
     """
     Test that all objects are in their intended states, during and
@@ -55,6 +60,7 @@ class TestState(TestMixin):
         Assign an editor
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        _fill_missing_affiliation_countries(project)
         editor = User.objects.get(username='amitupreti')
 
         # Add editor as a project author
@@ -98,6 +104,7 @@ class TestState(TestMixin):
         Assign an editor, then reassign it
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        _fill_missing_affiliation_countries(project)
         editor1 = User.objects.get(username='cindyehlert')
         editor2 = User.objects.get(username='amitupreti')
 
@@ -156,6 +163,7 @@ class TestState(TestMixin):
         Edit a project, rejecting it.
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
@@ -179,6 +187,7 @@ class TestState(TestMixin):
         Edit a project. Request resubmission, then accept.
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
@@ -232,6 +241,7 @@ class TestState(TestMixin):
         Copyedit a project
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
+        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username='admin')
         project.assign_editor(editor)
@@ -322,8 +332,7 @@ class TestState(TestMixin):
         Author approves publication
         """
         project = ActiveProject.objects.get(title='MIT-BIH Arrhythmia Database')
-        for author in project.authors.all():
-            author.affiliations.filter(country='').update(country='US')
+        _fill_missing_affiliation_countries(project)
 
         def get_project():
             return ActiveProject.objects.get(id=project.id)
@@ -1275,6 +1284,7 @@ class TestOnHold(TestMixin):
     def _submit_and_assign(self, editor_username=None):
         """Submit the project and optionally assign an editor."""
         project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
+        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         if editor_username:
             editor = User.objects.get(username=editor_username)
@@ -1601,6 +1611,7 @@ class TestExternalReview(TestMixin):
     def _submit_and_assign(self):
         """Submit the project and assign an editor."""
         project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
+        _fill_missing_affiliation_countries(project)
         project.submit(author_comments='')
         editor = User.objects.get(username=self.EDITOR_USER)
         self.client.login(username=self.ADMIN_USER, password=self.ADMIN_PASSWORD)

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -10,6 +10,7 @@ import pdb
 import requests_mock
 from django.contrib.sites.models import Site
 from django.core import mail
+from django.db.models import Q
 from django.test import TestCase
 from django.test.utils import get_runner
 from django.urls import reverse
@@ -37,7 +38,9 @@ LOGGER = logging.getLogger(__name__)
 
 def _fill_missing_affiliation_countries(project, country='US'):
     for author in project.authors.all():
-        author.affiliations.filter(country='').update(country=country)
+        author.affiliations.filter(
+            Q(country='') | Q(country__isnull=True)
+        ).update(country=country)
 
 
 class TestState(TestMixin):

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -4,6 +4,7 @@
   "pk": 1,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 1
   }
 },
@@ -12,6 +13,7 @@
   "pk": 2,
   "fields": {
     "name": "Harvard University",
+    "country": "US",
     "author": 1
   }
 },
@@ -20,6 +22,7 @@
   "pk": 3,
   "fields": {
     "name": "Beth Israel Deaconess Medical Center",
+    "country": "US",
     "author": 1
   }
 },
@@ -28,6 +31,7 @@
   "pk": 4,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 2
   }
 },
@@ -36,6 +40,7 @@
   "pk": 5,
   "fields": {
     "name": "Harvard University",
+    "country": "US",
     "author": 2
   }
 },
@@ -44,6 +49,7 @@
   "pk": 6,
   "fields": {
     "name": "Beth Israel Deaconess Medical Center",
+    "country": "US",
     "author": 2
   }
 },
@@ -52,6 +58,7 @@
   "pk": 7,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 5
   }
 },
@@ -60,6 +67,7 @@
   "pk": 8,
   "fields": {
     "name": "Harvard University",
+    "country": "US",
     "author": 5
   }
 },
@@ -68,6 +76,7 @@
   "pk": 9,
   "fields": {
     "name": "Beth Israel Deaconess Medical Center",
+    "country": "US",
     "author": 5
   }
 },
@@ -76,6 +85,7 @@
   "pk": 11,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 4
   }
 },
@@ -84,6 +94,7 @@
   "pk": 16,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 6
   }
 },
@@ -92,6 +103,7 @@
   "pk": 17,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 11
   }
 },
@@ -100,6 +112,7 @@
   "pk": 18,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 12
   }
 },
@@ -108,6 +121,7 @@
   "pk": 19,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 13
   }
 },
@@ -116,6 +130,7 @@
   "pk": 1,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 1
   }
 },
@@ -124,6 +139,7 @@
   "pk": 2,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 2
   }
 },
@@ -132,6 +148,7 @@
   "pk": 3,
   "fields": {
     "name": "Massachusetts Institute of Technology",
+    "country": "US",
     "author": 3
   }
 },
@@ -140,6 +157,7 @@
   "pk": 4,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 5
   }
 },
@@ -148,6 +166,7 @@
   "pk": 5,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 6
   }
 },
@@ -156,6 +175,7 @@
   "pk": 6,
   "fields": {
     "name": "MIT",
+    "country": "US",
     "author": 7
   }
 },

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -41,7 +41,7 @@ from project.models import (
     exists_project_slug,
     UploadedDocument,
 )
-from user.models import User, TrainingType
+from user.models import COUNTRIES, User, TrainingType
 from user.validators import validate_affiliation
 from django.forms import ModelMultipleChoiceField
 
@@ -491,8 +491,11 @@ class NewProjectVersionForm(forms.ModelForm):
                 corresponding_email=corresponding_email)
 
             for p_affiliation in p_author.affiliations.all():
-                Affiliation.objects.create(name=p_affiliation.name,
-                    author=author)
+                Affiliation.objects.create(
+                    name=p_affiliation.name,
+                    country=p_affiliation.country,
+                    author=author,
+                )
 
         # Other related objects
         for p_reference in self.latest_project.references.order_by('order'):
@@ -673,6 +676,21 @@ class DiscoveryForm(forms.ModelForm):
         return result
 
 
+COUNTRY_CHOICES_WITH_BLANK = (('', '---------'),) + COUNTRIES
+
+
+class AffiliationForm(forms.ModelForm):
+    country = forms.ChoiceField(
+        choices=COUNTRY_CHOICES_WITH_BLANK,
+        label='Country',
+        required=True,
+    )
+
+    class Meta:
+        model = Affiliation
+        fields = ('name', 'country')
+
+
 class AffiliationFormSet(forms.BaseInlineFormSet):
     """
     Formset for adding an author's affiliations
@@ -684,7 +702,10 @@ class AffiliationFormSet(forms.BaseInlineFormSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.max_forms = AffiliationFormSet.max_forms
-        self.help_text = 'Institutions you are affiliated with. Maximum of {}.'.format(self.max_forms)
+        self.help_text = (
+            'Institutions you are affiliated with and the country for each '
+            'affiliation. Maximum of {}.'
+        ).format(self.max_forms)
 
     def clean(self):
         """
@@ -1068,6 +1089,11 @@ class InvitationResponseForm(forms.ModelForm):
                                   label=('Your affiliation (displayed '
                                          'when the project is published)'),
                                   required=False)
+    affiliation_country = forms.ChoiceField(
+        choices=COUNTRY_CHOICES_WITH_BLANK,
+        label='Affiliation country',
+        required=False,
+    )
 
     def clean(self):
         """
@@ -1092,8 +1118,13 @@ class InvitationResponseForm(forms.ModelForm):
                 raise forms.ValidationError(
                     'You must specify your affiliation.'
                 )
+            if not cleaned_data.get('affiliation_country'):
+                raise forms.ValidationError(
+                    'You must specify your affiliation country.'
+                )
 
         return cleaned_data
+
 
 class AnonymousAccessLoginForm(forms.ModelForm):
     """

--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -689,6 +689,7 @@ class AffiliationForm(forms.ModelForm):
     class Meta:
         model = Affiliation
         fields = ('name', 'country')
+        labels = {'name': 'Institution'}
 
 
 class AffiliationFormSet(forms.BaseInlineFormSet):
@@ -696,7 +697,7 @@ class AffiliationFormSet(forms.BaseInlineFormSet):
     Formset for adding an author's affiliations
     """
     form_name = 'affiliations'
-    item_label = 'Affiliations'
+    item_label = 'Institutions'
     max_forms = Affiliation.MAX_AFFILIATIONS
 
     def __init__(self, *args, **kwargs):
@@ -704,7 +705,7 @@ class AffiliationFormSet(forms.BaseInlineFormSet):
         self.max_forms = AffiliationFormSet.max_forms
         self.help_text = (
             'Institutions you are affiliated with and the country for each '
-            'affiliation. Maximum of {}.'
+            'institution. Maximum of {}.'
         ).format(self.max_forms)
 
     def clean(self):
@@ -726,7 +727,7 @@ class AffiliationFormSet(forms.BaseInlineFormSet):
             if 'name' in form.cleaned_data:
                 name = form.cleaned_data['name']
                 if name in names:
-                    raise forms.ValidationError('Affiliation names must be unique.')
+                    raise forms.ValidationError('Institution names must be unique.')
                 names.append(name)
 
 
@@ -1086,12 +1087,12 @@ class InvitationResponseForm(forms.ModelForm):
 
     affiliation = forms.CharField(max_length=Affiliation.MAX_LENGTH,
                                   validators=[validate_affiliation],
-                                  label=('Your affiliation (displayed '
+                                  label=('Your institution (displayed '
                                          'when the project is published)'),
                                   required=False)
     affiliation_country = forms.ChoiceField(
         choices=COUNTRY_CHOICES_WITH_BLANK,
-        label='Affiliation country',
+        label='Country',
         required=False,
     )
 
@@ -1116,11 +1117,11 @@ class InvitationResponseForm(forms.ModelForm):
 
             if not cleaned_data.get('affiliation'):
                 raise forms.ValidationError(
-                    'You must specify your affiliation.'
+                    'You must specify your institution.'
                 )
             if not cleaned_data.get('affiliation_country'):
                 raise forms.ValidationError(
-                    'You must specify your affiliation country.'
+                    'You must specify your country.'
                 )
 
         return cleaned_data

--- a/physionet-django/project/migrations/0099_affiliation_country.py
+++ b/physionet-django/project/migrations/0099_affiliation_country.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0098_add_review_models'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='affiliation',
+            name='country',
+            field=models.CharField(blank=True, default='', max_length=2),
+        ),
+        migrations.AddField(
+            model_name='publishedaffiliation',
+            name='country',
+            field=models.CharField(blank=True, default='', max_length=2),
+        ),
+    ]

--- a/physionet-django/project/migrations/0099_affiliation_country.py
+++ b/physionet-django/project/migrations/0099_affiliation_country.py
@@ -11,11 +11,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='affiliation',
             name='country',
-            field=models.CharField(blank=True, default='', max_length=2),
+            field=models.CharField(blank=True, default='', max_length=2, null=True),
         ),
         migrations.AddField(
             model_name='publishedaffiliation',
             name='country',
-            field=models.CharField(blank=True, default='', max_length=2),
+            field=models.CharField(blank=True, default='', max_length=2, null=True),
         ),
     ]

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -350,6 +350,12 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                 self.integrity_errors.append('Author {0} has not fill in name'.format(author.user.username))
             if not author.affiliations.all():
                 self.integrity_errors.append('Author {0} has not filled in affiliations'.format(author.user.username))
+            elif author.affiliations.filter(country='').exists():
+                self.integrity_errors.append(
+                    'Author {0} has not filled in affiliation countries'.format(
+                        author.user.username
+                    )
+                )
             if author.is_corresponding:
                 if not author.user.associated_emails.filter(
                         is_verified=True,
@@ -650,12 +656,15 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                         display_order=author.display_order,
                         first_names=author_profile.first_names,
                         last_name=author_profile.last_name,
-                        )
+                    )
 
                     affiliations = author.affiliations.all()
                     for affiliation in affiliations:
-                        published_affiliation = PublishedAffiliation.objects.create(
-                            name=affiliation.name, author=published_author)
+                        PublishedAffiliation.objects.create(
+                            name=affiliation.name,
+                            country=affiliation.country,
+                            author=published_author,
+                        )
 
                     UploadedDocument.objects.filter(
                         object_id=self.pk, content_type=ContentType.objects.get_for_model(ActiveProject)

--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -10,6 +10,7 @@ from background_task import background
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
+from django.db.models import Q
 from django.db.models.fields.files import FieldFile
 from django.forms.utils import ErrorList
 from django.urls import reverse
@@ -350,7 +351,7 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                 self.integrity_errors.append('Author {0} has not fill in name'.format(author.user.username))
             if not author.affiliations.all():
                 self.integrity_errors.append('Author {0} has not filled in affiliations'.format(author.user.username))
-            elif author.affiliations.filter(country='').exists():
+            elif author.affiliations.filter(Q(country='') | Q(country__isnull=True)).exists():
                 self.integrity_errors.append(
                     'Author {0} has not filled in affiliation countries'.format(
                         author.user.username

--- a/physionet-django/project/modelcomponents/authors.py
+++ b/physionet-django/project/modelcomponents/authors.py
@@ -4,7 +4,11 @@ from django.db import models
 from django.utils import timezone
 
 from project.modelcomponents.generic import BaseInvitation
+from user.models import COUNTRIES
 from user.validators import validate_affiliation
+
+
+COUNTRY_NAMES = dict(COUNTRIES)
 
 
 class AuthorInvitation(BaseInvitation):
@@ -54,6 +58,7 @@ class Affiliation(models.Model):
     MAX_AFFILIATIONS = 3
     name = models.CharField(max_length=MAX_LENGTH,
                             validators=[validate_affiliation])
+    country = models.CharField(max_length=2, blank=True, default='')
     author = models.ForeignKey('project.Author', related_name='affiliations',
         on_delete=models.CASCADE)
 
@@ -61,18 +66,31 @@ class Affiliation(models.Model):
         default_permissions = ()
         unique_together = (('name', 'author'),)
 
+    def display_name(self):
+        country = COUNTRY_NAMES.get(self.country)
+        if country:
+            return '{}, {}'.format(self.name, country)
+        return self.name
+
 
 class PublishedAffiliation(models.Model):
     """
     Affiliations belonging to a published author
     """
     name = models.CharField(max_length=202, validators=[validate_affiliation])
+    country = models.CharField(max_length=2, blank=True, default='')
     author = models.ForeignKey('project.PublishedAuthor',
         related_name='affiliations', on_delete=models.CASCADE)
 
     class Meta:
         default_permissions = ()
         unique_together = (('name', 'author'),)
+
+    def display_name(self):
+        country = COUNTRY_NAMES.get(self.country)
+        if country:
+            return '{}, {}'.format(self.name, country)
+        return self.name
 
 
 class BaseAuthor(models.Model):
@@ -174,7 +192,9 @@ class Author(BaseAuthor):
         self.username = user.username
 
         if set_affiliations:
-            self.text_affiliations = [a.name for a in self.affiliations.all()]
+            self.text_affiliations = [
+                a.display_name() for a in self.affiliations.all()
+            ]
 
 
 class PublishedAuthor(BaseAuthor):
@@ -211,7 +231,9 @@ class PublishedAuthor(BaseAuthor):
         self.name = self.get_full_name()
         self.username = self.user.username
         self.email = self.user.email
-        self.text_affiliations = [a.name for a in self.affiliations.all()]
+        self.text_affiliations = [
+            a.display_name() for a in self.affiliations.all()
+        ]
 
     def initialed_name(self, commas=True, periods=True):
 

--- a/physionet-django/project/modelcomponents/authors.py
+++ b/physionet-django/project/modelcomponents/authors.py
@@ -58,7 +58,7 @@ class Affiliation(models.Model):
     MAX_AFFILIATIONS = 3
     name = models.CharField(max_length=MAX_LENGTH,
                             validators=[validate_affiliation])
-    country = models.CharField(max_length=2, blank=True, default='')
+    country = models.CharField(max_length=2, blank=True, null=True, default='')
     author = models.ForeignKey('project.Author', related_name='affiliations',
         on_delete=models.CASCADE)
 
@@ -78,7 +78,7 @@ class PublishedAffiliation(models.Model):
     Affiliations belonging to a published author
     """
     name = models.CharField(max_length=202, validators=[validate_affiliation])
-    country = models.CharField(max_length=2, blank=True, default='')
+    country = models.CharField(max_length=2, blank=True, null=True, default='')
     author = models.ForeignKey('project.PublishedAuthor',
         related_name='affiliations', on_delete=models.CASCADE)
 

--- a/physionet-django/project/static/project/js/project_home.js
+++ b/physionet-django/project/static/project/js/project_home.js
@@ -2,16 +2,24 @@ $('.author_invitation_response_form').each(function() {
     var response_select = $(this).find('select[name$="-response"]');
     var affiliation_label = $(this).find('label[for$="-affiliation"]');
     var affiliation_input = $(this).find('input[name$="-affiliation"]');
+    var affiliation_country_label = $(this).find('label[for$="-affiliation_country"]');
+    var affiliation_country_input = $(this).find('select[name$="-affiliation_country"]');
     function update_response() {
         if (this.value === '0') { // decline invitation
             affiliation_label.hide();
             affiliation_input.hide();
             affiliation_input.attr('required', false);
+            affiliation_country_label.hide();
+            affiliation_country_input.hide();
+            affiliation_country_input.attr('required', false);
         }
         else {
             affiliation_label.show();
             affiliation_input.show();
             affiliation_input.attr('required', true);
+            affiliation_country_label.show();
+            affiliation_country_input.show();
+            affiliation_country_input.attr('required', true);
         }
     }
     response_select.each(update_response);

--- a/physionet-django/project/templates/project/project_authors.html
+++ b/physionet-django/project/templates/project/project_authors.html
@@ -162,12 +162,12 @@
 {% endif %}
 <br>
 
-<h3>Your Affiliations</h3>
-<p>Set up to three affiliations for your author profile. Note: these fields are not tied to your user profile.</p>
-<form action="{% url 'project_authors' project.slug %}" method="post" class="form-signin no-pd" onsubmit="return validateItems('affiliation-list', 'name', 'Affiliations')">
+<h3>Your Institutions</h3>
+<p>Set up to three institutions for your author profile. Note: these fields are not tied to your user profile.</p>
+<form action="{% url 'project_authors' project.slug %}" method="post" class="form-signin no-pd" onsubmit="return validateItems('affiliation-list', 'name', 'Institutions')">
   {% csrf_token %}
   {% include 'project/item_list.html' with item="affiliation" item_label=affiliation_formset.item_label formset=affiliation_formset form_name=affiliation_formset.form_name add_item_url=add_item_url remove_item_url=remove_item_url %}
-  <button class="btn btn-primary btn-rsp" name="edit_affiliations" type="submit">Set Affiliations</button>
+  <button class="btn btn-primary btn-rsp" name="edit_affiliations" type="submit">Set Institutions</button>
 </form>
 <hr>
 <br>

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -205,6 +205,24 @@ class TestAccessPresubmission(TestMixin):
         self.assertMessage(response, 25)
         self.assertEqual(project.corresponding_author().user.username, 'aewj')
 
+        author = project.authors.get(user__username='rgmark')
+        author.affiliations.all().delete()
+        response = self.client.post(
+            reverse('project_authors', args=(project.slug,)),
+            data={
+                'edit_affiliations': '',
+                'affiliations-TOTAL_FORMS': '1',
+                'affiliations-INITIAL_FORMS': '0',
+                'affiliations-MIN_NUM_FORMS': '0',
+                'affiliations-MAX_NUM_FORMS': '3',
+                'affiliations-0-name': 'MIT',
+                'affiliations-0-country': 'US',
+            }
+        )
+        self.assertMessage(response, 25)
+        affiliation = author.affiliations.get(name='MIT')
+        self.assertEqual(affiliation.country, 'US')
+
     @prevent_request_warnings
     def test_project_access(self):
         """
@@ -1204,6 +1222,7 @@ class TestInteraction(TestMixin):
                 'form-TOTAL_FORMS': ['1'], 'form-MAX_NUM_FORMS': ['1000'],
                 'form-0-response': [str(inv_response)], 'form-MIN_NUM_FORMS': ['0'],
                 'form-0-affiliation': ['MIT' if inv_response else ''],
+                'form-0-affiliation_country': ['US' if inv_response else ''],
                 'form-INITIAL_FORMS': ['1'],
                 'form-0-id': [str(iid)], 'invitation_response': [str(iid)]
             }

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -13,6 +13,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db.models import Q
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -76,7 +77,9 @@ def _parse_html_form_fields(content):
 
 def _fill_missing_affiliation_countries(project, country='US'):
     for author in project.authors.all():
-        author.affiliations.filter(country='').update(country=country)
+        author.affiliations.filter(
+            Q(country='') | Q(country__isnull=True)
+        ).update(country=country)
 
 
 class TestAccessPresubmission(TestMixin):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -13,7 +13,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db.models import Q
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -73,13 +72,6 @@ def _parse_html_form_fields(content):
 
     Parser().feed(content)
     return fields
-
-
-def _fill_missing_affiliation_countries(project, country='US'):
-    for author in project.authors.all():
-        author.affiliations.filter(
-            Q(country='') | Q(country__isnull=True)
-        ).update(country=country)
 
 
 class TestAccessPresubmission(TestMixin):
@@ -539,17 +531,13 @@ class TestProjectEditing(TestCase):
     PASSWORD = 'Tester11!'
     PROJECT_TITLE = 'MIT-BIH Arrhythmia Database'
 
-    def setUp(self):
-        self.project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
-        _fill_missing_affiliation_countries(self.project)
-
     def test_content(self):
         """
         Test editing the project page content.
         """
         self.client.login(username=self.AUTHOR, password=self.PASSWORD)
 
-        project = self.project
+        project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
         self.assertTrue(project.is_submittable())
 
         content_url = reverse('project_content', args=(project.slug,))
@@ -628,7 +616,7 @@ class TestProjectEditing(TestCase):
         """
         self.client.login(username=self.AUTHOR, password=self.PASSWORD)
 
-        project = self.project
+        project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
         self.assertEqual(project.references.count(), 0)
         self.assertTrue(project.is_submittable())
 
@@ -1093,13 +1081,6 @@ class TestState(TestMixin):
     after review/publication state transitions.
 
     """
-    def setUp(self):
-        super().setUp()
-        self.project = ActiveProject.objects.get(
-            title='MIT-BIH Arrhythmia Database'
-        )
-        _fill_missing_affiliation_countries(self.project)
-
     def test_create_archive(self):
         """
         Create and archive a project

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -74,6 +74,11 @@ def _parse_html_form_fields(content):
     return fields
 
 
+def _fill_missing_affiliation_countries(project, country='US'):
+    for author in project.authors.all():
+        author.affiliations.filter(country='').update(country=country)
+
+
 class TestAccessPresubmission(TestMixin):
     """
     Test that certain views or content in their various states can only
@@ -531,13 +536,17 @@ class TestProjectEditing(TestCase):
     PASSWORD = 'Tester11!'
     PROJECT_TITLE = 'MIT-BIH Arrhythmia Database'
 
+    def setUp(self):
+        self.project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
+        _fill_missing_affiliation_countries(self.project)
+
     def test_content(self):
         """
         Test editing the project page content.
         """
         self.client.login(username=self.AUTHOR, password=self.PASSWORD)
 
-        project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
+        project = self.project
         self.assertTrue(project.is_submittable())
 
         content_url = reverse('project_content', args=(project.slug,))
@@ -616,7 +625,7 @@ class TestProjectEditing(TestCase):
         """
         self.client.login(username=self.AUTHOR, password=self.PASSWORD)
 
-        project = ActiveProject.objects.get(title=self.PROJECT_TITLE)
+        project = self.project
         self.assertEqual(project.references.count(), 0)
         self.assertTrue(project.is_submittable())
 
@@ -1081,6 +1090,13 @@ class TestState(TestMixin):
     after review/publication state transitions.
 
     """
+    def setUp(self):
+        super().setUp()
+        self.project = ActiveProject.objects.get(
+            title='MIT-BIH Arrhythmia Database'
+        )
+        _fill_missing_affiliation_countries(self.project)
+
     def test_create_archive(self):
         """
         Create and archive a project

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -219,6 +219,9 @@ def process_invitation_response(request, invitation_response_formset):
                 Affiliation.objects.create(
                     author=author,
                     name=invitation_response_form.cleaned_data['affiliation'],
+                    country=invitation_response_form.cleaned_data[
+                        'affiliation_country'
+                    ],
                 )
 
             notification.invitation_response_notify(invitation,
@@ -302,7 +305,7 @@ def project_home(request):
     invitation_response_formset = InvitationResponseFormSet(
         queryset=AuthorInvitation.get_user_invitations(user))
     invitation_response_formset.form_kwargs['initial'] = {
-        'affiliation': user.profile.affiliation
+        'affiliation': user.profile.affiliation,
     }
 
     data_access_requests = DataAccessRequest.objects.filter(
@@ -570,7 +573,7 @@ def edit_affiliation(request, project_slug, **kwargs):
         raise Http404()
 
     AffiliationFormSet = inlineformset_factory(parent_model=Author,
-        model=Affiliation, fields=('name',), extra=extra_forms,
+        model=Affiliation, form=forms.AffiliationForm, extra=extra_forms,
         max_num=forms.AffiliationFormSet.max_forms, can_delete=False,
         formset=forms.AffiliationFormSet, validate_max=True)
     formset = AffiliationFormSet(instance=author)
@@ -592,7 +595,7 @@ def project_authors(request, project_slug, **kwargs):
 
     author = authors.get(user=user)
     AffiliationFormSet = inlineformset_factory(parent_model=Author,
-        model=Affiliation, fields=('name',), extra=0,
+        model=Affiliation, form=forms.AffiliationForm, extra=0,
         max_num=forms.AffiliationFormSet.max_forms, can_delete=False,
         formset = forms.AffiliationFormSet, validate_max=True)
     affiliation_formset = AffiliationFormSet(instance=author)
@@ -1280,7 +1283,9 @@ def project_preview(request, project_slug, subdir='', **kwargs):
     authors = project.get_author_info()
     invitations = project.authorinvitations.filter(is_active=True)
     corresponding_author = authors.get(is_corresponding=True)
-    corresponding_author.text_affiliations = ', '.join(a.name for a in corresponding_author.affiliations.all())
+    corresponding_author.text_affiliations = ', '.join(
+        a.display_name() for a in corresponding_author.affiliations.all()
+    )
 
     references = project.references.all().order_by('order')
     publication = project.publications.all().first()

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -572,10 +572,12 @@ def edit_affiliation(request, project_slug, **kwargs):
     else:
         raise Http404()
 
-    AffiliationFormSet = inlineformset_factory(parent_model=Author,
+    AffiliationFormSet = inlineformset_factory(
+        parent_model=Author,
         model=Affiliation, form=forms.AffiliationForm, extra=extra_forms,
         max_num=forms.AffiliationFormSet.max_forms, can_delete=False,
-        formset=forms.AffiliationFormSet, validate_max=True)
+        formset=forms.AffiliationFormSet, validate_max=True,
+    )
     formset = AffiliationFormSet(instance=author)
     edit_url = reverse('edit_affiliation', args=[project.slug])
 
@@ -594,10 +596,12 @@ def project_authors(request, project_slug, **kwargs):
         ('user', 'project', 'authors', 'is_submitting'))
 
     author = authors.get(user=user)
-    AffiliationFormSet = inlineformset_factory(parent_model=Author,
+    AffiliationFormSet = inlineformset_factory(
+        parent_model=Author,
         model=Affiliation, form=forms.AffiliationForm, extra=0,
         max_num=forms.AffiliationFormSet.max_forms, can_delete=False,
-        formset = forms.AffiliationFormSet, validate_max=True)
+        formset=forms.AffiliationFormSet, validate_max=True,
+    )
     affiliation_formset = AffiliationFormSet(instance=author)
 
     if is_submitting:

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -455,7 +455,7 @@ def edit_affiliations(request, affiliation_formset):
     """
     if affiliation_formset.is_valid():
         affiliation_formset.save()
-        messages.success(request, 'Your author affiliations have been updated')
+        messages.success(request, 'Your author institutions have been updated')
         return True
     else:
         messages.error(request, 'Submission unsuccessful. See form for errors.')


### PR DESCRIPTION
This PR adds country metadata to project author affiliations.

Changes:
- Adds a country field to active and published author affiliations;
- Captures affiliation country in the author affiliation form and invitation acceptance flow;
- Preserves affiliation country when publishing a project;
- Displays affiliation country on published project author info;
- Adds tests for affiliation country capture and publication.

New country selection field in the project author affiliation form:

<img width="1147" height="378" alt="image" src="https://github.com/user-attachments/assets/43038d14-d166-4d35-a7e1-5443213c4cc8" />

How it is displayed on projects' landing page:

<img width="1359" height="562" alt="image" src="https://github.com/user-attachments/assets/e45d2375-4a7c-4ed8-be75-a55de2517c75" />

Fixes #2645 
