### PR TITLE
Update BigQuery access email

### DIFF
--- a/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
+++ b/physionet-django/notification/templates/notification/email/notify_gcp_access_request.html
@@ -17,7 +17,8 @@ To access this resource:
 1. Navigate to: https://console.cloud.google.com/bigquery
 2. Click the "+ADD DATA" button. 
 3. Select "Star a project by name", then enter "physionet-data".
-3. That's it! You should see the resources in the sidebar.
+4. Ensure your selected project (shown in the project picker in the top left of the BigQuery console) is linked to an active billing account. You are responsible for paying for query costs.
+5. That's it! You should see the resources in the sidebar.
 {% endif %}
 {% else %}We were unable to grant access to {{ project }} in GCP.
 


### PR DESCRIPTION
This PR updates the email sent to users once they gain access to BigQuery for a given dataset. It makes it clear that they need to link their BigQuery project to an active billing account since they have to pay for queries. 