### PR TITLE
Pin Poetry to <2 to fix sdist installation as root.

### DIFF
--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -69,8 +69,9 @@ jobs:
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           source $VIRTUAL_ENV/bin/activate
           if [ ${{matrix.pip3}} = 'poetry' ]; then
-            pip3 install poetry
+            pip3 install "poetry<2"
             poetry config virtualenvs.create false
+            poetry config installer.modern-installation false
             poetry install --no-root
           else
             pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,14 @@ RUN wget https://github.com/bemoody/lightwave/archive/0.73.tar.gz -O lightwave.t
     && (cd lightwave-* && make sandboxed-lightwave && mkdir -p /usr/local/bin && install -m 4755 sandboxed-lightwave /usr/local/bin) \
     && rm -rf lightwave*
 
-RUN pip install poetry \
+RUN pip install "poetry<2" \
     && rm -rf /root/.cache/pip
 
 WORKDIR /code
 COPY pyproject.toml poetry.lock ./
 
 RUN poetry config virtualenvs.create false \
+    && poetry config installer.modern-installation false \
     && poetry install --no-root \
     && rm -rf /root/.cache/pypoetry /root/.cache/pip
 


### PR DESCRIPTION
Poetry 2.x removed the pip-based installer fallback (installer.modern-installation = false). Without it, tarfile.chown() crashes when extracting sdists as root in Docker/CI due to packages with gname=None in tar metadata. Pin Poetry <2 and re-enable the fallback.

Addresses #2685