### PR TITLE
Configurable Python version for test-upgrade.sh

### DIFF
--- a/test-upgrade.sh
+++ b/test-upgrade.sh
@@ -107,6 +107,9 @@ oldrev=$(git rev-parse --verify "$oldrevname^{commit}")
 currevname=$(git describe --all --always --dirty)
 
 PYTHON=${PYTHON:-python3}
+py_ver=$("$PYTHON" -c 'import sys; print("%s-%s.%s" % (
+    sys.implementation.name, *sys.version_info[0:2]
+))')
 
 ################################################################
 # Functions for reporting test results
@@ -241,7 +244,7 @@ export PATH=$venvdir/bin:$PATH
     cd "$olddir/physionet-django"
 
     msg_testing "Installing old requirements"
-    cachefile=$venvcachedir/$old_reqs_hash.tar.gz
+    cachefile=$venvcachedir/$old_reqs_hash-$py_ver.tar.gz
     if [ -n "$venvcachedir" ] && [ -f "$cachefile" ]; then
         prereq_cmd mkdir "$venvdir"
         prereq_cmd tar -xzf "$cachefile" -C "$venvdir"
@@ -268,7 +271,7 @@ export PATH=$venvdir/bin:$PATH
 
     msg_testing "Installing new requirements"
     if ! cmp -s "$olddir/requirements.txt" "$topdir/requirements.txt"; then
-        cachefile=$venvcachedir/$old_reqs_hash-$new_reqs_hash.tar.gz
+        cachefile=$venvcachedir/$old_reqs_hash-$new_reqs_hash-$py_ver.tar.gz
         if [ -n "$venvcachedir" ] && [ -f "$cachefile" ]; then
             prereq_cmd rm -rf "$venvdir"
             prereq_cmd mkdir "$venvdir"

--- a/test-upgrade.sh
+++ b/test-upgrade.sh
@@ -106,6 +106,8 @@ oldrev=$(git rev-parse --verify "$oldrevname^{commit}")
 # Generate a pretty name for the "current" revision
 currevname=$(git describe --all --always --dirty)
 
+PYTHON=${PYTHON:-python3}
+
 ################################################################
 # Functions for reporting test results
 
@@ -245,7 +247,7 @@ export PATH=$venvdir/bin:$PATH
         prereq_cmd tar -xzf "$cachefile" -C "$venvdir"
     else
         prereq_cmd virtualenv --quiet --quiet \
-                   --no-download -ppython3 "$venvdir"
+                   --no-download -p"$PYTHON" "$venvdir"
         prereq_cmd pip3 install --require-hashes \
                    -r "$olddir/requirements.txt"
         if [ -n "$venvcachedir" ]; then


### PR DESCRIPTION
test-upgrade.sh is used to test the live upgrade process, and in part it works by creating a clean Python installation using virtualenv.
 
It's useful to be able to test different Python interpreters/versions, so if the PYTHON environment variable is set, then use that instead of `python3`.

(This doesn't mean that it supports upgrading from one Python version to a different version.  virtualenv doesn't support that.)
