### PR TITLE
Update approved credentialing email

### DIFF
--- a/physionet-django/notification/templates/notification/email/process_credential_complete.html
+++ b/physionet-django/notification/templates/notification/email/process_credential_complete.html
@@ -28,6 +28,10 @@ We also wanted to share these comments from the reviewer:
 {{ application.responder_comments }}
 {% endif %}
 {% if example_project %}
+Please note the following reminders regarding your credentialed access:
+
+- Access to credentialed PhysioNet data is granted only to the approved applicant. The data may not be shared with others. Each person who will access the data must complete the PhysioNet credentialing process individually.
+- Please ensure that any use of large language models (LLMs) with credentialed PhysioNet data complies with the PhysioNet Data Use Agreement and the guidance available here: https://physionet.org/news/post/llm-responsible-use/
 
 You are now able to access protected databases upon agreeing to the terms of usage and completing any required training. For example, you can access {{ example_project.title }} by following the steps below:
 


### PR DESCRIPTION
This PR updates the email sent once a credentialing application has been approved, as suggested in #2658 . The update adds reminders about each user needing to go through credentialing individually and to follow the guidance for appropriate use of LLMs with credentialed data. 

Fixes #2658.