### PR TITLE
Added search capabilities to Projects

### DIFF
--- a/physionet-django/console/static/console/js/search-console.js
+++ b/physionet-django/console/static/console/js/search-console.js
@@ -82,13 +82,11 @@ function searchSubmitted(url, value) {
 
             // Update badge counts and colors
             $.each(data.counts, function (key, count) {
-                // var badge = $('#badge-' + key).find('.badge');
                 var badgeWrapper = $('#badge-' + key);
                 var badge = badgeWrapper.find('.badge');
                 var original = parseInt(badgeWrapper.data('original'));
                 badge.text(count);
                 badge.removeClass('badge-info badge-danger')
-                    //  .addClass(count > 0 ? 'badge-danger': 'badge-info');
                 if (count > 0) {
                     // Results found for this search
                     badge.addClass('badge-danger');
@@ -98,7 +96,7 @@ function searchSubmitted(url, value) {
                 } else {
                     // Had projects originally but none match the search
                     badge.addClass('badge-info');
-            }
+                }
             });
         });
 

--- a/physionet-django/console/static/console/js/search-console.js
+++ b/physionet-django/console/static/console/js/search-console.js
@@ -18,3 +18,89 @@ function search(url, value){
         $('#searchitems').load(url, data);
     }, 500);
 }
+
+// Search the submitted-projects page: Displays only the projects
+// that match the search and updates each tab's badge count/color to
+// reflect how many matches fall in that status/hold bucket.
+function searchSubmitted(url, value) {
+    var csrftoken = getCookie('csrftoken');
+
+    clearTimeout(loadresults);
+    loadresults = setTimeout(function () {
+
+        if (!value.trim()) {
+            // Restore all hidden rows, remove messages, restore hidden tables
+            $('[data-project-id]').show();
+            $('.search-no-results-msg').remove();
+            $('.search-hidden-table').show().removeClass('search-hidden-table');
+            // Restore original badge counts and colors
+            $('[id^="badge-"]').each(function () {
+                var original = $(this).data('original');
+                var badge = $(this).find('.badge');
+                badge.text(original);
+                badge.removeClass('badge-success badge-danger badge-info')
+                     .addClass(original > 0 ? 'badge-danger' : 'badge-success');
+            });
+            return;
+        }
+
+        $.post(url, { 'csrfmiddlewaretoken': csrftoken, 'search': value }, function (data) {
+            var matchingIds = data.ids.map(String);
+
+            // Clean up from any previous search
+            $('.search-no-results-msg').remove();
+            $('.search-hidden-table').show().removeClass('search-hidden-table');
+
+            // Show/hide rows based on returned ids
+            $('[data-project-id]').each(function () {
+                var rowId = String($(this).data('project-id'));
+                $(this).toggle(matchingIds.includes(rowId));
+            });
+
+            // Check each table by comparing its row ids against matchingIds directly,
+            // rather than using :visible which is affected by which tab is active
+            $('tbody').each(function () {
+                var tbody = $(this);
+                var table = tbody.closest('table');
+                var allRows = tbody.find('[data-project-id]');
+
+                if (allRows.length === 0) return;
+
+                var hasMatch = allRows.filter(function () {
+                    return matchingIds.includes(String($(this).data('project-id')));
+                }).length > 0;
+
+                if (!hasMatch) {
+                    table.addClass('search-hidden-table').hide();
+                    table.after(
+                        '<p class="search-no-results-msg">' +
+                        '<i class="fas fa-check" style="color:green"></i> No projects found.' +
+                        '</p>'
+                    );
+                }
+            });
+
+            // Update badge counts and colors
+            $.each(data.counts, function (key, count) {
+                // var badge = $('#badge-' + key).find('.badge');
+                var badgeWrapper = $('#badge-' + key);
+                var badge = badgeWrapper.find('.badge');
+                var original = parseInt(badgeWrapper.data('original'));
+                badge.text(count);
+                badge.removeClass('badge-info badge-danger')
+                    //  .addClass(count > 0 ? 'badge-danger': 'badge-info');
+                if (count > 0) {
+                    // Results found for this search
+                    badge.addClass('badge-danger');
+                } else if (original === 0) {
+                    // Was already empty before the search
+                    badge.addClass('badge-success');
+                } else {
+                    // Had projects originally but none match the search
+                    badge.addClass('badge-info');
+            }
+            });
+        });
+
+    }, 500);
+}

--- a/physionet-django/console/templates/console/archived_submissions.html
+++ b/physionet-django/console/templates/console/archived_submissions.html
@@ -9,43 +9,22 @@
 {% endblock %}
 
 {% block content %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'console/js/search-console.js' %}"></script>
+
 <div class="card mb-3">
   <div class="card-header">
     Archived Projects <span class="badge badge-pill badge-info">{{ projects.paginator.count }}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">
-      <table class="table table-bordered">
-        <thead>
-          <tr>
-            <th>Project</th>
-            <th>Submission History</th>
-            <th>Version</th>
-            <th>Submitting Author</th>
-            <th>Editor</th>
-            <th>Creation Date</th>
-            <th>Archived Date</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for project in projects %}
-          <tr>
-            <td>{{ project.title }}</td>
-            <td><a href="{% url 'archived_submission_history' project.slug %}">View History</a></td>
-            <td>{{ project.version }}</td>
-            <td>{% if project.submitting_author %}
-              <a href="{% url 'user_management' project.submitting_author.user.username %}">{{ project.submitting_author }}</a>
-                {% else %}
-                  {{ project.submitting_author }}
-                {% endif %}</td>
-            <td>{{ project.editor }}</td>
-            <td>{{ project.creation_datetime|date }}</td>
-            <td>{{ project.archive_datetime|date }}</td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-      {% include "console/pagination.html" with pagination=projects %}
+      <input
+        type="search"
+        data-search-url="{% url 'project_search' bucket='archived' %}"
+        oninput="search(this.dataset.searchUrl, this.value);"
+        placeholder="Search..."
+      >
+      {% include "console/archived_submissions_list.html" %}
     </div>
   </div>
 </div>

--- a/physionet-django/console/templates/console/archived_submissions_list.html
+++ b/physionet-django/console/templates/console/archived_submissions_list.html
@@ -1,0 +1,35 @@
+<div id="searchitems">
+  <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+    <thead>
+      <tr>
+        <th>Project</th>
+        <th>Submission History</th>
+        <th>Version</th>
+        <th>Submitting Author</th>
+        <th>Editor</th>
+        <th>Creation Date</th>
+        <th>Archived Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for project in projects %}
+      <tr>
+        <td>{{ project.title }}</td>
+        <td><a href="{% url 'archived_submission_history' project.slug %}">View History</a></td>
+        <td>{{ project.version }}</td>
+        <td>
+          {% if project.submitting_author %}
+          <a href="{% url 'user_management' project.submitting_author.user.username %}">{{ project.submitting_author }}</a>
+          {% else %}
+          {{ project.submitting_author }}
+          {% endif %}
+        </td>
+        <td>{{ project.editor }}</td>
+        <td>{{ project.creation_datetime|date }}</td>
+        <td>{{ project.archive_datetime|date }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% include "console/pagination.html" with pagination=projects %}
+</div>

--- a/physionet-django/console/templates/console/project_search_list.html
+++ b/physionet-django/console/templates/console/project_search_list.html
@@ -1,0 +1,33 @@
+<div id="searchitems">
+  <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+    <thead>
+      <tr>
+        <th>Project</th>
+        <th>Submitted By</th>
+        <th>Status</th>
+        <th>Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for project in projects %}
+      <tr>
+        <td>
+          {% if bucket == 'submitted' %}
+          <a href="{% url 'submission_info' project.slug %}">{{ project.title }}</a>
+          {% else %}
+          <a href="{% url 'project_preview' project.slug %}?Admin=True">{{ project.title }}</a>
+          {% endif %}
+        </td>
+        <td>
+          {% if project.submitting_author %}
+          <a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a>
+          {% endif %}
+        </td>
+        <td>{{ project.submission_status_label }}</td>
+        <td>{{ project.creation_datetime|date }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% include "console/pagination.html" with pagination=projects %}
+</div>

--- a/physionet-django/console/templates/console/published_projects.html
+++ b/physionet-django/console/templates/console/published_projects.html
@@ -9,6 +9,9 @@
 {% endblock %}
 
 {% block content %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'console/js/search-console.js' %}"></script>
+
 <div class="card mb-3">
   <div class="card-header">
     {% if project_slug %}
@@ -21,35 +24,13 @@
   </div>
   <div class="card-body">
     <div class="table-responsive">
-      <table class="table table-bordered">
-        <thead>
-          <tr>
-            <th>Project</th>
-            <th>History</th>
-            <th>Version</th>
-            <th>Submitted By</th>
-            <th>Editor</th>
-            <th>Created</th>
-            <th>Published</th>
-            <th>Manage</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for project in projects %}
-          <tr>
-            <td><a href="{% url 'published_project' project.slug project.version %}">{{ project.title }}</a></td>
-            <td>{% if project.is_legacy %}Legacy{% else %}<a href="{% url 'published_submission_history' project.slug project.version %}">View History</a>{% endif %}</td>
-            <td>{{ project.version }}</td>
-            <td>{% if project.is_legacy %}Legacy{% else %}<a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}{% endif %}</td>
-            <td>{{ project.editor }}</td>
-            <td>{{ project.creation_datetime|date }}</td>
-            <td>{{ project.publish_datetime|date }}</td>
-            <td><a href="{% url 'manage_published_project' project.slug project.version %}" class="btn btn-sm btn-primary" role="button">Manage</a></td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-      {% include "console/pagination.html" with pagination=projects %}
+    <input
+        type="search"
+        data-search-url="{% url 'project_search' bucket='published' %}"
+        oninput="search(this.dataset.searchUrl, this.value);"
+        placeholder="Search..."
+    >      
+    {% include "console/published_projects_list.html" %}
     </div>
   </div>
 </div>

--- a/physionet-django/console/templates/console/published_projects.html
+++ b/physionet-django/console/templates/console/published_projects.html
@@ -29,7 +29,7 @@
         data-search-url="{% url 'project_search' bucket='published' %}"
         oninput="search(this.dataset.searchUrl, this.value);"
         placeholder="Search..."
-    >      
+    >
     {% include "console/published_projects_list.html" %}
     </div>
   </div>

--- a/physionet-django/console/templates/console/published_projects_list.html
+++ b/physionet-django/console/templates/console/published_projects_list.html
@@ -1,0 +1,31 @@
+<div id="searchitems">
+  <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+    <thead>
+      <tr>
+        <th>Project</th>
+        <th>History</th>
+        <th>Version</th>
+        <th>Submitted By</th>
+        <th>Editor</th>
+        <th>Created</th>
+        <th>Published</th>
+        <th>Manage</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for project in projects %}
+      <tr>
+        <td><a href="{% url 'published_project' project.slug project.version %}">{{ project.title }}</a></td>
+        <td>{% if project.is_legacy %}Legacy{% else %}<a href="{% url 'published_submission_history' project.slug project.version %}">View History</a>{% endif %}</td>
+        <td>{{ project.version }}</td>
+        <td>{% if project.is_legacy %}Legacy{% else %}<a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}{% endif %}</td>
+        <td>{{ project.editor }}</td>
+        <td>{{ project.creation_datetime|date }}</td>
+        <td>{{ project.publish_datetime|date }}</td>
+        <td><a href="{% url 'manage_published_project' project.slug project.version %}" class="btn btn-sm btn-primary" role="button">Manage</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% include "console/pagination.html" with pagination=projects %}
+</div>

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -1,45 +1,59 @@
 {% extends "console/base_console.html" %}
 
+{% load static %}
+
 {% block title %}Submitted Projects{% endblock %}
 
 {% load console_templatetags %}
 
 {% block content %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'console/js/search-console.js' %}"></script>
+
 <div class="card">
   <div class="card-header">
     <ul class="nav nav-tabs">
+    <input
+      type="search"
+      data-search-url="{% url 'project_search' bucket='submitted' %}"
+      oninput="searchSubmitted(this.dataset.searchUrl, this.value);"
+      placeholder="Search..."
+      class="mb-2"
+    >
+    <ul class="nav nav-tabs card-header-tabs">
       {% if perms.project.can_assign_editor %}
         <li class="nav-item">
-          <a class="nav-link active" id="assignment-tab" data-toggle="tab" href="#assignment" role="tab" aria-controls="assignment" aria-selected="true">Awaiting Editor Assignment {{ assignment_projects|task_count_badge|safe }}</a>
+          <a class="nav-link active" id="assignment-tab" data-toggle="tab" href="#assignment" role="tab" aria-controls="assignment" aria-selected="true">Awaiting Editor Assignment <span id="badge-assignment" data-original="{{ assignment_projects|length }}">{{ assignment_projects|task_count_badge|safe }}</span></a>
         </li>
       {% endif %}
       <li class="nav-item">
-        <a class="nav-link" id="reviewer-assignment-tab" data-toggle="tab" href="#reviewer-assignment" role="tab" aria-controls="reviewer-assignment" aria-selected="false">Awaiting Reviewer Assignment {{ reviewer_assignment_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="reviewer-assignment-tab" data-toggle="tab" href="#reviewer-assignment" role="tab" aria-controls="reviewer-assignment" aria-selected="false">Awaiting Reviewer Assignment <span id="badge-reviewer_assignment" data-original="{{ reviewer_assignment_projects|length }}">{{ reviewer_assignment_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="external-review-tab" data-toggle="tab" href="#external-review" role="tab" aria-controls="external-review" aria-selected="false">Awaiting External Review {{ external_review_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="external-review-tab" data-toggle="tab" href="#external-review" role="tab" aria-controls="external-review" aria-selected="false">Awaiting External Review <span id="badge-external_review" data-original="{{ external_review_projects|length }}">{{ external_review_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="decision-tab" data-toggle="tab" href="#decision" role="tab" aria-controls="decision" aria-selected="false">Awaiting Decision {{ decision_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="decision-tab" data-toggle="tab" href="#decision" role="tab" aria-controls="decision" aria-selected="false">Awaiting Decision <span id="badge-decision" data-original="{{ decision_projects|length }}">{{ decision_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="revision-tab" data-toggle="tab" href="#revision" role="tab" aria-controls="revision" aria-selected="false">Awaiting Author Revisions {{ revision_projects|task_count_badge|safe }}</span></a>
+        <a class="nav-link" id="revision-tab" data-toggle="tab" href="#revision" role="tab" aria-controls="revision" aria-selected="false">Awaiting Author Revisions <span id="badge-revision" data-original="{{ revision_projects|length }}">{{ revision_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="copyedit-tab" data-toggle="tab" href="#copyedit" role="tab" aria-controls="copyedit" aria-selected="false">Awaiting Copyedit {{ copyedit_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="copyedit-tab" data-toggle="tab" href="#copyedit" role="tab" aria-controls="copyedit" aria-selected="false">Awaiting Copyedit <span id="badge-copyedit" data-original="{{ copyedit_projects|length }}">{{ copyedit_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="approval-tab" data-toggle="tab" href="#approval" role="tab" aria-controls="approval" aria-selected="false">Awaiting Author Approval {{ approval_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="approval-tab" data-toggle="tab" href="#approval" role="tab" aria-controls="approval" aria-selected="false">Awaiting Author Approval <span id="badge-approval" data-original="{{ approval_projects|length }}">{{ approval_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="publish-tab" data-toggle="tab" href="#publish" role="tab" aria-controls="publish" aria-selected="false">Awaiting Publication {{ publish_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="publish-tab" data-toggle="tab" href="#publish" role="tab" aria-controls="publish" aria-selected="false">Awaiting Publication <span id="badge-publish" data-original="{{ publish_projects|length }}">{{ publish_projects|task_count_badge|safe }}</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="onhold-tab" data-toggle="tab" href="#onhold" role="tab" aria-controls="onhold" aria-selected="false">On Hold {{ on_hold_projects|task_count_badge|safe }}</a>
+        <a class="nav-link" id="onhold-tab" data-toggle="tab" href="#onhold" role="tab" aria-controls="onhold" aria-selected="false">On Hold <span id="badge-on_hold" data-original="{{ on_hold_projects|length }}">{{ on_hold_projects|task_count_badge|safe }}</span></a>
       </li>
     </ul>
   </div>
   <div class="card-body">
+    <!-- <div id="submitted-search-results" style="display:none;"></div> -->
     {# Awaiting editor assignment #}
     <div class="tab-content">
       {% if perms.project.can_assign_editor %}
@@ -57,7 +71,7 @@
                 </thead>
                 <tbody>
                 {% for project in assignment_projects %}
-                  <tr>
+                  <tr data-project-id="{{ project.id }}">
                     <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                     <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                     <td>{{ project.submission_datetime|date }}</td>
@@ -122,7 +136,7 @@
               </thead>
               <tbody>
               {% for project in reviewer_assignment_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.editor }}</td>
@@ -165,7 +179,7 @@
               </thead>
               <tbody>
               {% for project in external_review_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.editor }}</td>
@@ -205,7 +219,7 @@
               </thead>
               <tbody>
               {% for project in decision_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.editor }}</td>
@@ -240,7 +254,7 @@
           <div class="table-responsive">
             <table class="table table-bordered">
               <thead>
-                <tr>
+                <tr >
                   <th>Project</th>
                   <th>Submitted By</th>
                   <th>Submitted</th>
@@ -252,7 +266,7 @@
               </thead>
               <tbody>
               {% for project in revision_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.submission_datetime|date }}</td>
@@ -303,7 +317,7 @@
               </thead>
               <tbody>
               {% for project in copyedit_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</td>
                   <td>{{ project.submission_datetime|date }}</td>
@@ -345,7 +359,7 @@
               </thead>
               <tbody>
               {% for project in approval_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</td>
                   <td>{{ project.submission_datetime|date }}</td>
@@ -392,7 +406,7 @@
               </thead>
               <tbody>
               {% for project in publish_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author.user.username }}</a> - {{ project.submitting_author.user.email }}</td>
                   <td>{{ project.submission_datetime|date }}</td>
@@ -434,7 +448,7 @@
               </thead>
               <tbody>
               {% for project in on_hold_projects %}
-                <tr>
+                <tr data-project-id="{{ project.id }}">
                   <td><a href="{% url 'submission_info' project.slug %}">{{ project }}</a></td>
                   <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
                   <td>{{ project.editor|default:"Unassigned" }}</td>

--- a/physionet-django/console/templates/console/submitted_projects.html
+++ b/physionet-django/console/templates/console/submitted_projects.html
@@ -12,7 +12,6 @@
 
 <div class="card">
   <div class="card-header">
-    <ul class="nav nav-tabs">
     <input
       type="search"
       data-search-url="{% url 'project_search' bucket='submitted' %}"
@@ -20,7 +19,7 @@
       placeholder="Search..."
       class="mb-2"
     >
-    <ul class="nav nav-tabs card-header-tabs">
+    <ul class="nav nav-tabs">
       {% if perms.project.can_assign_editor %}
         <li class="nav-item">
           <a class="nav-link active" id="assignment-tab" data-toggle="tab" href="#assignment" role="tab" aria-controls="assignment" aria-selected="true">Awaiting Editor Assignment <span id="badge-assignment" data-original="{{ assignment_projects|length }}">{{ assignment_projects|task_count_badge|safe }}</span></a>
@@ -53,7 +52,6 @@
     </ul>
   </div>
   <div class="card-body">
-    <!-- <div id="submitted-search-results" style="display:none;"></div> -->
     {# Awaiting editor assignment #}
     <div class="tab-content">
       {% if perms.project.can_assign_editor %}
@@ -254,7 +252,7 @@
           <div class="table-responsive">
             <table class="table table-bordered">
               <thead>
-                <tr >
+                <tr>
                   <th>Project</th>
                   <th>Submitted By</th>
                   <th>Submitted</th>

--- a/physionet-django/console/templates/console/unsubmitted_projects.html
+++ b/physionet-django/console/templates/console/unsubmitted_projects.html
@@ -9,31 +9,22 @@
 {% endblock %}
 
 {% block content %}
+<script src="{% static 'custom/js/cookie.js' %}"></script>
+<script src="{% static 'console/js/search-console.js' %}"></script>
+
 <div class="card mb-3">
   <div class="card-header">
     Unsubmitted Projects <span class="badge badge-pill badge-info">{{ projects.paginator.count }}</span>
   </div>
   <div class="card-body">
     <div class="table-responsive">
-      <table class="table table-bordered">
-        <thead>
-          <tr>
-            <th>Project</th>
-            <th>Submitted By</th>
-            <th>Created</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for project in projects %}
-          <tr>
-            <td><a href="{% url 'project_preview' project.slug %}?Admin=True">{{ project.title }}</a></td>
-            <td><a href="{% url 'public_profile' project.submitting_author.user.username %}">{{ project.submitting_author }}</a></td>
-            <td>{{ project.creation_datetime|date }}</td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-      {% include "console/pagination.html" with pagination=projects %}
+      <input
+        type="search"
+        data-search-url="{% url 'project_search' bucket='unsubmitted' %}"
+        oninput="search(this.dataset.searchUrl, this.value);"
+        placeholder="Search..."
+      >
+      {% include "console/project_search_list.html" with bucket="unsubmitted" %}
     </div>
   </div>
 </div>

--- a/physionet-django/console/urls.py
+++ b/physionet-django/console/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path('published-projects/<project_slug>/', views.published_projects,
          name='published_projects_by_slug'),
     path('archived-submissions/', views.archived_submissions, name='archived_submissions'),
+    path('projects/search/<bucket>/', views.project_search, name='project_search'),
     path('project-access-manage/<pid>/', views.project_access_manage,
          name='project_access_manage'),
     path('published-projects/<project_slug>/<version>/',
@@ -357,6 +358,7 @@ TEST_CASES = {
 
     # Broken views: POST required for no reason
     'users_list_search': {'group': 'all', '_skip_': True},
+    'project_search': {'bucket': 'unsubmitted', '_skip_': True},
     'known_references_search': {'_skip_': True},
     'news_search': {'_skip_': True},
 }

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1466,6 +1466,86 @@ def archived_submissions(request):
                   {'projects': projects})
 
 
+PROJECT_SEARCH_BUCKETS = {
+    'unsubmitted': (ActiveProject, SubmissionStatus.UNSUBMITTED, 'creation_datetime',
+                    'console/project_search_list.html'),
+    'submitted': (ActiveProject, None, 'submission_datetime',
+                  'console/project_search_list.html'),
+    'published': (PublishedProject, None, '-publish_datetime',
+                  'console/published_projects_list.html'),
+    'archived': (ActiveProject, SubmissionStatus.ARCHIVED, 'creation_datetime',
+                 'console/archived_submissions_list.html'),
+}
+
+# Mirrors the status/hold buckets built in submitted_projects(), so the
+# tab badge counts can be updated live while searching that page.
+SUBMITTED_STATUS_BUCKETS = {
+    'assignment': SubmissionStatus.NEEDS_ASSIGNMENT,
+    'reviewer_assignment': SubmissionStatus.NEEDS_REVIEWER_ASSIGNMENT,
+    'external_review': SubmissionStatus.NEEDS_EXTERNAL_REVIEW,
+    'decision': SubmissionStatus.NEEDS_DECISION,
+    'revision': SubmissionStatus.NEEDS_RESUBMISSION,
+    'copyedit': SubmissionStatus.NEEDS_COPYEDIT,
+    'approval': SubmissionStatus.NEEDS_APPROVAL,
+    'publish': SubmissionStatus.NEEDS_PUBLICATION,
+}
+
+
+def _project_search_filter(projects, search_field):
+    """
+    Filter a project queryset by a free-text search term, across title,
+    resource type, and author name/username/email.
+    """
+    if not search_field:
+        return projects
+    author_q = (Q(authors__user__username__icontains=search_field)
+                | Q(authors__user__profile__first_names__icontains=search_field)
+                | Q(authors__user__profile__last_name__icontains=search_field)
+                | Q(authors__user__email__icontains=search_field))
+    return projects.filter(
+        Q(title__icontains=search_field)
+        | Q(resource_type__name__icontains=search_field)
+        | author_q
+    ).distinct()
+
+
+@console_permission_required('project.change_activeproject')
+def project_search(request, bucket):
+    """
+    Search projects within one of the console project-list buckets:
+    unsubmitted, submitted, published, or archived.
+    """
+    if request.method != 'POST' or bucket not in PROJECT_SEARCH_BUCKETS:
+        raise Http404()
+
+    search_field = request.POST['search']
+    model, status, order, template = PROJECT_SEARCH_BUCKETS[bucket]
+
+    if bucket == 'submitted':
+        base = model.objects.filter(submission_status__gt=SubmissionStatus.ARCHIVED)
+    elif status is not None:
+        base = model.objects.filter(submission_status=status)
+    else:
+        base = model.objects.all()
+
+    matched = _project_search_filter(base, search_field)
+
+    if bucket == 'submitted':
+        # The submitted-projects page keeps its existing tab tables and
+        # just shows/hides rows by id, so only the matching ids and the
+        # per-tab counts (for the badges) are needed here.
+        counts = {key: matched.filter(submission_status=value, is_on_hold=False).count()
+                  for key, value in SUBMITTED_STATUS_BUCKETS.items()}
+        counts['on_hold'] = matched.filter(is_on_hold=True).count()
+        return JsonResponse({'ids': list(matched.values_list('id', flat=True)), 'counts': counts})
+
+    projects = matched.order_by(order)
+    if len(search_field) == 0:
+        projects = paginate(request, projects, 50)
+
+    return render(request, template, {'projects': projects, 'bucket': bucket})
+
+
 @console_permission_required('user.view_user')
 def users(request, group='all'):
     """

--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1518,7 +1518,7 @@ def project_search(request, bucket):
     if request.method != 'POST' or bucket not in PROJECT_SEARCH_BUCKETS:
         raise Http404()
 
-    search_field = request.POST['search']
+    search_field = request.POST.get('search', '')
     model, status, order, template = PROJECT_SEARCH_BUCKETS[bucket]
 
     if bucket == 'submitted':


### PR DESCRIPTION
Originally we could not search for projects in the admin console (only worked for other sections of the console), this adds that capability in. For published, unpublished, and archived projects, I just hijacked the search method used by other sections (like users). Since submitted projects had a bunch of tabs within it, it required a different search script.