### PR TITLE
Fix/primary email integrity

### DIFF
--- a/physionet-django/static/custom/css/style.css
+++ b/physionet-django/static/custom/css/style.css
@@ -336,6 +336,8 @@ body .main {
   border-radius: 0.5rem;
   position: absolute;
   top: var(--nav-height);
+  /* anchor() needs the invoker as anchor; position-anchor's initial value no longer opts in implicitly */
+  position-anchor: auto;
   left: anchor(left);
   background-color: white;
   padding: 0.75rem;

--- a/physionet-django/user/management/commands/purgeaccounts.py
+++ b/physionet-django/user/management/commands/purgeaccounts.py
@@ -32,7 +32,8 @@ class Command(BaseCommand):
         LOGGER.info("Total accounts removed {}".format(len(deleted)))
 
         associated_email_list = AssociatedEmail.objects.filter(
-            is_verified=False, added_date__lt=limit, user__is_active=True)
+            is_verified=False, is_primary_email=False, added_date__lt=limit,
+            user__is_active=True)
         deleted = []
 
         for associated_email in associated_email_list:

--- a/physionet-django/user/migrations/0072_primary_email_integrity.py
+++ b/physionet-django/user/migrations/0072_primary_email_integrity.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+def restore_primary_emails(apps, schema_editor):
+    """
+    Repair users left without a primary associated email (caused by the
+    previously non-atomic primary-email swap and by purgeaccounts deleting
+    unverified primary emails). Promote the associated email matching the
+    user's email field; for users with a single associated email, promote
+    it and realign the user's email field.
+    """
+    User = apps.get_model('user', 'User')
+
+    broken = User.objects.exclude(
+        associated_emails__is_primary_email=True
+    ).prefetch_related('associated_emails')
+
+    for user in broken:
+        emails = list(user.associated_emails.all())
+        match = [ae for ae in emails if ae.email == user.email]
+        if match:
+            match[0].is_primary_email = True
+            match[0].save(update_fields=['is_primary_email'])
+        elif len(emails) == 1:
+            emails[0].is_primary_email = True
+            emails[0].save(update_fields=['is_primary_email'])
+            user.email = emails[0].email
+            user.save(update_fields=['email'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user', '0071_alter_khdpaccount_access_token'),
+    ]
+
+    operations = [
+        migrations.RunPython(restore_primary_emails,
+                             migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name='associatedemail',
+            constraint=models.UniqueConstraint(
+                condition=Q(is_primary_email=True),
+                fields=('user',),
+                name='unique_primary_email_per_user',
+            ),
+        ),
+    ]

--- a/physionet-django/user/models.py
+++ b/physionet-django/user/models.py
@@ -429,7 +429,14 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         Get the primary associated email
         """
-        return self.associated_emails.get(is_primary_email=True)
+        try:
+            return self.associated_emails.get(is_primary_email=True)
+        except ObjectDoesNotExist:
+            # Broken invariant (no primary flag set): fall back to the
+            # address on the user record instead of crashing every caller.
+            logger.error('User %s has no primary associated email',
+                         self.username)
+            return self.associated_emails.filter(email=self.email).first()
 
     def get_names(self):
         return self.profile.get_names()
@@ -572,6 +579,13 @@ class AssociatedEmail(models.Model):
 
     class Meta:
         default_permissions = ()
+        constraints = [
+            models.UniqueConstraint(
+                fields=['user'],
+                condition=Q(is_primary_email=True),
+                name='unique_primary_email_per_user',
+            ),
+        ]
 
     def __str__(self):
         return self.email
@@ -615,12 +629,16 @@ def update_associated_emails(sender, **kwargs):
     """
     user = kwargs['instance']
     if not kwargs['created'] and kwargs['update_fields'] and 'email' in kwargs['update_fields']:
-        old_primary_email = AssociatedEmail.objects.get(user=user, is_primary_email=True)
-        new_primary_email = AssociatedEmail.objects.get(user=user, email=user.email)
-        old_primary_email.is_primary_email = False
-        new_primary_email.is_primary_email = True
-        old_primary_email.save()
-        new_primary_email.save()
+        with transaction.atomic():
+            new_primary_email = AssociatedEmail.objects.filter(
+                user=user, email=user.email)
+            if new_primary_email.exists():
+                # Demote before promoting to satisfy the partial unique
+                # constraint; the transaction makes the swap all-or-nothing.
+                AssociatedEmail.objects.filter(
+                    user=user, is_primary_email=True).exclude(
+                    email=user.email).update(is_primary_email=False)
+                new_primary_email.update(is_primary_email=True)
 
 
 def photo_path(instance, filename):


### PR DESCRIPTION
This pull request addresses several issues related to the management and integrity of users' associated email addresses, particularly focusing on ensuring that each user always has a single, valid primary email. It introduces a new database constraint, migration, and logic updates to maintain this invariant, and fixes potential edge cases where users could be left without a primary email. Additionally, it includes a minor CSS update.

**Email integrity and primary email handling:**

* Added a partial unique constraint to the `AssociatedEmail` model to enforce that each user can have at most one primary associated email (`is_primary_email=True`). This is implemented both in the model definition and as a database migration. [[1]](diffhunk://#diff-e8178036221677f622720aa70ad8b6c37dcc82973d7901f556132b09bc540366R582-R588) [[2]](diffhunk://#diff-38665c983b1b6be9442b01ae97a94d65d5a453dbfce10206b337be4a68bb8400R1-R49)
* Introduced a data migration (`0072_primary_email_integrity.py`) that repairs users missing a primary associated email by promoting an appropriate associated email or realigning the user's main email field if needed.
* Refactored the logic for updating a user's primary email to use an atomic transaction, ensuring that demotion and promotion of primary emails is safe and respects the new unique constraint.
* Updated the method for retrieving a user's primary email to gracefully handle cases where the invariant is broken, logging an error and falling back to the user's main email if necessary.

**Account and email purging:**

* Modified the account purging command to avoid deleting unverified primary emails by filtering out primary emails from deletion, preventing users from being left without a primary email.