### PR TITLE
Allow all editors to view project ethics documents

### DIFF
--- a/demo-files/media/ethics/Ethics_Approval_ab1282e9-26e2-4e2d-a48c-42dfa02738a1.txt
+++ b/demo-files/media/ethics/Ethics_Approval_ab1282e9-26e2-4e2d-a48c-42dfa02738a1.txt
@@ -1,0 +1,6 @@
+To whom it may concern:
+
+The study described here has been approved and poses no ethical
+concerns.
+
+The Authorities

--- a/physionet-django/console/templates/console/submission_info_card.html
+++ b/physionet-django/console/templates/console/submission_info_card.html
@@ -118,7 +118,7 @@
         <h5>Uploaded Documents</h5>
         {% if project.uploaded_documents.all %}
           {% for uploaded_document in project.uploaded_documents.all %}
-            <p class="card_text"><a href="{% url 'serve_document' uploaded_document.document|filename %}" target="_blank">{{ uploaded_document.document_type }}</a></p>
+            <p class="card_text"><a href="{% url 'serve_active_project_ethics_doc' project.slug uploaded_document.document|filename %}" target="_blank">{{ uploaded_document.document_type }}</a></p>
           {% endfor %}
         {% else %}
           <p class="card_text">No documents were provided.</p>

--- a/physionet-django/project/fixtures/demo-project.json
+++ b/physionet-django/project/fixtures/demo-project.json
@@ -2517,6 +2517,19 @@
   }
 },
 {
+  "model": "project.uploadeddocument",
+  "pk": 2,
+  "fields": {
+    "document_type": 1,
+    "content_type": [
+      "project",
+      "activeproject"
+    ],
+    "object_id": 2,
+    "document": "ethics/Ethics_Approval_ab1282e9-26e2-4e2d-a48c-42dfa02738a1.txt"
+  }
+},
+{
   "model": "project.log",
   "pk": 1,
   "fields": {

--- a/physionet-django/project/urls.py
+++ b/physionet-django/project/urls.py
@@ -133,7 +133,7 @@ TEST_CASES = {
         '_query_': {'subdir': 'notes'},
     },
     'serve_document': {
-        'file_name': 'ethics/Ethics_Approval_567b029d-9ea6-41b8-b738-bf45675b24ce.txt',
+        'file_name': 'Ethics_Approval_567b029d-9ea6-41b8-b738-bf45675b24ce.txt',
     },
     'published_project_request_access': {
         # missing DataAccess in demo

--- a/physionet-django/project/urls.py
+++ b/physionet-django/project/urls.py
@@ -72,7 +72,11 @@ urlpatterns = [
     path('<project_slug>/submission/', views.project_submission, name='project_submission'),
     path('<project_slug>/ethics/', views.project_ethics, name='project_ethics'),
     path('<project_slug>/ethics/edit-document/', views.edit_ethics, name='edit_ethics'),
-    path('ethics/<path:file_name>/', views.serve_document, name='serve_document'),
+    path(
+        '<project_slug>/ethics/doc/<doc_name>',
+        views.serve_active_project_ethics_doc,
+        name='serve_active_project_ethics_doc',
+    ),
     path(
         '<project_slug>/view-required-trainings/',
         views.project_required_trainings_preview,
@@ -93,6 +97,9 @@ urlpatterns = [
         views.generate_signed_url,
         name='generate_signed_url',
     ),
+
+    # deprecated
+    path('ethics/<path:file_name>/', views.serve_document, name='serve_document'),
 ]
 
 # Parameters for testing URLs (see physionet/test_urls.py)
@@ -102,6 +109,7 @@ TEST_DEFAULTS = {
     'subdir': 'notes',
     'file_name': 'notes/notes.txt',
     'full_file_name': 'notes/notes.txt',
+    'doc_name': 'Ethics_Approval_ab1282e9-26e2-4e2d-a48c-42dfa02738a1.txt',
 }
 TEST_CASES = {
     'new_project_version': {

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1606,16 +1606,30 @@ def edit_ethics(request, project_slug, **kwargs):
 
 @login_required
 def serve_document(request, file_name):
-    projects = ActiveProject.objects.filter(Q(authors__user=request.user) | Q(editor=request.user)).values_list(
-        'id', flat=True
+    """
+    View an uploaded ethics document of an active project.
+    This view is deprecated.  Do not use it.
+    """
+    try:
+        document = UploadedDocument.objects.get(document=('ethics/' + file_name))
+    except UploadedDocument.DoesNotExist:
+        raise PermissionDenied
+    return serve_active_project_ethics_doc(
+        request,
+        project_slug=document.project.slug,
+        doc_name=file_name,
     )
+
+
+@project_auth(auth_mode=2)
+def serve_active_project_ethics_doc(request, project, doc_name, **kwargs):
+    """
+    View an uploaded ethics document of an active project.
+    """
     uploaded_document = get_object_or_404(
-        UploadedDocument.objects.filter(
-            object_id__in=projects, content_type=ContentType.objects.get_for_model(ActiveProject)
-        ),
-        document__iendswith=file_name,
+        project.uploaded_documents.filter(document=('ethics/' + doc_name))
     )
-    return ProjectFiles().serve_file_field(uploaded_document.document)
+    return project.files.serve_file_field(uploaded_document.document)
 
 
 @login_required


### PR DESCRIPTION
All editors, whether assigned to a project or not, are allowed to view active project content (e.g. the project preview), and are able to view pages such as http://127.0.0.1:8000/console/submitted-projects/SHuKI1APLrwWCqxSQnSk/info/ .

If there are uploaded documents, the Project Submission Info page will link to them, under the "Ethics" tab.  However, until now, only the project's authors and the project's assigned editor had permission to view those documents.

Instead, the standard project authorization logic (project_auth) should be used.  To be specific, the document will be accessible to all project authors and to all site editors, but not to anonymous viewers or to reviewers who are not site editors.

Fixes #2649
