### PR TITLE
Hides acknowledgements for anonymous sharing links

### DIFF
--- a/physionet-django/project/templates/project/project_preview_content.html
+++ b/physionet-django/project/templates/project/project_preview_content.html
@@ -1,12 +1,18 @@
 {% for section in project.content_sections %}
-  {% if section.body %}
+  {% if section.body and section.html_id == 'acknowledgements' and hide_authors %}
     <h2 id="{{ section.html_id }}">{{ section.title }}</h2>
+    <p>
+      <em>Acknowledgements hidden.</em>
+    </p>
+    <hr>
+  {% elif section.body %}
+<h2 id="{{ section.html_id }}">{{ section.title }}</h2>
     {{ section.body|safe }}
-    <hr>
+<hr>
   {% elif section.required %}
-    <h2 id="{{ section.html_id }}">{{ section.title }}</h2>
-    <p style="color:red"><strong>* Required field missing</strong></p>
-    <hr>
+<h2 id="{{ section.html_id }}">{{ section.title }}</h2>
+<p style="color:red"><strong>* Required field missing</strong></p>
+<hr>
   {% endif %}
 {% endfor %}
 
@@ -15,3 +21,5 @@
   {% include "project/reference_list.html" %}
   <hr>
 {% endif %}
+
+

--- a/physionet-django/project/templates/project/project_preview_content.html
+++ b/physionet-django/project/templates/project/project_preview_content.html
@@ -6,13 +6,13 @@
     </p>
     <hr>
   {% elif section.body %}
-<h2 id="{{ section.html_id }}">{{ section.title }}</h2>
+    <h2 id="{{ section.html_id }}">{{ section.title }}</h2>
     {{ section.body|safe }}
-<hr>
+    <hr>
   {% elif section.required %}
-<h2 id="{{ section.html_id }}">{{ section.title }}</h2>
-<p style="color:red"><strong>* Required field missing</strong></p>
-<hr>
+    <h2 id="{{ section.html_id }}">{{ section.title }}</h2>
+    <p style="color:red"><strong>* Required field missing</strong></p>
+    <hr>
   {% endif %}
 {% endfor %}
 
@@ -21,5 +21,3 @@
   {% include "project/reference_list.html" %}
   <hr>
 {% endif %}
-
-


### PR DESCRIPTION
This update hides the content of the acknowledgements from viewers of author-masking links so they can be used better for double-blind review.