### PR TITLE
Upgrade uwsgi from 2.0.22 to 2.0.31

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2756,13 +2756,13 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uwsgi"
-version = "2.0.22"
+version = "2.0.31"
 description = "The uWSGI server"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "uwsgi-2.0.22.tar.gz", hash = "sha256:4cc4727258671ac5fa17ab422155e9aaef8a2008ebb86e4404b66deaae965db2"},
+    {file = "uwsgi-2.0.31.tar.gz", hash = "sha256:e8f8b350ccc106ff93a65247b9136f529c14bf96b936ac5b264c6ff9d0c76257"},
 ]
 
 [[package]]
@@ -2940,4 +2940,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "7975b6be10572514bff562583346ab3154609e064fea23893b26c27f381c1b1d"
+content-hash = "e2e6784d5dabff6df5ea1aa44c945b2e20ce76db577df5e322f922079a91cd05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ jinja2 = "^3.1.6"
 Pillow = "^12.2.0"
 python-decouple = "^3.1"
 renameat2 = { version = "0.4.4", platform = "linux" }
-uWSGI = "2.0.22"
+uWSGI = "2.0.31"
 pyOpenSSL = "^24.0.0"
 google-api-python-client = "^2.177.0"
 psycopg2 = "2.9.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1432,8 +1432,8 @@ uritemplate==3.0.1 ; python_version >= "3.11" and python_version < "4.0" \
 urllib3==1.26.19 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3 \
     --hash=sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429
-uwsgi==2.0.22 ; python_version >= "3.11" and python_version < "4.0" \
-    --hash=sha256:4cc4727258671ac5fa17ab422155e9aaef8a2008ebb86e4404b66deaae965db2
+uwsgi==2.0.31 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:e8f8b350ccc106ff93a65247b9136f529c14bf96b936ac5b264c6ff9d0c76257
 webencodings==0.5.1 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923


### PR DESCRIPTION
uwsgi 2.0.22 fails to compile under Poetry 2.4.x's PEP 517 build isolation, causing upgrade test failures (OSError in threaded compilation leaves object files missing, breaking the link step).

e.g. see: https://github.com/MIT-LCP/physionet-build/actions/runs/29822812560/job/88609145846

This PR upgrades uwsgi from 2.0.22 to 2.0.31, which should fix Docker build failures.