### PR TITLE
Show pending training review message on project landing page

### DIFF
--- a/physionet-django/project/templates/project/published_project_unauthorized.html
+++ b/physionet-django/project/templates/project/published_project_unauthorized.html
@@ -18,21 +18,7 @@
         {% if not user.is_credentialed %}
           <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
         {% endif %}
-        {% if requires_training and not has_required_training %}
-          {% if has_training_under_review %}
-            <li>
-              Have your submitted training report approved. You can view its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
-            </li>
-          {% else %}
-            <li>complete required training:</li>
-            <ul>
-              {% for required_training in project.required_trainings.all %}
-                <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
-              {% endfor %}
-            </ul>
-            <li>You may submit your training <a href="{% url 'edit_training' %}">here</a>.</li>
-          {% endif %}
-        {% endif %}
+        {% include "project/training_requirements.html" %}
         {% if not has_signed_dua %}
           <li>
             <a href="{% url 'sign_dua' project.slug project.version %}">sign the data use agreement</a> for the project
@@ -42,21 +28,7 @@
         {% if not user.is_credentialed %}
           <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
         {% endif %}
-        {% if requires_training and not has_required_training %}
-          {% if has_training_under_review %}
-            <li>
-              Have your submitted training report approved. You can view its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
-            </li>
-          {% else %}
-            <li>complete required training:</li>
-            <ul>
-              {% for required_training in project.required_trainings.all %}
-                <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
-              {% endfor %}
-            </ul>
-            <li>You may submit your training <a href="{% url 'edit_training' %}">here</a>.</li>
-          {% endif %}
-        {% endif %}
+        {% include "project/training_requirements.html" %}
         {% if not has_accepted_access_request %}
           <li>
             <a href="{% url 'data_access_request_status' project.slug project.version %}">submit a request to the authors</a> to use the data for your project

--- a/physionet-django/project/templates/project/published_project_unauthorized.html
+++ b/physionet-django/project/templates/project/published_project_unauthorized.html
@@ -19,13 +19,19 @@
           <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
         {% endif %}
         {% if requires_training and not has_required_training %}
-          <li>complete required training:</li>
-          <ul>
-            {% for required_training in project.required_trainings.all %}
-              <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
-            {% endfor %}
-            You may submit your training <a href="{% url 'edit_training' %}">here</a>.
-          </ul>
+          {% if has_training_under_review %}
+            <li>
+              Have your submitted training report approved. You can view its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
+            </li>
+          {% else %}
+            <li>complete required training:</li>
+            <ul>
+              {% for required_training in project.required_trainings.all %}
+                <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
+              {% endfor %}
+            </ul>
+            <li>You may submit your training <a href="{% url 'edit_training' %}">here</a>.</li>
+          {% endif %}
         {% endif %}
         {% if not has_signed_dua %}
           <li>
@@ -37,13 +43,19 @@
           <li>be a <a href="{% url 'edit_credentialing' %}">credentialed user</a></li>
         {% endif %}
         {% if requires_training and not has_required_training %}
-          <li>complete required training:</li>
-          <ul>
-            {% for required_training in project.required_trainings.all %}
-              <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
-            {% endfor %}
-            You may submit your training <a href="{% url 'edit_training' %}">here</a>.
-          </ul>
+          {% if has_training_under_review %}
+            <li>
+              Have your submitted training report approved. You can view its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
+            </li>
+          {% else %}
+            <li>complete required training:</li>
+            <ul>
+              {% for required_training in project.required_trainings.all %}
+                <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
+              {% endfor %}
+            </ul>
+            <li>You may submit your training <a href="{% url 'edit_training' %}">here</a>.</li>
+          {% endif %}
         {% endif %}
         {% if not has_accepted_access_request %}
           <li>

--- a/physionet-django/project/templates/project/training_requirements.html
+++ b/physionet-django/project/templates/project/training_requirements.html
@@ -1,7 +1,7 @@
 {% if requires_training and not has_required_training %}
   {% if has_training_under_review %}
     <li>
-      Have your submitted training report approved. You can view its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
+      Your training report is under review. You can check its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
     </li>
   {% else %}
     <li>complete required training:</li>

--- a/physionet-django/project/templates/project/training_requirements.html
+++ b/physionet-django/project/templates/project/training_requirements.html
@@ -1,0 +1,15 @@
+{% if requires_training and not has_required_training %}
+  {% if has_training_under_review %}
+    <li>
+      Have your submitted training report approved. You can view its status on the <a href="{% url 'edit_certification' %}">Certification</a> page.
+    </li>
+  {% else %}
+    <li>complete required training:</li>
+    <ul>
+      {% for required_training in project.required_trainings.all %}
+        <li><a href="{% url 'published_project_required_training' project.slug project.version %}#{{ required_training.pk }}">{{ required_training.name }}</a></li>
+      {% endfor %}
+    </ul>
+    <li>You may submit your training <a href="{% url 'edit_training' %}">here</a>.</li>
+  {% endif %}
+{% endif %}

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -727,7 +727,7 @@ class TestAccessPublished(TestMixin):
 
         self.assertContains(response, reviewed_training.name)
         self.assertContains(response, outstanding_training.name)
-        self.assertNotContains(response, 'Have your submitted training report approved.')
+        self.assertNotContains(response, 'Your training report is under review.')
 
     def test_all_trainings_under_review(self):
         project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
@@ -753,7 +753,7 @@ class TestAccessPublished(TestMixin):
 
         response = self.client.get(reverse('published_project', args=(project.slug, project.version)))
 
-        self.assertContains(response, 'Have your submitted training report approved.')
+        self.assertContains(response, 'Your training report is under review.')
 
     @prevent_request_warnings
     def test_credentialed(self):

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -36,7 +36,8 @@ from project.models import (
     SubmissionStatus,
     AWS
 )
-from user.models import User
+from user.enums import TrainingStatus
+from user.models import Training, TrainingType, User
 from user.test_views import TestMixin, prevent_request_warnings
 
 PROJECT_VIEWS = [
@@ -707,6 +708,27 @@ class TestAccessPublished(TestMixin):
     Published projects.
 
     """
+    def test_pending_training_does_not_hide_other_requirements(self):
+        project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
+        user = User.objects.get(email='rgmark@mit.edu')
+        reviewed_training = TrainingType.objects.create(name='Reviewed training')
+        outstanding_training = TrainingType.objects.create(name='Outstanding training')
+        project.required_trainings.set([reviewed_training, outstanding_training])
+        Training.objects.create(
+            user=user,
+            slug='reviewed-training',
+            training_type=reviewed_training,
+            status=TrainingStatus.REVIEW,
+            reviewer_comments='',
+        )
+        self.client.login(username=user.username, password='Tester11!')
+
+        response = self.client.get(reverse('published_project', args=(project.slug, project.version)))
+
+        self.assertContains(response, reviewed_training.name)
+        self.assertContains(response, outstanding_training.name)
+        self.assertNotContains(response, 'Have your submitted training report approved.')
+
     @prevent_request_warnings
     def test_credentialed(self):
         """

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -708,7 +708,7 @@ class TestAccessPublished(TestMixin):
     Published projects.
 
     """
-    def test_pending_training_does_not_hide_other_requirements(self):
+    def test_pending_training_requirements(self):
         project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
         user = User.objects.get(email='rgmark@mit.edu')
         reviewed_training = TrainingType.objects.create(name='Reviewed training')
@@ -729,7 +729,7 @@ class TestAccessPublished(TestMixin):
         self.assertContains(response, outstanding_training.name)
         self.assertNotContains(response, 'Have your submitted training report approved.')
 
-    def test_all_pending_trainings_under_review(self):
+    def test_all_trainings_under_review(self):
         project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
         user = User.objects.get(email='rgmark@mit.edu')
         first_training = TrainingType.objects.create(name='First training')

--- a/physionet-django/project/test_views.py
+++ b/physionet-django/project/test_views.py
@@ -729,6 +729,32 @@ class TestAccessPublished(TestMixin):
         self.assertContains(response, outstanding_training.name)
         self.assertNotContains(response, 'Have your submitted training report approved.')
 
+    def test_all_pending_trainings_under_review(self):
+        project = PublishedProject.objects.get(title='Demo eICU Collaborative Research Database')
+        user = User.objects.get(email='rgmark@mit.edu')
+        first_training = TrainingType.objects.create(name='First training')
+        second_training = TrainingType.objects.create(name='Second training')
+        project.required_trainings.set([first_training, second_training])
+        Training.objects.create(
+            user=user,
+            slug='first-training',
+            training_type=first_training,
+            status=TrainingStatus.REVIEW,
+            reviewer_comments='',
+        )
+        Training.objects.create(
+            user=user,
+            slug='second-training',
+            training_type=second_training,
+            status=TrainingStatus.REVIEW,
+            reviewer_comments='',
+        )
+        self.client.login(username=user.username, password='Tester11!')
+
+        response = self.client.get(reverse('published_project', args=(project.slug, project.version)))
+
+        self.assertContains(response, 'Have your submitted training report approved.')
+
     @prevent_request_warnings
     def test_credentialed(self):
         """

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1998,15 +1998,20 @@ def published_project(request, project_slug, version, subdir=''):
         else Training.objects.get_valid().filter(training_type__in=project.required_trainings.all(), user=user).count()
         == project.required_trainings.count()
     )
-    has_training_under_review = (
-        False
-        if not user.is_authenticated
-        else Training.objects.filter(
+    has_training_under_review = False
+    if user.is_authenticated:
+        valid_training_type_ids = Training.objects.get_valid().filter(
+            training_type__in=project.required_trainings.all(), user=user
+        ).values('training_type_id')
+        missing_training_types = project.required_trainings.exclude(id__in=valid_training_type_ids)
+        under_review_training_type_ids = Training.objects.filter(
             status=TrainingStatus.REVIEW,
-            training_type__in=project.required_trainings.all(),
+            training_type__in=missing_training_types,
             user=user,
+        ).values('training_type_id')
+        has_training_under_review = missing_training_types.exists() and not missing_training_types.exclude(
+            id__in=under_review_training_type_ids
         ).exists()
-    )
     current_site = get_current_site(request)
     bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     all_project_versions = PublishedProject.objects.filter(slug=project_slug).order_by('version_order')

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -58,6 +58,7 @@ from project.modelcomponents.review import ReviewerInvitation
 from project.authorization.access import can_view_project_files, can_access_project
 from project.projectfiles import ProjectFiles
 from project.validators import validate_filename, validate_gcs_bucket_object
+from user.enums import TrainingStatus
 from user.forms import AssociatedEmailChoiceForm
 from user.models import AssociatedEmail, CloudInformation, CredentialApplication, Training
 from project.cloud.s3 import (
@@ -1997,6 +1998,15 @@ def published_project(request, project_slug, version, subdir=''):
         else Training.objects.get_valid().filter(training_type__in=project.required_trainings.all(), user=user).count()
         == project.required_trainings.count()
     )
+    has_training_under_review = (
+        False
+        if not user.is_authenticated
+        else Training.objects.filter(
+            status=TrainingStatus.REVIEW,
+            training_type__in=project.required_trainings.all(),
+            user=user,
+        ).exists()
+    )
     current_site = get_current_site(request)
     bulk_url_prefix = notification.get_url_prefix(request, bulk_download=True)
     all_project_versions = PublishedProject.objects.filter(slug=project_slug).order_by('version_order')
@@ -2056,6 +2066,7 @@ def published_project(request, project_slug, version, subdir=''):
         'has_accepted_access_request': has_accepted_access_request,
         'requires_training': requires_training,
         'has_required_training': has_required_training,
+        'has_training_under_review': has_training_under_review,
         'current_site': current_site,
         'bulk_url_prefix': bulk_url_prefix,
         'latest_version': latest_version,

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -58,7 +58,6 @@ from project.modelcomponents.review import ReviewerInvitation
 from project.authorization.access import can_view_project_files, can_access_project
 from project.projectfiles import ProjectFiles
 from project.validators import validate_filename, validate_gcs_bucket_object
-from user.enums import TrainingStatus
 from user.forms import AssociatedEmailChoiceForm
 from user.models import AssociatedEmail, CloudInformation, CredentialApplication, Training
 from project.cloud.s3 import (
@@ -2004,8 +2003,7 @@ def published_project(request, project_slug, version, subdir=''):
             training_type__in=project.required_trainings.all(), user=user
         ).values('training_type_id')
         missing_training_types = project.required_trainings.exclude(id__in=valid_training_type_ids)
-        under_review_training_type_ids = Training.objects.filter(
-            status=TrainingStatus.REVIEW,
+        under_review_training_type_ids = Training.objects.get_review().filter(
             training_type__in=missing_training_types,
             user=user,
         ).values('training_type_id')


### PR DESCRIPTION
This PR updates the restricted-access message shown in the Files section of a project landing page when the user has already submitted the required training report and it is still under review.

This avoids confusing users about whether they still need to submit a training report. It also adds a link to the Certification page, where users can check the status of their training submissions.