### PR TITLE
Add Cloud Build configuration for Artifact Registry image push

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,26 @@
+# Automated image build: on push to the primary branch (dev), Cloud Build runs
+# this config, builds the physionet/HDN image, tags it with the commit SHA, and
+# pushes it to Artifact Registry. The trigger runs as
+# image-builder@healthdatanexus-dev (artifactregistry.writer on the repo).
+#
+# Deploying a built image is a separate step: point the dev deploy pipeline's
+# _TF_VAR_HDN_IMAGE_TAG at the SHA and run it (CI here, not CD).
+substitutions:
+  _IMAGE: northamerica-northeast2-docker.pkg.dev/healthdatanexus-dev/physionet/core
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: build
+    args:
+      - build
+      - -t
+      - ${_IMAGE}:$COMMIT_SHA
+      - -t
+      - ${_IMAGE}:latest
+      - .
+images:
+  - ${_IMAGE}:$COMMIT_SHA
+  - ${_IMAGE}:latest
+timeout: 3600s
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8


### PR DESCRIPTION
This pull request introduces a new Cloud Build configuration to automate building and pushing Docker images for the project. The configuration ensures that every push to the primary branch triggers an image build and pushes the result to Artifact Registry, streamlining the CI process for image management.

**Cloud Build automation:**

* Added `cloudbuild.yaml` to define an automated pipeline that builds the `physionet/HDN` Docker image on every push to the primary branch, tags it with both the commit SHA and `latest`, and pushes it to Artifact Registry.
* Configured build steps to use a high-CPU machine and log output to Cloud Logging only, optimizing build performance and observability.
* Clarified in comments that deployment is a separate process, with instructions for referencing the built image in the deployment pipeline.