### PR TITLE
Validate credential reviewer comments

### DIFF
--- a/physionet-django/console/forms.py
+++ b/physionet-django/console/forms.py
@@ -962,7 +962,7 @@ class TrainingQuestionFormSet(forms.BaseModelFormSet):
 
 
 class CredentialReviewForm(forms.Form):
-    reviewer_comments = forms.CharField(widget=forms.Textarea(attrs={'rows': 5}), required=False)
+    reviewer_comments = forms.CharField(max_length=500, widget=forms.Textarea(attrs={'rows': 5}), required=False)
 
     def clean(self):
         if self.errors:

--- a/physionet-django/console/test_views.py
+++ b/physionet-django/console/test_views.py
@@ -13,6 +13,7 @@ from django.core import mail
 from django.test import TestCase
 from django.test.utils import get_runner
 from django.urls import reverse
+from console.forms import CredentialReviewForm
 from events.models import EventAgreement
 from project.models import (
     AccessPolicy,
@@ -33,6 +34,14 @@ from physionet.models import FrontPageButton, StaticPage
 from user.test_views import TestMixin, prevent_request_warnings
 
 LOGGER = logging.getLogger(__name__)
+
+
+class TestCredentialReviewForm(TestCase):
+    def test_reviewer_comments_max_length(self):
+        form = CredentialReviewForm(data={'reviewer_comments': 'x' * 501})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('reviewer_comments', form.errors)
 
 
 class TestState(TestMixin):


### PR DESCRIPTION
Prevent credential application processing from saving reviewer comments longer than the 500-character database limit.

Add a test for form validation.