### PR TITLE
Remove affiliation country integrity check

### DIFF
--- a/physionet-django/project/modelcomponents/activeproject.py
+++ b/physionet-django/project/modelcomponents/activeproject.py
@@ -10,7 +10,6 @@ from background_task import background
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
-from django.db.models import Q
 from django.db.models.fields.files import FieldFile
 from django.forms.utils import ErrorList
 from django.urls import reverse
@@ -351,16 +350,6 @@ class ActiveProject(Metadata, UnpublishedProject, SubmissionInfo):
                 self.integrity_errors.append('Author {0} has not fill in name'.format(author.user.username))
             if not author.affiliations.all():
                 self.integrity_errors.append('Author {0} has not filled in affiliations'.format(author.user.username))
-            elif (
-                    self.submission_status == SubmissionStatus.UNSUBMITTED
-                    and author.affiliations.filter(
-                        Q(country='') | Q(country__isnull=True)
-                    ).exists()):
-                self.integrity_errors.append(
-                    'Author {0} has not filled in institution countries'.format(
-                        author.user.username
-                    )
-                )
             if author.is_corresponding:
                 if not author.user.associated_emails.filter(
                         is_verified=True,


### PR DESCRIPTION
This PR removes affiliation-country integrity enforcement. Country will continue to be collected through submission forms, but missing historical values will no longer block the submission or publication of a new version created from an existing published project.