### PR TITLE
style.css: explicitly anchor navbar popups to their invoker.

### DIFF
--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -336,6 +336,8 @@ body .main {
   border-radius: 0.5rem;
   position: absolute;
   top: var(--nav-height);
+  /* anchor() needs the invoker as anchor; position-anchor's initial value no longer opts in implicitly */
+  position-anchor: auto;
   left: anchor(left);
   background-color: white;
   padding: 0.75rem;


### PR DESCRIPTION
Chrome's initial value for position-anchor ('normal') no longer uses the popover invoker as the implicit anchor, so anchor(left) and anchor(right) fail to resolve and open popups fall back to the UA popover style (inset: 0), rendering flush with the left edge of the viewport. Opt back in with position-anchor: auto.

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/206355a4-8860-4d76-91f1-3d8ab23d6488" />
