### PR TITLE
Bump lightwave version to 0.73 for tests

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install and setup lightwave
         run: |
-          wget https://github.com/bemoody/lightwave/archive/0.72.tar.gz -O lightwave.tar.gz
+          wget https://github.com/bemoody/lightwave/archive/0.73.tar.gz -O lightwave.tar.gz
           tar -xf lightwave.tar.gz
           (cd lightwave-* && make CGIDIR=/usr/local/bin sandboxed-server)
 

--- a/.github/workflows/physionet-upgrade-test.yml
+++ b/.github/workflows/physionet-upgrade-test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install lightwave
         run: |
-          wget https://github.com/bemoody/lightwave/archive/0.72.tar.gz \
+          wget https://github.com/bemoody/lightwave/archive/0.73.tar.gz \
                -O lightwave.tar.gz
           tar -xf lightwave.tar.gz
           (cd lightwave-* && make CGIDIR=/usr/local/bin sandboxed-server)

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN wget https://github.com/bemoody/wfdb/archive/10.7.0.tar.gz -O wfdb.tar.gz \
     && ldconfig \
     && rm -rf wfdb*
 
-RUN wget https://github.com/bemoody/lightwave/archive/0.72.tar.gz -O lightwave.tar.gz \
+RUN wget https://github.com/bemoody/lightwave/archive/0.73.tar.gz -O lightwave.tar.gz \
     && tar -xf lightwave.tar.gz \
     && (cd lightwave-* && make sandboxed-lightwave && mkdir -p /usr/local/bin && install -m 4755 sandboxed-lightwave /usr/local/bin) \
     && rm -rf lightwave*


### PR DESCRIPTION
LightWAVE version 0.73 fixes the sandbox so that it should hopefully now work with glibc 2.41 (Debian 13 amd64).

It also allows clients to see the error message from WFDB in the event that a record is not readable (for debugging; lightwave.js doesn't make the error message visible anywhere, but it could in the future.)
