### PR TITLE
validate_affiliation: accept institutions that begin with a digit

### DIFF
--- a/physionet-django/user/test_validators.py
+++ b/physionet-django/user/test_validators.py
@@ -2,10 +2,27 @@ from unittest import TestCase
 
 from django.core.exceptions import ValidationError
 
-from user.validators import validate_organization, validate_reference_response, validate_research_summary
+from user.validators import (
+    validate_affiliation,
+    validate_organization,
+    validate_reference_response,
+    validate_research_summary,
+)
 
 
 class TestValidators(TestCase):
+
+    def test_affiliation_with_special_character_is_valid(self):
+        self.assertIsNone(validate_affiliation('Massachusetts Institute of Technology (MIT)'))
+
+    def test_affiliation_with_number_as_first_character_is_valid(self):
+        self.assertIsNone(validate_affiliation('4YouandMe'))
+
+    def test_affiliation_with_special_character_as_first_character_is_invalid(self):
+        self.assertRaises(ValidationError, validate_affiliation, '&YouandMe')
+
+    def test_affiliation_with_consecutive_periods_is_invalid(self):
+        self.assertRaises(ValidationError, validate_affiliation, 'MIT.. Cambridge')
 
     def test_organization_with_newline_is_invalid(self):
         self.assertRaises(ValidationError, validate_organization, 'Johnson\nJohnson')

--- a/physionet-django/user/validators.py
+++ b/physionet-django/user/validators.py
@@ -70,12 +70,13 @@ def validate_name(value):
 
 def validate_affiliation(value):
     """
-    Validate affiliation that start with an alphabetical characters
+    Validate affiliation that start with an alphanumeric character
     followed by alphanumeric, spaces, underscores, hyphens, and apostrophes
     and the following special characters: ,()/&.
     """
-    if not re.fullmatch(r'[a-zA-Z][\w\',()/&. -]+', value) or '..' in value:
-        raise ValidationError('Letters, numbers, spaces, apostrophes, underscores and [,()/&.-] characters only. Must begin with a letter.')
+    if not re.fullmatch(r'[a-zA-Z0-9][\w\',()/&. -]+', value) or '..' in value:
+        raise ValidationError('Letters, numbers, spaces, apostrophes, underscores and [,()/&.-] '
+                              'characters only. Must begin with a letter or number.')
 
 
 def validate_location(value):


### PR DESCRIPTION
Organizations whose name starts with a digit — 4YouandMe, 23andMe, 3M — are rejected by `validate_affiliation`, and there is no UI path to enter them at all.

## The problem

```python
if not re.fullmatch(r'[a-zA-Z][\w\',()/&. -]+', value) or '..' in value:
```

The leading `[a-zA-Z]` means an affiliation must begin with a letter. Because this single validator is shared by the profile affiliation field, author affiliations, the invitation response form and the admin, a user at such an organization has no way to record it — every surface rejects the same value, so there is no workaround.

We hit this with a real user at 4YouandMe who could not enter their institution anywhere.

## The change

Widen only the first character class to `[a-zA-Z0-9]`, matching `validate_organization` in the same module, which already accepts alphanumeric starts:

```python
if not re.fullmatch(r'[a-zA-Z0-9][\w\',()/&. -]+', value) or '..' in value:
```

The charset whitelist and the `'..'` rejection are untouched — this strictly widens the accepted first character and nothing else. The error message is updated to match the new rule.

## Consistency note

`validate_organization` and `validate_affiliation` sit next to each other and describe near-identical inputs, but only the former accepted a leading digit. This aligns them.

## Tests

`user/test_validators.py` gains coverage for `validate_affiliation`: digit-leading names are accepted, and the existing rejections (`'..'`, disallowed characters) are asserted to still fail.

This has been running in production on our deployment since 2026-08-13.